### PR TITLE
ROM: Fix (cd rom/dev && make run) hang regression in #132

### DIFF
--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -284,8 +284,6 @@ impl InitDevIdLayer {
                 // Release access to the mailbox
                 txn.complete()?;
 
-                txn.set_status_complete();
-
                 cprintln!("[idev] CSR uploaded");
 
                 // exit the loop


### PR DESCRIPTION
The makefile passes --req-idevid-csr to the emulator app, which sets the idevid_csr_ready fields in soc_ifc. When these are set, the boot ROM enters a special mode that signs a ldevid/idevid CSR and places it in the mailbox. When fixing #129 I didn't realize that this logic existed, and didn't update it with the correct behavior.

When writing the CSR to the mailbox, the firmware MUST NOT set the status. According to the integration guide, status should only be set by the receiver of the command (the SoC). For more details, see #129.