### PR TITLE
[feat] Remove message retrieval capability from keyVault for ECC384 signature operation

### DIFF
--- a/drivers/src/kv_access.rs
+++ b/drivers/src/kv_access.rs
@@ -145,7 +145,6 @@ impl KvAccess {
                 .sha_block_dest_valid(key.usage.sha_data())
                 .ecc_pkey_dest_valid(key.usage.ecc_private_key())
                 .ecc_seed_dest_valid(key.usage.ecc_key_gen_seed())
-                .ecc_msg_dest_valid(key.usage.ecc_data())
         });
         Ok(())
     }

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -44,7 +44,7 @@ pub use data_vault::{
 };
 pub use doe::DeobfuscationEngine;
 pub use ecc384::{
-    Ecc384, Ecc384Data, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar, Ecc384Seed,
+    Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar, Ecc384Seed,
     Ecc384Signature,
 };
 pub use error::CaliptraComponent;

--- a/kat/src/ecc384_kat.rs
+++ b/kat/src/ecc384_kat.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::caliptra_err_def;
 use caliptra_drivers::{
-    Array4xN, CaliptraResult, Ecc384, Ecc384Data, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Signature,
+    Array4xN, CaliptraResult, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Signature,
 };
 
 caliptra_err_def! {
@@ -76,12 +76,9 @@ impl Ecc384Kat {
     }
 
     fn kat_signature_generate(&self, ecc: &Ecc384) -> CaliptraResult<()> {
-        let digest = [0u32; 12];
+        let digest: Array4xN<12, 48> = Array4xN([0u32; 12]);
         let signature = ecc
-            .sign(
-                Ecc384PrivKeyIn::from(&PRIV_KEY),
-                Ecc384Data::from(&digest.into()),
-            )
+            .sign(Ecc384PrivKeyIn::from(&PRIV_KEY), &digest)
             .map_err(|_| err_u32!(SignatureGenerateFailure))?;
 
         if signature != SIGNATURE {

--- a/rom/dev/src/flow/cold_reset/crypto.rs
+++ b/rom/dev/src/flow/cold_reset/crypto.rs
@@ -176,12 +176,9 @@ impl Crypto {
         data: &[u8],
     ) -> CaliptraResult<Ecc384Signature> {
         let digest = Self::sha384_digest(env, data)?;
-
-        let data = Ecc384Data::Array4x12(&digest);
-
         let priv_key_args = KeyReadArgs::new(priv_key);
         let priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
-        env.ecc384().map(|ecc| ecc.sign(priv_key, data))
+        env.ecc384().map(|ecc| ecc.sign(priv_key, &digest))
     }
 
     /// Verify the ECC Signature

--- a/sw-emulator/lib/periph/src/key_vault.rs
+++ b/sw-emulator/lib/periph/src/key_vault.rs
@@ -241,10 +241,6 @@ bitfield! {
 
     /// Flag indicating if the key can be used aas ECC Key Generation Seed
     pub ecc_key_gen_seed, set_ecc_key_gen_seed: 4;
-
-    /// Flag indicating if the key can be used aas ECC data part of signature
-    /// generation and verification process
-    pub ecc_data, set_ecc_data:5;
 }
 
 impl From<KeyUsage> for u32 {


### PR DESCRIPTION
This change removes the capability for the ECC384 driver sign api to retrieve the message from the keyvault.
This is done to account for a similar change in the RTL. Currently, there is no scneario in the ROM
that uses this capability.