### PR TITLE
[fix] [design] Handoff table fields need to fully describe storage location of handoff information in Caliptra.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
 name = "caliptra_common"
 version = "0.1.0"
 dependencies = [
+ "bitfield",
  "caliptra-drivers",
  "ufmt",
  "zerocopy",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 ufmt = "0.2.0"
 zerocopy = "0.6.1"
 caliptra-drivers = { path = "../drivers" }
+bitfield = "0.14.0"
 
 
 [features]

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,0 +1,2 @@
+// Licensed under the Apache-2.0 license
+

--- a/common/src/hand_off.rs
+++ b/common/src/hand_off.rs
@@ -14,7 +14,7 @@ pub const FHT_INVALID_ADDRESS: u32 = u32::MAX;
 
 #[repr(C)]
 #[derive(AsBytes, Copy, Clone, Debug, FromBytes, PartialEq)]
-pub struct HandOffDataHandle(u32);
+pub struct HandOffDataHandle(pub u32);
 pub const FHT_INVALID_HANDLE: HandOffDataHandle = HandOffDataHandle(u32::MAX);
 
 bitfield_bitrange! {struct HandOffDataHandle(u32)}

--- a/common/src/hand_off.rs
+++ b/common/src/hand_off.rs
@@ -1,13 +1,187 @@
 // Licensed under the Apache-2.0 license.
-
+use bitfield::{bitfield_bitrange, bitfield_fields};
+use caliptra_drivers::{
+    report_fw_error_non_fatal, ColdResetEntry4, ColdResetEntry48, KeyId, WarmResetEntry4,
+    WarmResetEntry48,
+};
 use zerocopy::{AsBytes, FromBytes};
 extern "C" {
     static mut FHT_ORG: u32;
 }
 
 pub const FHT_MARKER: u32 = 0x54484643;
-pub const FHT_INVALID_IDX: u8 = u8::MAX;
 pub const FHT_INVALID_ADDRESS: u32 = u32::MAX;
+
+#[repr(C)]
+#[derive(AsBytes, Copy, Clone, Debug, FromBytes, PartialEq)]
+pub struct HandOffDataHandle(u32);
+pub const FHT_INVALID_HANDLE: HandOffDataHandle = HandOffDataHandle(u32::MAX);
+
+bitfield_bitrange! {struct HandOffDataHandle(u32)}
+impl HandOffDataHandle {
+    bitfield_fields! {
+       u32;
+       reg_num, set_reg_num: 7, 0;
+       reg_type, set_reg_type: 11, 8;
+       vault, set_vault : 15, 12;
+       reserved, _: 31, 16;
+    }
+}
+
+#[repr(u32)]
+pub enum Vault {
+    KeyVault = 1,
+    PcrBank = 2,
+    DataVault = 3,
+}
+
+impl From<Vault> for u32 {
+    fn from(val: Vault) -> u32 {
+        match val {
+            Vault::KeyVault => 1,
+            Vault::PcrBank => 2,
+            Vault::DataVault => 3,
+        }
+    }
+}
+
+impl TryFrom<u32> for Vault {
+    type Error = ();
+    fn try_from(val: u32) -> Result<Self, Self::Error> {
+        match val {
+            1_u32 => Ok(Vault::KeyVault),
+            2_u32 => Ok(Vault::PcrBank),
+            3_u32 => Ok(Vault::DataVault),
+            _ => Err(()),
+        }
+    }
+}
+
+pub enum DataStore {
+    KeyVaultSlot(KeyId),
+    //PlatformConfigRegister(PcrId),
+    DataVaultSticky4(ColdResetEntry4),
+    DataVaultSticky48(ColdResetEntry48),
+    DataVaultNonSticky4(WarmResetEntry4),
+    DataVaultNonSticky48(WarmResetEntry48),
+    Invalid,
+}
+
+impl From<HandOffDataHandle> for u32 {
+    fn from(value: HandOffDataHandle) -> u32 {
+        value.0
+    }
+}
+#[allow(non_snake_case)]
+pub enum DataVaultRegister {
+    Sticky32BitReg = 1,
+    Sticky384BitReg = 2,
+    NonSticky32BitReg = 3,
+    NonSticky384BitReg = 4,
+}
+
+impl TryInto<DataStore> for HandOffDataHandle {
+    type Error = ();
+    fn try_into(self) -> Result<DataStore, Self::Error> {
+        let vault = Vault::try_from(self.vault())
+            .unwrap_or_else(|_| report_handoff_error_and_halt("Invalid Vault", 0xbadbad));
+        match vault {
+            Vault::KeyVault => Ok(DataStore::KeyVaultSlot(
+                KeyId::try_from(self.reg_num() as u8)
+                    .unwrap_or_else(|_| report_handoff_error_and_halt("Invalid KeyId", 0xbadbad)),
+            )),
+            Vault::DataVault => match self.reg_type() {
+                1 => {
+                    let entry = DataStore::DataVaultSticky4(
+                        ColdResetEntry4::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
+                            report_handoff_error_and_halt("Invalid ColdResetEntry4", 0xbadbad)
+                        }),
+                    );
+                    Ok(entry)
+                }
+
+                2 => {
+                    let entry = DataStore::DataVaultSticky48(
+                        ColdResetEntry48::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
+                            report_handoff_error_and_halt("Invalid ColdResetEntry48", 0xbadbad)
+                        }),
+                    );
+                    Ok(entry)
+                }
+
+                3 => {
+                    let entry =
+                        WarmResetEntry4::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
+                            report_handoff_error_and_halt("Invalid WarmResetEntry4", 0xbadbad)
+                        });
+
+                    let ds = DataStore::DataVaultNonSticky4(entry);
+                    Ok(ds)
+                }
+
+                4 => {
+                    let entry = DataStore::DataVaultNonSticky48(
+                        WarmResetEntry48::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
+                            report_handoff_error_and_halt("Invalid WarmResetEntry48", 0xbadbad)
+                        }),
+                    );
+                    Ok(entry)
+                }
+
+                _ => Err(()),
+            },
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<DataStore> for HandOffDataHandle {
+    fn from(val: DataStore) -> HandOffDataHandle {
+        match val {
+            DataStore::KeyVaultSlot(key_id) => {
+                let mut me = Self(0);
+                me.set_vault(u32::from(Vault::KeyVault));
+                me.set_reg_num(key_id.into());
+                me
+            }
+            DataStore::DataVaultSticky4(entry_id) => {
+                let mut me = Self(0);
+                me.set_vault(u32::from(Vault::DataVault));
+                me.set_reg_type(DataVaultRegister::Sticky32BitReg as u32);
+                me.set_reg_num(entry_id.into());
+                me
+            }
+            DataStore::DataVaultSticky48(entry_id) => {
+                let mut me = Self(0);
+                me.set_vault(Vault::DataVault as u32);
+                me.set_reg_type(DataVaultRegister::Sticky384BitReg as u32);
+                me.set_reg_num(entry_id.into());
+                me
+            }
+            DataStore::DataVaultNonSticky4(entry_id) => {
+                let mut me = Self(0);
+                me.set_vault(Vault::DataVault as u32);
+                me.set_reg_type(DataVaultRegister::NonSticky32BitReg as u32);
+                me.set_reg_num(entry_id.into());
+                me
+            }
+            DataStore::DataVaultNonSticky48(entry_id) => {
+                let mut me = Self(0);
+                me.set_vault(u32::from(Vault::DataVault));
+                me.set_reg_type(DataVaultRegister::NonSticky384BitReg as u32);
+                me.set_reg_num(entry_id.into());
+                me
+            }
+            _ => {
+                let mut me = Self(0);
+                me.set_vault(0);
+                me.set_reg_type(0);
+                me.set_reg_num(0);
+                me
+            }
+        }
+    }
+}
 
 /// The Firmware Handoff Table is a data structure that is resident at a well-known
 /// location in DCCM. It is initially populated by ROM and modified by FMC as a way
