### PR TITLE
Fix --features=verilator compile regression in #136

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -122,6 +122,9 @@ jobs:
           export CXX="sccache g++"
           sccache --show-stats
           (cd hw-model && cargo build --locked --release --features verilator --jobs 10)
+          # build all tests; need to make sure they still build with verilator
+          # even if we don't have time to run them.
+          cargo test --no-run --locked --release --features=verilator
           sccache --show-stats
 
       - name: Run unit tests

--- a/rom/dev/tests/test_image_validation.rs
+++ b/rom/dev/tests/test_image_validation.rs
@@ -3,7 +3,7 @@
 use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
 use caliptra_drivers::Array4x12;
 use caliptra_hw_model::{
-    BootParams, DeviceLifecycle, Fuses, HwModel, InitParams, ModelEmulated, SecurityState, U4,
+    BootParams, DefaultHwModel, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState, U4,
 };
 use caliptra_image_elf::ElfExecutable;
 use caliptra_image_fake_keys::{
@@ -687,7 +687,7 @@ fn update_fmc_runtime_ranges(
     image
 }
 
-fn build_hw_model_and_image_bundle(fuses: Fuses) -> (ModelEmulated, ImageBundle) {
+fn build_hw_model_and_image_bundle(fuses: Fuses) -> (DefaultHwModel, ImageBundle) {
     let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
     let hw = caliptra_hw_model::new(BootParams {
         init_params: InitParams {


### PR DESCRIPTION
Also, to prevent this from happening again in the future, have the
presubmit test ensure all tests can build with --features=verilator.
