### PR TITLE
Remove emu feature from caliptra-lib.

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -45,7 +45,7 @@ pub fn build_firmware_elf(fw_crate_name: &str, bin_name: &str) -> io::Result<Vec
             .arg("--locked")
             .arg("--target")
             .arg(TARGET)
-            .arg("--features=emu,riscv")
+            .arg("--features=riscv")
             .arg("--no-default-features")
             .arg("--profile")
             .arg(PROFILE)

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,5 +15,5 @@ caliptra-drivers = { path = "../drivers" }
 [features]
 default = ["std"]
 std = []
-emu = []
+uart = []
 

--- a/common/src/printer.rs
+++ b/common/src/printer.rs
@@ -24,7 +24,7 @@ impl uWrite for MutablePrinter {
     #[cfg(not(feature = "std"))]
     #[inline(never)]
     fn write_str(&mut self, _str: &str) -> Result<(), Self::Error> {
-        #[cfg(feature = "emu")]
+        #[cfg(feature = "uart")]
         caliptra_drivers::Uart::default().write(_str);
         Ok(())
     }

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -17,7 +17,6 @@ bitfield = "0.14.0"
 bitflags = "2.0.1"
 
 [features]
-emu = []
 verilator = ["caliptra-hw-model/verilator"]
 
 [dev-dependencies]

--- a/drivers/src/exit_ctrl.rs
+++ b/drivers/src/exit_ctrl.rs
@@ -26,13 +26,11 @@ impl ExitCtrl {
     ///
     /// This method does not return
     pub fn exit(exit_code: u32) -> ! {
-        if cfg!(feature = "emu") {
-            const STDOUT: *mut u32 = 0x3003_00C8 as *mut u32;
-            unsafe {
-                core::ptr::write_volatile(STDOUT, if exit_code == 0 { 0xff } else { 0x01 });
-            }
-        }
-
+        let soc_ifc = caliptra_registers::soc_ifc::RegisterBlock::soc_ifc_reg();
+        soc_ifc
+            .cptra_generic_output_wires()
+            .at(0)
+            .write(|_| if exit_code == 0 { 0xff } else { 0x01 });
         #[allow(clippy::empty_loop)]
         loop {}
     }

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -67,10 +67,6 @@ pub use sha384acc::{Sha384Acc, Sha384AccOp};
 pub use state::{DeviceState, Lifecycle, MfgState};
 pub use status_reporter::{report_boot_status, FlowStatus};
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "emu")] {
-        mod uart;
+mod uart;
 
-        pub use uart::Uart;
-    }
-}
+pub use uart::Uart;

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -7,14 +7,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers = { path = "..", features=["emu"] }
+caliptra-drivers = { path = ".." }
 caliptra-registers = { path = "../../registers" }
 caliptra-kat = { path = "../../kat" }
 cfg-if = "1.0.0"
 
 [features]
-emu = []
-
 # This feature is used to filter all these binary targets during normal builds
 # (targets must be built with cargo arguments:
 #     --target riscv32imc-unknown-none-elf \

--- a/drivers/test-fw/src/bin/harness/mod.rs
+++ b/drivers/test-fw/src/bin/harness/mod.rs
@@ -30,16 +30,9 @@ macro_rules! println {
 
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "emu")] {
-            use caliptra_drivers::Uart;
-            use core::fmt::Write;
-            Uart::new().write_fmt(args).unwrap();
-        }
-        else {
-            let _ = args;
-        }
-    }
+    use caliptra_drivers::Uart;
+    use core::fmt::Write;
+    Uart::new().write_fmt(args).unwrap();
 }
 
 #[macro_export]
@@ -55,14 +48,7 @@ macro_rules! test_suite {
         pub fn panic(info: &PanicInfo) -> ! {
             println!("[failed]");
             println!("Error: {}\n", info);
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "emu")] {
-                    use caliptra_drivers::ExitCtrl;
-                    ExitCtrl::exit(u32::MAX);
-                } else {
-                    loop {}
-                }
-            }
+            caliptra_drivers::ExitCtrl::exit(u32::MAX);
         }
 
         #[no_mangle]

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -22,7 +22,6 @@ caliptra-builder = { path = "../builder" }
 riscv = ["caliptra-cpu/riscv"]
 default = ["std"]
 std = ["ufmt/std", "caliptra_common/std"]
