### PR TITLE
[feat] PCR hash extend API for SHA384 driver

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -60,7 +60,7 @@ pub use pcr_bank::{PcrBank, PcrId};
 pub use reset::{ResetReason, ResetService};
 pub use sha1::{Sha1, Sha1Digest, Sha1DigestOp};
 pub use sha256::{Sha256, Sha256DigestOp};
-pub use sha384::{PcrHashExtendArgs, Sha384, Sha384Data, Sha384Digest, Sha384DigestOp};
+pub use sha384::{Sha384, Sha384Digest, Sha384DigestOp};
 pub use sha384acc::{Sha384Acc, Sha384AccOp};
 pub use state::{DeviceState, Lifecycle};
 pub use status_reporter::{report_boot_status, report_flow_status};

--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -16,7 +16,7 @@ Abstract:
 #![no_main]
 
 use caliptra_kat::Sha384Kat;
-use caliptra_lib::{Array4x12, PcrBank, PcrHashExtendArgs, PcrId, Sha384};
+use caliptra_lib::{Array4x12, PcrBank, PcrId, Sha384};
 
 mod harness;
 
@@ -30,7 +30,7 @@ fn test_digest0() {
 
     let data = &[];
     let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(data.into(), (&mut digest).into());
+    let result = Sha384::default().digest(data, &mut digest);
     assert!(result.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -44,7 +44,7 @@ fn test_digest1() {
     ];
     let data = "abc".as_bytes();
     let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(data.into(), (&mut digest).into());
+    let result = Sha384::default().digest(data.into(), &mut digest);
     assert!(result.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -58,7 +58,7 @@ fn test_digest2() {
     ];
     let data = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes();
     let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(data.into(), (&mut digest).into());
+    let result = Sha384::default().digest(data.into(), &mut digest);
     assert!(result.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -72,7 +72,7 @@ fn test_digest3() {
     ];
     let data = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_bytes();
     let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(data.into(), (&mut digest).into());
+    let result = Sha384::default().digest(data.into(), &mut digest);
     assert!(result.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -86,7 +86,7 @@ fn test_op0() {
     ];
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     let actual = digest_op.finalize();
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
@@ -101,7 +101,7 @@ fn test_op1() {
     ];
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     let actual = digest_op.finalize();
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
@@ -118,7 +118,7 @@ fn test_op2() {
     let data = "abc".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     assert!(digest_op.update(data).is_ok());
     let actual = digest_op.finalize();
     assert!(actual.is_ok());
@@ -135,7 +135,7 @@ fn test_op3() {
     let data = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     assert!(digest_op.update(data).is_ok());
     let actual = digest_op.finalize();
     assert!(actual.is_ok());
@@ -152,7 +152,7 @@ fn test_op4() {
     let data = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     assert!(digest_op.update(data).is_ok());
     let actual = digest_op.finalize();
     assert!(actual.is_ok());
@@ -169,7 +169,7 @@ fn test_op5() {
     const DATA: [u8; 1000] = [0x61; 1000];
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     for _ in 0..1_000 {
         assert!(digest_op.update(&DATA).is_ok());
     }
@@ -188,7 +188,7 @@ fn test_op6() {
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
@@ -207,7 +207,7 @@ fn test_op7() {
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
@@ -226,7 +226,7 @@ fn test_op8() {
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh".as_bytes();
     let mut digest = Array4x12::default();
     let sha384 = Sha384::default();
-    let mut digest_op = sha384.digest_init((&mut digest).into()).unwrap();
+    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
@@ -235,71 +235,14 @@ fn test_op8() {
     assert_eq!(digest, Array4x12::from(expected));
 }
 
-// fn test_kv() {
-//     let expected: [u8; 48] = [
-//         0x31, 0x15, 0x4d, 0x09, 0x2c, 0x9e, 0xf4, 0xc7, 0x23, 0x0c, 0xeb, 0x5d, 0x32, 0x65, 0x7f,
-//         0x11, 0x51, 0x79, 0xdb, 0x40, 0x30, 0xc0, 0x16, 0x71, 0x1e, 0x2a, 0xd2, 0x85, 0xb3, 0x66,
-//         0xaa, 0x5f, 0x78, 0x3a, 0xac, 0x7b, 0x3f, 0x71, 0xc3, 0xe0, 0x0e, 0xb9, 0x9b, 0xc5, 0x0e,
-//         0x75, 0x60, 0x64,
-//     ];
-
-//     let data: [u8; 48] = [
-//         0x9c, 0x2f, 0x48, 0x76, 0x0d, 0x13, 0xac, 0x42, 0xea, 0xd1, 0x96, 0xe5, 0x4d, 0xcb, 0xaa,
-//         0x5e, 0x58, 0x72, 0x06, 0x62, 0xa9, 0x6b, 0x91, 0x94, 0xe9, 0x81, 0x33, 0x29, 0xbd, 0xb6,
-//         0x27, 0xc7, 0xc1, 0xca, 0x77, 0x15, 0x31, 0x16, 0x32, 0xc1, 0x39, 0xe7, 0xa3, 0x59, 0x14,
-//         0xfc, 0x1e, 0xcd,
-//     ];
-
-//     //
-//     // Step 1: Hash a buffer from input and store the hash into key-vault slot 0.
-//     //
-//     let mut usage = KeyUsage(0);
-//     usage.set_sha_data(true);
-//     let key_out_1 = KeyWriteArgs {
-//         id: KeyId::KeyId0,
-//         usage,
-//     };
-//     let mut result = Sha384::default().digest((&data).into(), key_out_1.into());
-//     assert!(result.is_ok());
-
-//     //
-//     // Step 2: Hash the hash generated in step 1.
-//     // Success indicates hash was correctly stored in the key-vault in step 1.
-//     // Success also indicates buffer was correctly retrieved from the key-vault.
-//     //
-//     let mut digest = Array4x12::default();
-//     let key_in_2 = KeyReadArgs::new(KeyId::KeyId0);
-//     result = Sha384::default().digest(key_in_2.into(), (&mut digest).into());
-//     assert!(result.is_ok());
-//     assert_eq!(digest, Array4x12::from(expected));
-// }
-
-// fn test_kv_incorrect_key_acl() {
-//     let data = &[];
-//     let mut usage = KeyUsage(0);
-//     usage.set_sha_data(false);
-
-//     for key_id in KEY_IDS {
-//         //
-//         // Step 1: Hash a buffer from input and store the hash into key-vault slot 0.
-//         // Prevent the key to be used as sha data.
-//         //
-//         let key_out_1 = KeyWriteArgs { id: key_id, usage };
-//         let mut result = Sha384::default().digest((data).into(), key_out_1.into());
-//         assert!(result.is_ok());
-
-//         //
-//         // Step 2: Use the key generated in step 1 as SHA data.
-//         // This should fail since acl set on key should prevent it's usage as SHA data.
-//         //
-//         let mut digest = Array4x12::default();
-//         let key_in_2 = KeyReadArgs::new(key_id);
-//         result = Sha384::default().digest(key_in_2.into(), (&mut digest).into());
-//         assert!(result.is_err());
-//     }
-// }
-
 fn test_pcr_hash_extend_single_block() {
+    // fn change_endianess(arr: mut &[u8]) {
+    //     for idx in (0..self.len()).step_by(4) {
+    //         self.swap(idx, idx + 3);
+    //         self.swap(idx + 1, idx + 2);
+    //     }
+    // }
+
     let expected_round_1: [u8; 48] = [
         0x4d, 0xca, 0xf1, 0x2f, 0xab, 0xaa, 0x55, 0x47, 0xf4, 0x6c, 0x32, 0x64, 0xb1, 0xe4, 0x5b,
         0xc4, 0x5, 0x5c, 0x0, 0xe, 0x66, 0x2c, 0x6c, 0x8a, 0x2c, 0xca, 0x71, 0x2b, 0x44, 0x2d,
@@ -322,117 +265,110 @@ fn test_pcr_hash_extend_single_block() {
     pcr_bank.erase_all_pcrs();
 
     // Round 1: PCR is all zeros.
-    let mut digest = Array4x12::default();
-    let pcr_hash_extend_args = PcrHashExtendArgs {
-        slice: &data,
-        hash_extend: true,
-        id: PcrId::PcrId0,
-    };
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_1));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_1)
+    );
 
     // Round 2: PCR is expected_round_1
-    let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_2));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_2)
+    );
 }
 
-fn test_pcr_hash_extend_multi_block() {
+fn test_pcr_hash_extend_single_block_2() {
     let expected_round_1: [u8; 48] = [
-        0xb1, 0x6c, 0xce, 0x6c, 0x70, 0x51, 0x9c, 0x96, 0x58, 0xe3, 0xeb, 0x3e, 0xe1, 0xbd, 0x36,
-        0x96, 0x33, 0x85, 0xed, 0x38, 0xa2, 0x95, 0xe1, 0x85, 0x6c, 0xc, 0x44, 0x4d, 0x48, 0xd7,
-        0x76, 0x74, 0x73, 0x78, 0x3e, 0x29, 0x5a, 0x33, 0x59, 0x1c, 0x2e, 0xe6, 0xd2, 0x44, 0x36,
-        0xa0, 0xa6, 0x6b,
+        0x4d, 0xca, 0xf1, 0x2f, 0xab, 0xaa, 0x55, 0x47, 0xf4, 0x6c, 0x32, 0x64, 0xb1, 0xe4, 0x5b,
+        0xc4, 0x5, 0x5c, 0x0, 0xe, 0x66, 0x2c, 0x6c, 0x8a, 0x2c, 0xca, 0x71, 0x2b, 0x44, 0x2d,
+        0x82, 0x6a, 0xf0, 0xbc, 0x35, 0x96, 0x2b, 0x59, 0x45, 0x17, 0xb3, 0x2f, 0xe1, 0x66, 0x73,
+        0xd1, 0x20, 0x30,
     ];
     let expected_round_2: [u8; 48] = [
-        0xde, 0x46, 0xdd, 0xc9, 0x47, 0x0, 0x89, 0x2a, 0x74, 0x6f, 0x50, 0xc9, 0xf9, 0xb2, 0xa7,
-        0xab, 0x36, 0x87, 0x62, 0xf7, 0x12, 0x0, 0x2f, 0xf4, 0xed, 0xcb, 0x8b, 0x75, 0x9, 0x86,
-        0xca, 0x3d, 0xb0, 0x4b, 0x56, 0xbd, 0x79, 0x4d, 0x26, 0x50, 0xb5, 0x9a, 0xc5, 0x90, 0x89,
-        0xa4, 0x5e, 0xf9,
+        0x13, 0xc4, 0x1e, 0x3a, 0xd2, 0x7f, 0x9d, 0xaa, 0xdb, 0x92, 0x8f, 0x25, 0x9d, 0x35, 0xf9,
+        0xd1, 0x3d, 0xeb, 0x13, 0x39, 0x73, 0x2, 0x19, 0x21, 0x98, 0x7b, 0x32, 0x2b, 0xb6, 0xd4,
+        0xfa, 0xb0, 0xcc, 0x4f, 0xae, 0xfa, 0x43, 0xf1, 0xf7, 0x12, 0x1e, 0x66, 0x99, 0x7a, 0xb5,
+        0xdf, 0xa0, 0x3d,
     ];
-    let data: [u8; 82] = [
-        0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B,
-        0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A,
-        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F,
-        0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64,
-        0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73,
-        0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A,
+    let data: [u8; 48] = [
+        0x9c, 0x2f, 0x48, 0x76, 0x0d, 0x13, 0xac, 0x42, 0xea, 0xd1, 0x96, 0xe5, 0x4d, 0xcb, 0xaa,
+        0x5e, 0x58, 0x72, 0x06, 0x62, 0xa9, 0x6b, 0x91, 0x94, 0xe9, 0x81, 0x33, 0x29, 0xbd, 0xb6,
+        0x27, 0xc7, 0xc1, 0xca, 0x77, 0x15, 0x31, 0x16, 0x32, 0xc1, 0x39, 0xe7, 0xa3, 0x59, 0x14,
+        0xfc, 0x1e, 0xcd,
     ];
     let mut pcr_bank = PcrBank::default();
     pcr_bank.erase_all_pcrs();
 
     // Round 1: PCR is all zeros.
-    let mut digest = Array4x12::default();
-    let pcr_hash_extend_args = PcrHashExtendArgs {
-        slice: &data,
-        hash_extend: true,
-        id: PcrId::PcrId1,
-    };
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_1));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_1)
+    );
 
     // Round 2: PCR is expected_round_1
-    let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &[]);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_2));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_2)
+    );
 }
 
