### PR TITLE
[feat] Known Answer Tests (KAT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
 name = "caliptra-drivers-test-bin"
 version = "0.1.0"
 dependencies = [
+ "caliptra-kat",
  "caliptra-lib",
  "caliptra-registers",
  "cfg-if",
@@ -180,6 +181,13 @@ dependencies = [
  "caliptra-registers",
  "caliptra-verilated",
  "ureg",
+]
+
+[[package]]
+name = "caliptra-kat"
+version = "0.1.0"
+dependencies = [
+ "caliptra-lib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "ureg/lib/codegen",
   "ureg/lib/systemrdl",
   "x509",
+  "kat",
 ]
 
 [profile.firmware]

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -15,7 +15,7 @@ Abstract:
 #![no_std]
 
 mod array;
-mod error;
+pub mod error;
 mod wait;
 
 mod data_vault;

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 caliptra-lib = { path = "..", features=["emu"] }
 caliptra-registers = { path = "../../registers" }
+caliptra-kat = { path = "../../kat" }
 cfg-if = "1.0.0"
 
 [features]

--- a/drivers/test-fw/src/bin/ecc384_tests.rs
+++ b/drivers/test-fw/src/bin/ecc384_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Ecc384Kat;
 use caliptra_lib::{
     Array4x12, Ecc384, Ecc384Data, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar,
     Ecc384Seed, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
@@ -505,7 +506,12 @@ fn test_kv_seed_from_kv_msg_from_input() {
     assert!(result.is_ok());
 }
 
+fn test_kat() {
+    assert_eq!(Ecc384Kat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_gen_key_pair,
     test_sign,
     test_verify,

--- a/drivers/test-fw/src/bin/hmac384_tests.rs
+++ b/drivers/test-fw/src/bin/hmac384_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Hmac384Kat;
 use caliptra_lib::{Array4x12, Hmac384, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, Sha384};
 
 mod harness;
@@ -400,7 +401,12 @@ fn test_hmac_multi_block_two_step() {
     assert_eq!(out_tag, Array4x12::from(result));
 }
 
+fn test_kat() {
+    assert_eq!(Hmac384Kat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_hmac0,
     test_hmac1,
     test_hmac3,

--- a/drivers/test-fw/src/bin/sha1_tests.rs
+++ b/drivers/test-fw/src/bin/sha1_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Sha1Kat;
 use caliptra_lib::{Array4x5, Array4xN, Sha1};
 
 mod harness;
@@ -64,7 +65,12 @@ fn test_op1() {
     assert_eq!(digest, expected);
 }
 
+fn test_kat() {
+    assert_eq!(Sha1Kat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_digest0,
     test_digest1,
     test_digest2,

--- a/drivers/test-fw/src/bin/sha256_tests.rs
+++ b/drivers/test-fw/src/bin/sha256_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Sha256Kat;
 use caliptra_lib::{Array4x8, Sha256};
 
 mod harness;
@@ -222,7 +223,12 @@ fn test_op8() {
     assert_eq!(digest, Array4x8::from(expected));
 }
 
+fn test_kat() {
+    assert_eq!(Sha256Kat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_digest0,
     test_digest1,
     test_digest2,

--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Sha384Kat;
 use caliptra_lib::{Array4x12, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, Sha384};
 
 mod harness;
@@ -309,7 +310,12 @@ fn test_kv_incorrect_key_acl() {
     }
 }
 
+fn test_kat() {
+    assert_eq!(Sha384Kat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_digest0,
     test_digest1,
     test_digest2,

--- a/drivers/test-fw/src/bin/sha384acc_tests.rs
+++ b/drivers/test-fw/src/bin/sha384acc_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_kat::Sha384AccKat;
 use caliptra_lib::{Array4x12, Mailbox, Sha384Acc};
 mod harness;
 
@@ -149,7 +150,12 @@ fn test_digest_max_mailbox_size() {
     }
 }
 
+fn test_kat() {
+    assert_eq!(Sha384AccKat::default().execute().is_ok(), true);
+}
+
 test_suite! {
+    test_kat,
     test_digest_max_mailbox_size,
     test_digest0,
     test_digest1,

--- a/kat/Cargo.toml
+++ b/kat/Cargo.toml
@@ -1,0 +1,13 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-kat"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+test = false
+doctest = false
+
+[dependencies]
+caliptra-lib = { path = "../drivers" }

--- a/kat/src/crypto_kat.rs
+++ b/kat/src/crypto_kat.rs
@@ -1,0 +1,46 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    crypto_kat.rs
+
+Abstract:
+
+    File contains function to execute all the Known Answer Tests (KAT) for cryptography operations.
+
+--*/
+
+use crate::Ecc384Kat;
+use crate::Hmac384Kat;
+use crate::Sha1Kat;
+use crate::Sha256Kat;
+use crate::Sha384AccKat;
+use crate::Sha384Kat;
+use caliptra_lib::CaliptraResult;
+
+#[derive(Default, Debug)]
+pub struct CryptoKat {}
+
+impl CryptoKat {
+    // This function executes all the  Known Answer Tests (aka KAT).
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    #[allow(unused)]
+    pub fn execute(&self) -> CaliptraResult<()> {
+        Sha1Kat::default().execute()?;
+        Sha256Kat::default().execute()?;
+        Sha384Kat::default().execute()?;
+        Sha384AccKat::default().execute()?;
+        Hmac384Kat::default().execute()?;
+        Ecc384Kat::default().execute()?;
+        Ok(())
+    }
+}

--- a/kat/src/ecc384_kat.rs
+++ b/kat/src/ecc384_kat.rs
@@ -1,0 +1,126 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    ecc384_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for ECC-384 cryptography operations.
+
+--*/
+
+use caliptra_lib::{
+    caliptra_err_def, Array4x12, Array4xN, CaliptraResult, Ecc384, Ecc384Data, Ecc384PrivKeyIn,
+    Ecc384PubKey, Ecc384Scalar, Ecc384Signature,
+};
+
+caliptra_err_def! {
+    Ecc384,
+    Ecc384KatErr
+    {
+        SignatureGenerateFailure = 0x01,
+        SignatureVerifyFailure = 0x02,
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Ecc384Kat {}
+
+const SIGNATURE_R: [u32; 12] = [
+    0x36f85014, 0x6f400443, 0x848cae03, 0x57591032, 0xe6a395de, 0x66e7261a, 0x38049fb, 0xee15db19,
+    0x5dbd9786, 0x9439292a, 0x4f5792e4, 0x3a1231b7,
+];
+const SIGNATURE_S: [u32; 12] = [
+    0xeeea4294, 0x82fd8fa9, 0xd4d5f960, 0xa09edfa6, 0xc765efe5, 0xff4c17a5, 0x12e694fa, 0xcc45d3f6,
+    0xfc3d3b5c, 0x62739c1f, 0xb9fcae3, 0x26f54b43,
+];
+
+impl Ecc384Kat {
+    // This function executes the Known Answer Tests (aka KAT) for ECC384.
+    //
+    // Test vector source:
+    // Generated using MbedTLS library.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_signature_generate()?;
+        self.kat_signature_verify()?;
+        Ok(())
+    }
+
+    // Performs the signature generation operation.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    fn kat_signature_generate(&self) -> CaliptraResult<()> {
+        let priv_key = Array4xN([
+            0xc908585a, 0x486c3b3d, 0x8bbe50eb, 0x7d2eb8a0, 0x3aa04e3d, 0x8bde2c31, 0xa8a2a1e3,
+            0x349dc21c, 0xbbe6c90a, 0xe2f74912, 0x8884b622, 0xbb72b4c5,
+        ]);
+
+        let digest = [0u8; 48];
+        let result = Ecc384::default().sign(
+            Ecc384PrivKeyIn::from(&priv_key),
+            Ecc384Data::from(&Array4x12::from(digest)),
+        );
+        if result.is_err() {
+            raise_err!(SignatureGenerateFailure);
+        }
+        let signature = result.unwrap();
+        if signature.r != Ecc384Scalar::from(SIGNATURE_R)
+            || signature.s != Ecc384Scalar::from(SIGNATURE_S)
+        {
+            raise_err!(SignatureGenerateFailure);
+        }
+        Ok(())
+    }
+
+    // Performs the signature verification operation.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    fn kat_signature_verify(&self) -> CaliptraResult<()> {
+        let pub_key_x = Array4xN([
+            0x98233ca, 0x567a3f14, 0xbe784904, 0xc6921d43, 0x3b4f853a, 0x523742e4, 0xbc98767e,
+            0x23ca3da6, 0x656bec46, 0xa7b1119e, 0x63d266ca, 0x6254977f,
+        ]);
+        let pub_key_y = Array4xN([
+            0x75d0b401, 0xc8bac39a, 0xc5fb0f2b, 0x3b95372c, 0x41d9de40, 0x55fddb06, 0xf7484974,
+            0x8d0aed85, 0x9b6550ca, 0x750c3cd1, 0x1851e050, 0xbb7d20b2,
+        ]);
+
+        let pub_key = Ecc384PubKey {
+            x: pub_key_x,
+            y: pub_key_y,
+        };
+        let signature = Ecc384Signature {
+            r: Ecc384Scalar::from(SIGNATURE_R),
+            s: Ecc384Scalar::from(SIGNATURE_S),
+        };
+        let digest = [0u8; 48];
+        let result = Ecc384::default().verify(&pub_key, &Ecc384Scalar::from(digest), &signature);
+        if result.is_err() {
+            raise_err!(SignatureVerifyFailure);
+        }
+        Ok(())
+    }
+}

--- a/kat/src/hmac384_kat.rs
+++ b/kat/src/hmac384_kat.rs
@@ -1,0 +1,73 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    hmac384_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for HMAC-384 cryptography operations.
+
+--*/
+
+use caliptra_lib::{caliptra_err_def, Array4x12, Array4xN, CaliptraResult, Hmac384};
+
+caliptra_err_def! {
+    Hmac384,
+    Hmac384KatErr
+    {
+        // "No Data Test" failure
+        NoDataTestFailure = 0x01,
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Hmac384Kat {}
+
+impl Hmac384Kat {
+    // This function executes the Known Answer Tests (aka KAT) for HMAC384.
+    //
+    // Test vector source:
+    // Generated using MbedTLS library.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_no_data()?;
+        Ok(())
+    }
+
+    // Performs tag generation of a zero size buffer.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    fn kat_no_data(&self) -> CaliptraResult<()> {
+        let key = Array4xN([
+            0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b,
+            0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b, 0xb0b0b0b,
+        ]);
+        let data = &[];
+        let expected_tag = Array4xN([
+            0xb93a3e87, 0xa1bc85c8, 0x7b54f81d, 0xabb499a5, 0xe1a66254, 0x9198594c, 0x9088733c,
+            0x8edd0068, 0x83e4d461, 0x823e6259, 0x8b07a904, 0x28f9add9,
+        ]);
+        let mut tag = Array4x12::default();
+        let result = Hmac384::default().hmac((&key).into(), data.into(), (&mut tag).into());
+        if result.is_err() || tag != expected_tag {
+            raise_err!(NoDataTestFailure);
+        }
+        Ok(())
+    }
+}

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -1,0 +1,30 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    lib.rs
+
+Abstract:
+
+    File contains exports for the Caliptra Known Answer Tests.
+
+--*/
+
+#![no_std]
+
+mod crypto_kat;
+mod ecc384_kat;
+mod hmac384_kat;
+mod sha1_kat;
+mod sha256_kat;
+mod sha384_kat;
+mod sha384acc_kat;
+
+pub use ecc384_kat::Ecc384Kat;
+pub use hmac384_kat::Hmac384Kat;
+pub use sha1_kat::Sha1Kat;
+pub use sha256_kat::Sha256Kat;
+pub use sha384_kat::Sha384Kat;
+pub use sha384acc_kat::Sha384AccKat;

--- a/kat/src/sha1_kat.rs
+++ b/kat/src/sha1_kat.rs
@@ -1,0 +1,62 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    sha1_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for SHA-1 cryptography operations.
+
+--*/
+
+use caliptra_lib::caliptra_err_def;
+use caliptra_lib::Array4x5;
+use caliptra_lib::Array4xN;
+use caliptra_lib::CaliptraResult;
+use caliptra_lib::Sha1;
+
+caliptra_err_def! {
+    Sha1,
+    Sha1KatErr
+    {
+        // "No Data Test" failure
+        NoDataTestFailure = 0x01,
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Sha1Kat {}
+
+impl Sha1Kat {
+    // This function executes the Known Answer Tests (aka KAT) for SHA1.
+    //
+    // Test vector source:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_no_data()?;
+        Ok(())
+    }
+
+    fn kat_no_data(&self) -> CaliptraResult<()> {
+        let expected_digest =
+            Array4xN([0xda39a3ee, 0x5e6b4b0d, 0x3255bfef, 0x95601890, 0xafd80709]);
+        let data = [];
+        let mut digest = Array4x5::default();
+        let result = Sha1::default().digest(&data, &mut digest);
+        if result.is_err() || digest != expected_digest {
+            raise_err!(NoDataTestFailure);
+        }
+        Ok(())
+    }
+}

--- a/kat/src/sha256_kat.rs
+++ b/kat/src/sha256_kat.rs
@@ -1,0 +1,63 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    sha256_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for SHA-256 cryptography operations.
+
+--*/
+
+use caliptra_lib::Array4xN;
+use caliptra_lib::CaliptraResult;
+use caliptra_lib::Sha256;
+use caliptra_lib::{caliptra_err_def, Array4x8};
+
+caliptra_err_def! {
+    Sha256,
+    Sha256KatErr
+    {
+        // "No Data Test" failure
+        NoDataTestFailure = 0x01,
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Sha256Kat {}
+
+impl Sha256Kat {
+    // This function executes the Known Answer Tests (aka KAT) for SHA256.
+    //
+    // Test vector source:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_no_data()?;
+        Ok(())
+    }
+
+    fn kat_no_data(&self) -> CaliptraResult<()> {
+        let expected_digest = Array4xN([
+            0xe3b0c442, 0x98fc1c14, 0x9afbf4c8, 0x996fb924, 0x27ae41e4, 0x649b934c, 0xa495991b,
+            0x7852b855,
+        ]);
+        let data = [];
+        let mut digest = Array4x8::default();
+        let result = Sha256::default().digest(&data, &mut digest);
+        if result.is_err() || digest != expected_digest {
+            raise_err!(NoDataTestFailure);
+        }
+        Ok(())
+    }
+}

--- a/kat/src/sha384_kat.rs
+++ b/kat/src/sha384_kat.rs
@@ -1,0 +1,73 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    sha384_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for SHA-384 cryptography operations.
+
+--*/
+
+use caliptra_lib::caliptra_err_def;
+use caliptra_lib::Array4x12;
+use caliptra_lib::Array4xN;
+use caliptra_lib::CaliptraResult;
+use caliptra_lib::Sha384;
+
+caliptra_err_def! {
+    Sha384,
+    Sha384KatErr
+    {
+        // "No Data Test" failure
+        NoDataTestFailure = 0x01,
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Sha384Kat {}
+
+impl Sha384Kat {
+    // This function executes the Known Answer Tests (aka KAT) for SHA384.
+    //
+    // Test vector source:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_no_data()?;
+        Ok(())
+    }
+
+    // Performs the digest operation on a zero size buffer.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    fn kat_no_data(&self) -> CaliptraResult<()> {
+        let expected_digest = Array4xN([
+            0x38b060a7, 0x51ac9638, 0x4cd9327e, 0xb1b1e36a, 0x21fdb711, 0x14be0743, 0x4c0cc7bf,
+            0x63f6e1da, 0x274edebf, 0xe76f65fb, 0xd51ad2f1, 0x4898b95b,
+        ]);
+        let data = &[];
+        let mut digest = Array4x12::default();
+        let result = Sha384::default().digest(data.into(), (&mut digest).into());
+        if result.is_err() || digest != expected_digest {
+            raise_err!(NoDataTestFailure);
+        }
+        Ok(())
+    }
+}

--- a/kat/src/sha384acc_kat.rs
+++ b/kat/src/sha384acc_kat.rs
@@ -1,0 +1,75 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    sha384acc_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for SHA384 accelerator cryptography operations.
+
+--*/
+
+use caliptra_lib::{caliptra_err_def, Array4x12, Array4xN, CaliptraResult, Sha384Acc};
+
+caliptra_err_def! {
+    Sha384Acc,
+    Sha384AccKatErr
+    {
+        // "No Data Test" failure
+        NoDataTestFailure = 0x01,
+    }
+}
+
+#[derive(Default)]
+pub struct Sha384AccKat {}
+
+impl Sha384AccKat {
+    // This function executes the Known Answer Tests (aka KAT) for SHA384ACC.
+    //
+    // Test vector source:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self) -> CaliptraResult<()> {
+        self.kat_no_data()?;
+        Ok(())
+    }
+
+    // Performs the digest operation on a zero size buffer.
+    //
+    // # Arguments
+    //
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    fn kat_no_data(&self) -> CaliptraResult<()> {
+        let expected_digest = Array4xN([
+            0x38b060a7, 0x51ac9638, 0x4cd9327e, 0xb1b1e36a, 0x21fdb711, 0x14be0743, 0x4c0cc7bf,
+            0x63f6e1da, 0x274edebf, 0xe76f65fb, 0xd51ad2f1, 0x4898b95b,
+        ]);
+        let mut digest = Array4x12::default();
+        let sha_acc = Sha384Acc::default();
+        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+            let result = sha_acc_op.digest(0, 0, false, &mut digest);
+            if result.is_err() || digest != expected_digest {
+                raise_err!(NoDataTestFailure);
+            }
+            drop(sha_acc_op);
+        } else {
+            raise_err!(NoDataTestFailure);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This change adds the KAT for following crypto API:
	1. SHA256
	2. SHA384
	3. HMAC384
	4. ECC384
	5. SHA384ACC
	6. SHA1