### PR TITLE
Add ECDSA verify mailbox command

### DIFF
--- a/drivers/tests/integration_tests.rs
+++ b/drivers/tests/integration_tests.rs
@@ -190,7 +190,7 @@ fn test_mailbox_soc_to_uc() {
     {
         assert_eq!(
             model.mailbox_execute(0x8000_0000, &[0x88, 0x99, 0xaa, 0xbb]),
-            Err(ModelError::MailboxCmdFailed)
+            Err(ModelError::MailboxCmdFailed(0))
         );
         assert_eq!(model.output().take(usize::MAX), "cmd: 0x80000000\n");
 

--- a/rom/dev/tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/test_fmcalias_derivation.rs
@@ -17,7 +17,7 @@ fn test_zero_firmware_size() {
     // Zero-sized firmware.
     assert_eq!(
         hw.upload_firmware(&[]).unwrap_err(),
-        ModelError::MailboxCmdFailed
+        ModelError::MailboxCmdFailed(0x01020003)
     );
     assert_eq!(
         hw.soc_ifc().cptra_fw_error_non_fatal().read(),

--- a/rom/dev/tests/test_image_validation.rs
+++ b/rom/dev/tests/test_image_validation.rs
@@ -96,13 +96,9 @@ fn test_invalid_manifest_marker() {
     image_bundle.manifest.marker = 0xDEADBEEF;
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(MANIFEST_MARKER_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        MANIFEST_MARKER_MISMATCH
     );
 }
 
@@ -113,13 +109,9 @@ fn test_invalid_manifest_size() {
     image_bundle.manifest.size = (core::mem::size_of::<ImageManifest>() - 1) as u32;
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(MANIFEST_SIZE_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        MANIFEST_SIZE_MISMATCH
     );
 }
 
@@ -134,13 +126,9 @@ fn test_preamble_zero_vendor_pubkey_digest() {
         helpers::build_hw_model_and_image_bundle(fuses, ImageOptions::default());
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_PUB_KEY_DIGEST_INVALID),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_PUB_KEY_DIGEST_INVALID
     );
 }
 
@@ -155,13 +143,9 @@ fn test_preamble_vendor_pubkey_digest_mismatch() {
     let (mut hw, image_bundle) =
         helpers::build_hw_model_and_image_bundle(fuses, ImageOptions::default());
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_PUB_KEY_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_PUB_KEY_DIGEST_MISMATCH
     );
 }
 
@@ -176,13 +160,9 @@ fn test_preamble_owner_pubkey_digest_mismatch() {
         helpers::build_hw_model_and_image_bundle(fuses, ImageOptions::default());
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_PUB_KEY_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_PUB_KEY_DIGEST_MISMATCH
     );
 }
 
@@ -232,13 +212,9 @@ fn test_preamble_vendor_pubkey_revocation() {
                 .unwrap();
         } else {
             assert_eq!(
-                ModelError::MailboxCmdFailed,
+                ModelError::MailboxCmdFailed(VENDOR_ECC_PUB_KEY_REVOKED),
                 hw.upload_firmware(&image_bundle.to_bytes().unwrap())
                     .unwrap_err()
-            );
-            assert_eq!(
-                hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-                VENDOR_ECC_PUB_KEY_REVOKED
             );
         }
     }
@@ -251,13 +227,9 @@ fn test_preamble_vendor_pubkey_out_of_bounds() {
     image_bundle.manifest.preamble.vendor_ecc_pub_key_idx = VENDOR_ECC_KEY_COUNT;
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS
     );
 }
 
@@ -275,14 +247,9 @@ fn test_header_verify_vendor_sig_zero_pubkey() {
         .fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_PUB_KEY_DIGEST_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_PUB_KEY_DIGEST_INVALID_ARG
     );
 
     let (mut hw, mut image_bundle) =
@@ -296,13 +263,9 @@ fn test_header_verify_vendor_sig_zero_pubkey() {
         .fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_PUB_KEY_DIGEST_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_PUB_KEY_DIGEST_INVALID_ARG
     );
 }
 
