### PR TITLE
[fix] Add read capability for PCRs in the emulator

### DIFF
--- a/sw-emulator/lib/periph/src/asym_ecc384.rs
+++ b/sw-emulator/lib/periph/src/asym_ecc384.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use crate::helpers::{bytes_from_words_le, words_from_bytes_le};
 use crate::{KeyUsage, KeyVault};
 use caliptra_emu_bus::{BusError, Clock, ReadOnlyRegister, ReadWriteRegister, Timer, TimerAction};
 use caliptra_emu_crypto::{Ecc384, Ecc384PubKey, Ecc384Signature};
@@ -97,21 +98,6 @@ register_bitfields! [
         RSVD OFFSET(10) NUMBITS(22) [],
     ],
 ];
-
-pub fn words_from_bytes_le(arr: &[u8; 48]) -> [u32; 12] {
-    let mut result = [0u32; 12];
-    for i in 0..result.len() {
-        result[i] = u32::from_le_bytes(arr[i * 4..][..4].try_into().unwrap())
-    }
-    result
-}
-pub fn bytes_from_words_le(arr: &[u32; 12]) -> [u8; 48] {
-    let mut result = [0u8; 48];
-    for i in 0..arr.len() {
-        result[i * 4..][..4].copy_from_slice(&arr[i].to_le_bytes());
-    }
-    result
-}
 
 #[derive(Bus)]
 #[poll_fn(poll)]

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::asym_ecc384::words_from_bytes_le;
+use crate::helpers::words_from_bytes_le;
 use crate::key_vault::KeyUsage;
 use crate::KeyVault;
 use caliptra_emu_bus::{

--- a/sw-emulator/lib/periph/src/helpers.rs
+++ b/sw-emulator/lib/periph/src/helpers.rs
@@ -1,0 +1,30 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    helpers.rs
+
+Abstract:
+
+    File contains helper functions
+
+--*/
+#![allow(unused)]
+
+pub fn words_from_bytes_le(arr: &[u8; 48]) -> [u32; 12] {
+    let mut result = [0u32; 12];
+    for i in 0..result.len() {
+        result[i] = u32::from_le_bytes(arr[i * 4..][..4].try_into().unwrap())
+    }
+    result
+}
+
+pub fn bytes_from_words_le(arr: &[u32; 12]) -> [u8; 48] {
+    let mut result = [0u8; 48];
+    for i in 0..arr.len() {
+        result[i * 4..][..4].copy_from_slice(&arr[i].to_le_bytes());
+    }
+    result
+}

--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -19,6 +19,7 @@ mod doe;
 mod emu_ctrl;
 mod hash_sha256;
 mod hash_sha512;
+mod helpers;
 mod hmac_sha384;
 mod key_vault;
 mod mailbox;


### PR DESCRIPTION
This change adds the capability to read PCRs from the PCR vault in the emulator.