### PR TITLE
[feat] Basic framework for triggering and scheduling reset actions in the emulator

### DIFF
--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -139,6 +139,12 @@ impl<TBus: Bus> Bus for BusLogger<TBus> {
     fn poll(&mut self) {
         self.bus.poll();
     }
+    fn warm_reset(&mut self) {
+        self.bus.warm_reset();
+    }
+    fn update_reset(&mut self) {
+        self.bus.update_reset();
+    }
 }
 
 /// Emulated model

--- a/sw-emulator/lib/bus/src/bus.rs
+++ b/sw-emulator/lib/bus/src/bus.rs
@@ -63,4 +63,12 @@ pub trait Bus {
     fn poll(&mut self) {
         // By default, do nothing
     }
+
+    fn warm_reset(&mut self) {
+        // By default, do nothing
+    }
+
+    fn update_reset(&mut self) {
+        // By default, do nothing
+    }
 }

--- a/sw-emulator/lib/bus/src/lib.rs
+++ b/sw-emulator/lib/bus/src/lib.rs
@@ -22,7 +22,7 @@ mod rom;
 pub mod testing;
 
 pub use crate::bus::{Bus, BusError};
-pub use crate::clock::{Clock, Timer, TimerAction};
+pub use crate::clock::{Clock, Timer, TimerAction, TimerActionType};
 pub use crate::dynamic_bus::DynamicBus;
 pub use crate::ram::Ram;
 pub use crate::register::{

--- a/sw-emulator/lib/derive/src/lib.rs
+++ b/sw-emulator/lib/derive/src/lib.rs
@@ -16,7 +16,17 @@ mod util;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(Bus, attributes(peripheral, poll_fn, register, register_array))]
+#[proc_macro_derive(
+    Bus,
+    attributes(
+        peripheral,
+        poll_fn,
+        warm_reset_fn,
+        update_reset_fn,
+        register,
+        register_array
+    )
+)]
 pub fn derive_bus(input: TokenStream) -> TokenStream {
     crate::bus::derive_bus(input.into()).into()
 }

--- a/sw-emulator/lib/periph/src/asym_ecc384.rs
+++ b/sw-emulator/lib/periph/src/asym_ecc384.rs
@@ -104,6 +104,8 @@ register_bitfields! [
 
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct AsymEcc384 {
     /// Name 0 register
     #[register(offset = 0x0000_0000)]
@@ -485,6 +487,16 @@ impl AsymEcc384 {
         }
     }
 
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
     fn op_complete(&mut self) {
         match self.control.reg.read_as_enum(Control::CTRL) {
             Some(Control::CTRL::Value::GEN_KEY) => self.gen_key(),
@@ -831,7 +843,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut ecc);
+            clock.increment_and_process_timer_actions(1, &mut ecc);
         }
 
         let mut priv_key = bytes_from_words_le(&ecc.priv_key);
@@ -889,7 +901,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             assert_eq!(
@@ -905,7 +917,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             let mut priv_key = bytes_from_words_le(&ecc.priv_key);
@@ -974,7 +986,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             loop {
@@ -984,7 +996,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             let mut key_usage = KeyUsage::default();
@@ -1052,7 +1064,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut ecc);
+            clock.increment_and_process_timer_actions(1, &mut ecc);
         }
 
         let mut sig_r = bytes_from_words_le(&ecc.sig_r);
@@ -1116,7 +1128,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             assert_eq!(
@@ -1132,7 +1144,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             let mut sig_r = bytes_from_words_le(&ecc.sig_r);
@@ -1197,7 +1209,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
         }
     }
@@ -1243,7 +1255,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             let mut priv_key = PRIV_KEY;
@@ -1274,7 +1286,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
 
             let mut sig_r = bytes_from_words_le(&ecc.sig_r);
@@ -1329,7 +1341,7 @@ mod tests {
                     );
                     break;
                 }
-                clock.increment_and_poll(1, &mut ecc);
+                clock.increment_and_process_timer_actions(1, &mut ecc);
             }
         }
     }
@@ -1423,7 +1435,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut ecc);
+            clock.increment_and_process_timer_actions(1, &mut ecc);
         }
 
         let mut sig_s_reverse = bytes_from_words_le(&ecc.verify_r);

--- a/sw-emulator/lib/periph/src/doe.rs
+++ b/sw-emulator/lib/periph/src/doe.rs
@@ -58,6 +58,8 @@ register_bitfields! [
 
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct Doe {
     /// Initialization Vector
     #[peripheral(offset = 0x0000_0000, mask = 0x0000_000f)]
@@ -150,6 +152,16 @@ impl Doe {
                 .reg
                 .modify(Status::READY::SET + Status::VALID::SET);
         }
+    }
+
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
     }
 
     /// Unscramble unique device secret  (UDS) and store it in key vault
@@ -269,7 +281,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut doe);
+            clock.increment_and_process_timer_actions(1, &mut doe);
         }
 
         let mut key_usage = KeyUsage::default();
@@ -331,7 +343,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut doe);
+            clock.increment_and_process_timer_actions(1, &mut doe);
         }
 
         let mut key_usage = KeyUsage::default();
@@ -380,7 +392,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut doe);
+            clock.increment_and_process_timer_actions(1, &mut doe);
         }
 
         assert_eq!(soc_reg.uds(), expected_uds);

--- a/sw-emulator/lib/periph/src/hash_sha256.rs
+++ b/sw-emulator/lib/periph/src/hash_sha256.rs
@@ -54,9 +54,11 @@ const INIT_TICKS: u64 = 1000;
 /// The number of CPU clock cycles it takes to perform the hash update action.
 const UPDATE_TICKS: u64 = 1000;
 