@@ -316,13 +279,9 @@ fn test_header_verify_vendor_sig_zero_signature() {
     image_bundle.manifest.preamble.vendor_sigs.ecc_sig.r.fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_SIGNATURE_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_SIGNATURE_INVALID_ARG
     );
 
     let (mut hw, mut image_bundle) =
@@ -333,13 +292,9 @@ fn test_header_verify_vendor_sig_zero_signature() {
     image_bundle.manifest.preamble.vendor_sigs.ecc_sig.s.fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_SIGNATURE_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_SIGNATURE_INVALID_ARG
     );
 }
 
@@ -361,13 +316,9 @@ fn test_header_verify_vendor_sig_mismatch() {
         .clone_from_slice(Array4x12::from(PUB_KEY_Y).0.as_slice());
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_SIGNATURE_INVALID),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_SIGNATURE_INVALID
     );
 
     let (mut hw, mut image_bundle) =
@@ -392,13 +343,9 @@ fn test_header_verify_vendor_sig_mismatch() {
         .clone_from_slice(Array4x12::from(SIGNATURE_S).0.as_slice());
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_SIGNATURE_INVALID),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_SIGNATURE_INVALID
     );
 }
 
@@ -413,13 +360,9 @@ fn test_header_verify_vendor_pub_key_in_preamble_and_header() {
     update_header(&mut image_bundle);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(VENDOR_ECC_PUB_KEY_INDEX_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        VENDOR_ECC_PUB_KEY_INDEX_MISMATCH
     );
 }
 
@@ -484,14 +427,9 @@ fn test_header_verify_owner_sig_zero_fuses_zero_pubkey_x() {
     .unwrap();
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_PUB_KEY_DIGEST_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_PUB_KEY_DIGEST_INVALID_ARG
     );
 }
 
@@ -522,14 +460,9 @@ fn test_header_verify_owner_sig_corrupt_fuses() {
     .unwrap();
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_PUB_KEY_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_PUB_KEY_DIGEST_MISMATCH
     );
 }
 
@@ -573,14 +506,9 @@ fn test_header_verify_owner_sig_zero_pubkey_x() {
     .unwrap();
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_PUB_KEY_DIGEST_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_PUB_KEY_DIGEST_INVALID_ARG
     );
 }
 
@@ -624,14 +552,9 @@ fn test_header_verify_owner_sig_zero_pubkey_y() {
     .unwrap();
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_PUB_KEY_DIGEST_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_PUB_KEY_DIGEST_INVALID_ARG
     );
 }
 
@@ -669,14 +592,9 @@ fn test_header_verify_owner_sig_zero_signature_r() {
     image_bundle.manifest.preamble.owner_sigs.ecc_sig.r.fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_ECC_SIGNATURE_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_ECC_SIGNATURE_INVALID_ARG
     );
 }
 
@@ -714,14 +632,9 @@ fn test_header_verify_owner_sig_zero_signature_s() {
     image_bundle.manifest.preamble.owner_sigs.ecc_sig.s.fill(0);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(OWNER_ECC_SIGNATURE_INVALID_ARG),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        OWNER_ECC_SIGNATURE_INVALID_ARG
     );
 }
 
@@ -735,13 +648,9 @@ fn test_toc_invalid_entry_count() {
     update_header(&mut image_bundle);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(TOC_ENTRY_COUNT_INVALID),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        TOC_ENTRY_COUNT_INVALID
     );
 }
 
@@ -755,13 +664,9 @@ fn test_toc_invalid_toc_digest() {
     update_header(&mut image_bundle);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(TOC_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        TOC_DIGEST_MISMATCH
     );
 }
 
@@ -784,12 +689,8 @@ fn test_toc_fmc_range_overlap() {
         runtime_new_size,
     );
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_RUNTIME_OVERLAP),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_RUNTIME_OVERLAP
     );
 
     // Case 2: FMC offset > Runtime offset
