### PR TITLE
Implement caliptra_builder::build_and_sign_image.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-image-fake-keys"
+version = "0.1.0"
+dependencies = [
+ "caliptra-image-gen",
+ "caliptra-image-openssl",
+ "caliptra-image-types",
+]
+
+[[package]]
 name = "caliptra-image-gen"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,14 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 name = "caliptra-builder"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "caliptra-image-elf",
+ "caliptra-image-fake-keys",
+ "caliptra-image-gen",
+ "caliptra-image-openssl",
+ "caliptra-image-types",
  "elf",
+ "hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
   "image/app",
   "image/openssl",
   "image/elf",
+  "image/fake-keys",
   "rom/dev",
   "rom/dev/tools/test-fmc",
   "rom/dev/tools/test-rt",

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -9,3 +9,10 @@ edition = "2021"
 
 [dependencies]
 elf = "0.7.2"
+caliptra-image-elf = { path = "../image/elf" }
+caliptra-image-fake-keys = { path = "../image/fake-keys" }
+caliptra-image-gen = { path = "../image/gen" }
+caliptra-image-openssl = { path = "../image/openssl" }
+caliptra-image-types = { path = "../image/types" }
+hex = "0.4.3"
+anyhow = "1.0.70"

--- a/builder/src/elf_symbols.rs
+++ b/builder/src/elf_symbols.rs
@@ -178,6 +178,5 @@ mod test {
                 bind: SymbolBind::Global,
             })
         );
-        println!("{:?}", symbols);
     }
 }

