### PR TITLE
Fix mailbox incoming message notification. #129

### DIFF
--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 use crate::{caliptra_err_def, CaliptraResult};
+use caliptra_registers::mbox::enums::MboxFsmE;
 use caliptra_registers::mbox::{self, enums::MboxStatusE};
 use core::cmp::min;
 use core::mem::size_of;
@@ -69,8 +70,8 @@ impl Mailbox {
     /// * 'MailboxRecvTxn' - Object representing a receive operation
     pub fn try_start_recv_txn(&self) -> Option<MailboxRecvTxn> {
         let mbox = mbox::RegisterBlock::mbox_csr();
-        match mbox.status().read().status() {
-            MboxStatusE::DataReady => Some(MailboxRecvTxn::default()),
+        match mbox.status().read().mbox_fsm_ps() {
+            MboxFsmE::MboxExecuteUc => Some(MailboxRecvTxn::default()),
             _ => None,
         }
     }

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -210,11 +210,6 @@ pub trait HwModel {
             self.soc_mbox().datain().write(|_| last_word);
         }
 
-        // Set the status as DATA_READY.
-        self.soc_mbox()
-            .status()
-            .write(|w| w.status(|w| w.data_ready()));
-
         // Set Execute Bit
         self.soc_mbox().execute().write(|w| w.execute(true));
 
@@ -354,7 +349,6 @@ mod tests {
             caliptra_hw_model::FW_LOAD_CMD_OPCODE
         );
         assert_eq!(model.soc_mbox().dlen().read(), firmware.len() as u32);
-        assert!(model.soc_mbox().status().read().status().data_ready());
 
         // Read the data out of the mailbox.
         let mut temp: Vec<u32> = Vec::new();

--- a/sw-emulator/app/src/main.rs
+++ b/sw-emulator/app/src/main.rs
@@ -298,9 +298,6 @@ fn upload_fw_to_mailbox(mailbox: &mut Mailbox, firmware_buffer: Rc<Vec<u8>>) {
         let _ = mailbox.write_datain(last_word);
     }
 
-    // Set the status as DATA_READY.
-    let _ = mailbox.set_status_data_ready();
-
     // Set the execute register.
     let _ = mailbox.write_execute(1);
 }


### PR DESCRIPTION
Don't use mbox.status.status to detect incoming messages in the firmware, and stop using it in test cases to signal an incoming message, as this is incorrect according to the integration spec. See issue #129 for more details.