@@ -809,12 +710,8 @@ fn test_toc_fmc_range_overlap() {
     );
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_RUNTIME_OVERLAP),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_RUNTIME_OVERLAP
     );
 
     // // Case 3: FMC start offset < Runtime offset < FMC end offset
@@ -834,12 +731,8 @@ fn test_toc_fmc_range_overlap() {
     );
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_RUNTIME_OVERLAP),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_RUNTIME_OVERLAP
     );
 }
 
@@ -860,12 +753,8 @@ fn test_toc_fmc_range_incorrect_order() {
         runtime_new_size,
     );
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_RUNTIME_INCORRECT_ORDER),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_RUNTIME_INCORRECT_ORDER
     );
 }
 
@@ -878,13 +767,9 @@ fn test_fmc_digest_mismatch() {
     image_bundle.fmc[0..4].copy_from_slice(0xDEADBEEFu32.as_bytes());
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_DIGEST_MISMATCH
     );
 }
 
@@ -895,12 +780,8 @@ fn test_fmc_invalid_load_addr_before_iccm() {
 
     let image = update_load_addr(&mut image_bundle, true, ICCM_START_ADDR - 4);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_LOAD_ADDR_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_LOAD_ADDR_INVALID
     );
 }
 
@@ -911,12 +792,8 @@ fn test_fmc_invalid_load_addr_after_iccm() {
 
     let image = update_load_addr(&mut image_bundle, true, ICCM_END_ADDR + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_LOAD_ADDR_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_LOAD_ADDR_INVALID
     );
 }
 
@@ -927,12 +804,8 @@ fn test_fmc_load_addr_unaligned() {
     let load_addr = image_bundle.manifest.fmc.load_addr;
     let image = update_load_addr(&mut image_bundle, true, load_addr + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_LOAD_ADDR_UNALIGNED),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_LOAD_ADDR_UNALIGNED
     );
 }
 
@@ -943,12 +816,8 @@ fn test_fmc_invalid_entry_point_before_iccm() {
 
     let image = update_entry_point(&mut image_bundle, true, ICCM_START_ADDR - 4);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_ENTRY_POINT_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_ENTRY_POINT_INVALID
     );
 }
 
@@ -959,12 +828,8 @@ fn test_fmc_invalid_entry_point_after_iccm() {
 
     let image = update_entry_point(&mut image_bundle, true, ICCM_END_ADDR + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_ENTRY_POINT_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_ENTRY_POINT_INVALID
     );
 }
 
@@ -976,12 +841,8 @@ fn test_fmc_entry_point_unaligned() {
 
     let image = update_entry_point(&mut image_bundle, true, entry_point + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_ENTRY_POINT_UNALIGNED),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_ENTRY_POINT_UNALIGNED
     );
 }
 
@@ -1008,13 +869,9 @@ fn test_fmc_svn_greater_than_32() {
 
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_SVN_GREATER_THAN_MAX_SUPPORTED),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_SVN_GREATER_THAN_MAX_SUPPORTED
     );
 }
 
@@ -1041,13 +898,9 @@ fn test_fmc_svn_less_than_min_svn() {
     };
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_SVN_LESS_THAN_MIN_SUPPORTED),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_SVN_LESS_THAN_MIN_SUPPORTED
     );
 }
 
@@ -1075,13 +928,9 @@ fn test_fmc_svn_less_than_fuse_svn() {
 
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(FMC_SVN_LESS_THAN_FUSE),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        FMC_SVN_LESS_THAN_FUSE
     );
 }
 
@@ -1093,13 +942,9 @@ fn test_runtime_digest_mismatch() {
     // Change the FMC image.
     image_bundle.runtime[0..4].copy_from_slice(0xDEADBEEFu32.as_bytes());
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_DIGEST_MISMATCH),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_DIGEST_MISMATCH
     );
 }
 
@@ -1110,12 +955,8 @@ fn test_runtime_invalid_load_addr_before_iccm() {
 
     let image = update_load_addr(&mut image_bundle, false, ICCM_START_ADDR - 4);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_LOAD_ADDR_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_LOAD_ADDR_INVALID
     );
 }
 
