### PR TITLE
Mailbox negative test cases

### DIFF
--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -65,6 +65,11 @@ path = "src/bin/mailbox_driver_sender.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "mailbox_driver_negative_tests"
+path = "src/bin/mailbox_driver_negative_tests.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "keyvault"
 path = "src/bin/keyvault_tests.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/mailbox_driver_negative_tests.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_negative_tests.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that uses the driver to send mailbox messages
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::{self, println};
+
+use caliptra_drivers::{self, Mailbox, MailboxSendTxn};
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+fn start_send_txn() -> MailboxSendTxn {
+    let mbox = Mailbox::default();
+    loop {
+        if let Some(txn) = mbox.try_start_send_txn() {
+            return txn;
+        }
+    }
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    // 0 byte request
+    // The SoC will try to corrupt the CMD opcode and the Dlen field.
+    let mut txn = start_send_txn();
+    txn.send_request(0xa000_0000, b"").unwrap();
+    while !txn.is_response_ready() {}
+    txn.complete().unwrap();
+}

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -630,6 +630,31 @@ mod tests {
     }
 
     #[test]
+    /// Violate the mailbox protocol by having the sender trying to write to mailbox in execute state.
+    fn test_mbox_negative() {
+        let mut model = caliptra_hw_model::new_unbooted(InitParams {
+            ..Default::default()
+        })
+        .unwrap();
+
+        model.soc_ifc().cptra_fuse_wr_done().write(|w| w.done(true));
+        model.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
+
+        assert!(!model.soc_mbox().lock().read().lock());
+        assert!(model.soc_mbox().lock().read().lock());
+
+        model.soc_mbox().cmd().write(|_| 4242);
+        assert_eq!(model.soc_mbox().cmd().read(), 4242);
+
+        model.soc_mbox().execute().write(|w| w.execute(true));
+        model.soc_mbox().dlen().write(|_| [1, 2, 3].len() as u32);
+        assert_eq!([1, 2, 3].len() as u32, model.soc_mbox().dlen().read());
+        let _ = caliptra_hw_model::mbox_write_fifo(&model.soc_mbox(), &[1, 2, 3]);
+        let buf = caliptra_hw_model::mbox_read_fifo(model.soc_mbox());
+        assert_eq!(buf, &[0, 0, 0]);
+    }
+
+    #[test]
     fn test_execution() {
         let mut model = caliptra_hw_model::new(BootParams {
             init_params: InitParams {

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -485,6 +485,11 @@ impl MailboxRegs {
 
     /// Write to execute register
     pub fn write_ex(&mut self, _size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Only the lock owner can clear the execute bit.
+        if self.requester != self.state_machine.context.user {
+            return Ok(());
+        }
+
         let event = {
             match self.requester {
                 MailboxRequester::Caliptra => {


### PR DESCRIPTION
Mailbox negative tests  detect compliance of the software emulator to the RTL by purposely violating the mailbox sender and receiver protocols.

- Violate the sender mailbox protocol by having the sender try to write to mailbox in execute state.
- Violate the receiver mailbox protocol by having the receiver  try to unlock the mailbox while in execute state.

How to validate :
cargo test --release -p caliptra-hw-model --features verilator
cargo test --release -p caliptra-hw-model