### PR TITLE
HwModel: Prefix every log line with cycle count.

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -154,6 +154,7 @@ pub trait HwModel {
 
         hw.init_fuses(&run_params.fuses);
 
+        writeln!(hw.output().logger(), "writing to cptra_bootfsm_go")?;
         hw.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
 
         hw.step();
@@ -168,11 +169,7 @@ pub trait HwModel {
                     return Err(ModelError::ReadyForFirmwareTimeout { cycles }.into());
                 }
             }
-            writeln!(
-                hw.output().logger(),
-                "ready_for_fw high after {cycles} cycles"
-            )
-            .unwrap();
+            writeln!(hw.output().logger(), "ready_for_fw is high")?;
             hw.upload_firmware(fw_image)?;
         }
 

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -167,6 +167,7 @@ impl crate::HwModel for ModelEmulated {
         Self: Sized,
     {
         let clock = Clock::new();
+        let timer = clock.timer();
 
         let ready_for_fw = Rc::new(Cell::new(false));
         let ready_for_fw_clone = ready_for_fw.clone();
@@ -181,6 +182,7 @@ impl crate::HwModel for ModelEmulated {
         let bus_args = CaliptraRootBusArgs {
             rom: params.rom.into(),
             tb_services_cb: TbServicesCb::new(move |ch| {
+                output_sink.set_now(timer.now());
                 output_sink.push_uart_char(ch);
             }),
             ready_for_fw_cb: ReadyForFwCb::new(move |_| {
@@ -224,6 +226,9 @@ impl crate::HwModel for ModelEmulated {
     }
 
     fn output(&mut self) -> &mut Output {
+        // In case the caller wants to log something, make sure the log has the
+        // correct time.
+        self.output.sink().set_now(self.cpu.clock.now());
         &mut self.output
     }
 


### PR DESCRIPTION
This helps us debug performance problems in the verilator nightly.

For example:

```
$ cargo test -p caliptra-hw-model test_mailbox_execute --features=verilator
      4,099 ready_for_fuses is high
      4,265 writing to cptra_bootfsm_go
      4,274 <<< Executing mbox cmd 0x10000000 (10 bytes) from SoC
      6,789 >>> mbox cmd response data (14 bytes)
      6,808 <<< Executing mbox cmd 0x10000000 (8 bytes) from SoC
      7,369 >>> mbox cmd response data (12 bytes)
      7,386 <<< Executing mbox cmd 0x10001000 (0 bytes) from SoC
      7,503 >>> mbox cmd response data (7 bytes)
      7,518 <<< Executing mbox cmd 0x10001000 (1 bytes) from SoC
      7,620 >>> mbox cmd response data (7 bytes)
      7,635 <<< Executing mbox cmd 0x10002000 (0 bytes) from SoC
      7,718 >>> mbox cmd response data (0 bytes)
      7,729 <<< Executing mbox cmd 0x20000000 (0 bytes) from SoC
      7,813 >>> mbox cmd response: success
      7,821 <<< Executing mbox cmd 0x40000000 (10 bytes) from SoC
      7,900 >>> mbox cmd response: failed
```