### PR TITLE
HwModelVerilated: Support tracing AHB and APB bus.

### DIFF
--- a/hw-latest/verilated/caliptra_verilated.cpp
+++ b/hw-latest/verilated/caliptra_verilated.cpp
@@ -82,4 +82,17 @@ void caliptra_verilated_eval(struct caliptra_verilated* model,
   out->generic_load_data = v->generic_load_data;
 
   out->etrng_req = v->etrng_req;
+
+  out->uc_haddr = v->uc_haddr;
+  out->uc_hburst = v->uc_hburst;
+  out->uc_hmastlock = v->uc_hmastlock;
+  out->uc_hprot = v->uc_hprot;
+  out->uc_hsize = v->uc_hsize;
+  out->uc_htrans = v->uc_htrans;
+  out->uc_hwrite = v->uc_hwrite;
+  out->uc_hwdata = v->uc_hwdata;
+
+  out->uc_hrdata = v->uc_hrdata;
+  out->uc_hready = v->uc_hready;
+  out->uc_hresp = v->uc_hresp;
 }

--- a/hw-latest/verilated/caliptra_verilated.h
+++ b/hw-latest/verilated/caliptra_verilated.h
@@ -43,6 +43,19 @@ struct caliptra_verilated_sig_out {
   uint32_t generic_load_data;
 
   bool etrng_req;
+
+  uint32_t uc_haddr;
+  uint8_t uc_hburst;
+  bool uc_hmastlock;
+  uint8_t uc_hprot;
+  uint8_t uc_hsize;
+  uint8_t uc_htrans;
+  bool uc_hwrite;
+  uint64_t uc_hwdata;
+
+  uint64_t uc_hrdata;
+  bool uc_hready;
+  bool uc_hresp;
 };
 
 struct caliptra_verilated_init_args {

--- a/hw-latest/verilated/caliptra_verilated.sv
+++ b/hw-latest/verilated/caliptra_verilated.sv
@@ -52,11 +52,24 @@ module caliptra_verilated (
     output bit pslverr,
     output bit [`CALIPTRA_APB_DATA_WIDTH-1:0] prdata,
 
-
     output bit generic_load_en,
     output bit [31:0] generic_load_data,
 
-    output bit etrng_req
+    output bit etrng_req,
+
+    output bit [31:0] uc_haddr,
+    output bit [2:0] uc_hburst,
+    output bit uc_hmastlock,
+    output bit [3:0] uc_hprot,
+    output bit [2:0] uc_hsize,
+    output bit [1:0] uc_htrans,
+    output bit [63:0] uc_hwdata,
+    output bit uc_hwrite,
+
+    output bit [63:0] uc_hrdata,
+    output bit uc_hready,
+    output bit uc_hresp
+
     );
 
 
@@ -161,6 +174,19 @@ caliptra_top caliptra_top_dut (
 
 assign generic_load_en = caliptra_top_dut.soc_ifc_top1.i_soc_ifc_reg.field_combo.CPTRA_GENERIC_OUTPUT_WIRES[0].generic_wires.load_next;
 assign generic_load_data = caliptra_top_dut.soc_ifc_top1.i_soc_ifc_reg.field_combo.CPTRA_GENERIC_OUTPUT_WIRES[0].generic_wires.next;
+
+assign uc_haddr = caliptra_top_dut.rvtop.lsu_haddr;
+assign uc_hburst = caliptra_top_dut.rvtop.lsu_hburst;
+assign uc_hmastlock = caliptra_top_dut.rvtop.lsu_hmastlock;
+assign uc_hprot = caliptra_top_dut.rvtop.lsu_hprot;
+assign uc_hsize = caliptra_top_dut.rvtop.lsu_hsize;
+assign uc_htrans = caliptra_top_dut.rvtop.lsu_htrans;
+assign uc_hwdata = caliptra_top_dut.rvtop.lsu_hwdata;
+assign uc_hwrite = caliptra_top_dut.rvtop.lsu_hwrite;
+
+assign uc_hrdata = caliptra_top_dut.rvtop.lsu_hrdata;
+assign uc_hready = caliptra_top_dut.rvtop.lsu_hready;
+assign uc_hresp = caliptra_top_dut.rvtop.lsu_hresp;
 
 caliptra_veer_sram_export veer_sram_export_inst (
     .el2_mem_export(el2_mem_export.top)

--- a/hw-latest/verilated/src/bindings/real.rs
+++ b/hw-latest/verilated/src/bindings/real.rs
@@ -39,6 +39,17 @@ pub struct caliptra_verilated_sig_out {
     pub generic_load_en: bool,
     pub generic_load_data: u32,
     pub etrng_req: bool,
+    pub uc_haddr: u32,
+    pub uc_hburst: u8,
+    pub uc_hmastlock: bool,
+    pub uc_hprot: u8,
+    pub uc_hsize: u8,
+    pub uc_htrans: u8,
+    pub uc_hwrite: bool,
+    pub uc_hwdata: u64,
+    pub uc_hrdata: u64,
+    pub uc_hready: bool,
+    pub uc_hresp: bool,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/hw-model/src/bus_logger.rs
+++ b/hw-model/src/bus_logger.rs
@@ -1,0 +1,117 @@
+// Licensed under the Apache-2.0 license
+
+use std::{
+    cell::RefCell,
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+    rc::Rc,
+};
+
+use caliptra_emu_bus::Bus;
+use caliptra_emu_types::{RvAddr, RvData, RvSize};
+
+#[derive(Clone)]
+pub struct LogFile(Rc<RefCell<BufWriter<File>>>);
+impl LogFile {
+    pub fn open(path: &Path) -> std::io::Result<Self> {
+        Ok(Self(Rc::new(RefCell::new(BufWriter::new(File::create(
+            path,
+        )?)))))
+    }
+}
+impl Write for LogFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.borrow_mut().flush()
+    }
+}
+
+pub struct BusLogger<TBus: Bus> {
+    bus: TBus,
+    pub log: Option<LogFile>,
+}
+impl<TBus: Bus> BusLogger<TBus> {
+    pub fn new(bus: TBus) -> Self {
+        Self { bus, log: None }
+    }
+    pub fn log_read(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        result: Result<RvData, caliptra_emu_bus::BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(val) => {
+                    writeln!(log, "{bus_name} read{size} *0x{addr:08x} -> 0x{val:x}").unwrap()
+                }
+                Err(e) => {
+                    writeln!(log, "{bus_name} read{size}  *0x{addr:08x} ***FAULT {e:?}").unwrap()
+                }
+            }
+        }
+    }
+    pub fn log_write(
+        &mut self,
+        bus_name: &str,
+        size: RvSize,
+        addr: RvAddr,
+        val: RvData,
+        result: Result<(), caliptra_emu_bus::BusError>,
+    ) {
+        if addr < 0x1000_0000 {
+            // Don't care about memory
+            return;
+        }
+        if let Some(log) = &mut self.log {
+            let size = usize::from(size);
+            match result {
+                Ok(()) => {
+                    writeln!(log, "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x}").unwrap()
+                }
+                Err(e) => writeln!(
+                    log,
+                    "{bus_name} write{size} *0x{addr:08x} <- 0x{val:x} ***FAULT {e:?}"
+                )
+                .unwrap(),
+            }
+        }
+    }
+}
+impl<TBus: Bus> Bus for BusLogger<TBus> {
+    fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
+        let result = self.bus.read(size, addr);
+        self.log_read("UC", size, addr, result);
+        result
+    }
+
+    fn write(
+        &mut self,
+        size: RvSize,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), caliptra_emu_bus::BusError> {
+        let result = self.bus.write(size, addr, val);
+        self.log_write("UC", size, addr, val, result);
+        result
+    }
+    fn poll(&mut self) {
+        self.bus.poll();
+    }
+    fn warm_reset(&mut self) {
+        self.bus.warm_reset();
+    }
+    fn update_reset(&mut self) {
+        self.bus.update_reset();
+    }
+}

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -17,6 +17,7 @@ use rand::{rngs::StdRng, RngCore, SeedableRng};
 pub mod mmio;
 mod model_emulated;
 
+mod bus_logger;
 #[cfg(feature = "verilator")]
 mod model_verilated;
 mod output;


### PR DESCRIPTION
Example (note that the trace extension is .txt instead of .vcd):

```
$ CPTRA_TRACE_PATH=/tmp/trace.txt cargo test --features=verilator --release -p caliptra-test smoke_test
$ cat /tmp/trace.txt
SoC  read4 *0x300300ac -> 0x0
SoC write4 *0x30030200 <- 0x0
SoC write4 *0x30030204 <- 0x0
SoC write4 *0x30030208 <- 0x0
SoC write4 *0x3003020c <- 0x0
SoC write4 *0x30030210 <- 0x0
SoC write4 *0x30030214 <- 0x0
SoC write4 *0x30030218 <- 0x0
SoC write4 *0x3003021c <- 0x0
SoC write4 *0x30030220 <- 0x0
SoC write4 *0x30030224 <- 0x0
SoC write4 *0x30030228 <- 0x0
SoC write4 *0x3003022c <- 0x0
<snip>
UC write4 *0x100280a0 <- 0x0
UC write4 *0x100280a4 <- 0x0
UC write4 *0x100280a8 <- 0x0
UC write4 *0x100280ac <- 0x0
UC write4 *0x100280b0 <- 0x0
UC write4 *0x100280b4 <- 0x0
UC write4 *0x100280b8 <- 0x0
UC write4 *0x100280bc <- 0x0
UC  read4 *0x10028018 -> 0x1
UC write4 *0x10028010 <- 0x5
UC  read4 *0x10028018 -> 0x0
UC  read4 *0x10028018 -> 0x0
UC  read4 *0x10028018 -> 0x0
UC  read4 *0x10028018 -> 0x0
UC  read4 *0x10028018 -> 0x0
UC  read4 *0x10028018 -> 0x3
UC  read4 *0x10028100 -> 0xe3b0c442
UC  read4 *0x10028104 -> 0x98fc1c14
UC  read4 *0x10028108 -> 0x9afbf4c8
UC  read4 *0x1002810c -> 0x996fb924
UC  read4 *0x10028110 -> 0x27ae41e4
UC  read4 *0x10028114 -> 0x649b934c
UC  read4 *0x10028118 -> 0xa495991b
UC  read4 *0x1002811c -> 0x7852b855
UC write4 *0x300300c8 <- 0x5b
UC write4 *0x300300c8 <- 0x6b
UC write4 *0x300300c8 <- 0x61
UC write4 *0x300300c8 <- 0x74
```