### PR TITLE
Fix emulator mailbox peripheral to support response data and add mailbox command test for all HwModels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
 name = "caliptra-hw-model-test-fw"
 version = "0.1.0"
 dependencies = [
+ "caliptra-registers",
  "caliptra-test-harness",
 ]
 

--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -12,6 +12,7 @@ emu = ["caliptra-test-harness/emu"]
 
 [dependencies]
 caliptra-test-harness = { path = "../../test-harness" }
+caliptra-registers = { path = "../../registers" }
 
 [[bin]]
 name = "test_iccm_unaligned_write"
@@ -21,4 +22,9 @@ required-features = ["riscv"]
 [[bin]]
 name = "test_iccm_byte_write"
 path = "test_iccm_byte_write.rs"
+required-features = ["riscv"]
+
+[[bin]]
+name = "mailbox_responder"
+path = "mailbox_responder.rs"
 required-features = ["riscv"]

--- a/hw-model/test-fw/mailbox_responder.rs
+++ b/hw-model/test-fw/mailbox_responder.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that responds to the mailbox.
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness;
+
+use caliptra_registers;
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    let soc_ifc = caliptra_registers::soc_ifc::RegisterBlock::soc_ifc_reg();
+    soc_ifc.cptra_flow_status().write(|w| w.ready_for_fw(true));
+    let mbox = caliptra_registers::mbox::RegisterBlock::mbox_csr();
+
+    loop {
+        while !mbox.status().read().mbox_fsm_ps().mbox_execute_uc() {}
+        let cmd = mbox.cmd().read();
+
+        match cmd {
+            // Consumes input, and echoes the request back as the response with
+            // the command-id prepended.
+            0x1000_0000 => {
+                let dlen = mbox.dlen().read();
+                let dlen_words = usize::try_from((dlen + 3) / 4).unwrap();
+                let mut buf = [0u32; 8];
+                for i in 0..dlen_words {
+                    buf[i] = mbox.dataout().read();
+                }
+                mbox.dlen().write(|_| dlen + 4);
+                mbox.datain().write(|_| cmd);
+                for i in 0..dlen_words {
+                    mbox.datain().write(|_| buf[i]);
+                }
+                mbox.status().write(|w| w.status(|w| w.data_ready()));
+            }
+            // Returns a response of 7 hard-coded bytes; doesn't consume input.
+            0x1000_1000 => {
+                mbox.dlen().write(|_| 7);
+                mbox.datain().write(|_| 0x6745_2301);
+                mbox.datain().write(|_| 0xefcd_ab89);
+
+                mbox.status().write(|w| w.status(|w| w.data_ready()));
+            }
+            // Returns a response of 0 bytes; doesn't consume input.
+            0x1000_2000 => {
+                mbox.dlen().write(|_| 0);
+                mbox.status().write(|w| w.status(|w| w.data_ready()));
+            }
+            // Returns a success response; doesn't consume input.
+            0x2000_0000 => {
+                mbox.status().write(|w| w.status(|w| w.cmd_complete()));
+            }
+            // Everything else returns a failure response; doesn't consume input.
+            _ => {
+                mbox.status().write(|w| w.status(|w| w.cmd_failure()));
+            }
+        }
+    }
+}

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -418,6 +418,8 @@ statemachine! {
         RdyForData + DataWrite(DataIn) / enqueue = RdyForData,
         RdyForData + ExecSet = Exec,
         Exec + DataRead / dequeue = Exec,
+        Exec + DlenWrite(DataLength) / init_dlen = Exec,
+        Exec + DataWrite(DataIn) / enqueue = Exec,
         Exec + ExecClear [is_locked] / unlock = Idle
     }
 }
@@ -477,6 +479,7 @@ impl StateMachineContext for Context {
     }
     // actions
     fn init_dlen(&mut self, data_len: &DataLength) {
+        self.ring_buffer.reset();
         self.dlen = data_len.0;
     }
 


### PR DESCRIPTION
test_mailbox_execute() runs as a presubmit against both verilator and sw-emulator.