-fn test_pcr_hash_extend_multi_block_2() {
+fn test_pcr_hash_extend_single_block_3() {
     let expected_round_1: [u8; 48] = [
-        0x69, 0x98, 0x44, 0x57, 0xe9, 0xbc, 0xf2, 0xe2, 0xa, 0xe6, 0x68, 0xdb, 0x87, 0xf8, 0x95,
-        0x63, 0xf, 0x18, 0x3a, 0xe, 0x21, 0xa8, 0x15, 0x27, 0x83, 0x65, 0xfe, 0xc0, 0xf9, 0x51,
-        0xbb, 0x9a, 0xdf, 0x3e, 0x5d, 0x3e, 0x6a, 0x2f, 0x74, 0xd2, 0x98, 0xa4, 0xbe, 0xbc, 0x10,
-        0x41, 0x99, 0x38,
+        0x4d, 0xca, 0xf1, 0x2f, 0xab, 0xaa, 0x55, 0x47, 0xf4, 0x6c, 0x32, 0x64, 0xb1, 0xe4, 0x5b,
+        0xc4, 0x5, 0x5c, 0x0, 0xe, 0x66, 0x2c, 0x6c, 0x8a, 0x2c, 0xca, 0x71, 0x2b, 0x44, 0x2d,
+        0x82, 0x6a, 0xf0, 0xbc, 0x35, 0x96, 0x2b, 0x59, 0x45, 0x17, 0xb3, 0x2f, 0xe1, 0x66, 0x73,
+        0xd1, 0x20, 0x30,
     ];
     let expected_round_2: [u8; 48] = [
-        0xb, 0xed, 0x91, 0x11, 0xb0, 0xcf, 0xa2, 0x18, 0xa1, 0x4b, 0x27, 0x41, 0xeb, 0x75, 0x6c,
-        0xf8, 0x3c, 0x5a, 0x6, 0xd8, 0xce, 0xf1, 0x58, 0x25, 0x77, 0x16, 0xf2, 0xa6, 0x8, 0x77,
-        0xba, 0xb2, 0x75, 0x44, 0xc0, 0xd6, 0x48, 0x6e, 0xa9, 0xca, 0xfd, 0x44, 0x4e, 0x6b, 0xe3,
-        0xbe, 0x43, 0x77,
+        0xa1, 0xaa, 0x37, 0xde, 0x2b, 0x9f, 0x9e, 0x93, 0xac, 0xd4, 0x38, 0xbb, 0x2b, 0x80, 0xf4,
+        0xf4, 0x88, 0x5f, 0x6b, 0x96, 0xef, 0x2f, 0xe8, 0x74, 0xd8, 0x2f, 0x46, 0x77, 0x65, 0x35,
+        0x7, 0x66, 0x34, 0x1a, 0x62, 0x43, 0xf4, 0xaa, 0x72, 0x26, 0x4f, 0x10, 0xe0, 0xa5, 0x1b,
+        0x77, 0xae, 0xc3,
     ];
-    let data: [u8; 256] = [
-        0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B,
-        0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A,
-        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F,
-        0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64,
-        0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73,
-        0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64,
-        0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73,
-        0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
-        0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
-        0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C,
-        0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x77,
-        0x78, 0x79, 0x7A, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C,
-        0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x61,
-        0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
-        0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
-        0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
-        0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70,
-        0x70,
+    let data: [u8; 48] = [
+        0x9c, 0x2f, 0x48, 0x76, 0x0d, 0x13, 0xac, 0x42, 0xea, 0xd1, 0x96, 0xe5, 0x4d, 0xcb, 0xaa,
+        0x5e, 0x58, 0x72, 0x06, 0x62, 0xa9, 0x6b, 0x91, 0x94, 0xe9, 0x81, 0x33, 0x29, 0xbd, 0xb6,
+        0x27, 0xc7, 0xc1, 0xca, 0x77, 0x15, 0x31, 0x16, 0x32, 0xc1, 0x39, 0xe7, 0xa3, 0x59, 0x14,
+        0xfc, 0x1e, 0xcd,
     ];
+    let extended_data: [u8; 1] = [0xa];
+
     let mut pcr_bank = PcrBank::default();
     pcr_bank.erase_all_pcrs();
 
     // Round 1: PCR is all zeros.
-    let mut digest = Array4x12::default();
-    let pcr_hash_extend_args = PcrHashExtendArgs {
-        slice: &data,
-        hash_extend: true,
-        id: PcrId::PcrId2,
-    };
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_1));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_1)
+    );
 
     // Round 2: PCR is expected_round_1
