### PR TITLE
Remove "current" PCR1.

### DIFF
--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -73,8 +73,8 @@ impl DiceLayer for FmcAliasLayer {
         // populate data vault
         Self::populate_data_vault(env, &info);
 
-        // Extend PCR0 & PCR1
-        Self::extend_pcrs(env)?;
+        // Extend PCR0
+        pcr::extend_pcr0(env)?;
 
         // Load the image
         Self::load_image(env, &manifest, &txn)?;
@@ -319,25 +319,6 @@ impl FmcAliasLayer {
 
         env.data_vault()
             .map(|d| d.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, slice));
-    }
-
-    /// Extend the PCR0 & PCR1
-    ///
-    /// PCR0 is a journey PCR and is locked for clear on cold boot. PCR1
-    /// is the current PCR and is cleared on any reset
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    fn extend_pcrs(env: &RomEnv) -> CaliptraResult<()> {
-        pcr::extend_pcr0(env)?;
-        pcr::extend_pcr1(env)?;
-
-        // TODO: Check PCR0 != 0
-
-        // TODO: Check PCR0 == PCR1
-
-        Ok(())
     }
 
     /// Derive Composite Device Identity (CDI) from FMC measurements

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -22,7 +22,7 @@ Note:
 --*/
 
 use crate::rom_env::RomEnv;
-use caliptra_drivers::{CaliptraResult, PcrId};
+use caliptra_drivers::{Array4x12, CaliptraResult, PcrId};
 
 /// Extend PCR0
 ///
@@ -30,6 +30,7 @@ use caliptra_drivers::{CaliptraResult, PcrId};
 ///
 /// * `env` - ROM Environment
 pub fn extend_pcr0(env: &RomEnv) -> CaliptraResult<()> {
+    let sha = env.sha384();
     let pcr_bank = env.pcr_bank();
 
     // Clear the PCR
@@ -38,74 +39,26 @@ pub fn extend_pcr0(env: &RomEnv) -> CaliptraResult<()> {
     // Lock the PCR from clear
     pcr_bank.map(|p| p.set_pcr_lock(caliptra_drivers::PcrId::PcrId0));
 
-    // Extend common data into PCR
-    extend_pcr_common(env, PcrId::PcrId0)
-}
+    let extend = |data: Array4x12| {
+        let bytes: &[u8; 48] = &data.into();
+        sha.map(|s| pcr_bank.map(|p| p.extend_pcr(PcrId::PcrId0, s, bytes)))
+    };
 
-/// Extend PCR1
-///
-/// # Arguments
-///
-/// * `env` - ROM Environment
-pub fn extend_pcr1(env: &RomEnv) -> CaliptraResult<()> {
-    let pcr_bank = env.pcr_bank();
+    let extend_u8 = |data: u8| {
+        let bytes = &data.to_le_bytes();
+        sha.map(|s| pcr_bank.map(|p| p.extend_pcr(PcrId::PcrId0, s, bytes)))
+    };
 
-    // Clear the PCR
-    pcr_bank.map(|p| p.erase_pcr(caliptra_drivers::PcrId::PcrId1))?;
+    extend_u8(env.dev_state().map(|d| d.lifecycle()) as u8)?;
+    extend_u8(env.dev_state().map(|d| d.debug_locked()) as u8)?;
+    extend_u8(env.fuse_bank().map(|f| f.anti_rollback_disable()) as u8)?;
+    extend(env.fuse_bank().map(|f| f.vendor_pub_key_hash()))?;
+    extend(env.data_vault().map(|d| d.owner_pk_hash()))?;
+    extend_u8(env.data_vault().map(|d| d.vendor_pk_index()) as u8)?;
+    extend(env.data_vault().map(|d| d.fmc_tci()))?;
+    extend_u8(env.data_vault().map(|d| d.fmc_svn()) as u8)?;
 
-    // Extend common data into PCR
-    extend_pcr_common(env, PcrId::PcrId1)
-}
-
-/// Extend common data into PCR
-///
-/// # Arguments
-///
-/// * `env` - ROM Environment
-/// * `pcr_id` - PCR slot to extend the data into
-fn extend_pcr_common(env: &RomEnv, pcr_id: PcrId) -> CaliptraResult<()> {
-    let pcr_bank = env.pcr_bank();
-    let sha = env.sha384();
-
-    // Extend Device Lifecycle state
-    let data = env.dev_state().map(|d| d.lifecycle()) as u8;
-    let bytes = &data.to_le_bytes();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend Debug Lock state
-    let data = env.dev_state().map(|d| d.debug_locked()) as u8;
-    let bytes = &data.to_le_bytes();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend Anti-Rollback disable fuse
-    let data = env.fuse_bank().map(|f| f.anti_rollback_disable()) as u8;
-    let bytes = &data.to_le_bytes();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend Vendor Public Key Hash
-    let data = env.fuse_bank().map(|f| f.vendor_pub_key_hash());
-    let bytes: &[u8; 48] = &data.into();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend Owner Public Key Hash
-    let data = env.data_vault().map(|d| d.owner_pk_hash());
-    let bytes: &[u8; 48] = &data.into();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend Vendor Public Key Index used to validate the firmware image bundle
-    let data = env.data_vault().map(|d| d.vendor_pk_index()) as u8;
-    let bytes = &data.to_le_bytes();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend FMC TCI (Hash)
-    let data = env.data_vault().map(|d| d.fmc_tci());
-    let bytes: &[u8; 48] = &data.into();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
-
-    // Extend FMC SVN
-    let data = env.data_vault().map(|d| d.fmc_svn()) as u8;
-    let bytes = &data.to_le_bytes();
-    sha.map(|s| pcr_bank.map(|p| p.extend_pcr(pcr_id, s, bytes)))?;
+    // TODO: Check PCR0 != 0
 
     Ok(())
 }


### PR DESCRIPTION
This is no longer needed as we do not have the PCR locking semantics to make it useful.