### PR TITLE
[feat] Implementing Support For Update Reset

### DIFF
--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -90,4 +90,13 @@ pub trait ImageVerificationEnv {
 
     // Get Device Lifecycle state
     fn dev_lifecycle(&self, image: Self::Image) -> Lifecycle;
+
+    // Get the vendor key index saved on cold boot in data vault
+    fn vendor_pub_key_idx_dv(&self) -> u32;
+
+    // Get the owner key digest saved on cold boot in data vault
+    fn owner_pub_key_digest_dv(&self) -> ImageDigest;
+
+    // Save the fmc digest in the data vault on cold boot
+    fn get_fmc_digest_dv(&self) -> ImageDigest;
 }

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -49,6 +49,10 @@ caliptra_err_def! {
         OwnerEccSignatureInvalidArg = 26,
         VendorPubKeyDigestInvalidArg = 27,
         VendorEccSignatureInvalidArg = 28,
+        UpdateResetOwnerDigestFailure = 29,
+        UpdateResetVenPubKeyIdxMismatch = 30,
+        UpdateResetFmcDigestMismatch = 31,
+        UpdateResetVenPubKeyIdxOutOfBounds = 32,
     }
 }
 
@@ -103,7 +107,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         &self,
         manifest: &ImageManifest,
         image: Env::Image,
-        _reason: ResetReason,
+        reason: ResetReason,
     ) -> CaliptraResult<ImageVerificationInfo> {
         // Check if manifest has required marker
         if manifest.marker != MANIFEST_MARKER {
@@ -117,7 +121,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
 
         // Verify the preamble
         let preamble = &manifest.preamble;
-        let header_info = self.verify_preamble(image, preamble)?;
+        let header_info = self.verify_preamble(image, preamble, reason)?;
 
         // Verify Header
         let header = &manifest.header;
@@ -127,7 +131,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         let image_info = self.verify_toc(image, manifest, &toc_info)?;
 
         // Verify FMC
-        let fmc_info = self.verify_fmc(image, image_info.fmc)?;
+        let fmc_info = self.verify_fmc(image, image_info.fmc, reason)?;
 
         // Verify Runtime
         let runtime_info = self.verify_runtime(image, image_info.runtime)?;
@@ -147,15 +151,20 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         &self,
         image: Env::Image,
         preamble: &'a ImagePreamble,
+        reason: ResetReason,
     ) -> CaliptraResult<HeaderInfo<'a>> {
         // Verify Vendor Public Key Digest
         self.verify_vendor_pk_digest(image)?;
 
         // Verify Owner Public Key Digest
-        let owner_pk_digest = self.verify_owner_pk_digest(image)?;
+        let owner_pk_digest = self.verify_owner_pk_digest(image, reason)?;
 
         // Verify Vendor Key Index
-        let vendor_ecc_pub_key_idx = self.verify_vendor_ecc_pk_idx(preamble, image)?;
+        let vendor_ecc_pub_key_idx = self.verify_vendor_ecc_pk_idx(preamble, image, reason)?;
+
+        if vendor_ecc_pub_key_idx >= VENDOR_ECC_KEY_COUNT {
+            raise_err!(UpdateResetVenPubKeyIdxOutOfBounds)
+        }
 
         // Vendor Information
         let vendor_info = (
@@ -191,6 +200,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         &self,
         preamble: &ImagePreamble,
         image: Env::Image,
+        reason: ResetReason,
     ) -> CaliptraResult<u32> {
         const SECOND_LAST_KEY_IDX: u32 = VENDOR_ECC_KEY_COUNT - 2;
         const LAST_KEY_IDX: u32 = VENDOR_ECC_KEY_COUNT - 1;
@@ -209,6 +219,13 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
                 // The last key is never revoked
             }
             _ => raise_err!(VendorEccPubKeyIndexOutOfBounds),
+        }
+
+        if reason == ResetReason::UpdateReset {
+            let expected = self.env.vendor_pub_key_idx_dv();
+            if expected != key_idx {
+                raise_err!(UpdateResetVenPubKeyIdxMismatch)
+            }
         }
 
         Ok(key_idx)
