### PR TITLE
Always use linker relaxation for risc-v.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.riscv32imc-unknown-none-elf]
+rustflags = ["-C", "target-feature=+relax"]


### PR DESCRIPTION
This typically shaves around 10% off the size of .text. For the ROM (with UART), this decreases  .text from 28128 to 25188 (11%).