### PR TITLE
[feat] Add vendor key hash and owner key hash inputs to the emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "clap",
  "gdbstub",
  "gdbstub_arch",
+ "hex",
 ]
 
 [[package]]
@@ -310,6 +311,10 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "common"
+version = "0.1.0"
 
 [[package]]
 name = "compliance-test"

--- a/sw-emulator/app/Cargo.toml
+++ b/sw-emulator/app/Cargo.toml
@@ -15,3 +15,4 @@ caliptra-emu-periph = { path = "../lib/periph" }
 caliptra-emu-types = { path = "../lib/types" }
 gdbstub = "0.6.3"
 gdbstub_arch = "0.2.4"
+hex = "0.4.3"

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -88,6 +88,8 @@ pub struct CaliptraRootBusArgs {
     /// a write to the tb-services register write is performed.
     pub tb_services_cb: TbServicesCb,
     pub ready_for_fw_cb: ReadyForFwCb,
+    pub mfg_pk_hash: Vec<u8>,
+    pub owner_pk_hash: Vec<u8>,
 }
 
 #[derive(Bus)]

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -657,8 +657,26 @@ impl SocRegistersImpl {
 
         regs.set_cptra_dbg_manuf_service_reg(&args);
         regs.set_idevid_cert_attr(&args);
+        regs.set_fuse_vendor_pk_hash(&args);
+        regs.set_fuse_owner_pk_hash(&args);
 
         regs
+    }
+
+    fn set_fuse_vendor_pk_hash(&mut self, args: &CaliptraRootBusArgs) {
+        if args.mfg_pk_hash.len() == FUSE_VENDOR_PK_HASH_SIZE {
+            self.fuse_vendor_pk_hash
+                .data_mut()
+                .copy_from_slice(array_ref![args.mfg_pk_hash, 0, FUSE_VENDOR_PK_HASH_SIZE]);
+        }
+    }
+
+    fn set_fuse_owner_pk_hash(&mut self, args: &CaliptraRootBusArgs) {
+        if args.owner_pk_hash.len() == FUSE_OWNER_PK_HASH_SIZE {
+            self.fuse_owner_pk_hash
+                .data_mut()
+                .copy_from_slice(array_ref![args.owner_pk_hash, 0, FUSE_OWNER_PK_HASH_SIZE]);
+        }
     }
 
     fn set_cptra_dbg_manuf_service_reg(&mut self, args: &CaliptraRootBusArgs) {


### PR DESCRIPTION
This change adds the capability to the emulator to take the vendor key hash and owner key hash as cmdline parameters.