### PR TITLE
Make x509 library compatible with openssl 1.1, and have CI ensure compatibility.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     env:
       RUST_TOOLCHAIN_VERSION: 1.68.0
@@ -21,7 +21,7 @@ jobs:
       SCCACHE_GHA_CACHE_FROM: sccache-caliptra-sw
 
       # Change this to a new random value if you suspect the cache is corrupted
-      SCCACHE_C_CUSTOM_CACHE_BUSTER: c73dbfa95cb3
+      SCCACHE_C_CUSTOM_CACHE_BUSTER: 68a6835b420c
 
     steps:
       - uses: actions/checkout@v3

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -14,6 +14,7 @@ Abstract:
 
 use openssl::bn::BigNumContext;
 use openssl::ec::EcGroup;
+use openssl::ec::EcKey;
 use openssl::ec::PointConversionForm;
 use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
@@ -98,16 +99,17 @@ impl AsymKey for Ecc384AsymKey {
 impl Default for Ecc384AsymKey {
     /// Returns the "default value" for a type.
     fn default() -> Self {
-        let priv_key = PKey::ec_gen("secp384r1").unwrap();
         let ecc_group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+        let priv_key = EcKey::generate(&ecc_group).unwrap();
         let mut bn_ctx = BigNumContext::new().unwrap();
         let pub_key = priv_key
-            .ec_key()
-            .unwrap()
             .public_key()
             .to_bytes(&ecc_group, PointConversionForm::UNCOMPRESSED, &mut bn_ctx)
             .unwrap();
-        Self { priv_key, pub_key }
+        Self {
+            priv_key: PKey::from_ec_key(priv_key).unwrap(),
+            pub_key,
+        }
     }
 }
 

--- a/x509/src/test_util.rs
+++ b/x509/src/test_util.rs
@@ -17,7 +17,7 @@ pub mod tests {
 
     use openssl::{
         bn::BigNumContext,
-        ec::{EcGroup, PointConversionForm},
+        ec::{EcGroup, EcKey, PointConversionForm},
         nid::Nid,
         pkey::{PKey, Private},
         sha::{Sha1, Sha256},
@@ -56,16 +56,17 @@ pub mod tests {
 
     impl Default for Ecc384AsymKey {
         fn default() -> Self {
-            let priv_key = PKey::ec_gen("secp384r1").unwrap();
             let ecc_group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+            let priv_key = EcKey::generate(&ecc_group).unwrap();
             let mut bn_ctx = BigNumContext::new().unwrap();
             let pub_key = priv_key
-                .ec_key()
-                .unwrap()
                 .public_key()
                 .to_bytes(&ecc_group, PointConversionForm::UNCOMPRESSED, &mut bn_ctx)
                 .unwrap();
-            Self { priv_key, pub_key }
+            Self {
+                priv_key: PKey::from_ec_key(priv_key).unwrap(),
+                pub_key,
+            }
         }
     }
 }


### PR DESCRIPTION
OpenSSL 3.0 is currently too bleeding edge. For example, Debian stable is still using 1.1.1, and could not be used previously for building Caliptra.

Switch Github runners from ubuntu 22.04 to 20.04. This version of Ubuntu has more in common with the older Linux distributions found at some corporations. By running our workflows with an older distribution, it is less likely we accidentally break these users' build in the future.