@@ -31,64 +205,64 @@ pub struct FirmwareHandoffTable {
 
     /// Physical base address of FIPS Module in ROM or ICCM SRAM.
     /// May be NULL if there is no discrete module.
-    pub fips_fw_load_addr_idx: u8,
+    pub fips_fw_load_addr_hdl: HandOffDataHandle,
 
     /// Physical base address of Runtime FW Module in ICCM SRAM.
-    pub rt_fw_load_addr_idx: u8,
+    pub rt_fw_load_addr_hdl: HandOffDataHandle,
 
     /// Entry point of Runtime FW Module in ICCM SRAM.
-    pub rt_fw_entry_point_idx: u8,
+    pub rt_fw_entry_point_hdl: HandOffDataHandle,
 
     /// Index of FMC TCI value in the Data Vault.
-    pub fmc_tci_dv_idx: u8,
+    pub fmc_tci_dv_hdl: HandOffDataHandle,
 
     /// Index of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.
-    pub fmc_cdi_kv_idx: u8,
+    pub fmc_cdi_kv_hdl: HandOffDataHandle,
 
     /// Index of FMC Private Alias Key in the Key Vault.
-    pub fmc_priv_key_kv_idx: u8,
+    pub fmc_priv_key_kv_hdl: HandOffDataHandle,
 
     /// Index of FMC Public Alias Key X Coordinate in the Data Vault.
-    pub fmc_pub_key_x_dv_idx: u8,
+    pub fmc_pub_key_x_dv_hdl: HandOffDataHandle,
 
     /// Index of FMC Public Alias Key Y Coordinate in the Data Vault.
-    pub fmc_pub_key_y_dv_idx: u8,
+    pub fmc_pub_key_y_dv_hdl: HandOffDataHandle,
 
     /// Index of FMC Certificate Signature R Component in the Data Vault.
-    pub fmc_cert_sig_r_dv_idx: u8,
+    pub fmc_cert_sig_r_dv_hdl: HandOffDataHandle,
 
     /// Index of FMC Certificate Signature S Component in the Data Vault.
-    pub fmc_cert_sig_s_dv_idx: u8,
+    pub fmc_cert_sig_s_dv_hdl: HandOffDataHandle,
 
     /// Index of FMC SVN value in the Data Vault
-    pub fmc_svn_dv_idx: u8,
+    pub fmc_svn_dv_hdl: HandOffDataHandle,
 
     /// Index of RT TCI value in the Data Vault.
-    pub rt_tci_dv_idx: u8,
+    pub rt_tci_dv_hdl: HandOffDataHandle,
 
     /// Index of RT CDI value in the Key Vault.
-    pub rt_cdi_kv_idx: u8,
+    pub rt_cdi_kv_hdl: HandOffDataHandle,
 
     /// Index of RT Private Alias Key in the Key Vault.
-    pub rt_priv_key_kv_idx: u8,
+    pub rt_priv_key_kv_hdl: HandOffDataHandle,
 
     /// Index of RT Public Alias Key X Coordinate in the Data Vault.
-    pub rt_pub_key_x_dv_idx: u8,
+    pub rt_pub_key_x_dv_hdl: HandOffDataHandle,
 
     /// Index of RT Public Alias Key Y Coordinate in the Data Vault.
-    pub rt_pub_key_y_dv_idx: u8,
+    pub rt_pub_key_y_dv_hdl: HandOffDataHandle,
 
     /// Index of RT Certificate Signature R Component in the Data Vault.
-    pub rt_cert_sig_r_dv_idx: u8,
+    pub rt_cert_sig_r_dv_hdl: HandOffDataHandle,
 
     /// Index of RT Certificate Signature S Component in the Data Vault.
-    pub rt_cert_sig_s_dv_idx: u8,
+    pub rt_cert_sig_s_dv_hdl: HandOffDataHandle,
 
     /// Index of RT SVN value in the Data Vault
-    pub rt_svn_dv_idx: u8,
+    pub rt_svn_dv_hdl: HandOffDataHandle,
 
     /// Reserved for future use.
-    pub reserved: [u8; 29],
+    pub reserved: [u8; 32],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -98,28 +272,96 @@ impl Default for FirmwareHandoffTable {
             fht_major_ver: 0,
             fht_minor_ver: 0,
             manifest_load_addr: FHT_INVALID_ADDRESS,
-            fips_fw_load_addr_idx: FHT_INVALID_IDX,
-            rt_fw_load_addr_idx: FHT_INVALID_IDX,
-            rt_fw_entry_point_idx: FHT_INVALID_IDX,
-            fmc_tci_dv_idx: FHT_INVALID_IDX,
-            fmc_cdi_kv_idx: FHT_INVALID_IDX,
-            fmc_priv_key_kv_idx: FHT_INVALID_IDX,
-            fmc_pub_key_x_dv_idx: FHT_INVALID_IDX,
-            fmc_pub_key_y_dv_idx: FHT_INVALID_IDX,
-            fmc_cert_sig_r_dv_idx: FHT_INVALID_IDX,
-            fmc_cert_sig_s_dv_idx: FHT_INVALID_IDX,
-            fmc_svn_dv_idx: FHT_INVALID_IDX,
-            rt_tci_dv_idx: FHT_INVALID_IDX,
-            rt_cdi_kv_idx: FHT_INVALID_IDX,
-            rt_priv_key_kv_idx: FHT_INVALID_IDX,
-            rt_pub_key_x_dv_idx: FHT_INVALID_IDX,
-            rt_pub_key_y_dv_idx: FHT_INVALID_IDX,
-            rt_cert_sig_r_dv_idx: FHT_INVALID_IDX,
-            rt_cert_sig_s_dv_idx: FHT_INVALID_IDX,
-            rt_svn_dv_idx: FHT_INVALID_IDX,
-            reserved: [0; 29],
+            fips_fw_load_addr_hdl: FHT_INVALID_HANDLE,
+            rt_fw_load_addr_hdl: FHT_INVALID_HANDLE,
+            rt_fw_entry_point_hdl: FHT_INVALID_HANDLE,
+            fmc_tci_dv_hdl: FHT_INVALID_HANDLE,
+            fmc_cdi_kv_hdl: FHT_INVALID_HANDLE,
+            fmc_priv_key_kv_hdl: FHT_INVALID_HANDLE,
+            fmc_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
+            fmc_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
+            fmc_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
+            fmc_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
+            fmc_svn_dv_hdl: FHT_INVALID_HANDLE,
+            rt_tci_dv_hdl: FHT_INVALID_HANDLE,
+            rt_cdi_kv_hdl: FHT_INVALID_HANDLE,
+            rt_priv_key_kv_hdl: FHT_INVALID_HANDLE,
+            rt_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
+            rt_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
+            rt_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
+            rt_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
+            rt_svn_dv_hdl: FHT_INVALID_HANDLE,
+            reserved: [0; 32],
         }
     }