@@ -1126,12 +967,8 @@ fn test_runtime_invalid_load_addr_after_iccm() {
 
     let image = update_load_addr(&mut image_bundle, false, ICCM_END_ADDR + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_LOAD_ADDR_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_LOAD_ADDR_INVALID
     );
 }
 
@@ -1142,12 +979,8 @@ fn test_runtime_load_addr_unaligned() {
     let load_addr = image_bundle.manifest.runtime.load_addr;
     let image = update_load_addr(&mut image_bundle, false, load_addr + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_LOAD_ADDR_UNALIGNED),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_LOAD_ADDR_UNALIGNED
     );
 }
 
@@ -1158,12 +991,8 @@ fn test_runtime_invalid_entry_point_before_iccm() {
 
     let image = update_entry_point(&mut image_bundle, false, ICCM_START_ADDR - 4);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_ENTRY_POINT_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_ENTRY_POINT_INVALID
     );
 }
 
@@ -1174,12 +1003,8 @@ fn test_runtime_invalid_entry_point_after_iccm() {
 
     let image = update_entry_point(&mut image_bundle, false, ICCM_END_ADDR + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_ENTRY_POINT_INVALID),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_ENTRY_POINT_INVALID
     );
 }
 
@@ -1190,12 +1015,8 @@ fn test_runtime_entry_point_unaligned() {
     let entry_point = image_bundle.manifest.runtime.entry_point;
     let image = update_entry_point(&mut image_bundle, false, entry_point + 1);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_ENTRY_POINT_UNALIGNED),
         hw.upload_firmware(&image).unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_ENTRY_POINT_UNALIGNED
     );
 }
 
@@ -1221,13 +1042,9 @@ fn test_runtime_svn_greater_than_64() {
 
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_SVN_GREATER_THAN_MAX_SUPPORTED),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_SVN_GREATER_THAN_MAX_SUPPORTED
     );
 }
 
@@ -1255,13 +1072,9 @@ fn test_runtime_svn_less_than_min_svn() {
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
 
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_SVN_LESS_THAN_MIN_SUPPORTED),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
-    );
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        RUNTIME_SVN_LESS_THAN_MIN_SUPPORTED
     );
 }
 
