### PR TITLE
[fix] Emulator should generate an NMI when CPU tries to write to a locked ICCM.

### DIFF
--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -25,6 +25,12 @@ path = "test_iccm_byte_write.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "test_iccm_write_locked"
+path = "test_iccm_write_locked.rs"
+required-features = ["riscv"]
+
+
+[[bin]]
 name = "mailbox_responder"
 path = "mailbox_responder.rs"
 required-features = ["riscv"]
@@ -33,3 +39,4 @@ required-features = ["riscv"]
 name = "mailbox_sender"
 path = "mailbox_sender.rs"
 required-features = ["riscv"]
+

--- a/hw-model/test-fw/test_iccm_write_locked.rs
+++ b/hw-model/test-fw/test_iccm_write_locked.rs
@@ -1,0 +1,28 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that sends mailbox transactions.
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::println;
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    let soc_ifc_regs = caliptra_registers::soc_ifc::RegisterBlock::soc_ifc_reg();
+    soc_ifc_regs.internal_iccm_lock().modify(|w| w.lock(true));
+
+    unsafe {
+        let iccm_start = 0x40000000_u32;
+        let iccm_ptr = iccm_start as *mut u32;
+        *iccm_ptr = 0xdeadbeef;
+    }
+    loop {}
+}

--- a/hw-model/tests/model_tests.rs
+++ b/hw-model/tests/model_tests.rs
@@ -74,3 +74,22 @@ fn test_iccm_unaligned_write_nmi_failure() {
     assert!(ext_info.mepc >= main_addr + 4 && ext_info.mepc <= main_addr + 12);
     assert_eq!(ext_info.mcause, harness::NMI_CAUSE_DBUS_STORE_ERROR);
 }
+
+#[test]
+fn test_iccm_write_locked_nmi_failure() {
+    let elf = caliptra_builder::build_firmware_elf(&FwId {
+        bin_name: "test_iccm_write_locked",
+        ..BASE_FWID
+    })
+    .unwrap();
+
+    let mut model = run_fw_elf(&elf);
+    model.step_until_exit_success().unwrap_err();
+    let soc_ifc: caliptra_registers::soc_ifc::RegisterBlock<_> = model.soc_ifc();
+    assert_eq!(
+        soc_ifc.cptra_fw_error_non_fatal().read(),
+        harness::ERROR_NMI
+    );
+    let ext_info = harness::ExtErrorInfo::from(soc_ifc.cptra_fw_extended_error_info().read());
+    assert_eq!(ext_info.mcause, harness::NMI_CAUSE_DBUS_STORE_ERROR);
+}


### PR DESCRIPTION
Write accesses to a locked ICCM should result in an NMI.  This commit provides a test which can be run against the Verilator model and the emulation model plus the associated  software emulator fix to align the emulated behavior to the RTL. 

How to validate : 
cargo test --release -p caliptra-hw-model --features verilator
cargo test --release -p caliptra-hw-model 