+}
+
+/// Print the Firmware Handoff Table.
+pub fn print_fht(fht: &FirmwareHandoffTable) {
+    crate::cprintln!("Firmware Handoff Table");
+    crate::cprintln!("----------------------");
+    crate::cprintln!("FHT Marker: 0x{:08x}", fht.fht_marker);
+    crate::cprintln!("FHT Major Version: {}", fht.fht_major_ver);
+    crate::cprintln!("FHT Minor Version: {}", fht.fht_minor_ver);
+    crate::cprintln!("Manifest Load Address: 0x{:08x}", fht.manifest_load_addr);
+    crate::cprintln!(
+        "FIPS FW Load Address: 0x{:08x}",
+        fht.fips_fw_load_addr_hdl.0
+    );
+    crate::cprintln!(
+        "Runtime FW Load Address: 0x{:08x}",
+        fht.rt_fw_load_addr_hdl.0
+    );
+    crate::cprintln!(
+        "Runtime FW Entry Point: 0x{:08x}",
+        fht.rt_fw_entry_point_hdl.0
+    );
+    crate::cprintln!("FMC TCI DV Handle: 0x{:08x}", fht.fmc_tci_dv_hdl.0);
+    crate::cprintln!("FMC CDI KV Handle: 0x{:08x}", fht.fmc_cdi_kv_hdl.0);
+    crate::cprintln!(
+        "FMC Private Key KV Handle: 0x{:08x}",
+        fht.fmc_priv_key_kv_hdl.0
+    );
+    crate::cprintln!(
+        "FMC Public Key X DV Handle: 0x{:08x}",
+        fht.fmc_pub_key_x_dv_hdl.0
+    );
+    crate::cprintln!(
+        "FMC Public Key Y DV Handle: 0x{:08x}",
+        fht.fmc_pub_key_y_dv_hdl.0
+    );
+    crate::cprintln!(
+        "FMC Certificate Signature R DV Handle: 0x{:08x}",
+        fht.fmc_cert_sig_r_dv_hdl.0
+    );
+    crate::cprintln!(
+        "FMC Certificate Signature S DV Handle: 0x{:08x}",
+        fht.fmc_cert_sig_s_dv_hdl.0
+    );
+    crate::cprintln!("FMC SVN DV Handle: 0x{:08x}", fht.fmc_svn_dv_hdl.0);
+    crate::cprintln!("RT TCI DV Handle: 0x{:08x}", fht.rt_tci_dv_hdl.0);
+    crate::cprintln!("RT CDI KV Handle: 0x{:08x}", fht.rt_cdi_kv_hdl.0);
+    crate::cprintln!(
+        "RT Private Key KV Handle: 0x{:08x}",
+        fht.rt_priv_key_kv_hdl.0
+    );
+    crate::cprintln!(
+        "RT Public Key X DV Handle: 0x{:08x}",
+        fht.rt_pub_key_x_dv_hdl.0
+    );
+    crate::cprintln!(
+        "RT Public Key Y DV Handle: 0x{:08x}",
+        fht.rt_pub_key_y_dv_hdl.0
+    );
+    crate::cprintln!(
+        "RT Certificate Signature R DV Handle: 0x{:08x}",
+        fht.rt_cert_sig_r_dv_hdl.0
+    );
+    crate::cprintln!(
+        "RT Certificate Signature S DV Handle: 0x{:08x}",
+        fht.rt_cert_sig_s_dv_hdl.0
+    );
+    crate::cprintln!("RT SVN DV Handle: 0x{:08x}", fht.rt_svn_dv_hdl.0);
 }
 
 impl FirmwareHandoffTable {
@@ -128,17 +370,17 @@ impl FirmwareHandoffTable {
     /// valid data before it transfers control to mutable code.
     pub fn is_valid(&self) -> bool {
         self.fht_marker == FHT_MARKER
-            && self.fmc_cdi_kv_idx != FHT_INVALID_IDX
+            && self.fmc_cdi_kv_hdl != FHT_INVALID_HANDLE
             && self.manifest_load_addr != FHT_INVALID_ADDRESS
-            && self.fmc_pub_key_x_dv_idx != FHT_INVALID_IDX
-            && self.fmc_pub_key_y_dv_idx != FHT_INVALID_IDX
-            && self.fmc_cert_sig_r_dv_idx != FHT_INVALID_IDX
-            && self.fmc_cert_sig_s_dv_idx != FHT_INVALID_IDX
-            && self.rt_fw_load_addr_idx != FHT_INVALID_IDX
-            && self.rt_tci_dv_idx != FHT_INVALID_IDX
-            && self.rt_fw_entry_point_idx != FHT_INVALID_IDX
+            && self.fmc_pub_key_x_dv_hdl != FHT_INVALID_HANDLE
+            && self.fmc_pub_key_y_dv_hdl != FHT_INVALID_HANDLE
+            && self.fmc_cert_sig_r_dv_hdl != FHT_INVALID_HANDLE
+            && self.fmc_cert_sig_s_dv_hdl != FHT_INVALID_HANDLE
+            && self.rt_fw_load_addr_hdl != FHT_INVALID_HANDLE
+            && self.rt_tci_dv_hdl != FHT_INVALID_HANDLE
+            && self.rt_fw_entry_point_hdl != FHT_INVALID_HANDLE
             // This is for Gen1 POR.
-            && self.fips_fw_load_addr_idx == FHT_INVALID_IDX
+            && self.fips_fw_load_addr_hdl == FHT_INVALID_HANDLE
     }
     /// Load FHT from its fixed address and perform validity check of
     /// its data.
@@ -154,10 +396,18 @@ impl FirmwareHandoffTable {
         let fht = FirmwareHandoffTable::read_from(slice.as_bytes()).unwrap();
 
         if fht.is_valid() {
+            print_fht(&fht);
             return Some(fht);
         }
         None
     }
+}
+/// Report a non fatal firmware error and halt.
+#[allow(clippy::empty_loop)]
+pub fn report_handoff_error_and_halt(msg: &str, code: u32) -> ! {
+    crate::cprintln!("Handoff Error: {} 0x{:08X}", msg, code);
+    report_fw_error_non_fatal(code);
+    loop {}
 }
 
 #[cfg(all(test, target_family = "unix"))]
@@ -165,12 +415,28 @@ mod tests {
     use super::*;
     use core::mem;
     // FHT is currently defined to be 60 bytes in length.
-    const FHT_SIZE: usize = 60;
+    const FHT_SIZE: usize = 120;
+
+    fn rt_tci_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultNonSticky48(WarmResetEntry48::RtTci))
+    }
 
     #[test]
     fn test_fht_is_valid() {
         let fht = FirmwareHandoffTable::default();
         assert!(!fht.is_valid());
         assert_eq!(FHT_SIZE, mem::size_of::<FirmwareHandoffTable>());
+    }
+    #[test]
+    fn test_dv_nonsticky_384bit_set() {
+        let fht = crate::hand_off::FirmwareHandoffTable {
+            rt_tci_dv_hdl: rt_tci_store(),
+            ..Default::default()
+        };
+        assert_eq!(fht.rt_tci_dv_hdl.vault(), Vault::DataVault as u32);
+        assert_eq!(
+            fht.rt_tci_dv_hdl.reg_type(),
+            DataVaultRegister::NonSticky384BitReg as u32
+        );
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,10 +1,14 @@
 // Licensed under the Apache-2.0 license.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod crypto;
 pub mod hand_off;
 #[macro_use]
 pub mod printer;
-pub use hand_off::FirmwareHandoffTable;
+pub use hand_off::HandOffDataHandle;
+pub use hand_off::FHT_INVALID_HANDLE;
 pub use hand_off::FHT_MARKER;
+pub use hand_off::{print_fht, report_handoff_error_and_halt, DataStore, FirmwareHandoffTable};
+
 pub use printer::MutablePrinter;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,9 +6,10 @@ pub mod crypto;
 pub mod hand_off;
 #[macro_use]
 pub mod printer;
-pub use hand_off::HandOffDataHandle;
-pub use hand_off::FHT_INVALID_HANDLE;
-pub use hand_off::FHT_MARKER;
-pub use hand_off::{print_fht, report_handoff_error_and_halt, DataStore, FirmwareHandoffTable};
+///merge imports
+pub use hand_off::{
+    print_fht, report_handoff_error_and_halt, DataStore, DataVaultRegister, FirmwareHandoffTable,
+    HandOffDataHandle, Vault, FHT_INVALID_HANDLE, FHT_MARKER,
+};
 
 pub use printer::MutablePrinter;

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -30,7 +30,32 @@ pub enum ColdResetEntry48 {
     OwnerPubKeyHash = 9,
 }
 
+impl TryFrom<u8> for ColdResetEntry48 {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ColdResetEntry48::LDevDiceSigR),
+            1 => Ok(ColdResetEntry48::LDevDiceSigS),
+            2 => Ok(ColdResetEntry48::LDevDicePubKeyX),
+            3 => Ok(ColdResetEntry48::LDevDicePubKeyY),
+            4 => Ok(ColdResetEntry48::FmcDiceSigR),
+            5 => Ok(ColdResetEntry48::FmcDiceSigS),
+            6 => Ok(ColdResetEntry48::FmcPubKeyX),
+            7 => Ok(ColdResetEntry48::FmcPubKeyY),
+            8 => Ok(ColdResetEntry48::FmcTci),
+            9 => Ok(ColdResetEntry48::OwnerPubKeyHash),
+            _ => Err(()),
+        }
+    }
+}
+
 impl From<ColdResetEntry48> for u8 {
+    fn from(value: ColdResetEntry48) -> Self {
+        value as Self
+    }
+}
+
+impl From<ColdResetEntry48> for u32 {
     fn from(value: ColdResetEntry48) -> Self {
         value as Self
     }
@@ -50,7 +75,26 @@ pub enum ColdResetEntry4 {
     VendorPubKeyIndex = 3,
 }
 
+impl TryFrom<u8> for ColdResetEntry4 {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::FmcSvn),
+            1 => Ok(Self::FmcLoadAddr),
+            2 => Ok(Self::FmcEntryPoint),
+            3 => Ok(Self::VendorPubKeyIndex),
+            _ => Err(()),
+        }
+    }
+}
+
 impl From<ColdResetEntry4> for u8 {
+    fn from(value: ColdResetEntry4) -> Self {
+        value as Self
+    }
+}
+
+impl From<ColdResetEntry4> for u32 {
     fn from(value: ColdResetEntry4) -> Self {
         value as Self
     }
@@ -67,17 +111,13 @@ pub enum WarmResetEntry48 {
     RtTci = 0,
 }
 
-impl TryFrom<u8> for WarmResetEntry48 {
-    type Error = ();
-    fn try_from(original: u8) -> Result<Self, Self::Error> {
-        match original {
-            0 => Ok(Self::RtTci),
-            _ => Err(()),
-        }
+impl From<WarmResetEntry48> for u8 {
+    fn from(value: WarmResetEntry48) -> Self {
+        value as Self
     }
 }
 
-impl From<WarmResetEntry48> for u8 {
+impl From<WarmResetEntry48> for u32 {
     fn from(value: WarmResetEntry48) -> Self {
         value as Self
     }
@@ -103,6 +143,12 @@ impl From<WarmResetEntry4> for u8 {
     }
 }
 
+impl From<WarmResetEntry4> for u32 {
+    fn from(value: WarmResetEntry4) -> Self {
+        value as Self
+    }
+}
+
 impl From<WarmResetEntry4> for usize {
     fn from(value: WarmResetEntry4) -> Self {
         value as Self
@@ -117,6 +163,16 @@ impl TryFrom<u8> for WarmResetEntry4 {
             1 => Ok(Self::RtLoadAddr),
             2 => Ok(Self::RtEntryPoint),
             3 => Ok(Self::ManifestAddr),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<u8> for WarmResetEntry48 {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::RtTci),
             _ => Err(()),
         }
     }
@@ -426,7 +482,7 @@ impl DataVault {
     /// # Returns
     ///    cold reset entry value  
     ///
-    fn read_cold_reset_entry48(&self, entry: ColdResetEntry48) -> Array4x12 {
+    pub fn read_cold_reset_entry48(&self, entry: ColdResetEntry48) -> Array4x12 {
         let dv = dv::RegisterBlock::dv_reg();
         Array4x12::read_from_reg(dv.sticky_data_vault_entry().at(entry.into()))
     }
@@ -520,7 +576,7 @@ impl DataVault {
     /// # Returns
     ///    cold reset entry value  
     ///
-    fn read_cold_reset_entry4(&self, entry: ColdResetEntry4) -> u32 {
+    pub fn read_cold_reset_entry4(&self, entry: ColdResetEntry4) -> u32 {
         let dv = dv::RegisterBlock::dv_reg();
         dv.sticky_lockable_scratch_reg().at(entry.into()).read()
     }

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -112,25 +112,25 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | fht_major_ver         | 2            | ROM        | Major version of FHT.                                                                                    |
 | fht_minor_ver         | 2            | ROM, FMC   | Minor version of FHT. Initially written by ROM but may be changed to a higher version by FMC.            |
 | manifest_load_addr    | 4            | ROM        | Physical base address of Manifest in DCCM SRAM.                                                          |
-| fips_fw_load_addr_idx | 4            | ROM        | Index of base address of FIPS Module in ROM or ICCM SRAM. May be 0xFF if there is no discrete module.    |
-| rt_fw_load_addr_idx   | 4            | ROM        | Index of load address of Runtime FW Module value in data vault.SRAM.                                                 |
-| rt_fw_entry_point_idx | 4            | ROM        | Index of entry point of Runtime FW Module value in data vault. SRAM.                                                           |
-| fmc_tci_dv_idx        | 1            | ROM        | Index of FMC TCI value in the Data Vault.                                                                |
-| fmc_cdi_kv_idx        | 1            | ROM        | Index of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.                            |
-| fmc_priv_key_kv_idx   | 1            | ROM        | Index of FMC Private Alias Key in the Key Vault.                                                         |
-| fmc_pub_key_x_dv_idx  | 1            | ROM        | Index of FMC Public Alias Key X Coordinate in the Data Vault.                                            |
-| fmc_pub_key_y_dv_idx  | 1            | ROM        | Index of FMC Public Alias Key Y Coordinate in the Data Vault                                             |
-| fmc_cert_sig_r_dv_idx | 1            | ROM        | Index of FMC Certificate Signature R Component in the Data Vault.                                        |
-| fmc_cert_sig_s_dv_idx | 1            | ROM        | Index of FMC Certificate Signature S Component in the Data Vault.                                        |
-| fmc_svn_dv_idx        | 1            | ROM        | Index of FMC SVN value in the Data Vault.                                                                |
-| rt_tci_dv_idx         | 1            | ROM        | Index of RT TCI value in the Data Vault.                                                                 |
-| rt_cdi_kv_idx         | 1            | FMC        | Index of RT CDI value in the Key Vault.                                                                  |
-| rt_priv_key_kv_idx    | 1            | FMC        | Index of RT Private Alias Key in the Key Vault.                                                          |
-| rt_pub_key_x_dv_idx   | 1            | FMC        | Index of RT Public Alias Key X Coordinate in the Data Vault.                                             |
-| rt_pub_key_y_dv_idx   | 1            | FMC        | Index of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
-| rt_cert_sig_r_dv_idx  | 1            | FMC        | Index of RT Certificate Signature R Component in the Data Vault.                                         |
-| rt_cert_sig_s_dv_idx  | 1            | FMC        | Index of RT Certificate Signature S Component in the Data Vault.                                         |
-| rt_svn_dv_idx         | 1            | FMC        | Index of RT SVN value in the Data Vault.                                                                 |
+| fips_fw_load_addr_hdl | 4            | ROM        | Handle of base address of FIPS Module in ROM or ICCM SRAM. May be 0xFF if there is no discrete module.    |
+| rt_fw_load_addr_hdl   | 4            | ROM        | Handle of load address of Runtime FW Module value in data vault.SRAM.                                                 |
+| rt_fw_entry_point_hdl | 4            | ROM        | Handle of entry point of Runtime FW Module value in data vault. SRAM.                                                           |
+| fmc_tci_dv_hdl        | 1            | ROM        | Handle of FMC TCI value in the Data Vault.                                                                |
+| fmc_cdi_kv_hdl        | 1            | ROM        | Handle of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.                            |
+| fmc_priv_key_kv_hdl   | 1            | ROM        | Handle of FMC Private Alias Key in the Key Vault.                                                         |
+| fmc_pub_key_x_dv_hdl  | 1            | ROM        | Handle of FMC Public Alias Key X Coordinate in the Data Vault.                                            |
+| fmc_pub_key_y_dv_hdl  | 1            | ROM        | Handle of FMC Public Alias Key Y Coordinate in the Data Vault                                             |
+| fmc_cert_sig_r_dv_hdl | 1            | ROM        | Handle of FMC Certificate Signature R Component in the Data Vault.                                        |
+| fmc_cert_sig_s_dv_hdl | 1            | ROM        | Handle of FMC Certificate Signature S Component in the Data Vault.                                        |
+| fmc_svn_dv_hdl        | 1            | ROM        | Handle of FMC SVN value in the Data Vault.                                                                |
+| rt_tci_dv_hdl         | 1            | ROM        | Handle of RT TCI value in the Data Vault.                                                                 |
+| rt_cdi_kv_hdl         | 1            | FMC        | Handle of RT CDI value in the Key Vault.                                                                  |
+| rt_priv_key_kv_hdl    | 1            | FMC        | Handle of RT Private Alias Key in the Key Vault.                                                          |
+| rt_pub_key_x_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key X Coordinate in the Data Vault.                                             |
+| rt_pub_key_y_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
+| rt_cert_sig_r_dv_hdl  | 1            | FMC        | Handle of RT Certificate Signature R Component in the Data Vault.                                         |
+| rt_cert_sig_s_dv_hdl  | 1            | FMC        | Handle of RT Certificate Signature S Component in the Data Vault.                                         |
+| rt_svn_dv_hdl         | 1            | FMC        | Handle of RT SVN value in the Data Vault.                                                                 |
 | reserved              | 20           |            | Reserved for future use.                                                                                 |
 
 *FHT is currently defined to be 60 bytes in length.*
@@ -155,67 +155,67 @@ additional data to the first 4 bytes of the reserved space at the end of the FHT
 This is the physical address of the location in SRAM where ROM has placed a complete copy of the Firmware Manifest. This must remain resident such that firmware
 is able to re-run firmware integrity checks on-demand (required by FIPS 140-3).
 
-### fips_fw_load_addr_idx
+### fips_fw_load_addr_hdl
 
-*Future feature, not currently supported.* This field provides the index of the DV entry that stores the physical address of the location in ROM or SRAM where a discrete FIPS Crypto module resides. If a
+*Future feature, not currently supported.* This field provides the Handle of the DV entry that stores the physical address of the location in ROM or SRAM where a discrete FIPS Crypto module resides. If a
 discrete FIPS module does not exist, then this field shall be 0xFF and ROM, FMC, and RT FW must all carry their own code for accessing crypto resources and
 keys.
 
-### rt_fw_load_addr_idx
+### rt_fw_load_addr_hdl
 
-This field provides the index of the DV entry that stores the physical address of the location in ICCM SRAM where ROM has placed the authenticated Runtime Firmware module.
+This field provides the Handle of the DV entry that stores the physical address of the location in ICCM SRAM where ROM has placed the authenticated Runtime Firmware module.
 
-### rt_fw_entry_point_idx
+### rt_fw_entry_point_hdl
 
-This field provides the index of the DV entry that stores the physical address of the Entry Point of Runtime FW Module in ICCM SRAM.
+This field provides the Handle of the DV entry that stores the physical address of the Entry Point of Runtime FW Module in ICCM SRAM.
 
-### fmc_tci_dv_idx
+### fmc_tci_dv_hdl
 
-This field provides the index into the Data Vault where the TCI<sub>FMC</sub> is stored. TCI<sub>FMC</sub> is a SHA-384 Hash of the FMC Module.
+This field provides the Handle into the Data Vault where the TCI<sub>FMC</sub> is stored. TCI<sub>FMC</sub> is a SHA-384 Hash of the FMC Module.
 
-### fmc_cdi_kv_idx
+### fmc_cdi_kv_hdl
 
-This field provides the index into the Key Vault where the CDI<sub>FMC</sub> is stored.
+This field provides the Handle into the Key Vault where the CDI<sub>FMC</sub> is stored.
 
-### fmc_priv_key_kv_idx
+### fmc_priv_key_kv_hdl
 
-This field provides the index into the Key Vault where the PrivateKey<sub>FMC</sub> is stored.
+This field provides the Handle into the Key Vault where the PrivateKey<sub>FMC</sub> is stored.
 
-### fmc_pub_key_x_dv_idx, fmc_pub_key_y_dv_idx
+### fmc_pub_key_x_dv_hdl, fmc_pub_key_y_dv_hdl
 
 These fields provide the indices into the Data Vault where the PublicKey<sub>FMC</sub> X and Y coordinates are stored.
 
-### fmc_cert_sig_r_dv_idx, fmc_cert_sig_s_dv_idx
+### fmc_cert_sig_r_dv_hdl, fmc_cert_sig_s_dv_hdl
 
 These fields provide the indices into the Data Vault where the Cert<sub>FMC</sub> signature R and S components are stored.
 
-### fmc_svn_dv_idx
+### fmc_svn_dv_hdl
 
-This field provides the index into the Data Vault where the SVN<sub>FMC</sub> is stored.
+This field provides the Handle into the Data Vault where the SVN<sub>FMC</sub> is stored.
 
-### rt_tci_dv_idx
+### rt_tci_dv_hdl
 
-This field provides the index into the Data Vault where the TCI<sub>RT</sub> is stored. TCI<sub>RT</sub> is a SHA-384 Hash of the RT FW Module.
+This field provides the Handle into the Data Vault where the TCI<sub>RT</sub> is stored. TCI<sub>RT</sub> is a SHA-384 Hash of the RT FW Module.
 
-### rt_cdi_kv_idx
+### rt_cdi_kv_hdl
 
-This field provides the index into the Key Vault where the CDI<sub>RT</sub> is stored.
+This field provides the Handle into the Key Vault where the CDI<sub>RT</sub> is stored.
 
-### rt_priv_key_kv_idx
+### rt_priv_key_kv_hdl
 
-This field provides the index into the Key Vault where the PrivateKey<sub>RT</sub> is stored.
+This field provides the Handle into the Key Vault where the PrivateKey<sub>RT</sub> is stored.
 
-### rt_pub_key_x_dv_idx, rt_pub_key_y_dv_idx
+### rt_pub_key_x_dv_hdl, rt_pub_key_y_dv_hdl
 
 These fields provide the indices into the Data Vault where the PublicKey<sub>RT</sub> X and Y coordinates are stored.
 
-### rt_cert_sig_r_dv_idx, rt_cert_sig_s_dv_idx
+### rt_cert_sig_r_dv_hdl, rt_cert_sig_s_dv_hdl
 
 These fields provide the indices into the Data Vault where the Cert<sub>RT</sub> signature R and S components are stored.
 
-### rt_svn_dv_idx
+### rt_svn_dv_hdl
 
-This field provides the index into the Data Vault where the SVN<sub>RT</sub> is stored.
+This field provides the Handle into the Data Vault where the SVN<sub>RT</sub> is stored.
 
 ### reserved
 
@@ -234,13 +234,13 @@ The following list of steps are to be performed by FMC on each boot when ROM jum
 1. FMC reads the measurement of the Runtime FW Module, TCI<sub>RT</sub>, from the Data Vault that has previously been validated by ROM.
 1. FMC extends Caliptra PCR registers with TCI<sub>RT</sub>.
 1. FMC derives CDI<sub>RT</sub> from CDI<sub>FMC</sub> mixed with TCI<sub>RT</sub> and stores it in the Key Vault.
-1. FMC updates fht.rt_cdi_kv_idx in the FHT.
+1. FMC updates fht.rt_cdi_kv_hdl in the FHT.
 1. FMC derives AliasKeyPair<sub>RT</sub> from CDI<sub>RT</sub>. The Private Key is stored in the Key Vault while the Public Key X and Y coordinates are stored
    in the Data Vault.
-1. FMC updates fht.rt_priv_key_kv_idx, fht.rt_pub_key_x_dv_idx, and fht.rt_pub_key_y_dv_idx in the FHT.
+1. FMC updates fht.rt_priv_key_kv_hdl, fht.rt_pub_key_x_dv_hdl, and fht.rt_pub_key_y_dv_hdl in the FHT.
 1. FMC generates an x509 certificate with PubKey<sub>RT</sub> as the subject and signed by PrivKey<sub>FMC</sub>.
 1. FMC stores the Cert<sub>RT</sub> signature in the Data Vault.
-1. FMC updates fht.rt_cert_sig_r_dv_idx and fht.rt_cert_sig_r_dv_idx in the FHT.
+1. FMC updates fht.rt_cert_sig_r_dv_hdl and fht.rt_cert_sig_r_dv_hdl in the FHT.
 1. FMC ensures that CDI<sub>FMC</sub> and PrivateKey<sub>FMC</sub> are locked to block further usage until the next boot.
 1. FMC locates the Runtime FW Module in ICCM at fht.rt_fw_load_addr.
 1. FMC jumps to the Runtime FW Module entry point at fht.rt_fw_entry_point.
@@ -267,22 +267,22 @@ sequenceDiagram
     FMC->>+FIPS: InitFipsFw() (if needed)
     FIPS-->>-FMC: return()
     FMC->>FMC: LocateManifest(fht)
-    FMC->>FMC: GetRtMeasurement(fht.rt_tci_dv_idx)
-    FMC->>+FIPS: ExtendPcr(PCR_IDX_RT, RtTci)
+    FMC->>FMC: GetRtMeasurement(fht.rt_tci_dv_hdl)
+    FMC->>+FIPS: ExtendPcr(PCR_hdl_RT, RtTci)
     FIPS-->>-FMC: return()
 
     rect rgba(0, 0, 200, .2)
     note over FIPS, FMC: DICE-related derivations will be<br> defined in greater detail later
 
-    FMC->>+FIPS: DeriveCdi(fht.FmcCdiKvIdx, RtTci)
-    FIPS-->>-FMC: return(fht.rt_cdi_kv_idx)
-    FMC->>+FIPS: DeriveKeyPair(fht.rt_cdi_kv_idx)
-    FIPS-->>-FMC: return(fht.rt_priv_key_kv_idx,<br> fht.rt_pub_key_x_dv_idx,<br> fht.rt_pub_key_y_dv_idx)
-    FMC->>+FIPS: CertifyKey(fht.rt_pub_key_x_dv_idx,<br> fht.rt_pub_key_y_dv_idx,<br> fht.fmc_priv_key_kv_idx)
-    FIPS-->>-FMC: return(fht.rt_cert_sig_r_dv_idx, fht.rt_cert_sig_s_dv_idx)
-    FMC->>+FIPS: LockKey(fht.fmc_cdi_kv_idx)
+    FMC->>+FIPS: DeriveCdi(fht.FmcCdiKvhdl, RtTci)
+    FIPS-->>-FMC: return(fht.rt_cdi_kv_hdl)
+    FMC->>+FIPS: DeriveKeyPair(fht.rt_cdi_kv_hdl)
+    FIPS-->>-FMC: return(fht.rt_priv_key_kv_hdl,<br> fht.rt_pub_key_x_dv_hdl,<br> fht.rt_pub_key_y_dv_hdl)
+    FMC->>+FIPS: CertifyKey(fht.rt_pub_key_x_dv_hdl,<br> fht.rt_pub_key_y_dv_hdl,<br> fht.fmc_priv_key_kv_hdl)
+    FIPS-->>-FMC: return(fht.rt_cert_sig_r_dv_hdl, fht.rt_cert_sig_s_dv_hdl)
+    FMC->>+FIPS: LockKey(fht.fmc_cdi_kv_hdl)
     FIPS-->>-FMC: return()
-    FMC->>+FIPS: LockKey(fht.fmc_priv_key_kv_idx)
+    FMC->>+FIPS: LockKey(fht.fmc_priv_key_kv_hdl)
     FIPS-->>-FMC: return()
 
     end %% rect

--- a/fmc/test-fw/test-rt/src/main.rs
+++ b/fmc/test-fw/test-rt/src/main.rs
@@ -35,18 +35,7 @@ const BANNER: &str = r#"
 pub extern "C" fn entry_point() -> ! {
     cprintln!("{}", BANNER);
 
-    if let Some(fht) = caliptra_common::FirmwareHandoffTable::try_load() {
-        cprintln!("[rt] FHT Marker: 0x{:08X}", fht.fht_marker);
-        cprintln!("[rt] FHT Major Version: 0x{:04X}", fht.fht_major_ver);
-        cprintln!("[rt] FHT Minor Version: 0x{:04X}", fht.fht_minor_ver);
-        cprintln!("[rt] FHT Manifest Addr: 0x{:08X}", fht.manifest_load_addr);
-        cprintln!("[rt] FHT FMC CDI KV KeyID: {}", fht.fmc_cdi_kv_idx);
-        cprintln!("[rt] FHT FMC PrivKey KV KeyID: {}", fht.fmc_priv_key_kv_idx);
-        cprintln!(
-            "[rt] FHT RT Load Address: 0x{:08x}",
-            fht.rt_fw_load_addr_idx
-        );
-        cprintln!("[rt] FHT RT Entry Point: 0x{:08x}", fht.rt_fw_load_addr_idx);
+    if let Some(_fht) = caliptra_common::FirmwareHandoffTable::try_load() {
         caliptra_drivers::ExitCtrl::exit(0)
     } else {
         caliptra_drivers::ExitCtrl::exit(0xff)

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -13,7 +13,8 @@ Abstract:
 --*/
 
 use caliptra_common::{
-    DataStore, FirmwareHandoffTable, HandOffDataHandle, FHT_INVALID_HANDLE, FHT_MARKER,
+    DataVaultRegister, FirmwareHandoffTable, HandOffDataHandle, Vault, FHT_INVALID_HANDLE,
+    FHT_MARKER,
 };
 use caliptra_drivers::{ColdResetEntry4, ColdResetEntry48, WarmResetEntry4, WarmResetEntry48};
 use zerocopy::AsBytes;
@@ -29,40 +30,92 @@ const FHT_MINOR_VERSION: u16 = 0;
 
 struct FhtDataStore {}
 impl FhtDataStore {
-    pub fn fmc_cdi_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_CDI))
+    /// The FMC CDI is stored in a 32-bit DataVault sticky register.
+    pub const fn fmc_cdi_store() -> HandOffDataHandle {
+        HandOffDataHandle(((Vault::KeyVault as u32) << 12) | KEY_ID_CDI as u32)
     }
-    pub fn fmc_priv_key_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_PRIV_KEY))
+    /// The FMC private key is stored in a 32-bit DataVault sticky register.
+    pub const fn fmc_priv_key_store() -> HandOffDataHandle {
+        HandOffDataHandle(((Vault::KeyVault as u32) << 12) | KEY_ID_PRIV_KEY as u32)
     }
-    pub fn fmc_svn_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky4(ColdResetEntry4::FmcSvn))
+    /// The FMC SVN is stored in a 32-bit DataVault sticky register.
+    pub const fn fmc_svn_store() -> HandOffDataHandle {
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::Sticky32BitReg as u32) << 8
+                | ColdResetEntry4::FmcSvn as u32,
+        )
     }
-    pub fn fmc_tci_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcTci))
+    /// The FMC TCI is stored in a 384-bit DataVault sticky register.
+    pub const fn fmc_tci_store() -> HandOffDataHandle {
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::Sticky384BitReg as u32) << 8
+                | ColdResetEntry48::FmcTci as u32,
+        )
     }
-    pub fn fmc_cert_sig_r_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcDiceSigR))
+
+    /// The FMC certificate signature R value is stored in a 384-bit DataVault
+    /// sticky register.
+    pub const fn fmc_cert_sig_r_store() -> HandOffDataHandle {
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::Sticky384BitReg as u32) << 8
+                | ColdResetEntry48::FmcDiceSigR as u32,
+        )
     }
