### PR TITLE
Use Cargo dependency resolver v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 # Licensed under the Apache-2.0 license
 
 [workspace]
+
+# Use dependency resolver v2 to allow [dev-dependencies] to have different
+# features from [dependencies]. See
+# https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
+resolver = "2"
+
 exclude = [
   # Uses a custom .cargo/config
   "sw-emulator/example",


### PR DESCRIPTION
This allows [dev-dependencies] to have different features from [dependencies], which is critical to prevent compilation errors when an integration test uses the same dependency as the code-under-test, but with the "std" feature. For more information:

https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2