### PR TITLE
Fix register reset values

### DIFF
--- a/registers/src/csrng.rs
+++ b/registers/src/csrng.rs
@@ -1103,12 +1103,15 @@ pub mod meta {
     pub type InterruptTest = ureg::WriteOnlyReg32<0, crate::csrng::regs::InterruptTestWriteVal>;
     pub type AlertTest = ureg::WriteOnlyReg32<0, crate::csrng::regs::AlertTestWriteVal>;
     pub type Regwen = ureg::ReadWriteReg32<
-        0,
+        1,
         crate::csrng::regs::RegwenReadVal,
         crate::csrng::regs::RegwenWriteVal,
     >;
-    pub type Ctrl =
-        ureg::ReadWriteReg32<0, crate::csrng::regs::CtrlReadVal, crate::csrng::regs::CtrlWriteVal>;
+    pub type Ctrl = ureg::ReadWriteReg32<
+        0x999,
+        crate::csrng::regs::CtrlReadVal,
+        crate::csrng::regs::CtrlWriteVal,
+    >;
     pub type CmdReq = ureg::WriteOnlyReg32<0, u32>;
     pub type SwCmdSts = ureg::ReadOnlyReg32<crate::csrng::regs::SwCmdStsReadVal>;
     pub type GenbitsVld = ureg::ReadOnlyReg32<crate::csrng::regs::GenbitsVldReadVal>;

--- a/registers/src/ecc.rs
+++ b/registers/src/ecc.rs
@@ -1090,7 +1090,7 @@ pub mod meta {
     pub type Version = ureg::ReadOnlyReg32<u32>;
     pub type Ctrl = ureg::WriteOnlyReg32<0, crate::ecc::regs::CtrlWriteVal>;
     pub type Status = ureg::ReadOnlyReg32<crate::ecc::regs::StatusReadVal>;
-    pub type Scaconfig = ureg::WriteOnlyReg32<0, crate::ecc::regs::ScaconfigWriteVal>;
+    pub type Scaconfig = ureg::WriteOnlyReg32<7, crate::ecc::regs::ScaconfigWriteVal>;
     pub type Seed = ureg::WriteOnlyReg32<0, u32>;
     pub type Msg = ureg::WriteOnlyReg32<0, u32>;
     pub type Privkey = ureg::ReadWriteReg32<0, u32, u32>;

--- a/registers/src/entropy_src.rs
+++ b/registers/src/entropy_src.rs
@@ -3116,50 +3116,50 @@ pub mod meta {
         ureg::WriteOnlyReg32<0, crate::entropy_src::regs::InterruptTestWriteVal>;
     pub type AlertTest = ureg::WriteOnlyReg32<0, crate::entropy_src::regs::AlertTestWriteVal>;
     pub type MeRegwen = ureg::ReadWriteReg32<
-        0,
+        1,
         crate::entropy_src::regs::MeRegwenReadVal,
         crate::entropy_src::regs::MeRegwenWriteVal,
     >;
     pub type SwRegupd = ureg::ReadWriteReg32<
-        0,
+        1,
         crate::entropy_src::regs::SwRegupdReadVal,
         crate::entropy_src::regs::SwRegupdWriteVal,
     >;
     pub type Regwen = ureg::ReadOnlyReg32<crate::entropy_src::regs::RegwenReadVal>;
     pub type Rev = ureg::ReadOnlyReg32<crate::entropy_src::regs::RevReadVal>;
     pub type ModuleEnable = ureg::ReadWriteReg32<
-        0,
+        9,
         crate::entropy_src::regs::ModuleEnableReadVal,
         crate::entropy_src::regs::ModuleEnableWriteVal,
     >;
     pub type Conf = ureg::ReadWriteReg32<
-        0,
+        0x909099,
         crate::entropy_src::regs::ConfReadVal,
         crate::entropy_src::regs::ConfWriteVal,
     >;
     pub type EntropyControl = ureg::ReadWriteReg32<
-        0,
+        0x99,
         crate::entropy_src::regs::EntropyControlReadVal,
         crate::entropy_src::regs::EntropyControlWriteVal,
     >;
     pub type EntropyData = ureg::ReadOnlyReg32<u32>;
     pub type HealthTestWindows = ureg::ReadWriteReg32<
-        0,
+        0x600200,
         crate::entropy_src::regs::HealthTestWindowsReadVal,
         crate::entropy_src::regs::HealthTestWindowsWriteVal,
     >;
     pub type RepcntThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::RepcntThresholdsReadVal,
         crate::entropy_src::regs::RepcntThresholdsWriteVal,
     >;
     pub type RepcntsThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::RepcntsThresholdsReadVal,
         crate::entropy_src::regs::RepcntsThresholdsWriteVal,
     >;
     pub type AdaptpHiThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::AdaptpHiThresholdsReadVal,
         crate::entropy_src::regs::AdaptpHiThresholdsWriteVal,
     >;
@@ -3169,12 +3169,12 @@ pub mod meta {
         crate::entropy_src::regs::AdaptpLoThresholdsWriteVal,
     >;
     pub type BucketThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::BucketThresholdsReadVal,
         crate::entropy_src::regs::BucketThresholdsWriteVal,
     >;
     pub type MarkovHiThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::MarkovHiThresholdsReadVal,
         crate::entropy_src::regs::MarkovHiThresholdsWriteVal,
     >;
@@ -3184,7 +3184,7 @@ pub mod meta {
         crate::entropy_src::regs::MarkovLoThresholdsWriteVal,
     >;
     pub type ExthtHiThresholds = ureg::ReadWriteReg32<
-        0,
+        0xffffffff,
         crate::entropy_src::regs::ExthtHiThresholdsReadVal,
         crate::entropy_src::regs::ExthtHiThresholdsWriteVal,
     >;
@@ -3221,7 +3221,7 @@ pub mod meta {
     pub type ExthtHiTotalFails = ureg::ReadOnlyReg32<u32>;
     pub type ExthtLoTotalFails = ureg::ReadOnlyReg32<u32>;
     pub type AlertThreshold = ureg::ReadWriteReg32<
-        0,
+        0xfffd0002,
         crate::entropy_src::regs::AlertThresholdReadVal,
         crate::entropy_src::regs::AlertThresholdWriteVal,
     >;
@@ -3232,12 +3232,12 @@ pub mod meta {
     pub type ExthtFailCounts =
         ureg::ReadOnlyReg32<crate::entropy_src::regs::ExthtFailCountsReadVal>;
     pub type FwOvControl = ureg::ReadWriteReg32<
-        0,
+        0x99,
         crate::entropy_src::regs::FwOvControlReadVal,
         crate::entropy_src::regs::FwOvControlWriteVal,
     >;
     pub type FwOvSha3Start = ureg::ReadWriteReg32<
-        0,
+        9,
         crate::entropy_src::regs::FwOvSha3StartReadVal,
         crate::entropy_src::regs::FwOvSha3StartWriteVal,
     >;
@@ -3250,7 +3250,7 @@ pub mod meta {
     pub type FwOvRdData = ureg::ReadOnlyReg32<u32>;
     pub type FwOvWrData = ureg::WriteOnlyReg32<0, u32>;
     pub type ObserveFifoThresh = ureg::ReadWriteReg32<
-        0,
+        0x20,
         crate::entropy_src::regs::ObserveFifoThreshReadVal,
         crate::entropy_src::regs::ObserveFifoThreshWriteVal,
     >;

--- a/registers/src/hmac.rs
+++ b/registers/src/hmac.rs
@@ -845,7 +845,7 @@ pub mod meta {
     pub type Key = ureg::WriteOnlyReg32<0, u32>;
     pub type Block = ureg::WriteOnlyReg32<0, u32>;
     pub type Tag = ureg::ReadOnlyReg32<u32>;
-    pub type LfsrSeed = ureg::WriteOnlyReg32<0, u32>;
+    pub type LfsrSeed = ureg::WriteOnlyReg32<0x3cabffb0, u32>;
     pub type KvRdKeyCtrl = ureg::ReadWriteReg32<
         0,
         crate::regs::KvReadCtrlRegReadVal,

--- a/registers/src/sha256.rs
+++ b/registers/src/sha256.rs
@@ -196,7 +196,7 @@ pub mod meta {
     //! Additional metadata needed by ureg.
     pub type Name = ureg::ReadOnlyReg32<u32>;
     pub type Version = ureg::ReadOnlyReg32<u32>;
-    pub type Ctrl = ureg::WriteOnlyReg32<0, crate::sha256::regs::CtrlWriteVal>;
+    pub type Ctrl = ureg::WriteOnlyReg32<4, crate::sha256::regs::CtrlWriteVal>;
     pub type Status = ureg::ReadOnlyReg32<crate::sha256::regs::StatusReadVal>;
     pub type Block = ureg::WriteOnlyReg32<0, u32>;
     pub type Digest = ureg::ReadOnlyReg32<u32>;

--- a/registers/src/sha512.rs
+++ b/registers/src/sha512.rs
@@ -875,7 +875,7 @@ pub mod meta {
     //! Additional metadata needed by ureg.
     pub type Name = ureg::ReadOnlyReg32<u32>;
     pub type Version = ureg::ReadOnlyReg32<u32>;
-    pub type Ctrl = ureg::WriteOnlyReg32<0, crate::sha512::regs::CtrlWriteVal>;
+    pub type Ctrl = ureg::WriteOnlyReg32<8, crate::sha512::regs::CtrlWriteVal>;
     pub type Status = ureg::ReadOnlyReg32<crate::sha512::regs::StatusReadVal>;
     pub type Block = ureg::WriteOnlyReg32<0, u32>;
     pub type Digest = ureg::ReadOnlyReg32<u32>;

--- a/registers/src/soc_ifc.rs
+++ b/registers/src/soc_ifc.rs
@@ -1414,13 +1414,13 @@ pub mod meta {
     pub type CptraResetReason = ureg::ReadOnlyReg32<crate::soc_ifc::regs::CptraResetReasonReadVal>;
     pub type CptraSecurityState =
         ureg::ReadOnlyReg32<crate::soc_ifc::regs::CptraSecurityStateReadVal>;
-    pub type CptraValidPauser = ureg::ReadWriteReg32<0, u32, u32>;
+    pub type CptraValidPauser = ureg::ReadWriteReg32<0xffffffff, u32, u32>;
     pub type CptraPauserLock = ureg::ReadWriteReg32<
         0,
         crate::soc_ifc::regs::PauserLockReadVal,
         crate::soc_ifc::regs::PauserLockWriteVal,
     >;
-    pub type CptraTrngValidPauser = ureg::ReadWriteReg32<0, u32, u32>;
+    pub type CptraTrngValidPauser = ureg::ReadWriteReg32<0xffffffff, u32, u32>;
     pub type CptraTrngPauserLock = ureg::ReadWriteReg32<
         0,
         crate::soc_ifc::regs::PauserLockReadVal,
@@ -1489,7 +1489,7 @@ pub mod meta {
         crate::soc_ifc::regs::InternalFwUpdateResetWriteVal,
     >;
     pub type InternalFwUpdateResetWaitCycles = ureg::ReadWriteReg32<
-        0,
+        5,
         crate::soc_ifc::regs::InternalFwUpdateResetWaitCyclesReadVal,
         crate::soc_ifc::regs::InternalFwUpdateResetWaitCyclesWriteVal,
     >;

--- a/ureg/lib/systemrdl/src/error.rs
+++ b/ureg/lib/systemrdl/src/error.rs
@@ -18,6 +18,7 @@ pub enum Error {
     FieldsCannotHaveMultipleDimensions,
     UnsupportedRegWidth(u64),
     AccessTypeNaUnsupported,
+    ResetValueOnRegisterUnsupported,
     RdlError(systemrdl::RdlError<'static>),
     BlockError {
         block_name: String,
@@ -73,6 +74,9 @@ impl Display for Error {
             }
             Self::UnsupportedRegWidth(w) => write!(f, "Unsupported register width {w}"),
             Self::AccessTypeNaUnsupported => write!(f, "AccessType 'na' is not supported"),
+            Self::ResetValueOnRegisterUnsupported => {
+                write!(f, "reset value on register is unsupported")
+            }
             Self::RdlError(err) => write!(f, "systemrdl error: {err}"),
             Self::BlockError { block_name, err } => write!(f, "block {block_name:?} {err}"),
             Self::FieldError { field_name, err } => write!(f, "field {field_name:?} {err}"),


### PR DESCRIPTION
The current codegen attempts to parse a reset value from the top-level _register_ definitions, but it appears all of the RDLs define reset values on individual _fields_.

This patch adjusts the codegen to produce the register reset value from the field reset values. The codegen will now also report an error if it detects a register reset value since it's not clear which of (register, field) reset values has precedence.

I checked current usages of the modified registers, and no code on `main` relies on the reset values, so this patch shouldn't break existing code.