### PR TITLE
systemrdl parser should ignore '_' in verilog-style literals.

### DIFF
--- a/systemrdl/src/bits.rs
+++ b/systemrdl/src/bits.rs
@@ -54,7 +54,9 @@ impl FromStr for Bits {
             Some('h') => 16,
             _ => return Err(()),
         };
-        let val = u64::from_str_radix(i.as_str(), radix).map_err(|_| ())?;
+
+        let str_val = i.as_str().replace('_', "");
+        let val = u64::from_str_radix(&str_val, radix).map_err(|_| ())?;
         if val > mask(w)? {
             return Err(());
         }
@@ -116,5 +118,13 @@ mod tests {
         assert_eq!(Ok(Bits::new(4, 0xf)), Bits::from_str("4'hF"));
         assert_eq!(Err(()), Bits::from_str("4'h10"));
         assert_eq!(Ok(Bits::new(32, 0xf00d)), Bits::from_str("32'hf00d"));
+        assert_eq!(
+            Ok(Bits::new(32, 0xf00d_baaf)),
+            Bits::from_str("32'hf00d_baaf")
+        );
+        assert_eq!(
+            Ok(Bits::new(32, 0xf00d_baaf)),
+            Bits::from_str("32'hf0_0d_ba_af")
+        );
     }
 }

--- a/systemrdl/src/lexer.rs
+++ b/systemrdl/src/lexer.rs
@@ -217,7 +217,7 @@ mod test {
 
     #[test]
     fn test_foo() {
-        let tokens: Vec<Token> = Lexer::new("field 35\tiDentifier2_ 0x24\n\r 0xf00_bad 2'b01 5'o27 4'd9 16'h1caf /* ignore comment */ %= // line comment\n += \"string 1\" \"string\\\"2\" {}[]();:,.=@#reg field regfile addrmap signal enum mem constraint").take(35).collect();
+        let tokens: Vec<Token> = Lexer::new("field 35\tiDentifier2_ 0x24\n\r 0xf00_bad 100_200 2'b01 5'o27 4'd9 16'h1caf 32'h3CAB_FFB0 /* ignore comment */ %= // line comment\n += \"string 1\" \"string\\\"2\" {}[]();:,.=@#reg field regfile addrmap signal enum mem constraint").take(37).collect();
         assert_eq!(
             tokens,
             vec![
@@ -226,10 +226,12 @@ mod test {
                 Token::Identifier("iDentifier2_"),
                 Token::Number(0x24),
                 Token::Number(0xf00bad),
+                Token::Number(100_200),
                 Token::Bits(Bits::new(2, 1)),
                 Token::Bits(Bits::new(5, 0o27)),
                 Token::Bits(Bits::new(4, 9)),
                 Token::Bits(Bits::new(16, 0x1caf)),
+                Token::Bits(Bits::new(32, 0x3cab_ffb0)),
                 Token::PercentEqual,
                 Token::PlusEqual,
                 Token::StringLiteral("\"string 1\""),


### PR DESCRIPTION
See section 4.6 of the SystemRDL_2.0 spec for details.