### PR TITLE
Add panic detection tests to FMC and RT crates.

### DIFF
--- a/fmc/tests/test_panic_missing.rs
+++ b/fmc/tests/test_panic_missing.rs
@@ -1,0 +1,14 @@
+// Licensed under the Apache-2.0 license
+use caliptra_builder::FMC_WITH_UART;
+
+#[test]
+fn test_panic_missing() {
+    let fmc_elf = caliptra_builder::build_firmware_elf(&FMC_WITH_UART).unwrap();
+    let symbols = caliptra_builder::elf_symbols(&fmc_elf).unwrap();
+    if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
+        panic!(
+            "The caliptra FMC contains the panic_is_possible symbol, which is not allowed. \
+                Please remove any code that might panic."
+        )
+    }
+}

--- a/runtime/tests/test_panic_missing.rs
+++ b/runtime/tests/test_panic_missing.rs
@@ -1,0 +1,14 @@
+// Licensed under the Apache-2.0 license
+use caliptra_builder::APP_WITH_UART;
+
+#[test]
+fn test_panic_missing() {
+    let rt_elf = caliptra_builder::build_firmware_elf(&APP_WITH_UART).unwrap();
+    let symbols = caliptra_builder::elf_symbols(&rt_elf).unwrap();
+    if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
+        panic!(
+            "The caliptra RT contains the panic_is_possible symbol, which is not allowed. \
+                Please remove any code that might panic."
+        )
+    }
+}


### PR DESCRIPTION
This commit adds adds tests to prevent code that panics to be introduced in the mutable code modules. This ensures we are producing robust panic-free code. 