### PR TITLE
Give Verilator Hardware Model / Build and Test job a unique name

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test:
-    name: Build and Test
+    name: Verilator Build and Test
     runs-on: ubuntu-22.04
 
     env:


### PR DESCRIPTION
Unfortunately, Github doesn't always include the workflow name when showing jobs in the UI, making it hard to tell the difference between the "Build and Test" job in the "Build and Test" workflow and the "Build and Test" job in the "Verilator Hardware Model" workflow.

So rename it to "Verilator Build and Test".