### PR TITLE
Remove unnecesary PAT from verilator workflow.

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-          token: ${{secrets.CALIPTRA_PAT_READ}}
 
       - name: Restore Cargo index
         uses: actions/cache/restore@v3


### PR DESCRIPTION
Now that caliptra-rtl is public, this isn't needed for read-access to that repo.