+
+    /// The FMC certificate signature S value is stored in a 384-bit DataVault
+    /// sticky register.
     pub fn fmc_cert_sig_s_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcDiceSigS))
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::Sticky384BitReg as u32) << 8
+                | ColdResetEntry48::FmcDiceSigS as u32,
+        )
     }
-    pub fn fmc_pub_key_x_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcPubKeyX))
+    /// The FMC public key X coordinate is stored in a 384-bit DataVault
+    /// sticky register.
+    pub const fn fmc_pub_key_x_store() -> HandOffDataHandle {
+        HandOffDataHandle(
+            (Vault::DataVault as u32) << 12
+                | (DataVaultRegister::Sticky384BitReg as u32) << 8
+                | ColdResetEntry48::FmcPubKeyX as u32,
+        )
     }
+    /// FMC public key Y coordinate is stored in a 384-bit DataVault
+    /// sticky register.
     pub fn fmc_pub_key_y_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcPubKeyY))
+        HandOffDataHandle(
+            (Vault::DataVault as u32) << 12
+                | (DataVaultRegister::Sticky384BitReg as u32) << 8
+                | ColdResetEntry48::FmcPubKeyY as u32,
+        )
     }
+    /// The RT SVN is stored in a 32-bit DataVault non-sticky register.
     pub fn rt_svn_data_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultNonSticky4(WarmResetEntry4::RtSvn))
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::NonSticky32BitReg as u32) << 8
+                | WarmResetEntry4::RtSvn as u32,
+        )
     }
