### PR TITLE
[fix] Mailbox Panic removal & cleanup

### DIFF
--- a/drivers/src/error.rs
+++ b/drivers/src/error.rs
@@ -63,16 +63,6 @@ macro_rules! caliptra_err_def {
         }
 
         #[allow(unused_macros)]
-        macro_rules! kv_err {
-            ($name: ident, $err_code: literal) => (
-                paste::paste! {
-                    [<$name>_HwReadyTimeout] = $err_code,
-                    [<$name>_HwValidTimeout] = $err_code + 1,
-                }
-            )
-        }
-
-        #[allow(unused_macros)]
         macro_rules! raise_err { ($comp_err: ident) => {
             Err(((($crate::error::CaliptraComponent::$comp_name) as u32) << 24) | ($enum_name::$comp_err as u32))?
         } }

--- a/drivers/test-fw/src/bin/mailbox_tests.rs
+++ b/drivers/test-fw/src/bin/mailbox_tests.rs
@@ -25,7 +25,7 @@ mod harness;
 fn test_send_txn_drop() {
     let mut ii = 0;
     while ii < 2 {
-        if let Ok(txn) = Mailbox::try_start_send_txn() {
+        if let Some(txn) = Mailbox::default().try_start_send_txn() {
             drop(txn);
         } else {
             assert!(false);
@@ -35,7 +35,7 @@ fn test_send_txn_drop() {
 }
 
 fn test_send_txn_error() {
-    if let Ok(mut txn) = Mailbox::try_start_send_txn() {
+    if let Some(mut txn) = Mailbox::default().try_start_send_txn() {
         assert!(txn.write_dlen(0x01).is_err());
         assert!(txn.execute_request().is_err());
         assert!(txn.complete().is_err());
@@ -44,11 +44,11 @@ fn test_send_txn_error() {
 }
 
 fn test_try_start_rcv_txn_error() {
-    if let Ok(_recv_txn) = Mailbox::try_start_recv_txn() {
+    if let Some(_recv_txn) = Mailbox::default().try_start_recv_txn() {
         assert!(false);
     }
-    if let Ok(_txn) = Mailbox::try_start_send_txn() {
-        if let Ok(_recv_txn) = Mailbox::try_start_recv_txn() {
+    if let Some(_txn) = Mailbox::default().try_start_send_txn() {
+        if let Some(_recv_txn) = Mailbox::default().try_start_recv_txn() {
             assert!(false);
         }
     } else {
@@ -86,7 +86,7 @@ fn test_mailbox_loopback() {
 
     let mut ii = 0;
     while ii < 2 {
-        if let Ok(mut txn) = Mailbox::try_start_send_txn() {
+        if let Some(mut txn) = Mailbox::default().try_start_send_txn() {
             const CMD: u32 = 0x1c;
 
             assert!(txn.send_request(CMD, request).is_ok());
@@ -96,7 +96,7 @@ fn test_mailbox_loopback() {
             assert_eq!(mbox.dlen().read(), request.len() as u32);
             // Initialize an empty receive buffer.
             // Send a bigger buffer than needed.
-            if let Ok(mut recv_txn) = Mailbox::try_start_recv_txn() {
+            if let Some(mut recv_txn) = Mailbox::default().try_start_recv_txn() {
                 assert_eq!(mbox.dlen().read(), recv_txn.dlen());
                 assert!(recv_txn.recv_request(&mut request_received[..]).is_ok());
                 assert_eq!(request, &request_received[..request.len()]);

--- a/drivers/test-fw/src/bin/sha384acc_tests.rs
+++ b/drivers/test-fw/src/bin/sha384acc_tests.rs
@@ -32,7 +32,7 @@ fn test_digest0() {
         0xa3, 0xc7, 0x9b,
     ];
 
-    if let Ok(mut txn) = Mailbox::try_start_send_txn() {
+    if let Some(mut txn) = Mailbox::default().try_start_send_txn() {
         const CMD: u32 = 0x1c;
         assert!(txn.send_request(CMD, &data).is_ok());
 
@@ -59,7 +59,7 @@ fn test_digest1() {
         0x74, 0x60, 0x39,
     ];
 
-    if let Ok(mut txn) = Mailbox::try_start_send_txn() {
+    if let Some(mut txn) = Mailbox::default().try_start_send_txn() {
         const CMD: u32 = 0x1c;
         assert!(txn.send_request(CMD, &data).is_ok());
 
@@ -89,7 +89,7 @@ fn test_digest2() {
     let mut digest = Array4x12::default();
     let sha_acc = Sha384Acc::default();
 
-    if let Ok(mut txn) = Mailbox::try_start_send_txn() {
+    if let Some(mut txn) = Mailbox::default().try_start_send_txn() {
         const CMD: u32 = 0x1c;
         assert!(txn.send_request(CMD, &data).is_ok());
 


### PR DESCRIPTION
This commit fixes following issues:
 - Mailbox should be default constructable
 - Mailbox try_start* methods should return and Option instead of Result
 - Fixes to remove panics

Following needs to be fixed in future
 - Drop implementation needs to be refactored to avoid unwraps or Result returning calls