### PR TITLE
Fix casting const slice to mut array ref

### DIFF
--- a/sw-emulator/lib/bus/src/register.rs
+++ b/sw-emulator/lib/bus/src/register.rs
@@ -336,7 +336,7 @@ impl<const N: usize> ReadWriteMemory<N> {
 
     /// Mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8; N] {
-        let ptr = self.data.data().as_ptr() as *mut [u8; N];
+        let ptr = self.data.data_mut().as_mut_ptr() as *mut [u8; N];
         unsafe { &mut *ptr }
     }
 }
@@ -392,7 +392,7 @@ impl<const N: usize> ReadOnlyMemory<N> {
 
     /// Mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8; N] {
-        let ptr = self.data.data().as_ptr() as *mut [u8; N];
+        let ptr = self.data.data_mut().as_mut_ptr() as *mut [u8; N];
         unsafe { &mut *ptr }
     }
 }
@@ -437,7 +437,7 @@ impl<const N: usize> WriteOnlyMemory<N> {
 
     /// Mutable reference to data
     pub fn data_mut(&mut self) -> &mut [u8; N] {
-        let ptr = self.data.data().as_ptr() as *mut [u8; N];
+        let ptr = self.data.data_mut().as_mut_ptr() as *mut [u8; N];
         unsafe { &mut *ptr }
     }
 }


### PR DESCRIPTION
The original code goes through these type transitions:

`&[u8]` to `*const u8` to `*mut [u8; N]` to `&mut [u8; N]`

The intent of the method was likely to start from `&mut [u8]`.