+    /// The RT TCI is stored in a 384-bit DataVault non-sticky register.
     pub fn rt_tci_data_store() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultNonSticky48(WarmResetEntry48::RtTci))
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::NonSticky384BitReg as u32) << 8
+                | WarmResetEntry48::RtTci as u32,
+        )
     }
-    pub fn rt_fw_entry_point() -> HandOffDataHandle {
-        HandOffDataHandle::from(DataStore::DataVaultNonSticky4(
-            WarmResetEntry4::RtEntryPoint,
-        ))
+    /// The runtime firmware entry point is stored in a 32-bit DataVault
+    /// non-sticky register.
+    pub const fn rt_fw_entry_point() -> HandOffDataHandle {
+        HandOffDataHandle(
+            ((Vault::DataVault as u32) << 12)
+                | (DataVaultRegister::NonSticky32BitReg as u32) << 8
+                | WarmResetEntry4::RtEntryPoint as u32,
+        )
     }
 }
 

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -12,7 +12,9 @@ Abstract:
 
 --*/
 
-use caliptra_common::{FirmwareHandoffTable, FHT_MARKER};
+use caliptra_common::{
+    DataStore, FirmwareHandoffTable, HandOffDataHandle, FHT_INVALID_HANDLE, FHT_MARKER,
+};
 use caliptra_drivers::{ColdResetEntry4, ColdResetEntry48, WarmResetEntry4, WarmResetEntry48};
 use zerocopy::AsBytes;
 
