### PR TITLE
Fix (cd rom/dev && make run) hang regression in #132

### DIFF
--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -137,10 +137,6 @@ impl MailboxSendTxn {
         // Copy data to mailbox
         self.enqueue(data)?;
 
-        // Write Status
-        let mbox = mbox::RegisterBlock::mbox_csr();
-        mbox.status().write(|w| w.status(|w| w.data_ready()));
-
         self.state = MailboxOpState::RdyForData;
 
         Ok(())
@@ -201,6 +197,7 @@ impl MailboxSendTxn {
 
     /// Checks if receiver processed the request.
     pub fn is_response_ready(&self) -> bool {
+        // TODO: Handle MboxStatusE::DataReady
         let mbox = mbox::RegisterBlock::mbox_csr();
 
         matches!(
@@ -212,11 +209,6 @@ impl MailboxSendTxn {
     pub fn status(&self) -> MboxStatusE {
         let mbox = mbox::RegisterBlock::mbox_csr();
         mbox.status().read().status()
-    }
-
-    pub fn set_status_complete(&self) {
-        let mbox = mbox::RegisterBlock::mbox_csr();
-        mbox.status().write(|w| w.status(|w| w.cmd_complete()));
     }
 
     ///

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -284,8 +284,6 @@ impl InitDevIdLayer {
                 // Release access to the mailbox
                 txn.complete()?;
 
-                txn.set_status_complete();
-
                 cprintln!("[idev] CSR uploaded");
 
                 // exit the loop

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -479,6 +479,8 @@ impl StateMachineContext for Context {
     }
     fn unlock(&mut self) {
         self.locked = 0;
+        // Reset status
+        self.status.set(0);
     }
     fn dequeue(&mut self) {
         self.data_out = self.ring_buffer.dequeue();

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -176,6 +176,10 @@ impl Mailbox {
         matches!(self.regs.borrow_mut().state_machine.state, States::Exec)
     }
 
+    pub fn is_status_cmd_busy(&mut self) -> bool {
+        self.match_status(Status::STATUS::CMD_BUSY.value)
+    }
+
     pub fn is_status_data_ready(&mut self) -> bool {
         self.match_status(Status::STATUS::DATA_READY.value)
     }

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -172,6 +172,10 @@ impl Mailbox {
         Ok(())
     }
 
+    pub fn is_command_exec_requested(&self) -> bool {
+        matches!(self.regs.borrow_mut().state_machine.state, States::Exec)
+    }
+
     pub fn is_status_data_ready(&mut self) -> bool {
         self.match_status(Status::STATUS::DATA_READY.value)
     }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -897,7 +897,7 @@ impl SocRegistersImpl {
     }
 
     fn download_idev_id_csr(&mut self) {
-        if !self.mailbox.is_status_data_ready() {
+        if !self.mailbox.is_command_exec_requested() {
             return;
         }
 
@@ -909,7 +909,7 @@ impl SocRegistersImpl {
     }
 
     fn download_ldev_id_cert(&mut self) {
-        if !self.mailbox.is_status_data_ready() {
+        if !self.mailbox.is_command_exec_requested() {
             return;
         }
 
@@ -941,6 +941,7 @@ impl SocRegistersImpl {
                 file.write_all(&[byte]).unwrap();
             }
         }
+        self.mailbox.set_status_cmd_complete().unwrap();
     }
 
     fn reset_common(&mut self) {

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1227,7 +1227,7 @@ impl Bus for SocRegistersImpl {
 
         if self.timer.fired(&mut self.op_fw_read_complete_action) {
             // Receiver sets status as CMD_COMPLETE after reading the mailbox data.
-            if self.mailbox.is_status_cmd_complete() {
+            if !self.mailbox.is_status_cmd_busy() {
                 // Reset the execute bit
                 self.mailbox.write_execute(0).unwrap();
             } else {


### PR DESCRIPTION
The makefile passes --req-idevid-csr to the emulator app, which sets the idevid_csr_ready fields in soc_ifc. When these are set, the boot ROM enters a special mode that signs a ldevid/idevid CSR and places it in the mailbox. The emulator's soc_ifc peripheral has some hacks in the implementation that check for this, and download the CSR from the
mailbox into a file "/tmp/caliptra_?devid_cert.der". Unfortunately, this logic was broken by https://github.com/chipsalliance/caliptra-sw/pull/132, as I didn't realize this logic existed at the time.

In order to make this work, I also had to fix a some issues with the emulator's mailbox implementation:

 * Mailbox status should reset upon unlock.
 * Make CSR download hacks in soc_ifc compatible with fix for 129.

I also noticed some other issues with the emulator's mailbox peripheral, which I fixed:

 * App firmware-download logic should clear execute bit on error.
 * Mailbox state machine should look at execute bit.