### PR TITLE
Add end-to-end smoke test using HwModel.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,14 @@ name = "caliptra-systemrdl"
 version = "0.1.0"
 
 [[package]]
+name = "caliptra-test"
+version = "0.1.0"
+dependencies = [
+ "caliptra-builder",
+ "caliptra-hw-model",
+]
+
+[[package]]
 name = "caliptra-verilated"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "rom/dev",
   "rom/dev/tools/test-fmc",
   "rom/dev/tools/test-rt",
+  "test",
 ]
 
 [profile.firmware]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,0 +1,15 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+caliptra-builder = { path = "../builder" }
+caliptra-hw-model = { path = "../hw-model" }
+
+[features]
+verilator = ["caliptra-hw-model/verilator"]

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,1 @@
+Tests that cover the integration of the ROM, FMC, and Runtime firmware.

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,0 +1,1 @@
+// Licensed under the Apache-2.0 license

--- a/test/tests/smoke_test.rs
+++ b/test/tests/smoke_test.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_hw_model::{HwModel, InitParams};
+
+#[track_caller]
+fn assert_output_contains(haystack: &str, needle: &str) {
+    assert!(
+        haystack.contains(needle),
+        "Expected substring in output not found: {needle}"
+    );
+}
+
+#[test]
+fn smoke_test() {
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+    let mut hw = caliptra_hw_model::create(InitParams {
+        rom: &rom,
+        ..Default::default()
+    })
+    .unwrap();
+    hw.upload_firmware(&image).unwrap();
+    let mut output = vec![];
+    hw.copy_output_until_exit_success(&mut output).unwrap();
+    let output = String::from_utf8_lossy(&output);
+    assert_output_contains(&output, "Running Caliptra ROM");
+    assert_output_contains(&output, "[cold-reset]");
+    assert_output_contains(&output, "Running Caliptra FMC");
+    assert_output_contains(
+        &output,
+        r#"
+ / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
+| |   / _` | | | '_ \| __| '__/ _` | | |_) || |
+| |__| (_| | | | |_) | |_| | | (_| | |  _ < | |
+ \____\__,_|_|_| .__/ \__|_|  \__,_| |_| \_\|_|"#,
+    );
+}


### PR DESCRIPTION
To run: `cargo test -p caliptra-test smoke_test`