### PR TITLE
Check in CI that generated registers match caliptra-rtl submodule.

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -97,6 +97,10 @@ jobs:
           rustup update
           rustup target add riscv32imc-unknown-none-elf
 
+      - name: Check that generated register code matches caliptra-rtl submodule
+        run: |
+          cargo run -p caliptra_registers_generator -- --check hw-latest/caliptra-rtl registers/src
+
       - name: Build
         run: |
           export RUSTFLAGS="-D warnings"


### PR DESCRIPTION
This has two benefits:

- The firmware register definitions are guaranteed to be in sync with the linked RTL repo.

- The generated code does unsafe pointer manipulation, and this test ensures that someone can't place a subtle backdoor there without modifying the code generator (reviewers don't inspect the generated register code with the same rigor they would for the code generator itself). 
