### PR TITLE
[feat] New FlowStatus API

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -63,7 +63,7 @@ pub use sha256::{Sha256, Sha256DigestOp};
 pub use sha384::{Sha384, Sha384Digest, Sha384DigestOp};
 pub use sha384acc::{Sha384Acc, Sha384AccOp};
 pub use state::{DeviceState, Lifecycle};
-pub use status_reporter::{report_boot_status, report_flow_status};
+pub use status_reporter::{report_boot_status, FlowStatus};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "emu")] {

--- a/drivers/src/status_reporter.rs
+++ b/drivers/src/status_reporter.rs
@@ -24,16 +24,27 @@ pub fn report_boot_status(val: u32) {
     soc_ifc.cptra_boot_status().write(|_| val);
 }
 
-/// Report flow status
-///
-/// # Arguments
-///
-/// * `val` - Flow status code.
-pub fn report_flow_status(val: u32) {
-    let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
+#[derive(Default, Debug)]
+pub struct FlowStatus {}
 
-    let flow_status = soc_ifc.cptra_flow_status().read();
-    soc_ifc
-        .cptra_flow_status()
-        .write(|_| flow_status.modify().status(val));
+impl FlowStatus {
+    /// Set IDEVID CSR ready
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    pub fn set_idevid_csr_ready(&mut self) {
+        let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
+        soc_ifc.cptra_flow_status().write(|w| w.status(0x0800_0000));
+    }
+
+    /// Set ready for firmware
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    pub fn set_ready_for_firmware(&mut self) {
+        let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
+        soc_ifc.cptra_flow_status().write(|w| w.ready_for_fw(true));
+    }
 }

--- a/drivers/test-fw/src/bin/status_reporter_tests.rs
+++ b/drivers/test-fw/src/bin/status_reporter_tests.rs
@@ -15,7 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
-use caliptra_lib::{report_boot_status, report_flow_status};
+use caliptra_lib::{report_boot_status, FlowStatus};
 use caliptra_registers::soc_ifc;
 
 mod harness;
@@ -25,24 +25,26 @@ fn retrieve_boot_status() -> u32 {
     soc_ifc.cptra_boot_status().read()
 }
 
-fn retrieve_flow_status() -> u32 {
-    let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
-    soc_ifc.cptra_flow_status().read().status()
-}
-
 fn test_report_boot_status() {
     let val: u32 = 0xbeef2;
     report_boot_status(val);
     assert_eq!(val, retrieve_boot_status());
 }
 
-fn test_report_flow_status() {
-    let val: u32 = 0xbeef3;
-    report_flow_status(val);
-    assert_eq!(val, retrieve_flow_status());
+fn test_report_idevid_csr_ready() {
+    let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
+    FlowStatus::default().set_idevid_csr_ready();
+    assert_eq!(0x0800_0000, soc_ifc.cptra_flow_status().read().status());
+}
+
+fn test_report_ready_for_firmware() {
+    let soc_ifc = soc_ifc::RegisterBlock::soc_ifc_reg();
+    FlowStatus::default().set_ready_for_firmware();
+    assert!(soc_ifc.cptra_flow_status().read().ready_for_fw());
 }
 
 test_suite! {
     test_report_boot_status,
-    test_report_flow_status,
+    test_report_idevid_csr_ready,
+    test_report_ready_for_firmware,
 }


### PR DESCRIPTION
This change adds api to retrieve the IDEVID CSR ready and firmware ready statuses from the CPTRA_FLOW_STATUS SOC register.