### PR TITLE
Refactor DICE computation in ROM

### DIFF
--- a/common/src/hand_off.rs
+++ b/common/src/hand_off.rs
@@ -60,6 +60,8 @@ pub struct FirmwareHandoffTable {
     /// Index of FMC SVN value in the Data Vault
     pub fmc_svn_dv_idx: u8,
 
+    pub fmc_measurements_dv_idx: u8,
+
     /// Index of RT TCI value in the Data Vault.
     pub rt_tci_dv_idx: u8,
 
@@ -85,7 +87,7 @@ pub struct FirmwareHandoffTable {
     pub rt_svn_dv_idx: u8,
 
     /// Reserved for future use.
-    pub reserved: [u8; 29],
+    pub reserved: [u8; 28],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -106,6 +108,7 @@ impl Default for FirmwareHandoffTable {
             fmc_cert_sig_r_dv_idx: FHT_INVALID_IDX,
             fmc_cert_sig_s_dv_idx: FHT_INVALID_IDX,
             fmc_svn_dv_idx: FHT_INVALID_IDX,
+            fmc_measurements_dv_idx: FHT_INVALID_IDX,
             rt_tci_dv_idx: FHT_INVALID_IDX,
             rt_cdi_kv_idx: FHT_INVALID_IDX,
             rt_priv_key_kv_idx: FHT_INVALID_IDX,
@@ -114,7 +117,7 @@ impl Default for FirmwareHandoffTable {
             rt_cert_sig_r_dv_idx: FHT_INVALID_IDX,
             rt_cert_sig_s_dv_idx: FHT_INVALID_IDX,
             rt_svn_dv_idx: FHT_INVALID_IDX,
-            reserved: [0; 29],
+            reserved: [0; 28],
         }
     }
 }
@@ -131,6 +134,7 @@ impl FirmwareHandoffTable {
             && self.fmc_pub_key_y_dv_idx != FHT_INVALID_IDX
             && self.fmc_cert_sig_r_dv_idx != FHT_INVALID_IDX
             && self.fmc_cert_sig_s_dv_idx != FHT_INVALID_IDX
+            && self.fmc_measurements_dv_idx != FHT_INVALID_IDX
             && self.rt_fw_load_addr_idx != FHT_INVALID_IDX
             && self.rt_tci_dv_idx != FHT_INVALID_IDX
             && self.rt_fw_entry_point_idx != FHT_INVALID_IDX

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -28,6 +28,7 @@ pub enum ColdResetEntry48 {
     FmcPubKeyY = 7,
     FmcTci = 8,
     OwnerPubKeyHash = 9,
+    FmcMeasurements = 10,
 }
 
 impl From<ColdResetEntry48> for u8 {
@@ -243,6 +244,26 @@ impl DataVault {
     ///
     pub fn owner_pk_hash(&self) -> Array4x12 {
         self.read_cold_reset_entry48(ColdResetEntry48::OwnerPubKeyHash)
+    }
+
+    /// Set the FMC alias measurement
+    ///
+    /// # Arguments
+    ///
+    /// * `hash` - FMC alias measurement
+    ///
+    pub fn set_fmc_measurements(&mut self, hash: &Array4x12) {
+        self.write_lock_cold_reset_entry48(ColdResetEntry48::FmcMeasurements, hash);
+    }
+
+    /// Get the FMC alias measurement
+    ///
+    /// # Returns
+    ///
+    /// * `Array4x12` - FMC alias measurement
+    ///
+    pub fn fmc_measurements(&self) -> Array4x12 {
+        self.read_cold_reset_entry48(ColdResetEntry48::FmcMeasurements)
     }
 
     /// Set the fmc security version number.

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -108,30 +108,31 @@ fields may not be changed or removed). Table revisions with different Major Vers
 
 | Field                 | Size (bytes) | Written By | Description                                                                                              |
 |:----------------------|:-------------|:-----------|:---------------------------------------------------------------------------------------------------------|
-| fht_marker            | 4            | ROM        | Magic Number marking start of FHT. Value must be 0x54484643, ‘CFHT’ when viewed as little-endian ASCII.  |
-| fht_major_ver         | 2            | ROM        | Major version of FHT.                                                                                    |
-| fht_minor_ver         | 2            | ROM, FMC   | Minor version of FHT. Initially written by ROM but may be changed to a higher version by FMC.            |
-| manifest_load_addr    | 4            | ROM        | Physical base address of Manifest in DCCM SRAM.                                                          |
-| fips_fw_load_addr_idx | 4            | ROM        | Index of base address of FIPS Module in ROM or ICCM SRAM. May be 0xFF if there is no discrete module.    |
-| rt_fw_load_addr_idx   | 4            | ROM        | Index of load address of Runtime FW Module value in data vault.SRAM.                                                 |
-| rt_fw_entry_point_idx | 4            | ROM        | Index of entry point of Runtime FW Module value in data vault. SRAM.                                                           |
-| fmc_tci_dv_idx        | 1            | ROM        | Index of FMC TCI value in the Data Vault.                                                                |
-| fmc_cdi_kv_idx        | 1            | ROM        | Index of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.                            |
-| fmc_priv_key_kv_idx   | 1            | ROM        | Index of FMC Private Alias Key in the Key Vault.                                                         |
-| fmc_pub_key_x_dv_idx  | 1            | ROM        | Index of FMC Public Alias Key X Coordinate in the Data Vault.                                            |
-| fmc_pub_key_y_dv_idx  | 1            | ROM        | Index of FMC Public Alias Key Y Coordinate in the Data Vault                                             |
-| fmc_cert_sig_r_dv_idx | 1            | ROM        | Index of FMC Certificate Signature R Component in the Data Vault.                                        |
-| fmc_cert_sig_s_dv_idx | 1            | ROM        | Index of FMC Certificate Signature S Component in the Data Vault.                                        |
-| fmc_svn_dv_idx        | 1            | ROM        | Index of FMC SVN value in the Data Vault.                                                                |
-| rt_tci_dv_idx         | 1            | ROM        | Index of RT TCI value in the Data Vault.                                                                 |
-| rt_cdi_kv_idx         | 1            | FMC        | Index of RT CDI value in the Key Vault.                                                                  |
-| rt_priv_key_kv_idx    | 1            | FMC        | Index of RT Private Alias Key in the Key Vault.                                                          |
-| rt_pub_key_x_dv_idx   | 1            | FMC        | Index of RT Public Alias Key X Coordinate in the Data Vault.                                             |
-| rt_pub_key_y_dv_idx   | 1            | FMC        | Index of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
-| rt_cert_sig_r_dv_idx  | 1            | FMC        | Index of RT Certificate Signature R Component in the Data Vault.                                         |
-| rt_cert_sig_s_dv_idx  | 1            | FMC        | Index of RT Certificate Signature S Component in the Data Vault.                                         |
-| rt_svn_dv_idx         | 1            | FMC        | Index of RT SVN value in the Data Vault.                                                                 |
-| reserved              | 20           |            | Reserved for future use.                                                                                 |
+| fht_marker              | 4            | ROM        | Magic Number marking start of FHT. Value must be 0x54484643, ‘CFHT’ when viewed as little-endian ASCII.  |
+| fht_major_ver           | 2            | ROM        | Major version of FHT.                                                                                    |
+| fht_minor_ver           | 2            | ROM, FMC   | Minor version of FHT. Initially written by ROM but may be changed to a higher version by FMC.            |
+| manifest_load_addr      | 4            | ROM        | Physical base address of Manifest in DCCM SRAM.                                                          |
+| fips_fw_load_addr_idx   | 4            | ROM        | Index of base address of FIPS Module in ROM or ICCM SRAM. May be 0xFF if there is no discrete module.    |
+| rt_fw_load_addr_idx     | 4            | ROM        | Index of load address of Runtime FW Module value in data vault.SRAM.                                                 |
+| rt_fw_entry_point_idx   | 4            | ROM        | Index of entry point of Runtime FW Module value in data vault. SRAM.                                                           |
+| fmc_tci_dv_idx          | 1            | ROM        | Index of FMC TCI value in the Data Vault.                                                                |
+| fmc_cdi_kv_idx          | 1            | ROM        | Index of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.                            |
+| fmc_priv_key_kv_idx     | 1            | ROM        | Index of FMC Private Alias Key in the Key Vault.                                                         |
+| fmc_pub_key_x_dv_idx    | 1            | ROM        | Index of FMC Public Alias Key X Coordinate in the Data Vault.                                            |
+| fmc_pub_key_y_dv_idx    | 1            | ROM        | Index of FMC Public Alias Key Y Coordinate in the Data Vault                                             |
+| fmc_cert_sig_r_dv_idx   | 1            | ROM        | Index of FMC Certificate Signature R Component in the Data Vault.                                        |
+| fmc_cert_sig_s_dv_idx   | 1            | ROM        | Index of FMC Certificate Signature S Component in the Data Vault.                                        |
+| fmc_svn_dv_idx          | 1            | ROM        | Index of FMC SVN value in the Data Vault.                                                                |
+| fmc_measurements_dv_idx | 1            | ROM        | Index of FMC Measurements value in the Data Vault.                                                                |
+| rt_tci_dv_idx           | 1            | ROM        | Index of RT TCI value in the Data Vault.                                                                 |
+| rt_cdi_kv_idx           | 1            | FMC        | Index of RT CDI value in the Key Vault.                                                                  |
+| rt_priv_key_kv_idx      | 1            | FMC        | Index of RT Private Alias Key in the Key Vault.                                                          |
+| rt_pub_key_x_dv_idx     | 1            | FMC        | Index of RT Public Alias Key X Coordinate in the Data Vault.                                             |
+| rt_pub_key_y_dv_idx     | 1            | FMC        | Index of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
+| rt_cert_sig_r_dv_idx    | 1            | FMC        | Index of RT Certificate Signature R Component in the Data Vault.                                         |
+| rt_cert_sig_s_dv_idx    | 1            | FMC        | Index of RT Certificate Signature S Component in the Data Vault.                                         |
+| rt_svn_dv_idx           | 1            | FMC        | Index of RT SVN value in the Data Vault.                                                                 |
+| reserved                | 20           |            | Reserved for future use.                                                                                 |
 
 *FHT is currently defined to be 60 bytes in length.*
 

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -28,10 +28,9 @@ impl DiceLayer for RtAliasLayer {
 }
 
 impl RtAliasLayer {
-    /// Extend the PCR0 & PCR1
+    /// Extend PCR0
     ///
-    /// PCR0 is a journey PCR and is locked for clear on cold boot. PCR1
-    /// is the current PCR and is cleared on any reset
+    /// PCR0 is a journey PCR and is locked for clear on cold boot.
     ///
     /// # Arguments
     ///

--- a/rom/dev/doc/svg/cold-reset.svg
+++ b/rom/dev/doc/svg/cold-reset.svg
@@ -187,12 +187,12 @@
 						dy="1.2em" class="st7">From Mailbox</tspan></text>		</g>
 		<g id="shape1048-145" transform="translate(320.089,-409.875)">
 			<title>Subprocess.1048</title>
-			<desc>PCR0/PCR1 Generation</desc>
+			<desc>Measurement Generation</desc>
 			<path d="M0 585.75 L72 585.75 L72 531.75 L0 531.75 L0 585.75 Z" class="st1"/>
 			<path d="M0 585.75 L72 585.75 L72 531.75 L0 531.75 L0 585.75" class="st2"/>
 			<path d="M9 585.75 L9 531.75" class="st2"/>
 			<path d="M63 585.75 L63 531.75" class="st2"/>
-			<text x="17.66" y="556.35" class="st3">PCR0/PCR1 <tspan x="17.62" dy="1.2em" class="st7">Generation</tspan></text>		</g>
+			<text x="17.66" y="556.35" class="st3">Measurement <tspan x="17.62" dy="1.2em" class="st7">Generation</tspan></text>		</g>
 		<g id="shape1049-152" transform="translate(14.6621,-158.304)">
 			<title>Subprocess.1049</title>
 			<desc>IDEVID Key Pair Generation</desc>

--- a/rom/dev/doc/svg/update-reset.svg
+++ b/rom/dev/doc/svg/update-reset.svg
@@ -222,7 +222,7 @@
 						x="22.18" dy="1.2em" class="st4">Runtime<v:newlineChar/></tspan><tspan x="13.44" dy="1.2em" class="st4">From Mailbox</tspan></text>		</g>
 		<g id="shape1014-49" v:mID="1014" v:groupContext="shape" v:layerMember="0" transform="translate(113.011,-224.442)">
 			<title>Subprocess.1048</title>
-			<desc>PCR1 Generation</desc>
+			<desc>Measurement Generation</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -253,7 +253,7 @@
 			<path d="M0 548.82 L72 548.82 L72 494.82 L0 494.82 L0 548.82" class="st2"/>
 			<path d="M9 548.82 L9 494.82" class="st2"/>
 			<path d="M63 548.82 L63 494.82" class="st2"/>
-			<text x="27.6" y="519.42" class="st3" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>PCR1<v:newlineChar/><tspan
+			<text x="27.6" y="519.42" class="st3" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>Measurement<v:newlineChar/><tspan
 						x="17.62" dy="1.2em" class="st4">Generation</tspan></text>		</g>
 		<g id="shape1016-56" v:mID="1016" v:groupContext="shape" v:layerMember="1" transform="translate(84.6593,-36.375)">
 			<title>Dynamic connector.1062</title>

--- a/rom/dev/src/env_cell.rs
+++ b/rom/dev/src/env_cell.rs
@@ -23,7 +23,7 @@ pub struct EnvCell<T> {
     val: UnsafeCell<T>,
 }
 
-impl<T> EnvCell<T> {
+impl<'a, T: 'a> EnvCell<T> {
     /// Create a new `RentalCell` with `value`
     pub fn new(value: T) -> Self {
         Self {
@@ -34,7 +34,7 @@ impl<T> EnvCell<T> {
     /// Helper function to use the Cell
     pub fn map<F, R>(&self, closure: F) -> R
     where
-        F: FnOnce(&mut T) -> R,
+        F: FnOnce(&'a mut T) -> R,
     {
         closure(unsafe { &mut *self.val.get() })
     }

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -42,6 +42,7 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         fmc_cert_sig_s_dv_idx: ColdResetEntry48::FmcDiceSigS.into(),
         fmc_tci_dv_idx: ColdResetEntry48::FmcTci.into(),
         fmc_svn_dv_idx: ColdResetEntry4::FmcSvn.into(),
+        fmc_measurements_dv_idx: ColdResetEntry48::FmcMeasurements.into(),
         rt_cdi_kv_idx: u8::MAX,
         rt_priv_key_kv_idx: u8::MAX,
         rt_pub_key_x_dv_idx: u8::MAX,

--- a/rom/dev/src/flow/cold_reset/crypto.rs
+++ b/rom/dev/src/flow/cold_reset/crypto.rs
@@ -103,16 +103,12 @@ impl Crypto {
     /// * `key` - HMAC384 key
     /// * `data` - Input data to hash
     /// * `tag` - Key slot to store the tag
-    ///
-    /// # Returns
-    ///
-    /// * `KeyId` - Key Id inputted
     pub fn hmac384_mac(
         env: &RomEnv,
         key: Hmac384Key,
         data: Hmac384Data,
         tag: KeyId,
-    ) -> CaliptraResult<KeyId> {
+    ) -> CaliptraResult<()> {
         // Tag
         let mut usage = KeyUsage::default();
         usage.set_hmac_key(true);
@@ -122,7 +118,7 @@ impl Crypto {
         // Calculate the CDI
         env.hmac384().map(|h| h.hmac(key, data, tag_args))?;
 
-        Ok(tag)
+        Ok(())
     }
 
     /// Generate ECC Key Pair

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -162,7 +162,7 @@ impl InitDevIdLayer {
         // CDI Key
         let key = Hmac384Key::Array4x12(&IDEVID_CDI_KEY);
         let data = Hmac384Data::Key(KeyReadArgs::new(uds));
-        let cdi = Crypto::hmac384_mac(env, key, data, cdi)?;
+        Crypto::hmac384_mac(env, key, data, cdi)?;
 
         cprintln!("[idev] Erasing UDS.KEYID = {}", uds as u8);
         env.key_vault().map(|k| k.erase_key(uds))?;

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -103,7 +103,7 @@ impl LocalDevIdLayer {
         // CDI Key
         let key = Hmac384Key::Key(KeyReadArgs::new(cdi));
         let data = Hmac384Data::Key(KeyReadArgs::new(uds));
-        let cdi = Crypto::hmac384_mac(env, key, data, cdi)?;
+        Crypto::hmac384_mac(env, key, data, cdi)?;
 
         cprintln!("[ldev] Erasing FE.KEYID = {}", uds as u8);
         env.key_vault().map(|k| k.erase_key(uds))?;

--- a/rom/dev/src/lock.rs
+++ b/rom/dev/src/lock.rs
@@ -25,6 +25,8 @@ use crate::rom_env::RomEnv;
 /// * `env` - ROM Environment
 /// * `reset_reason` - Reset reason
 pub fn lock_registers(env: &RomEnv, reset_reason: ResetReason) {
+    // Note that these registers should already have been locked when they
+    // were first written; locking is performed here as a precaution.
     if reset_reason == ResetReason::ColdReset {
         lock_cold_reset_reg(env);
         lock_warm_reset_reg(env);
@@ -40,29 +42,16 @@ pub fn lock_registers(env: &RomEnv, reset_reason: ResetReason) {
 ///
 /// * `env` - ROM Environment
 fn lock_cold_reset_reg(env: &RomEnv) {
-    // Lock the FMC TCI in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry48(ColdResetEntry48::FmcTci));
-
-    // Lock the FMC SVN  in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry4(ColdResetEntry4::FmcSvn));
-
-    // Lock the FMC load address in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr));
-
-    // Lock the FMC entry point in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint));
-
-    // Lock the Owner Public Key Hash in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry48(ColdResetEntry48::OwnerPubKeyHash));
-
-    // Lock the Vendor Public Key Index in data vault until next cold reset
-    env.data_vault()
-        .map(|d| d.lock_cold_reset_entry4(ColdResetEntry4::VendorPubKeyIndex));
+    // Lock values until next cold reset.
+    env.data_vault().map(|d| {
+        d.lock_cold_reset_entry48(ColdResetEntry48::FmcTci);
+        d.lock_cold_reset_entry4(ColdResetEntry4::FmcSvn);
+        d.lock_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr);
+        d.lock_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint);
+        d.lock_cold_reset_entry48(ColdResetEntry48::OwnerPubKeyHash);
+        d.lock_cold_reset_entry4(ColdResetEntry4::VendorPubKeyIndex);
+        d.lock_cold_reset_entry48(ColdResetEntry48::FmcMeasurements);
+	});
 }
 
 /// Lock registers on a warm reset
@@ -71,23 +60,12 @@ fn lock_cold_reset_reg(env: &RomEnv) {
 ///
 /// * `env` - ROM Environment
 fn lock_warm_reset_reg(env: &RomEnv) {
-    // Lock the Runtime TCI in data vault until next warm reset
-    env.data_vault()
-        .map(|d| d.lock_warm_reset_entry48(WarmResetEntry48::RtTci));
-
-    // Lock the Runtime SVN  in data vault until next warm reset
-    env.data_vault()
-        .map(|d| d.lock_warm_reset_entry4(WarmResetEntry4::RtSvn));
-
-    // Lock the Runtime load address in data vault until next warm reset
-    env.data_vault()
-        .map(|d| d.lock_warm_reset_entry4(WarmResetEntry4::RtLoadAddr));
-
-    // Lock the Runtime entry point in data vault until next warm reset
-    env.data_vault()
-        .map(|d| d.lock_warm_reset_entry4(WarmResetEntry4::RtEntryPoint));
-
-    // Lock the Manifest addr in data vault until next warm reset
-    env.data_vault()
-        .map(|d| d.lock_warm_reset_entry4(WarmResetEntry4::ManifestAddr));
+    // Lock values until next warm reset
+    env.data_vault().map(|d| {
+    	d.lock_warm_reset_entry48(WarmResetEntry48::RtTci);
+    	d.lock_warm_reset_entry4(WarmResetEntry4::RtSvn);
+    	d.lock_warm_reset_entry4(WarmResetEntry4::RtLoadAddr);
+    	d.lock_warm_reset_entry4(WarmResetEntry4::RtEntryPoint);
+    	d.lock_warm_reset_entry4(WarmResetEntry4::ManifestAddr);
+    });
 }

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -69,6 +69,13 @@ fn gen_fmc_alias_cert(out_dir: &str) {
             0,
             &[
                 FwidParam {
+                    name: "TCB_INFO_FMC_MEASUREMENTS",
+                    fwid: Fwid {
+                        hash_alg: asn1::oid!(/*sha384*/ 2, 16, 840, 1, 101, 3, 4, 2, 2),
+                        digest: &[0xCD; 48],
+                    },
+                },
+                FwidParam {
                     name: "TCB_INFO_FMC_TCI",
                     fwid: Fwid {
                         hash_alg: asn1::oid!(/*sha384*/ 2, 16, 840, 1, 101, 3, 4, 2, 2),

--- a/x509/src/fmc_alias_cert.rs
+++ b/x509/src/fmc_alias_cert.rs
@@ -56,6 +56,8 @@ mod tests {
                 .unwrap(),
             tcb_info_owner_pk_hash: &[0xCDu8; FmcAliasCertTbsParams::TCB_INFO_OWNER_PK_HASH_LEN],
             tcb_info_fmc_tci: &[0xEFu8; FmcAliasCertTbsParams::TCB_INFO_FMC_TCI_LEN],
+            tcb_info_fmc_measurements: &[0xEFu8;
+                FmcAliasCertTbsParams::TCB_INFO_FMC_MEASUREMENTS_LEN],
         };
 
         let cert = FmcAliasCertTbs::new(&params);
@@ -109,6 +111,12 @@ mod tests {
             &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_TCI_OFFSET
                 ..FmcAliasCertTbs::TCB_INFO_FMC_TCI_OFFSET + FmcAliasCertTbs::TCB_INFO_FMC_TCI_LEN],
             params.tcb_info_fmc_tci,
+        );
+        assert_eq!(
+            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_MEASUREMENTS_OFFSET
+                ..FmcAliasCertTbs::TCB_INFO_FMC_MEASUREMENTS_OFFSET
+                    + FmcAliasCertTbs::TCB_INFO_FMC_MEASUREMENTS_LEN],
+            params.tcb_info_fmc_measurements,
         );
 
         let ecdsa_sig = crate::Ecdsa384Signature {


### PR DESCRIPTION
This commit makes the following changes:

* Captures fuse state and FMC state as one hash, rather than a chain of PCR extensions.
* Corrects comments referring to the measurement as the UDS.
* Centralizes FMC measurement generation in fmc_alias.rs, rather than pcr.rs.
* Captures the generated FMC measurement in the data vault.
* Represents the generated FMC measurement in the FMC alias cert.
* Deprecates usage of PCR1.
* Uses data vault helper functions which lock slots as they are written.
* Updates README.md accordingly.