-emu = [
-    "caliptra_common/emu",
-    "caliptra-drivers/emu"
+uart = [
+    "caliptra_common/uart",
 ]

--- a/fmc/Makefile
+++ b/fmc/Makefile
@@ -31,7 +31,7 @@ build-emu:
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu,riscv \
+		--features uart,riscv \
 
 build-rom:
 	$(RUSTFLAGS) cargo build \
@@ -39,7 +39,7 @@ build-rom:
 		--manifest-path ../rom/dev/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features uart \
 
 objcopy-rom: 
 	riscv64-unknown-elf-objcopy \
@@ -57,7 +57,7 @@ build-test-rt:
 		--manifest-path ../runtime/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu,riscv \
+		--features uart,riscv \
 
 gen-certs:
 	$(shell bash $(CURRENT_DIR)/tools/scripts/gen_test_certs.sh $(TARGET_DIR))

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -24,7 +24,7 @@ caliptra-builder = { path = "../../builder" }
 [features]
 riscv = []
 default = ["std"]
-emu = ["caliptra-drivers/emu"]
+uart = []
 std = [
   "caliptra-x509/std",
   "caliptra-image-types/std",

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -30,7 +30,7 @@ build-emu:
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features uart \
 		
 build-test-fmc:
 	$(RUSTFLAGS) cargo build \
@@ -38,7 +38,7 @@ build-test-fmc:
 		--manifest-path tools/test-fmc/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features uart \
 
 build-test-rt:
 	$(RUSTFLAGS) cargo build \
@@ -46,7 +46,7 @@ build-test-rt:
 		--manifest-path tools/test-rt/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features uart \
 
 gen-certs:
 	$(shell bash $(CURRENT_DIR)/tools/scripts/gen_test_certs.sh $(TARGET_DIR))

--- a/rom/dev/src/print.rs
+++ b/rom/dev/src/print.rs
@@ -24,7 +24,7 @@ impl uWrite for RomPrinter {
     #[cfg(not(feature = "std"))]
     #[inline(never)]
     fn write_str(&mut self, _str: &str) -> Result<(), Self::Error> {
-        #[cfg(feature = "emu")]
+        #[cfg(feature = "uart")]
         caliptra_drivers::Uart::default().write(_str);
         Ok(())
     }

--- a/rom/dev/tools/test-fmc/Cargo.toml
+++ b/rom/dev/tools/test-fmc/Cargo.toml
@@ -16,5 +16,5 @@ cfg-if = "1.0.0"
 
 [features]
 default = ["std"]
-emu = ["caliptra-drivers/emu"]
+uart = []
 std = ["ufmt/std", "caliptra_common/std"]

--- a/rom/dev/tools/test-fmc/src/print.rs
+++ b/rom/dev/tools/test-fmc/src/print.rs
@@ -24,7 +24,7 @@ impl uWrite for RomPrinter {
     #[cfg(not(feature = "std"))]
     #[inline(never)]
     fn write_str(&mut self, _str: &str) -> Result<(), Self::Error> {
-        #[cfg(feature = "emu")]
+        #[cfg(feature = "uart")]
         caliptra_drivers::Uart::default().write(_str);
         Ok(())
     }

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -14,5 +14,5 @@ cfg-if = "1.0.0"
 
 [features]
 default = ["std"]
-emu = ["caliptra-drivers/emu"]
+uart = []
 std = ["ufmt/std"]

--- a/rom/dev/tools/test-rt/src/print.rs
+++ b/rom/dev/tools/test-rt/src/print.rs
@@ -24,7 +24,7 @@ impl uWrite for RomPrinter {
     #[cfg(not(feature = "std"))]
     #[inline(never)]
     fn write_str(&mut self, _str: &str) -> Result<(), Self::Error> {
-        #[cfg(feature = "emu")]
+        #[cfg(feature = "uart")]
         caliptra_drivers::Uart::default().write(_str);
         Ok(())
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,8 +21,7 @@ caliptra-builder = { path = "../builder" }
 [features]
 riscv = ["caliptra-cpu/riscv"]
 default = ["std"]
-emu = [
-    "caliptra_common/emu",
-    "caliptra-drivers/emu"
+uart = [
+    "caliptra_common/uart",
 ]
 std = ["ufmt/std", "caliptra_common/std"]


### PR DESCRIPTION
Replace with a new uart feature in ROM and fmc firmware, which enables logging via cprintln!(). Regardless of the uart feature, the Uart and ExitCtrl peripherals are still available in caliptra-lib.

This is important, because we need to switch to cargo dependency resolver v2 to allow for independent features in [dev-dependencies] vs [dependencies]. This also means that features set on the command line are no longer forwarded implicitly to dependencies, so the "emu" features is lost when compiling test cases.