@@ -25,31 +27,70 @@ use crate::{
 const FHT_MAJOR_VERSION: u16 = 1;
 const FHT_MINOR_VERSION: u16 = 0;
 
+struct FhtDataStore {}
+impl FhtDataStore {
+    pub fn fmc_cdi_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_CDI))
+    }
+    pub fn fmc_priv_key_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_PRIV_KEY))
+    }
+    pub fn fmc_svn_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky4(ColdResetEntry4::FmcSvn))
+    }
+    pub fn fmc_tci_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcTci))
+    }
+    pub fn fmc_cert_sig_r_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcDiceSigR))
+    }
+    pub fn fmc_cert_sig_s_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcDiceSigS))
+    }
+    pub fn fmc_pub_key_x_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcPubKeyX))
+    }
+    pub fn fmc_pub_key_y_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultSticky48(ColdResetEntry48::FmcPubKeyY))
+    }
+    pub fn rt_svn_data_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultNonSticky4(WarmResetEntry4::RtSvn))
+    }
+    pub fn rt_tci_data_store() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultNonSticky48(WarmResetEntry48::RtTci))
+    }
+    pub fn rt_fw_entry_point() -> HandOffDataHandle {
+        HandOffDataHandle::from(DataStore::DataVaultNonSticky4(
+            WarmResetEntry4::RtEntryPoint,
+        ))
+    }
+}
+
 pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
     FirmwareHandoffTable {
         fht_marker: FHT_MARKER,
         fht_major_ver: FHT_MAJOR_VERSION,
         fht_minor_ver: FHT_MINOR_VERSION,
         manifest_load_addr: env.data_vault().map(|d| d.manifest_addr()),
-        fips_fw_load_addr_idx: u8::MAX,
-        rt_fw_load_addr_idx: WarmResetEntry4::RtLoadAddr.into(),
-        rt_fw_entry_point_idx: WarmResetEntry4::RtEntryPoint.into(),
-        fmc_cdi_kv_idx: KEY_ID_CDI.into(),
-        fmc_priv_key_kv_idx: KEY_ID_PRIV_KEY.into(),
-        fmc_pub_key_x_dv_idx: ColdResetEntry48::FmcPubKeyX.into(),
-        fmc_pub_key_y_dv_idx: ColdResetEntry48::FmcPubKeyY.into(),
-        fmc_cert_sig_r_dv_idx: ColdResetEntry48::FmcDiceSigR.into(),
-        fmc_cert_sig_s_dv_idx: ColdResetEntry48::FmcDiceSigS.into(),
-        fmc_tci_dv_idx: ColdResetEntry48::FmcTci.into(),
-        fmc_svn_dv_idx: ColdResetEntry4::FmcSvn.into(),
-        rt_cdi_kv_idx: u8::MAX,
-        rt_priv_key_kv_idx: u8::MAX,
-        rt_pub_key_x_dv_idx: u8::MAX,
-        rt_pub_key_y_dv_idx: u8::MAX,
-        rt_cert_sig_r_dv_idx: u8::MAX,
-        rt_cert_sig_s_dv_idx: u8::MAX,
-        rt_tci_dv_idx: WarmResetEntry48::RtTci.into(),
-        rt_svn_dv_idx: WarmResetEntry4::RtSvn.into(),
+        fips_fw_load_addr_hdl: FHT_INVALID_HANDLE,
+        rt_fw_load_addr_hdl: FhtDataStore::rt_fw_entry_point(),
+        rt_fw_entry_point_hdl: FhtDataStore::rt_fw_entry_point(),
+        fmc_cdi_kv_hdl: FhtDataStore::fmc_cdi_store(),
+        fmc_priv_key_kv_hdl: FhtDataStore::fmc_priv_key_store(),
+        fmc_pub_key_x_dv_hdl: FhtDataStore::fmc_pub_key_x_store(),
+        fmc_pub_key_y_dv_hdl: FhtDataStore::fmc_pub_key_y_store(),
+        fmc_cert_sig_r_dv_hdl: FhtDataStore::fmc_cert_sig_r_store(),
+        fmc_cert_sig_s_dv_hdl: FhtDataStore::fmc_cert_sig_s_store(),
+        fmc_tci_dv_hdl: FhtDataStore::fmc_tci_store(),
+        fmc_svn_dv_hdl: FhtDataStore::fmc_svn_store(),
+        rt_cdi_kv_hdl: FHT_INVALID_HANDLE,
+        rt_priv_key_kv_hdl: FHT_INVALID_HANDLE,
+        rt_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
+        rt_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
+        rt_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
+        rt_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
+        rt_tci_dv_hdl: FhtDataStore::rt_tci_data_store(),
+        rt_svn_dv_hdl: FhtDataStore::rt_svn_data_store(),
         ..Default::default()
     }
 }