-    let mut digest = Array4x12::default();
-    let result = Sha384::default().digest(pcr_hash_extend_args.into(), (&mut digest).into());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &extended_data);
     assert!(result.is_ok());
-    assert_eq!(digest, Array4x12::from(expected_round_2));
+    assert_eq!(
+        pcr_bank.read_pcr(PcrId::PcrId0),
+        Array4x12::from(expected_round_2)
+    );
+}
+
+fn test_pcr_hash_extend_limit() {
+    let data_allowed: [u8; 79] = [0u8; 79];
+    let data_not_allowed: [u8; 80] = [0u8; 80];
+
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data_allowed);
+    assert!(result.is_ok());
+    let result = Sha384::default().pcr_extend(PcrId::PcrId0, &data_not_allowed);
+    assert!(result.is_err());
 }
 
 fn test_kat() {
@@ -458,6 +394,7 @@ test_suite! {
     test_op7,
     test_op8,
     test_pcr_hash_extend_single_block,
-    test_pcr_hash_extend_multi_block,
-    test_pcr_hash_extend_multi_block_2,
+    test_pcr_hash_extend_single_block_2,
+    test_pcr_hash_extend_single_block_3,
+    test_pcr_hash_extend_limit,
 }

--- a/kat/src/sha384_kat.rs
+++ b/kat/src/sha384_kat.rs
@@ -53,7 +53,7 @@ impl Sha384Kat {
         let data = &[];
         let mut digest = Array4x12::default();
 
-        sha.digest(data.into(), (&mut digest).into())
+        sha.digest(data, &mut digest)
             .map_err(|_| err_u32!(DigestFailure))?;
 
         if digest != SHA384_EXPECTED_DIGEST {


### PR DESCRIPTION
This change adds a new api to the SHA384 driver to hash extend PCRs.