### PR TITLE
Remove RUSTFLAGS envvar from CI workflows

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -24,6 +24,9 @@ jobs:
       # Change this to a new random value if you suspect the cache is corrupted
       SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1d
 
+      # Compiler warnings should fail to compile
+      EXTRA_CARGO_CONFIG: "target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -131,7 +134,7 @@ jobs:
           (cd hw-model && cargo build --locked --release --features verilator --jobs 10)
           # build all tests; need to make sure they still build with verilator
           # even if we don't have time to run them.
-          cargo test --no-run --locked --release --features=verilator
+          cargo --config "$EXTRA_CARGO_CONFIG" test --no-run --locked --release --features=verilator
           sccache --show-stats
 
       - name: Run unit tests
@@ -139,8 +142,8 @@ jobs:
           export RUSTFLAGS="-D warnings"
           export RUSTC_WRAPPER=~/.cargo/bin/sccache
           export CXX="sccache g++"
-          (cd hw-model && cargo test --locked --release --features verilator)
-          (cd hw-latest/verilated && cargo test --locked --release --features verilator)
+          (cd hw-model && cargo --config "$EXTRA_CARGO_CONFIG" test --locked --release --features verilator)
+          (cd hw-latest/verilated && cargo --config "$EXTRA_CARGO_CONFIG" test --locked --release --features verilator)
 
       - name: Check source-code formatting (run "cargo fmt" if this fails)
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,6 +23,9 @@ jobs:
       # Change this to a new random value if you suspect the cache is corrupted
       SCCACHE_C_CUSTOM_CACHE_BUSTER: 68a6835b420c
 
+      # Compiler warnings should fail to compile
+      EXTRA_CARGO_CONFIG: "target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
+
     steps:
       - uses: actions/checkout@v3
 
@@ -108,9 +111,8 @@ jobs:
 
       - name: Build
         run: |
-          export RUSTFLAGS="-D warnings"
-          cargo build --locked
-          cargo build --locked --release
+          cargo --config "$EXTRA_CARGO_CONFIG" build --locked
+          cargo --config "$EXTRA_CARGO_CONFIG" build --locked --release
           drivers/test-fw/build.sh
           (cd fmc && ./build.sh)
           (cd runtime && ./build.sh)
@@ -125,9 +127,8 @@ jobs:
 
       - name: Run tests
         run: |
-          export RUSTFLAGS="-D warnings"
-          cargo test --locked
-          cargo test --locked --release  
+          cargo --config "$EXTRA_CARGO_CONFIG" test --locked
+          cargo --config "$EXTRA_CARGO_CONFIG" test --locked --release
           sccache --show-stats
 
       - name: Run emulator conformance tests

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -111,10 +111,15 @@ pub fn build_firmware_elf(id: &FwId) -> io::Result<Vec<u8>> {
         features_csv.push_str("riscv");
     }
 
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.current_dir(WORKSPACE_DIR);
+    if option_env!("GITHUB_ACTIONS").is_some() {
+        // In continuous integration, warnings are always errors.
+        cmd.arg("--config")
+            .arg("target.'cfg(all())'.rustflags = [\"-Dwarnings\"]");
+    }
     run_cmd(
-        Command::new(env!("CARGO"))
-            .current_dir(WORKSPACE_DIR)
-            .arg("build")
+        cmd.arg("build")
             .arg("--quiet")
             .arg("--locked")
             .arg("--target")


### PR DESCRIPTION
Unfortunately, the RUSTFLAGS envronment variable overrides any settings in .cargo/config. The CI was previously using RUSTFLAGS to turn warnings into errors (via -Dwarnings), but that prevented target-specific settings (such as linker relaxation) from being applied.

Now, we set -Dwarnings with [targetcfgrustflags](https://doc.rust-lang.org/cargo/reference/config.html#targetcfgrustflags ) via cargo's --config command-line-flag, which gets merged with the per-target settings in .cargo/config.