### PR TITLE
Move firmware upload to emulator application logic

### DIFF
--- a/sw-emulator/app/src/main.rs
+++ b/sw-emulator/app/src/main.rs
@@ -150,7 +150,7 @@ fn main() -> io::Result<()> {
             0xFF => exit(0x00),
             _ => print!("{}", val as char),
         }),
-        ready_for_fw_cb: ReadyForFwCb::new(move |mailbox: &mut Mailbox, firmware: &Vec<u8>| {
+        ready_for_fw_cb: ReadyForFwCb::new(move |mailbox: &mut Mailbox, firmware: &[u8]| {
             // Write the cmd to mailbox.
             let _ = mailbox.write_cmd(FW_LOAD_CMD_OPCODE);
 

--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -37,7 +37,7 @@ pub use hmac_sha384::HmacSha384;
 pub use key_vault::KeyUsage;
 pub use key_vault::KeyVault;
 pub use mailbox::{Mailbox, MailboxRam};
-pub use root_bus::{CaliptraRootBus, CaliptraRootBusArgs, TbServicesCb};
+pub use root_bus::{CaliptraRootBus, CaliptraRootBusArgs, ReadyForFwCb, TbServicesCb};
 pub use sha512_acc::Sha512Accelerator;
 pub use soc_reg::SocRegisters;
 pub use uart::Uart;

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -47,10 +47,10 @@ impl From<Box<dyn FnMut(u8) + 'static>> for TbServicesCb {
     }
 }
 
-type ReadyForFwFn = Box<dyn FnMut(&mut Mailbox, &[u8])>;
+type ReadyForFwFn = Box<dyn FnMut(&mut Mailbox)>;
 pub struct ReadyForFwCb(pub ReadyForFwFn);
 impl ReadyForFwCb {
-    pub fn new(f: impl FnMut(&mut Mailbox, &[u8]) + 'static) -> Self {
+    pub fn new(f: impl FnMut(&mut Mailbox) + 'static) -> Self {
         Self(Box::new(f))
     }
     pub(crate) fn take(&mut self) -> ReadyForFwFn {
@@ -59,7 +59,7 @@ impl ReadyForFwCb {
 }
 impl Default for ReadyForFwCb {
     fn default() -> Self {
-        Self(Box::new(|_, _| {}))
+        Self(Box::new(|_| {}))
     }
 }
 impl std::fmt::Debug for ReadyForFwCb {
@@ -69,8 +69,8 @@ impl std::fmt::Debug for ReadyForFwCb {
             .finish()
     }
 }
-impl From<Box<dyn FnMut(&mut Mailbox, &[u8]) + 'static>> for ReadyForFwCb {
-    fn from(value: Box<dyn FnMut(&mut Mailbox, &[u8])>) -> Self {
+impl From<Box<dyn FnMut(&mut Mailbox) + 'static>> for ReadyForFwCb {
+    fn from(value: Box<dyn FnMut(&mut Mailbox)>) -> Self {
         Self(value)
     }
 }
@@ -79,7 +79,6 @@ impl From<Box<dyn FnMut(&mut Mailbox, &[u8]) + 'static>> for ReadyForFwCb {
 #[derive(Default, Debug)]
 pub struct CaliptraRootBusArgs {
     pub rom: Vec<u8>,
-    pub firmware: Vec<u8>,
     pub log_dir: PathBuf,
     pub ueid: u64,
     pub idev_key_id_algo: String,

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -47,10 +47,10 @@ impl From<Box<dyn FnMut(u8) + 'static>> for TbServicesCb {
     }
 }
 
-type ReadyForFwFn = Box<dyn FnMut(&mut Mailbox, &Vec<u8>)>;
+type ReadyForFwFn = Box<dyn FnMut(&mut Mailbox, &[u8])>;
 pub struct ReadyForFwCb(pub ReadyForFwFn);
 impl ReadyForFwCb {
-    pub fn new(f: impl FnMut(&mut Mailbox, &Vec<u8>) + 'static) -> Self {
+    pub fn new(f: impl FnMut(&mut Mailbox, &[u8]) + 'static) -> Self {
         Self(Box::new(f))
     }
     pub(crate) fn take(&mut self) -> ReadyForFwFn {
@@ -69,8 +69,8 @@ impl std::fmt::Debug for ReadyForFwCb {
             .finish()
     }
 }
-impl From<Box<dyn FnMut(&mut Mailbox, &Vec<u8>) + 'static>> for ReadyForFwCb {
-    fn from(value: Box<dyn FnMut(&mut Mailbox, &Vec<u8>)>) -> Self {
+impl From<Box<dyn FnMut(&mut Mailbox, &[u8]) + 'static>> for ReadyForFwCb {
+    fn from(value: Box<dyn FnMut(&mut Mailbox, &[u8])>) -> Self {
         Self(value)
     }
 }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -27,7 +27,7 @@ use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::registers::InMemoryRegister;
 
-type ReadyForFwCallback = Box<dyn FnMut(&mut Mailbox, &Vec<u8>)>;
+type ReadyForFwCallback = Box<dyn FnMut(&mut Mailbox, &[u8])>;
 
 /// CPTRA_HW_ERROR_FATAL Register Start Address
 const CPTRA_HW_ERROR_FATAL_START: u32 = 0x0;


### PR DESCRIPTION
The intent of this commit is to create a callback mechanism so applications using the emulator library can customize the handling of the ready_for_fw event.

Validated with rom-dev branch using make run.