### PR TITLE
FMC package added

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,6 +39,7 @@ jobs:
           (cd drivers && cargo build)
           (cd drivers && cargo build --release)
           drivers/test-fw/build.sh
+          fmc/build.sh
 
       - name: Run unit tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ exclude = [
 members = [
   "drivers",
   "drivers/test-fw",
+  "fmc",
   "hw-model",
   "registers",
   "registers/bin/generator",

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fmc"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+riscv = []
+
+[[bin]]
+name = "fmc"
+required-features = ["riscv"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+caliptra-lib = { path = "../drivers" }
+caliptra-registers = { path = "../registers" }
+cfg-if = "1.0.0"
+

--- a/fmc/build.sh
+++ b/fmc/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+cargo build \
+  --target riscv32imc-unknown-none-elf \
+  --features=riscv \
+  --profile=firmware \
+  --bin=fmc

--- a/fmc/src/lib.rs
+++ b/fmc/src/lib.rs
@@ -1,0 +1,17 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    lib.rs
+
+Abstract:
+
+    File contains Macros and APIs for the FMC
+
+References:
+    https://os.phil-opp.com/vga-text-mode for print functionality.
+
+--*/
+#![no_std]

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -1,0 +1,13 @@
+#![no_std]
+#![no_main]
+
+#[no_mangle]
+pub extern "C" fn main() -> ! {
+    loop {}
+}
+
+#[panic_handler]
+#[inline(never)]
+fn fmc_panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
This commit creates the FMC package of Caliptra. The FMC package is both a library crate  that can compile to x86 and RISCV, to make unit tests easy  and a RISCV-only binary crate which calls into the  FMC library.