### PR TITLE
Cleanup ROM CSR test logic

### DIFF
--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -20,8 +20,9 @@ use super::dice::{DiceInput, DiceLayer, DiceOutput};
 use super::x509::X509;
 use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::flow::cold_reset::{KEY_ID_CDI, KEY_ID_FMC_PRIV_KEY};
+use crate::print::HexBytes;
 use crate::verifier::RomImageVerificationEnv;
-use crate::{cprint, cprint_slice, cprintln, pcr};
+use crate::{cprint, cprintln, pcr};
 use crate::{rom_env::RomEnv, rom_err_def};
 use caliptra_common::dice;
 use caliptra_drivers::{
@@ -436,13 +437,13 @@ impl FmcAliasLayer {
 
         let _pub_x: [u8; 48] = pub_key.x.into();
         let _pub_y: [u8; 48] = pub_key.y.into();
-        cprint_slice!("[afmc] PUB.X", _pub_x);
-        cprint_slice!("[afmc] PUB.Y", _pub_y);
+        cprintln!("[afmc] PUB.X = {}", HexBytes(&_pub_x));
+        cprintln!("[afmc] PUB.Y = {}", HexBytes(&_pub_y));
 
         let _sig_r: [u8; 48] = sig.r.into();
         let _sig_s: [u8; 48] = sig.s.into();
-        cprint_slice!("[afmc] SIG.R", _sig_r);
-        cprint_slice!("[afmc] SIG.S", _sig_s);
+        cprintln!("[afmc] SIG.R = {}", HexBytes(&_sig_r));
+        cprintln!("[afmc] SIG.S = {}", HexBytes(&_sig_s));
 
         // Lock the FMC Certificate Signature in data vault until next boot
         env.data_vault().map(|d| d.set_fmc_dice_signature(&sig));

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -16,9 +16,9 @@ Abstract:
 use super::crypto::*;
 use super::dice::*;
 use super::x509::*;
-use crate::cprint_slice;
 use crate::cprintln;
 use crate::flow::cold_reset::{KEY_ID_CDI, KEY_ID_FE, KEY_ID_IDEVID_PRIV_KEY, KEY_ID_UDS};
+use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
 use crate::rom_err_def;
 use caliptra_drivers::*;
@@ -244,15 +244,15 @@ impl InitDevIdLayer {
 
         let _sig_r: [u8; 48] = sig.r.into();
         let _sig_s: [u8; 48] = sig.s.into();
-        cprint_slice!("[idev] SIG.R", _sig_r);
-        cprint_slice!("[idev] SIG.S", _sig_s);
+        cprintln!("[idev] SIG.R = {}", HexBytes(&_sig_r));
+        cprintln!("[idev] SIG.S = {}", HexBytes(&_sig_s));
 
         // Build the CSR with `To Be Signed` & `Signature`
         let mut csr = [0u8; MAX_CSR_SIZE];
         let csr_bldr =
             Ecdsa384CsrBuilder::new(tbs.tbs(), &sig.to_ecdsa()).ok_or(err_u32!(CsrBuilderInit))?;
         let csr_len = csr_bldr.build(&mut csr).ok_or(err_u32!(CsrBuilderBuild))?;
-        cprint_slice!("[idev] CSR", csr);
+        cprintln!("[idev] CSR = {}", HexBytes(&csr));
 
         // Execute Send CSR Flow
         Self::send_csr(env, InitDevIdCsr::new(&csr, csr_len))

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -252,7 +252,7 @@ impl InitDevIdLayer {
         let csr_bldr =
             Ecdsa384CsrBuilder::new(tbs.tbs(), &sig.to_ecdsa()).ok_or(err_u32!(CsrBuilderInit))?;
         let csr_len = csr_bldr.build(&mut csr).ok_or(err_u32!(CsrBuilderBuild))?;
-        cprintln!("[idev] CSR = {}", HexBytes(&csr));
+        cprintln!("[idev] CSR = {}", HexBytes(&csr[..csr_len]));
 
         // Execute Send CSR Flow
         Self::send_csr(env, InitDevIdCsr::new(&csr, csr_len))

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -16,10 +16,10 @@ Abstract:
 use super::crypto::*;
 use super::dice::*;
 use super::x509::*;
-use crate::cprint_slice;
 use crate::cprintln;
 use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::flow::cold_reset::{KEY_ID_CDI, KEY_ID_FE, KEY_ID_LDEVID_PRIV_KEY};
+use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
 use crate::rom_err_def;
 use caliptra_drivers::*;
@@ -175,13 +175,13 @@ impl LocalDevIdLayer {
 
         let _pub_x: [u8; 48] = pub_key.x.into();
         let _pub_y: [u8; 48] = pub_key.y.into();
-        cprint_slice!("[ldev] PUB.X", _pub_x);
-        cprint_slice!("[ldev] PUB.Y", _pub_y);
+        cprintln!("[ldev] PUB.X = {}", HexBytes(&_pub_x));
+        cprintln!("[ldev] PUB.Y = {}", HexBytes(&_pub_y));
 
         let _sig_r: [u8; 48] = sig.r.into();
         let _sig_s: [u8; 48] = sig.s.into();
-        cprint_slice!("[ldev] SIG.R", _sig_r);
-        cprint_slice!("[ldev] SIG.S", _sig_s);
+        cprintln!("[ldev] SIG.R = {}", HexBytes(&_sig_r));
+        cprintln!("[ldev] SIG.S = {}", HexBytes(&_sig_s));
 
         // Lock the Local Device ID cert signature in data vault until
         // cold reset

--- a/rom/dev/src/print.rs
+++ b/rom/dev/src/print.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 use core::convert::Infallible;
-use ufmt::uWrite;
+use ufmt::{uDisplay, uWrite};
 
 #[derive(Default)]
 pub struct RomPrinter;
@@ -51,13 +51,15 @@ macro_rules! cprintln {
     }}
 }
 
-#[macro_export]
-macro_rules! cprint_slice  {
-    ($name:expr, $arr:expr) => {
-        $crate::cprint!("{} = ", $name);
-        for byte in $arr {
-            $crate::cprint!("{:02X}" byte);
+pub struct HexBytes<'a>(pub &'a [u8]);
+impl uDisplay for HexBytes<'_> {
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        for byte in self.0.iter() {
+            ufmt::uwrite!(f, "{:02X}", *byte)?;
         }
-        $crate::cprintln!("");
+        Ok(())
     }
 }

--- a/rom/dev/tests/helpers.rs
+++ b/rom/dev/tests/helpers.rs
@@ -5,8 +5,6 @@ use caliptra_hw_model::DefaultHwModel;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_image_types::ImageBundle;
 
-const MAX_CSR_SIZE: usize = 512;
-
 pub fn build_hw_model_and_image_bundle(
     fuses: Fuses,
     image_options: ImageOptions,
@@ -49,21 +47,19 @@ pub fn get_data(to_match: &str, haystack: &str) -> String {
     str
 }
 
-pub fn get_csr(hw: &mut DefaultHwModel) -> [u8; MAX_CSR_SIZE] {
-    let mut csr_downloaded = [0u8; MAX_CSR_SIZE];
+pub fn get_csr(hw: &mut DefaultHwModel) -> Vec<u8> {
+    let mut csr_downloaded = Vec::new();
     hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().status() == 0x0800_0000);
     let mbox = hw.soc_mbox();
     let byte_count = mbox.dlen().read() as usize;
     let remainder = byte_count % core::mem::size_of::<u32>();
     let n = byte_count - remainder;
-    let mut idx = 0;
     for _ in (0..n).step_by(core::mem::size_of::<u32>()) {
-        csr_downloaded[idx..idx + 4].copy_from_slice(&mbox.dataout().read().to_le_bytes());
-        idx += 4;
+        csr_downloaded.extend_from_slice(&mbox.dataout().read().to_le_bytes());
     }
     if remainder > 0 {
         let part = mbox.dataout().read();
-        csr_downloaded[idx..idx + 4].copy_from_slice(&part.to_le_bytes());
+        csr_downloaded.extend_from_slice(&part.to_le_bytes()[0..remainder]);
     }
     hw.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
     csr_downloaded

--- a/rom/dev/tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/test_idevid_derivation.rs
@@ -20,7 +20,7 @@ fn test_generate_csr() {
         .write(|_| flags.bits());
 
     // Download the CSR from the mailbox.
-    let csr_downloaded = helpers::get_csr(&mut hw);
+    let csr_downloaded = helpers::get_csr(&mut hw).unwrap();
 
     // Wait for uploading firmware.
     hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_fw());


### PR DESCRIPTION
- Replace cprint_slice with HexBytes(). This has a few benefits:
    - Smaller code size (rom is 320 bytes smaller).
    - Callers can pass slices rather than fixed-size arrays.
- Don't print out extra bytes at end of CSR buffer in the ROM
- Use HwModel::wait_for_mailbox_receive() to get ROM CSR.