--- a/drivers/tests/integration_tests.rs
+++ b/drivers/tests/integration_tests.rs
@@ -1,10 +1,15 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_builder::FwId;
 use caliptra_hw_model::{HwModel, InitParams};
 
 fn run_driver_test(test_bin_name: &str) {
-    let rom =
-        caliptra_builder::build_firmware_rom("caliptra-drivers-test-bin", test_bin_name).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&FwId {
+        crate_name: "caliptra-drivers-test-bin",
+        bin_name: test_bin_name,
+        features: &["emu"],
+    })
+    .unwrap();
     let mut model = caliptra_hw_model::create(InitParams {
         rom: &rom,
         ..Default::default()

--- a/image/fake-keys/Cargo.toml
+++ b/image/fake-keys/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+caliptra-image-gen = { path = "../gen" }
 caliptra-image-types = { path = "../types" }
 
 [dev-dependencies]

--- a/image/fake-keys/src/lib.rs
+++ b/image/fake-keys/src/lib.rs
@@ -1,6 +1,10 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_image_types::{ImageEccPrivKey, ImageEccPubKey};
+use caliptra_image_gen::{ImageGeneratorOwnerConfig, ImageGeneratorVendorConfig};
+use caliptra_image_types::{
+    ImageEccPrivKey, ImageEccPubKey, ImageOwnerPrivKeys, ImageOwnerPubKeys, ImageVendorPrivKeys,
+    ImageVendorPubKeys,
+};
 
 /// Generated with
 ///
@@ -98,3 +102,51 @@ pub const OWNER_KEY_PRIVATE: ImageEccPrivKey = [
     0x59fdf849, 0xe39f4256, 0x19342ed2, 0x81d28d3d, 0x45ab3219, 0x5174582c, 0xecb4e9df, 0x9cc2e991,
     0xb75f88fd, 0xfa4bc6a4, 0x6b88340f, 0x05dd8890,
 ];
+
+pub const VENDOR_PUBLIC_KEYS: ImageVendorPubKeys = ImageVendorPubKeys {
+    ecc_pub_keys: [
+        VENDOR_KEY_0_PUBLIC,
+        VENDOR_KEY_1_PUBLIC,
+        VENDOR_KEY_2_PUBLIC,
+        VENDOR_KEY_3_PUBLIC,
+    ],
+};
+
+pub const VENDOR_PRIVATE_KEYS: ImageVendorPrivKeys = ImageVendorPrivKeys {
+    ecc_priv_keys: [
+        VENDOR_KEY_0_PRIVATE,
+        VENDOR_KEY_1_PRIVATE,
+        VENDOR_KEY_2_PRIVATE,
+        VENDOR_KEY_3_PRIVATE,
+    ],
+};
+
+pub const VENDOR_CONFIG_KEY_0: ImageGeneratorVendorConfig = ImageGeneratorVendorConfig {
+    pub_keys: VENDOR_PUBLIC_KEYS,
+    ecc_key_idx: 0,
+    priv_keys: Some(VENDOR_PRIVATE_KEYS),
+};
+
+pub const VENDOR_CONFIG_KEY_1: ImageGeneratorVendorConfig = ImageGeneratorVendorConfig {
+    ecc_key_idx: 1,
+    ..VENDOR_CONFIG_KEY_0
+};
+
+pub const VENDOR_CONFIG_KEY_2: ImageGeneratorVendorConfig = ImageGeneratorVendorConfig {
+    ecc_key_idx: 2,
+    ..VENDOR_CONFIG_KEY_0
+};
+
+pub const VENDOR_CONFIG_KEY_3: ImageGeneratorVendorConfig = ImageGeneratorVendorConfig {
+    ecc_key_idx: 3,
+    ..VENDOR_CONFIG_KEY_0
+};
+
+pub const OWNER_CONFIG: ImageGeneratorOwnerConfig = ImageGeneratorOwnerConfig {
+    pub_keys: ImageOwnerPubKeys {
+        ecc_pub_key: OWNER_KEY_PUBLIC,
+    },
+    priv_keys: Some(ImageOwnerPrivKeys {
+        ecc_priv_key: OWNER_KEY_PRIVATE,
+    }),
+};

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -69,6 +69,42 @@ pub struct ImageBundle {
     pub runtime: Vec<u8>,
 }
 
+#[cfg(feature = "std")]
+impl ImageBundle {
+    pub fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
+        use std::io::ErrorKind;
+        let mut result = vec![];
+        result.extend_from_slice(self.manifest.as_bytes());
+        if self.manifest.fmc.offset as usize != result.len() {
+            return Err(std::io::Error::new(
+                ErrorKind::Other,
+                "actual fmc offset does not match manifest",
+            ));
+        }
+        if self.manifest.fmc.size as usize != self.fmc.len() {
+            return Err(std::io::Error::new(
+                ErrorKind::Other,
+                "actual fmc size does not match manifest",
+            ));
+        }
+        result.extend_from_slice(&self.fmc);
+        if self.manifest.runtime.offset as usize != result.len() {
+            return Err(std::io::Error::new(
+                ErrorKind::Other,
+                "actual runtime offset does not match manifest",
+            ));
+        }
+        if self.manifest.runtime.size as usize != self.runtime.len() {
+            return Err(std::io::Error::new(
+                ErrorKind::Other,
+                "actual runtime size does not match manifest",
+            ));
+        }
+        result.extend_from_slice(&self.runtime);
+        Ok(result)
+    }
+}
+
 /// Calipatra Image Manifest
 #[repr(C)]
 #[derive(AsBytes, FromBytes, Default, Debug)]

--- a/rom/dev/tests/test_panic_missing.rs
+++ b/rom/dev/tests/test_panic_missing.rs
@@ -1,8 +1,10 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_builder::ROM_WITH_UART;
+
 #[test]
 fn test_panic_missing() {
-    let rom_elf = caliptra_builder::build_firmware_elf("caliptra-rom", "caliptra-rom").unwrap();
+    let rom_elf = caliptra_builder::build_firmware_elf(&ROM_WITH_UART).unwrap();
     let symbols = caliptra_builder::elf_symbols(&rom_elf).unwrap();
     if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
         panic!(


### PR DESCRIPTION
This is used for building fmc/app-fw bundles for use in integration
tests.