@@ -64,6 +105,6 @@ pub fn load_fht(fht: FirmwareHandoffTable) {
         cprintln!("[fht] Loading FHT @ 0x{:08X}", ptr as u32);
         core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FirmwareHandoffTable>())
     };
-
+    caliptra_common::print_fht(&fht);
     slice.copy_from_slice(fht.as_bytes());
 }

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -53,24 +53,7 @@ pub extern "C" fn fmc_entry() -> ! {
     };
 
     let fht = FirmwareHandoffTable::read_from(slice).unwrap();
-
-    cprintln!("[fmc] FHT Marker: 0x{:08X}", fht.fht_marker);
-    cprintln!("[fmc] FHT Major Version: 0x{:04X}", fht.fht_major_ver);
-    cprintln!("[fmc] FHT Minor Version: 0x{:04X}", fht.fht_minor_ver);
-    cprintln!("[fmc] FHT Manifest Addr: 0x{:08X}", fht.manifest_load_addr);
-    cprintln!("[fmc] FHT FMC CDI KV KeyID: {}", fht.fmc_cdi_kv_idx);
-    cprintln!(
-        "[fmc] FHT FMC PrivKey KV KeyID: {}",
-        fht.fmc_priv_key_kv_idx
-    );
-    cprintln!(
-        "[fmc] FHT RT Load Address: 0x{:08x}",
-        fht.rt_fw_load_addr_idx
-    );
-    cprintln!(
-        "[fmc] FHT RT Entry Point: 0x{:08x}",
-        fht.rt_fw_load_addr_idx
-    );
+    assert!(fht.is_valid());
 
     create_certs();
 

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -35,18 +35,7 @@ const BANNER: &str = r#"
 pub extern "C" fn entry_point() -> ! {
     cprintln!("{}", BANNER);
 
-    if let Some(fht) = caliptra_common::FirmwareHandoffTable::try_load() {
-        cprintln!("[rt] FHT Marker: 0x{:08X}", fht.fht_marker);
-        cprintln!("[rt] FHT Major Version: 0x{:04X}", fht.fht_major_ver);
-        cprintln!("[rt] FHT Minor Version: 0x{:04X}", fht.fht_minor_ver);
-        cprintln!("[rt] FHT Manifest Addr: 0x{:08X}", fht.manifest_load_addr);
-        cprintln!("[rt] FHT FMC CDI KV KeyID: {}", fht.fmc_cdi_kv_idx);
-        cprintln!("[rt] FHT FMC PrivKey KV KeyID: {}", fht.fmc_priv_key_kv_idx);
-        cprintln!(
-            "[rt] FHT RT Load Address: 0x{:08x}",
-            fht.rt_fw_load_addr_idx
-        );
-        cprintln!("[rt] FHT RT Entry Point: 0x{:08x}", fht.rt_fw_load_addr_idx);
+    if let Some(_fht) = caliptra_common::FirmwareHandoffTable::try_load() {
         caliptra_drivers::ExitCtrl::exit(0)
     } else {
         caliptra_drivers::ExitCtrl::exit(0xff)


### PR DESCRIPTION
- The FHT struct fields providing a level of indirection for the actual handoff information,  formerly modeled as 8-bit indexes are now 32-bit handles.
- A 32-bit handle describes the storage location as the tuple (vault, regType, regNum).
- The element vault identifies the storage spaces in Caliptra (e.g. keyVault, dataVault)
- The element regType identifies the attribute of the register bank instantiated by the vault (e.g. sticky, non-sticky)
- The element regNum identifies the register entry in the bank.
 