### PR TITLE
Fix emulator app callbacks

### DIFF
--- a/sw-emulator/app/src/main.rs
+++ b/sw-emulator/app/src/main.rs
@@ -251,7 +251,7 @@ fn main() -> io::Result<()> {
         }),
         ready_for_fw_cb: ReadyForFwCb::new(move |args| {
             // Lock the mailbox
-            while !args.mailbox.try_acquire_lock() {}
+            while !args.mailbox.as_external().try_acquire_lock() {}
 
             let firmware_buffer = current_fw_buf.clone();
             args.schedule_later(FW_WRITE_TICKS, move |mailbox: &mut MailboxInternal| {

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -734,9 +734,9 @@ impl SocRegistersImpl {
 
         if self.timer.fired(&mut self.op_fw_read_complete_action) {
             // Receiver sets status as CMD_COMPLETE after reading the mailbox data.
-            if !self.mailbox.is_status_cmd_busy() {
+            if !self.mailbox.as_external().is_status_cmd_busy() {
                 // Reset the execute bit
-                self.mailbox.write_execute(0).unwrap();
+                self.mailbox.as_external().write_execute(0).unwrap();
             } else {
                 self.op_fw_read_complete_action =
                     Some(self.timer.schedule_poll_in(Self::FW_READ_TICKS));


### PR DESCRIPTION
Emulator app  callbacks and complete actions inside the library were not using MailboxExternal.