### PR TITLE
[feat] FMC: extend PCRs

### DIFF
--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -67,6 +67,16 @@ pub enum WarmResetEntry48 {
     RtTci = 0,
 }
 
+impl TryFrom<u8> for WarmResetEntry48 {
+    type Error = ();
+    fn try_from(original: u8) -> Result<Self, Self::Error> {
+        match original {
+            0 => Ok(Self::RtTci),
+            _ => Err(()),
+        }
+    }
+}
+
 impl From<WarmResetEntry48> for u8 {
     fn from(value: WarmResetEntry48) -> Self {
         value as Self
@@ -463,7 +473,7 @@ impl DataVault {
     /// # Returns
     ///    warm reset entry value  
     ///
-    fn read_warm_reset_entry48(&self, entry: WarmResetEntry48) -> Array4x12 {
+    pub fn read_warm_reset_entry48(&self, entry: WarmResetEntry48) -> Array4x12 {
         let dv = dv::RegisterBlock::dv_reg();
         Array4x12::read_from_reg(dv.nonsticky_data_vault_entry().at(entry.into()))
     }

--- a/fmc/src/flow/dice.rs
+++ b/fmc/src/flow/dice.rs
@@ -45,9 +45,6 @@ pub struct DiceInput {
 
     /// Temporary KeyId used during DICE derivations
     pub uds_key: KeyId,
-
-    /// Field entropy key.
-    pub fe_key: KeyId,
 }
 
 /// DICE Layer Output

--- a/fmc/src/flow/mod.rs
+++ b/fmc/src/flow/mod.rs
@@ -17,10 +17,10 @@ mod unknown_reset;
 mod update_reset;
 mod warm_reset;
 
-pub mod dice;
+mod dice;
+mod pcr;
 mod rt_alias;
 
-use crate::flow::dice::{DiceInput, DiceLayer};
 use crate::flow::rt_alias::RtAliasLayer;
 
 use crate::fmc_env::FmcEnv;
@@ -28,23 +28,14 @@ use crate::HandOff;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::ResetReason;
 
-/// Extract DiceInput from handoff information.
-pub fn try_from_hand_off(_env: &FmcEnv, _hand_off: &mut HandOff) -> Option<DiceInput> {
-    None
-}
-
 /// Execute FMC Flows based on reset resason
 ///
 /// # Arguments
 ///
 /// * `env` - FMC Environment
 pub fn run(env: &FmcEnv, hand_off: &mut HandOff) -> CaliptraResult<()> {
-    // Placeholder.
-    if let Some(input) = try_from_hand_off(env, hand_off) {
-        let _ = RtAliasLayer::derive(env, &input);
-    } else {
-        // TODO : handle error
-    }
+    let _ = RtAliasLayer::run(env, hand_off);
+    // Retrieve reset reason.
     let reset_reason = env.reset().map(|r| r.reset_reason());
     match reset_reason {
         // Cold Reset Flow

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -1,0 +1,67 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    pcr.rs
+
+Abstract:
+
+    File contains execution routines for extending PCR0 & PCR1
+
+Environment:
+
+    ROM
+
+Note:
+
+    PCR0 - Journey PCR unlocked and cleared on cold reset
+    PCR1 - Current PCR unlocked and cleared on any reset
+
+--*/
+
+use crate::fmc_env::FmcEnv;
+use crate::HandOff;
+use caliptra_drivers::{CaliptraResult, PcrId};
+
+/// Extend PCR0
+///
+/// # Arguments
+///
+/// * `env` - FMC Environment
+pub fn extend_pcr0(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+    extend_pcr_common(env, hand_off, PcrId::PcrId0)
+}
+
+/// Extend PCR1
+///
+/// # Arguments
+///
+/// * `env` - FMC Environment
+pub fn extend_pcr1(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+    extend_pcr_common(env, hand_off, PcrId::PcrId1)
+}
+
+/// Extend common data into PCR
+///
+/// # Arguments
+///
+/// * `env` - FMC Environment
+/// * `pcr_id` - PCR slot to extend the data into
+fn extend_pcr_common(env: &FmcEnv, hand_off: &HandOff, pcr_id: PcrId) -> CaliptraResult<()> {
+    let pcr_bank = env.pcr_bank();
+    let sha = env.sha384();
+
+    // Extend RT TCI (Hash over runtime code)
+    let data = hand_off.rt_tci(env);
+    let bytes: &[u8; 48] = &data.into();
+    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
+
+    // Extend RT SVN
+    let data = hand_off.rt_svn(env);
+    let bytes = &data.to_le_bytes();
+    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
+
+    Ok(())
+}

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -8,16 +8,16 @@ File Name:
 
 Abstract:
 
-    File contains execution routines for extending PCR0 & PCR1
+    File contains execution routines for extending current and journey PCRs.
 
 Environment:
 
-    ROM
+    FMC
 
 Note:
 
-    PCR0 - Journey PCR unlocked and cleared on cold reset
-    PCR1 - Current PCR unlocked and cleared on any reset
+    PCR2 - Journey PCR unlocked and cleared on cold reset
+    PCR3 - Current PCR unlocked and cleared on any reset
 
 --*/
 
@@ -25,22 +25,25 @@ use crate::fmc_env::FmcEnv;
 use crate::HandOff;
 use caliptra_drivers::{CaliptraResult, PcrId};
 
-/// Extend PCR0
+const CURRENT_PCR: PcrId = PcrId::PcrId3;
+const JOURNEY_PCR: PcrId = PcrId::PcrId2;
+
+/// Extend current PCR
 ///
 /// # Arguments
 ///
 /// * `env` - FMC Environment
 pub fn extend_current_pcr(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    extend_pcr_common(env, hand_off, PcrId::PcrId3)
+    extend_pcr_common(env, hand_off, CURRENT_PCR)
 }
 
-/// Extend PCR1
+/// Extend journey PCR
 ///
 /// # Arguments
 ///
 /// * `env` - FMC Environment
 pub fn extend_journey_pcr(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    extend_pcr_common(env, hand_off, PcrId::PcrId2)
+    extend_pcr_common(env, hand_off, JOURNEY_PCR)
 }
 
 /// Extend common data into PCR

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -30,8 +30,8 @@ use caliptra_drivers::{CaliptraResult, PcrId};
 /// # Arguments
 ///
 /// * `env` - FMC Environment
-pub fn extend_pcr0(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    extend_pcr_common(env, hand_off, PcrId::PcrId0)
+pub fn extend_current_pcr(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+    extend_pcr_common(env, hand_off, PcrId::PcrId3)
 }
 
 /// Extend PCR1
@@ -39,8 +39,8 @@ pub fn extend_pcr0(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
 /// # Arguments
 ///
 /// * `env` - FMC Environment
-pub fn extend_pcr1(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    extend_pcr_common(env, hand_off, PcrId::PcrId1)
+pub fn extend_journey_pcr(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+    extend_pcr_common(env, hand_off, PcrId::PcrId2)
 }
 
 /// Extend common data into PCR

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -11,9 +11,11 @@ Abstract:
     Crypto helper routines
 
 --*/
-
 use crate::flow::dice::{DiceInput, DiceLayer, DiceOutput};
+use crate::flow::pcr::{extend_pcr0, extend_pcr1};
 use crate::fmc_env::FmcEnv;
+use crate::HandOff;
+use caliptra_common::cprintln;
 use caliptra_drivers::CaliptraResult;
 
 #[derive(Default)]
@@ -21,13 +23,28 @@ pub struct RtAliasLayer {}
 
 impl DiceLayer for RtAliasLayer {
     /// Perform derivations for the DICE layer
-    fn derive(env: &FmcEnv, _: &DiceInput) -> CaliptraResult<DiceOutput> {
-        Self::extend_pcrs(env)?;
-        Err(0)
+    fn derive(env: &FmcEnv, _input: &DiceInput) -> CaliptraResult<DiceOutput> {
+        // At this point PCR0 & PCR1 must have the same value. We use the value
+        // of PCR1 as the data for deriving the CDI
+        let _measurement = env
+            .pcr_bank()
+            .map(|p| p.read_pcr(caliptra_drivers::PcrId::PcrId1));
+
+        // TODO : implement derivation.
+        // Derive the Rt layer CDI.
+        //let cdi = Self::derive_cdi(env, _measurement, input.cdi)?;
+        Err(0xdead)
     }
 }
 
 impl RtAliasLayer {
+    #[inline(never)]
+    pub fn run(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+        cprintln!("[art] Extend PCRs");
+        Self::extend_pcrs(env, hand_off)?;
+        Ok(())
+    }
+
     /// Extend the PCR0 & PCR1
     ///
     /// PCR0 is a journey PCR and is locked for clear on cold boot. PCR1
@@ -35,9 +52,25 @@ impl RtAliasLayer {
     ///
     /// # Arguments
     ///
-    /// * `env` - ROM Environment
-    pub fn extend_pcrs(_env: &FmcEnv) -> CaliptraResult<()> {
-        // TODO
+    /// * `env` - FMC Environment
+    pub fn extend_pcrs(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+        extend_pcr0(env, hand_off)?;
+        extend_pcr1(env, hand_off)?;
         Ok(())
     }
+
+    // Derive Composite Device Identity (CDI) from accumulated measurements.
+    //
+    // # Arguments
+    //
+    // * `env` - FMC Environment
+    // * `pcr_meas` - Array containing the measurements read from the PCR.
+    // * `cdi` - Key Slot to store the generated CDI
+    //
+    // # Returns
+    //
+    // * `KeyId` - KeySlot containing the DICE CDI
+    //fn derive_cdi(env: &FmcEnv, pcr_measurement: Array4x12, cdi: KeyId) -> CaliptraResult<KeyId> {
+    //    Err(0xdead)
+    //}
 }

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -8,7 +8,7 @@ File Name:
 
 Abstract:
 
-    Crypto helper routines
+    Alias RT DICE Layer & PCR extension
 
 --*/
 use crate::flow::dice::{DiceInput, DiceLayer, DiceOutput};
@@ -23,16 +23,8 @@ pub struct RtAliasLayer {}
 
 impl DiceLayer for RtAliasLayer {
     /// Perform derivations for the DICE layer
-    fn derive(env: &FmcEnv, _input: &DiceInput) -> CaliptraResult<DiceOutput> {
-        // At this point PCR0 & PCR1 must have the same value. We use the value
-        // of PCR1 as the data for deriving the CDI
-        let _measurement = env
-            .pcr_bank()
-            .map(|p| p.read_pcr(caliptra_drivers::PcrId::PcrId1));
-
+    fn derive(_env: &FmcEnv, _input: &DiceInput) -> CaliptraResult<DiceOutput> {
         // TODO : implement derivation.
-        // Derive the Rt layer CDI.
-        //let cdi = Self::derive_cdi(env, _measurement, input.cdi)?;
         Err(0xdead)
     }
 }
@@ -55,19 +47,4 @@ impl RtAliasLayer {
         extend_journey_pcr(env, hand_off)?;
         Ok(())
     }
-
-    // Derive Composite Device Identity (CDI) from accumulated measurements.
-    //
-    // # Arguments
-    //
-    // * `env` - FMC Environment
-    // * `pcr_meas` - Array containing the measurements read from the PCR.
-    // * `cdi` - Key Slot to store the generated CDI
-    //
-    // # Returns
-    //
-    // * `KeyId` - KeySlot containing the DICE CDI
-    //fn derive_cdi(env: &FmcEnv, pcr_measurement: Array4x12, cdi: KeyId) -> CaliptraResult<KeyId> {
-    //    Err(0xdead)
-    //}
 }

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 use crate::flow::dice::{DiceInput, DiceLayer, DiceOutput};
-use crate::flow::pcr::{extend_pcr0, extend_pcr1};
+use crate::flow::pcr::{extend_current_pcr, extend_journey_pcr};
 use crate::fmc_env::FmcEnv;
 use crate::HandOff;
 use caliptra_common::cprintln;
@@ -45,17 +45,14 @@ impl RtAliasLayer {
         Ok(())
     }
 
-    /// Extend the PCR0 & PCR1
-    ///
-    /// PCR0 is a journey PCR and is locked for clear on cold boot. PCR1
-    /// is the current PCR and is cleared on any reset
+    /// Extend current and journey PCRs
     ///
     /// # Arguments
     ///
     /// * `env` - FMC Environment
     pub fn extend_pcrs(env: &FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-        extend_pcr0(env, hand_off)?;
-        extend_pcr1(env, hand_off)?;
+        extend_current_pcr(env, hand_off)?;
+        extend_journey_pcr(env, hand_off)?;
         Ok(())
     }
 


### PR DESCRIPTION
- FMC reads the measurement of the Runtime FW Module, TCIRT, from the Data Vault that has previously been validated by ROM.
- FMC reads SVN RT from the Data Vault that has previously been validated by ROM.
- FMC extends Caliptra PCR registers with TCIRT.
- FMC extends Caliptra PCR registers with SVN RT.