@@ -247,7 +264,11 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify owner public key digest
-    fn verify_owner_pk_digest(&self, image: Env::Image) -> CaliptraResult<Option<ImageDigest>> {
+    fn verify_owner_pk_digest(
+        &self,
+        image: Env::Image,
+        reason: ResetReason,
+    ) -> CaliptraResult<Option<ImageDigest>> {
         let expected = self.env.owner_pub_key_digest(image);
 
         // Skip Verification if owner public key digest is zero
@@ -264,6 +285,13 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
 
         if expected != actual {
             raise_err!(OwnerPubKeyDigestMismatch)
+        }
+
+        if reason == ResetReason::UpdateReset {
+            let cold_boot_digest = self.env.owner_pub_key_digest(image);
+            if cold_boot_digest != expected {
+                raise_err!(UpdateResetOwnerDigestFailure)
+            }
         }
 
         Ok(Some(expected))
@@ -414,6 +442,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         &self,
         image: Env::Image,
         verify_info: &ImageTocEntry,
+        reason: ResetReason,
     ) -> CaliptraResult<ImageVerificationExeInfo> {
         let range = verify_info.image_range();
 
@@ -443,6 +472,10 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         // 0. Skip SVN check in unprovisioned mode or when antirollback is disabled
         // 1. SVN is not more than 32
         // 2. SVN is valid against min_svn and fuse_svn
+
+        if reason == ResetReason::UpdateReset && actual != self.env.get_fmc_digest_dv() {
+            raise_err!(UpdateResetFmcDigestMismatch)
+        }
 
         Ok(info)
     }
@@ -512,6 +545,120 @@ mod tests {
     };
 
     #[test]
+    fn test_vendor_ecc_pk_idx_update_rst() {
+        let test_env = TestEnv {
+            verify_result: true,
+            ..Default::default()
+        };
+        let verifier = ImageVerifier::new(test_env);
+        let preamble = ImagePreamble::default();
+
+        let result = verifier.verify_vendor_ecc_pk_idx(&preamble, (), ResetReason::UpdateReset);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_vendor_ecc_pk_idx_mismatch_update_rst() {
+        let test_env = TestEnv {
+            verify_result: true,
+            ..Default::default()
+        };
+        let verifier = ImageVerifier::new(test_env);
+
+        let preamble = ImagePreamble {
+            vendor_ecc_pub_key_idx: 2,
+            ..Default::default()
+        };
+
+        let result = verifier.verify_vendor_ecc_pk_idx(&preamble, (), ResetReason::UpdateReset);
+        assert_eq!(
+            result.err(),
+            Some(err_u32!(UpdateResetVenPubKeyIdxMismatch))
+        );
+    }
+
+    #[test]
+    fn test_owner_pk_digest_update_rst() {
+        let test_env = TestEnv {
+            lifecycle: Lifecycle::Production,
+            vendor_pub_key_digest: DUMMY_DATA,
+            owner_pub_key_digest: DUMMY_DATA,
+            digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let verifier = ImageVerifier::new(test_env);
+        let preamble = ImagePreamble::default();
+
+        let result = verifier.verify_preamble((), &preamble, ResetReason::UpdateReset);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_fmc_update_rst() {
+        let test_env = TestEnv {
+            lifecycle: Lifecycle::Production,
+            vendor_pub_key_digest: DUMMY_DATA,
+            owner_pub_key_digest: DUMMY_DATA,
+            digest: DUMMY_DATA,
+            fmc_digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let verifier = ImageVerifier::new(test_env);
+
+        let verify_info = ImageTocEntry {
+            digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let result = verifier.verify_fmc((), &verify_info, ResetReason::UpdateReset);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_fmc_mismatch_update_rst() {
+        let test_env = TestEnv {
+            lifecycle: Lifecycle::Production,
+            vendor_pub_key_digest: DUMMY_DATA,
+            owner_pub_key_digest: DUMMY_DATA,
+            digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let verifier = ImageVerifier::new(test_env);
+        // let mut verify_info = ImageTocEntry::default();
+
+        // verify_info.digest = DUMMY_DATA;
+
+        let verify_info = ImageTocEntry {
+            digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let result = verifier.verify_fmc((), &verify_info, ResetReason::UpdateReset);
+        assert_eq!(result.err(), Some(err_u32!(UpdateResetFmcDigestMismatch)));
+    }
+
+    #[test]
+    fn test_owner_verify_preamble_update_rst() {
+        let test_env = TestEnv {
+            lifecycle: Lifecycle::Production,
+            vendor_pub_key_digest: DUMMY_DATA,
+            owner_pub_key_digest: DUMMY_DATA,
+            digest: DUMMY_DATA,
+            fmc_digest: DUMMY_DATA,
+            ..Default::default()
+        };
+
+        let verifier = ImageVerifier::new(test_env);
+        let preamble = ImagePreamble::default();
+
+        let result = verifier.verify_preamble((), &preamble, ResetReason::UpdateReset);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_manifest_marker() {
         let manifest = ImageManifest::default();
         let verifier = ImageVerifier::new(TestEnv::default());
@@ -540,7 +687,7 @@ mod tests {
             ..Default::default()
         };
         let verifier = ImageVerifier::new(test_env);
-        let result = verifier.verify_preamble((), &preamble);
+        let result = verifier.verify_preamble((), &preamble, ResetReason::ColdReset);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(err_u32!(VendorPubKeyDigestInvalid)));
     }
@@ -557,7 +704,7 @@ mod tests {
         let verifier = ImageVerifier::new(test_env);
         let preamble = ImagePreamble::default();
 
-        let result = verifier.verify_preamble((), &preamble);
+        let result = verifier.verify_preamble((), &preamble, ResetReason::ColdReset);
         assert!(result.is_ok());
     }
 
@@ -571,7 +718,7 @@ mod tests {
         };
         let verifier = ImageVerifier::new(test_env);
         let preamble = ImagePreamble::default();
-        let result = verifier.verify_preamble((), &preamble);
+        let result = verifier.verify_preamble((), &preamble, ResetReason::ColdReset);
         assert_eq!(result.err(), Some(err_u32!(VendorPubKeyDigestMismatch)));
     }
 
@@ -848,7 +995,7 @@ mod tests {
             digest: DUMMY_DATA,
             ..Default::default()
         };
-        let result = verifier.verify_fmc((), &verify_info);
+        let result = verifier.verify_fmc((), &verify_info, ResetReason::ColdReset);
         assert_eq!(result.err(), Some(err_u32!(FmcDigestMismatch)));
     }
 
@@ -864,7 +1011,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = verifier.verify_fmc((), &verify_info);
+        let result = verifier.verify_fmc((), &verify_info, ResetReason::ColdReset);
         assert!(result.is_ok());
         let info = result.unwrap();
         assert_eq!(info.load_addr, 0xCAFEB0BA);
@@ -907,6 +1054,7 @@ mod tests {
 
     struct TestEnv {
         digest: ImageDigest,
+        fmc_digest: ImageDigest,
         verify_result: bool,
         vendor_pub_key_digest: ImageDigest,
         vendor_pub_key_revocation: VendorPubKeyRevocation,
@@ -918,6 +1066,7 @@ mod tests {
         fn default() -> Self {
             TestEnv {
                 digest: ImageDigest::default(),
+                fmc_digest: ImageDigest::default(),
                 verify_result: false,
                 vendor_pub_key_digest: ImageDigest::default(),
                 vendor_pub_key_revocation: VendorPubKeyRevocation::default(),
@@ -967,6 +1116,18 @@ mod tests {
 
         fn dev_lifecycle(&self, _image: Self::Image) -> Lifecycle {
             self.lifecycle
+        }
+
+        fn vendor_pub_key_idx_dv(&self) -> u32 {
+            0
+        }
+
+        fn owner_pub_key_digest_dv(&self) -> ImageDigest {
+            self.owner_pub_key_digest
+        }
+
+        fn get_fmc_digest_dv(&self) -> ImageDigest {
+            self.fmc_digest
         }
     }
 }

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -108,6 +108,20 @@ run: build-emu build-fw-image objcopy
 		--firmware $(TARGET_DIR)/caliptra-rom-test-fw \
 		--device-lifecycle unprovisioned \
 
+run-update: build-emu build-fw-image objcopy
+		cargo run \
+		--manifest-path ../../sw-emulator/Cargo.toml \
+		--release \
+		--bin caliptra-emu \
+		-- \
+		--req-idevid-csr \
+		--idevid-key-id-algo sha1 \
+		--rom $(TARGET_DIR)/caliptra-rom.bin \
+		--firmware $(TARGET_DIR)/caliptra-rom-test-fw \
+		--update-firmware $(TARGET_DIR)/caliptra-rom-test-fw \
+		--device-lifecycle unprovisioned \
+
+
 size:
 	$(RUSTFLAGS) cargo size \
 		--profile firmware \

--- a/rom/dev/src/error.rs
+++ b/rom/dev/src/error.rs
@@ -23,8 +23,11 @@ pub enum RomComponent {
     /// FMC Alias Layer
     FmcAlias = 0x102,
 
+    /// Update Reset Errors
+    UpdateReset = 0x103,
+
     /// Global Error
-    Global = 0x103,
+    Global = 0x104,
 }
 
 #[macro_export]

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -11,15 +11,35 @@ Abstract:
     File contains the implementation of update reset flow.
 
 --*/
+use crate::{cprintln, fht, rom_env::RomEnv, rom_err_def, verifier::RomImageVerificationEnv};
 
-use crate::{cprintln, fht, rom_env::RomEnv};
 use caliptra_common::FirmwareHandoffTable;
-use caliptra_drivers::CaliptraResult;
+use caliptra_drivers::{CaliptraResult, MailboxRecvTxn, ResetReason};
+use caliptra_image_types::ImageManifest;
+use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
+use zerocopy::{AsBytes, FromBytes};
+
+extern "C" {
+    static mut MAN2_ORG: u32;
+    static mut MAN1_ORG: u32;
+}
+
+rom_err_def! {
+    UpdateReset,
+    UpdateResetErr
+    {
+        ManifestReadFailure = 0x2,
+        InvalidFirmwareCommand = 0x03,
+        MailboxAccessFailure = 0x04,
+    }
+}
 
 #[derive(Default)]
 pub struct UpdateResetFlow {}
 
 impl UpdateResetFlow {
+    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
+
     /// Execute update reset flow
     ///
     /// # Arguments
@@ -28,10 +48,137 @@ impl UpdateResetFlow {
     pub fn run(env: &RomEnv) -> CaliptraResult<FirmwareHandoffTable> {
         cprintln!("[update-reset] ++");
 
-        // TODO: Implement
+        let Some(recv_txn) = env.mbox().map(|m| m.try_start_recv_txn()) else {
+            cprintln!("Failed To Get Mailbox Transaction");
+            raise_err!(MailboxAccessFailure)
+        };
 
-        cprintln!("[update-reset] --");
+        if recv_txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
+            cprintln!("Invalid command 0x{:08x} received", recv_txn.cmd());
+            raise_err!(InvalidFirmwareCommand)
+        }
 
+        let manifest = Self::load_manifest(&recv_txn)?;
+
+        let info = Self::verify_image(env, &manifest)?;
+
+        cprintln!(
+            "[update-reset] Image verified using Vendor ECC Key Index {}",
+            info.vendor_ecc_pub_key_idx
+        );
+
+        Self::load_image(env, &manifest, recv_txn)?;
+
+        Self::copy_regions(&manifest);
+        cprintln!("[update-reset Success] --");
         Ok(fht::make_fht(env))
+    }
+
+    /// Verify the image
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - ROM Environment
+    /// * 'manifest'- Manifest
+    ///
+    fn verify_image(
+        env: &RomEnv,
+        manifest: &ImageManifest,
+    ) -> CaliptraResult<ImageVerificationInfo> {
+        let venv = RomImageVerificationEnv::new(env);
+
+        let verifier = ImageVerifier::new(venv);
+
+        let info = verifier.verify(manifest, (), ResetReason::UpdateReset)?;
+
+        Ok(info)
+    }
+
+    ///
+    /// Copy the verified MAN_2 region to MAN_1
+    ///
+    /// # Arguments
+    ///
+    /// * `manifest` - Manifest
+    ///
+    fn copy_regions(manifest: &ImageManifest) {
+        cprintln!("[update-reset] Copying MAN_2 To MAN_1");
+
+        let dst = unsafe {
+            let ptr = &mut MAN1_ORG as *mut u32;
+            core::slice::from_raw_parts_mut(
+                ptr,
+                (core::mem::size_of::<ImageManifest>()
+                    + manifest.fmc.size as usize
+                    + manifest.runtime.size as usize
+                    + 3)
+                    / 4,
+            )
+        };
+
+        let src = unsafe {
+            let ptr = &mut MAN2_ORG as *mut u32;
+
+            core::slice::from_raw_parts_mut(
+                ptr,
+                (core::mem::size_of::<ImageManifest>()
+                    + manifest.fmc.size as usize
+                    + manifest.runtime.size as usize
+                    + 3)
+                    / 4,
+            )
+        };
+        dst.clone_from_slice(src);
+    }
+
+    /// Load the image to ICCM & DCCM
+    ///
+    /// # Arguments
+    ///
+    /// * `env`      - ROM Environment
+    /// * `manifest` - Manifest
+    /// * `txn`      - Mailbox Receive Transaction
+    fn load_image(
+        _env: &RomEnv,
+        manifest: &ImageManifest,
+        mut txn: MailboxRecvTxn,
+    ) -> CaliptraResult<()> {
+        cprintln!(
+            "[update-reset] Loading Runtime at address 0x{:08x} len {}",
+            manifest.runtime.load_addr,
+            manifest.runtime.size
+        );
+
+        let runtime_dest = unsafe {
+            let addr = (manifest.runtime.load_addr) as *mut u32;
+            core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
+        };
+
+        txn.copy_request(0, runtime_dest)?;
+
+        //Call the complete here to reset the execute bit
+        txn.complete(true)?;
+
+        // Drop the tranaction and release the Mailbox lock after the image
+        // has been successfully verified and loaded in memory
+        drop(txn);
+
+        Ok(())
+    }
+
+    /// Load the manifest
+    ///
+    /// # Returns
+    ///
+    /// * `Manifest` - Caliptra Image Bundle Manifest
+    fn load_manifest(txn: &MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
+        let slice = unsafe {
+            let ptr = &mut MAN2_ORG as *mut u32;
+            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
+        };
+
+        txn.copy_request(0, slice)?;
+
+        ImageManifest::read_from(slice.as_bytes()).ok_or(err_u32!(ManifestReadFailure))
     }
 }

--- a/rom/dev/src/verifier.rs
+++ b/rom/dev/src/verifier.rs
@@ -102,4 +102,19 @@ impl<'a> ImageVerificationEnv for RomImageVerificationEnv<'a> {
     fn dev_lifecycle(&self, _image: Self::Image) -> Lifecycle {
         self.env.dev_state().map(|d| d.lifecycle())
     }
+
+    /// Get the vendor key index saved in data vault on cold boot
+    fn vendor_pub_key_idx_dv(&self) -> u32 {
+        self.env.data_vault().map(|dv| dv.vendor_pk_index())
+    }
+
+    /// Get the owner public key digest saved in the dv on cold boot
+    fn owner_pub_key_digest_dv(&self) -> ImageDigest {
+        self.env.data_vault().map(|dv| dv.owner_pk_hash()).into()
+    }
+
+    // Get the fmc digest from the data vault on cold boot
+    fn get_fmc_digest_dv(&self) -> ImageDigest {
+        self.env.data_vault().map(|dv| dv.fmc_tci()).into()
+    }
 }


### PR DESCRIPTION
This commit adds the support for update reset flow. Modifications to the verifier to check the reset reason and perform additional checks for the image being downloaded.

