### PR TITLE
Switch slack workflow from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,6 +1,6 @@
 name: Publish merged PRs on Slack
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
This should allow slack notifications to be sent for PRs that originated from a forked repo. (The workflow will against the main branch rather than the PR branch, so github trusts it to have access to the slack webhook secret, even if it doesn't trust the PR branch).