@@ -1289,7 +1102,7 @@ fn test_runtime_svn_less_than_fuse_svn() {
 
     let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
     assert_eq!(
-        ModelError::MailboxCmdFailed,
+        ModelError::MailboxCmdFailed(RUNTIME_SVN_LESS_THAN_FUSE),
         hw.upload_firmware(&image_bundle.to_bytes().unwrap())
             .unwrap_err()
     );

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -140,6 +140,9 @@ Table: `GET_LDEV_CERT` output arguments
 
 ### ECDSA384\_SIGNATURE\_VERIFY
 
+Verifies an ECDSA P-384 signature. The hash to be verified is taken from
+Caliptra's SHA384 accelerator peripheral.
+
 Command Code: `0x5349_4756` ("SIGV")
 
 Table: `ECDSA384_SIGNATURE_VERIFY` input arguments
@@ -147,7 +150,6 @@ Table: `ECDSA384_SIGNATURE_VERIFY` input arguments
 | **Name**     | **Type** | **Description**
 | --------     | -------- | ---------------
 | chksum       | u32      | Checksum over other input arguments, computed by the caller. Little endian.
-| data         | u8[48]   | Signed hash to verify
 | pub\_key\_x  | u8[48]   | X portion of ECDSA verification key
 | pub\_key\_y  | u8[48]   | Y portion of ECDSA verification key
 | signature\_r | u8[48]   | R portion of signature to verify

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3,14 +3,14 @@
 #![no_std]
 
 mod mailbox;
+mod verify;
 
 use mailbox::Mailbox;
 
 use caliptra_common::cprintln;
 use caliptra_drivers::{caliptra_err_def, CaliptraResult};
-use caliptra_registers::mbox::enums::MboxStatusE;
-
-use core::mem::size_of;
+use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc};
+use zerocopy::{AsBytes, FromBytes};
 
 caliptra_err_def! {
     Runtime,
@@ -18,7 +18,60 @@ caliptra_err_def! {
     {
         // Internal
         InternalErr = 0x1,
+        UnimplementedCommand = 0x2,
+        InsufficientMemory = 0x3,
     }
+}
+
+#[derive(PartialEq, Eq)]
+pub struct CommandId(pub u32);
+
+impl CommandId {
+    pub const FIRMWARE_LOAD: Self = Self(0x46574C44); // "FWLD"
+    pub const GET_IDEV_CSR: Self = Self(0x49444556); // "IDEV"
+    pub const GET_LDEV_CERT: Self = Self(0x4C444556); // "LDEV"
+    pub const ECDSA384_VERIFY: Self = Self(0x53494756); // "SIGV"
+    pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
+    pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
+}
+impl From<u32> for CommandId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+impl From<CommandId> for u32 {
+    fn from(value: CommandId) -> Self {
+        value.0
+    }
+}
+
+#[repr(C)]
+#[derive(AsBytes, FromBytes)]
+pub struct EcdsaVerifyCmd {
+    pub chksum: u32,
+    pub pub_key_x: [u8; 48],
+    pub pub_key_y: [u8; 48],
+    pub signature_r: [u8; 48],
+    pub signature_s: [u8; 48],
+}
+
+impl Default for EcdsaVerifyCmd {
+    fn default() -> Self {
+        Self {
+            chksum: 0,
+            pub_key_x: [0u8; 48],
+            pub_key_y: [0u8; 48],
+            signature_r: [0u8; 48],
+            signature_s: [0u8; 48],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(AsBytes, FromBytes)]
+pub struct EcdsaVerifyResponse {
+    pub chksum: u32,
+    pub result: u32,
 }
 
 fn wait_for_cmd() {
@@ -29,21 +82,40 @@ fn wait_for_cmd() {
     //}
 }
 
-fn handle_command() -> CaliptraResult<()> {
+fn handle_command() -> CaliptraResult<MboxStatusE> {
     let cmd_id = Mailbox::cmd();
+    let dlen = Mailbox::dlen() as usize;
     let dlen_words = Mailbox::dlen_words() as usize;
     let mut buf = [0u32; 1024];
     Mailbox::copy_from_mbox(buf.get_mut(..dlen_words).ok_or(err_u32!(InternalErr))?);
 
-    // TODO: Actually handle command
-    cprintln!("[rt] Received command={}, len={}", cmd_id, Mailbox::dlen());
+    if dlen > buf.len() * 4 {
+        // dlen larger than max message
+        return Err(err_u32!(InsufficientMemory));
+    }
 
-    // Write response
-    let out_buf = [0xFFFFFFFFu32; 4];
-    Mailbox::set_dlen((out_buf.len() * size_of::<u32>()) as u32);
-    Mailbox::copy_to_mbox(&out_buf);
+    let cmd_bytes = buf
+        .as_bytes()
+        .get(..dlen)
+        .ok_or(err_u32!(InsufficientMemory))?;
 
-    Ok(())
+    cprintln!(
+        "[rt] Received command=0x{:x}, len={}",
+        cmd_id,
+        Mailbox::dlen()
+    );
+    match CommandId::from(cmd_id) {
+        CommandId::FIRMWARE_LOAD => Err(err_u32!(UnimplementedCommand)),
+        CommandId::GET_IDEV_CSR => Err(err_u32!(UnimplementedCommand)),
+        CommandId::GET_LDEV_CERT => Err(err_u32!(UnimplementedCommand)),
+        CommandId::ECDSA384_VERIFY => {
+            verify::handle_ecdsa_verify(cmd_bytes)?;
+            Ok(MboxStatusE::DataReady)
+        }
+        CommandId::STASH_MEASUREMENT => Err(err_u32!(UnimplementedCommand)),
+        CommandId::INVOKE_DPE => Err(err_u32!(UnimplementedCommand)),
+        _ => Err(err_u32!(UnimplementedCommand)),
+    }
 }
 
 pub fn handle_mailbox_commands() {
@@ -51,10 +123,16 @@ pub fn handle_mailbox_commands() {
         wait_for_cmd();
 
         if Mailbox::is_cmd_ready() {
-            if handle_command().is_ok() {
-                Mailbox::set_status(MboxStatusE::DataReady);
-            } else {
-                Mailbox::set_status(MboxStatusE::CmdFailure);
+            match handle_command() {
+                Ok(status) => {
+                    Mailbox::set_status(status);
+                }
+                Err(e) => {
+                    let soc_ifc_regs = soc_ifc::RegisterBlock::soc_ifc_reg();
+                    soc_ifc_regs.cptra_fw_error_non_fatal().write(|_| e.into());
+
+                    Mailbox::set_status(MboxStatusE::CmdFailure);
+                }
             }
         }
     }

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{EcdsaVerifyCmd, EcdsaVerifyResponse, Mailbox, RuntimeErr};
+use caliptra_drivers::{
+    Array4x12, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Scalar, Ecc384Signature,
+};
+use caliptra_registers::sha512_acc;
+use zerocopy::{AsBytes, FromBytes};
+
+/// Handle the `ECDSA384_SIGNATURE_VERIFY` mailbox command
+pub fn handle_ecdsa_verify(cmd_args: &[u8]) -> CaliptraResult<()> {
+    if let Some(cmd) = EcdsaVerifyCmd::read_from(cmd_args) {
+        let sha_acc = sha512_acc::RegisterBlock::sha512_acc_csr();
+
+        // Won't panic, full_digest is always larger than digest
+        let full_digest = sha_acc.digest().read();
+        let mut digest = Array4x12::default();
+        for (i, target_word) in digest.0.iter_mut().enumerate() {
+            *target_word = full_digest[i];
+        }
+
+        let pubkey = Ecc384PubKey {
+            x: Ecc384Scalar::from(cmd.pub_key_x),
+            y: Ecc384Scalar::from(cmd.pub_key_y),
+        };
+
+        let sig = Ecc384Signature {
+            r: Ecc384Scalar::from(cmd.signature_r),
+            s: Ecc384Scalar::from(cmd.signature_s),
+        };
+
+        let ecdsa = Ecc384::default();
+        let success = ecdsa.verify(&pubkey, &digest, &sig)?;
+
+        let response = EcdsaVerifyResponse {
+            chksum: 0, // TODO: Implement checksum
+            result: success as u32,
+        };
+
+        Mailbox::write_response(response.as_bytes())?;
+    } else {
+        return Err(RuntimeErr::InsufficientMemory.into());
+    };
+
+    Ok(())
+}

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -294,9 +294,8 @@ impl CaliptraRootBus {
 
     pub fn soc_to_caliptra_bus(&self) -> SocToCaliptraBus {
         SocToCaliptraBus {
-            // TODO: This should not be the same mailbox bus as the one used
-            // internaly
             mailbox: self.mailbox.as_external(),
+            sha512_acc: self.sha512_acc.clone(),
             soc_ifc: self.soc_reg.external_regs(),
         }
     }
@@ -306,6 +305,9 @@ impl CaliptraRootBus {
 pub struct SocToCaliptraBus {
     #[peripheral(offset = 0x3002_0000, mask = 0x0000_0fff)]
     mailbox: MailboxExternal,
+
+    #[peripheral(offset = 0x3002_1000, mask = 0x0000_0fff)]
+    sha512_acc: Sha512Accelerator,
 
     #[peripheral(offset = 0x3003_0000, mask = 0x0000_ffff)]
     soc_ifc: SocRegistersExternal,


### PR DESCRIPTION
Commit 1: Add support to sw-emulator for using the sha512acc from SoC in streaming mode

Commit 2: Add scaffolding more mailbox commands and implement the ECDSA verify command. The signature is assumed to be over the data hashed into the sha512acc peripheral.