-/// SHA-512 Peripheral
+/// SHA-256 Peripheral
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct HashSha256 {
     /// Name 0 register
     #[register(offset = 0x0000_0000)]
@@ -196,6 +198,16 @@ impl HashSha256 {
                 .reg
                 .modify(Status::READY::SET + Status::VALID::SET);
         }
+    }
+
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
     }
 
     pub fn hash(&self) -> &[u8] {
@@ -355,7 +367,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut sha256);
+                clock.increment_and_process_timer_actions(1, &mut sha256);
             }
         }
 

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -122,6 +122,8 @@ fn sha512_block_bytes_from_words_le(
 /// SHA-512 Peripheral
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct HashSha512 {
     /// Name 0 register
     #[register(offset = 0x0000_0000)]
@@ -400,6 +402,16 @@ impl HashSha512 {
         } else if self.timer.fired(&mut self.op_hash_write_complete_action) {
             self.hash_write_complete();
         }
+    }
+
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
     }
 
     fn op_complete(&mut self) {
@@ -832,7 +844,7 @@ mod tests {
 
                         break;
                     }
-                    clock.increment_and_poll(1, &mut sha512);
+                    clock.increment_and_process_timer_actions(1, &mut sha512);
                 }
             }
 
@@ -889,7 +901,7 @@ mod tests {
                     }
                 }
 
-                clock.increment_and_poll(1, &mut sha512);
+                clock.increment_and_process_timer_actions(1, &mut sha512);
             }
         }
 
@@ -1169,7 +1181,7 @@ mod tests {
             if block_read_status.is_set(BlockReadStatus::VALID) {
                 break;
             }
-            clock.increment_and_poll(1, &mut sha512);
+            clock.increment_and_process_timer_actions(1, &mut sha512);
         }
 
         // Transfer the data to the block registers
@@ -1238,7 +1250,7 @@ mod tests {
                 if status.is_set(Status::VALID) && status.is_set(Status::READY) {
                     break;
                 }
-                clock.increment_and_poll(1, &mut sha512);
+                clock.increment_and_process_timer_actions(1, &mut sha512);
             }
         }
 

--- a/sw-emulator/lib/periph/src/hmac_sha384.rs
+++ b/sw-emulator/lib/periph/src/hmac_sha384.rs
@@ -106,6 +106,8 @@ const KEY_RW_TICKS: u64 = 100;
 /// HMAC-SHA-384 Peripheral
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct HmacSha384 {
     /// Name 0 register
     #[register(offset = 0x0000_0000)]
@@ -401,6 +403,16 @@ impl HmacSha384 {
         } else if self.timer.fired(&mut self.op_tag_write_complete_action) {
             self.tag_write_complete();
         }
+    }
+
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
     }
 
     fn op_complete(&mut self) {
@@ -892,7 +904,7 @@ mod tests {
                     }
                     break;
                 }
-                clock.increment_and_poll(1, &mut hmac);
+                clock.increment_and_process_timer_actions(1, &mut hmac);
             }
         }
 
@@ -941,7 +953,7 @@ mod tests {
 
                         break;
                     }
-                    clock.increment_and_poll(1, &mut hmac);
+                    clock.increment_and_process_timer_actions(1, &mut hmac);
                 }
             }
 
@@ -984,7 +996,7 @@ mod tests {
                     }
                 }
 
-                clock.increment_and_poll(1, &mut hmac);
+                clock.increment_and_process_timer_actions(1, &mut hmac);
             }
         }
 

--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -39,7 +39,9 @@ pub use iccm::Iccm;
 pub use key_vault::KeyUsage;
 pub use key_vault::KeyVault;
 pub use mailbox::{Mailbox, MailboxRam};
-pub use root_bus::{CaliptraRootBus, CaliptraRootBusArgs, ReadyForFwCb, TbServicesCb};
+pub use root_bus::{
+    CaliptraRootBus, CaliptraRootBusArgs, ReadyForFwCb, TbServicesCb, UploadUpdateFwCb,
+};
 pub use sha512_acc::Sha512Accelerator;
 pub use soc_reg::SocRegisters;
 pub use uart::Uart;

--- a/sw-emulator/lib/periph/src/sha512_acc.rs
+++ b/sw-emulator/lib/periph/src/sha512_acc.rs
@@ -79,6 +79,8 @@ register_bitfields! [
 
 #[derive(Bus)]
 #[poll_fn(poll)]
+#[warm_reset_fn(warm_reset)]
+#[update_reset_fn(update_reset)]
 pub struct Sha512Accelerator {
     /// LOCK register
     #[register(offset = 0x0000_0000, read_fn = on_read_lock, write_fn = on_write_lock)]
@@ -438,6 +440,16 @@ impl Sha512Accelerator {
         }
     }
 
+    /// Called by Bus::warm_reset() to indicate a warm reset
+    fn warm_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
+    /// Called by Bus::update_reset() to indicate an update reset
+    fn update_reset(&mut self) {
+        // TODO: Reset registers
+    }
+
     fn op_complete(&mut self) {
         // Update the 'Valid' status bit
         self.status.reg.modify(Status::VALID::SET);
@@ -620,7 +632,7 @@ mod tests {
                 break;
             }
 
-            clock.increment_and_poll(1, &mut sha_accl);
+            clock.increment_and_process_timer_actions(1, &mut sha_accl);
         }
 
         // Read the hash.


### PR DESCRIPTION
This change adds the following features to the emulator:
	1. Uses soc register::generic_output_wires_1 to trigger a warm reset flow in the emulator.
	2. Adds a 'timer action' attribute to the timer callbacks for triggering different actions. Currently, poll, warm reset and update reset are the supported timer actions.

	TODO Items:
	1. Merge the warm and update reset callbacks into a single reset callback with reset reason as the argument.
	2. Reset the appropriate registers on various peripherals on their respective reset callbacks.