### PR TITLE
Expose sw-emulator mbox regs via ureg. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-emu-types",
  "tock-registers",
+ "ureg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "caliptra-emu-derive",
  "caliptra-emu-types",
  "caliptra-hw-model-types",
+ "caliptra-registers",
  "lazy_static",
  "smlang",
  "tock-registers",

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -21,8 +21,8 @@ mod model_verilated;
 mod output;
 mod rv32_builder;
 
+pub use caliptra_emu_bus::BusMmio;
 pub use caliptra_hw_model_types::{DeviceLifecycle, Fuses, SecurityState, U4};
-pub use mmio::BusMmio;
 use output::ExitStatus;
 pub use output::Output;
 

--- a/hw-model/src/mmio.rs
+++ b/hw-model/src/mmio.rs
@@ -1,20 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use std::cell::{Cell, RefCell};
-
-use caliptra_emu_bus::Bus;
-use caliptra_emu_types::RvSize;
+use std::cell::Cell;
 
 use crate::rv32_builder::Rv32Builder;
-
-const fn rvsize<T>() -> RvSize {
-    match core::mem::size_of::<T>() {
-        1 => RvSize::Byte,
-        2 => RvSize::HalfWord,
-        4 => RvSize::Word,
-        _other => panic!("Unsupported RvSize"),
-    }
-}
 
 unsafe fn transmute_to_u32<T>(src: &T) -> u32 {
     match std::mem::size_of::<T>() {
@@ -22,63 +10,6 @@ unsafe fn transmute_to_u32<T>(src: &T) -> u32 {
         2 => std::mem::transmute_copy::<T, u16>(src).into(),
         4 => std::mem::transmute_copy::<T, u32>(src),
         _ => panic!("Unsupported write size"),
-    }
-}
-
-/// An MMIO implementation that reads and writes to a `caliptra_emu_bus::Bus`.
-pub struct BusMmio<TBus: Bus> {
-    bus: RefCell<TBus>,
-}
-impl<TBus: Bus> BusMmio<TBus> {
-    pub fn new(bus: TBus) -> Self {
-        Self {
-            bus: RefCell::new(bus),
-        }
-    }
-    pub fn into_inner(self) -> TBus {
-        self.bus.into_inner()
-    }
-}
-impl<TBus: Bus> ureg::Mmio for BusMmio<TBus> {
-    /// Loads from address `src` on the bus and returns the value.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if the bus faults.
-    ///
-    /// # Safety
-    ///
-    /// As the pointer isn't read from, this Mmio implementation isn't actually
-    /// unsafe for POD types like u8/u16/u32.
-    unsafe fn read_volatile<T: Clone + Copy + Sized>(&self, src: *const T) -> T {
-        let val_u32 = self
-            .bus
-            .borrow_mut()
-            .read(rvsize::<T>(), src as usize as u32)
-            .unwrap();
-        match std::mem::size_of::<T>() {
-            1 => std::mem::transmute_copy::<u8, T>(&(val_u32 as u8)),
-            2 => std::mem::transmute_copy::<u16, T>(&(val_u32 as u16)),
-            4 => std::mem::transmute_copy::<u32, T>(&val_u32),
-            _ => panic!("Unsupported read size"),
-        }
-    }
-
-    /// Stores `src` to address `dst` on the bus.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if the bus faults.
-    ///
-    /// # Safety
-    ///
-    /// As the pointer isn't written to, this Mmio implementation isn't actually
-    /// unsafe for POD types like u8/u16/u32.
-    unsafe fn write_volatile<T: Clone + Copy>(&self, dst: *mut T, src: T) {
-        self.bus
-            .borrow_mut()
-            .write(rvsize::<T>(), dst as usize as u32, transmute_to_u32(&src))
-            .unwrap()
     }
 }
 
@@ -121,28 +52,9 @@ impl ureg::Mmio for Rv32GenMmio {
 
 #[cfg(test)]
 mod tests {
-    use caliptra_emu_bus::Ram;
     use ureg::Mmio;
 
     use super::*;
-
-    #[test]
-    fn test_bus_mmio() {
-        let mmio = BusMmio::new(Ram::new(vec![0u8; 12]));
-        unsafe {
-            mmio.write_volatile(4 as *mut u32, 0x3abc_9321);
-            mmio.write_volatile(8 as *mut u16, 0x39af);
-            mmio.write_volatile(10 as *mut u8, 0xf3);
-
-            assert_eq!(mmio.read_volatile(4 as *const u32), 0x3abc_9321);
-            assert_eq!(mmio.read_volatile(8 as *const u16), 0x39af);
-            assert_eq!(mmio.read_volatile(10 as *const u8), 0xf3);
-        }
-        assert_eq!(
-            mmio.into_inner().data(),
-            &[0x00, 0x00, 0x00, 0x00, 0x21, 0x93, 0xbc, 0x3a, 0xaf, 0x39, 0xf3, 0x00]
-        );
-    }
 
     #[test]
     fn test_rv32gen_mmio() {

--- a/sw-emulator/lib/bus/Cargo.toml
+++ b/sw-emulator/lib/bus/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 
 [dependencies]
 caliptra-emu-types = { path = "../types" }
+ureg = { path = "../../../ureg" }
 tock-registers = { git = "https://github.com/tock/tock.git"}

--- a/sw-emulator/lib/bus/src/lib.rs
+++ b/sw-emulator/lib/bus/src/lib.rs
@@ -15,6 +15,7 @@ mod bus;
 mod clock;
 mod dynamic_bus;
 mod mem;
+mod mmio;
 mod ram;
 mod register;
 mod register_array;
@@ -24,6 +25,7 @@ pub mod testing;
 pub use crate::bus::{Bus, BusError};
 pub use crate::clock::{ActionHandle, Clock, Timer, TimerAction};
 pub use crate::dynamic_bus::DynamicBus;
+pub use crate::mmio::BusMmio;
 pub use crate::ram::Ram;
 pub use crate::register::{
     ReadOnlyMemory, ReadOnlyRegister, ReadWriteMemory, ReadWriteRegister, Register,

--- a/sw-emulator/lib/bus/src/mmio.rs
+++ b/sw-emulator/lib/bus/src/mmio.rs
@@ -1,0 +1,108 @@
+// Licensed under the Apache-2.0 license
+
+use std::cell::RefCell;
+
+use caliptra_emu_types::RvSize;
+
+use crate::Bus;
+
+const fn rvsize<T>() -> RvSize {
+    match core::mem::size_of::<T>() {
+        1 => RvSize::Byte,
+        2 => RvSize::HalfWord,
+        4 => RvSize::Word,
+        _other => panic!("Unsupported RvSize"),
+    }
+}
+
+unsafe fn transmute_to_u32<T>(src: &T) -> u32 {
+    match std::mem::size_of::<T>() {
+        1 => std::mem::transmute_copy::<T, u8>(src).into(),
+        2 => std::mem::transmute_copy::<T, u16>(src).into(),
+        4 => std::mem::transmute_copy::<T, u32>(src),
+        _ => panic!("Unsupported write size"),
+    }
+}
+
+/// An MMIO implementation that reads and writes to a `caliptra_emu_bus::Bus`.
+pub struct BusMmio<TBus: Bus> {
+    bus: RefCell<TBus>,
+}
+impl<TBus: Bus> BusMmio<TBus> {
+    pub fn new(bus: TBus) -> Self {
+        Self {
+            bus: RefCell::new(bus),
+        }
+    }
+    pub fn into_inner(self) -> TBus {
+        self.bus.into_inner()
+    }
+}
+impl<TBus: Bus> ureg::Mmio for BusMmio<TBus> {
+    /// Loads from address `src` on the bus and returns the value.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the bus faults.
+    ///
+    /// # Safety
+    ///
+    /// As the pointer isn't read from, this Mmio implementation isn't actually
+    /// unsafe for POD types like u8/u16/u32.
+    unsafe fn read_volatile<T: Clone + Copy + Sized>(&self, src: *const T) -> T {
+        let val_u32 = self
+            .bus
+            .borrow_mut()
+            .read(rvsize::<T>(), src as usize as u32)
+            .unwrap();
+        match std::mem::size_of::<T>() {
+            1 => std::mem::transmute_copy::<u8, T>(&(val_u32 as u8)),
+            2 => std::mem::transmute_copy::<u16, T>(&(val_u32 as u16)),
+            4 => std::mem::transmute_copy::<u32, T>(&val_u32),
+            _ => panic!("Unsupported read size"),
+        }
+    }
+
+    /// Stores `src` to address `dst` on the bus.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the bus faults.
+    ///
+    /// # Safety
+    ///
+    /// As the pointer isn't written to, this Mmio implementation isn't actually
+    /// unsafe for POD types like u8/u16/u32.
+    unsafe fn write_volatile<T: Clone + Copy>(&self, dst: *mut T, src: T) {
+        self.bus
+            .borrow_mut()
+            .write(rvsize::<T>(), dst as usize as u32, transmute_to_u32(&src))
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Ram;
+    use ureg::Mmio;
+
+    use super::*;
+
+    #[test]
+    fn test_bus_mmio() {
+        let mmio = BusMmio::new(Ram::new(vec![0u8; 12]));
+        unsafe {
+            mmio.write_volatile(4 as *mut u32, 0x3abc_9321);
+            mmio.write_volatile(8 as *mut u16, 0x39af);
+            mmio.write_volatile(10 as *mut u8, 0xf3);
+
+            assert_eq!(mmio.read_volatile(4 as *const u32), 0x3abc_9321);
+            assert_eq!(mmio.read_volatile(8 as *const u16), 0x39af);
+            assert_eq!(mmio.read_volatile(10 as *const u8), 0xf3);
+        }
+        assert_eq!(
+            mmio.into_inner().data(),
+            &[0x00, 0x00, 0x00, 0x00, 0x21, 0x93, 0xbc, 0x3a, 0xaf, 0x39, 0xf3, 0x00]
+        );
+    }
+}

--- a/sw-emulator/lib/periph/Cargo.toml
+++ b/sw-emulator/lib/periph/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-emu-crypto = { path = "../crypto"}
 caliptra-emu-derive = { path = "../derive" }
 caliptra-emu-types = { path = "../types" }
 caliptra-hw-model-types = { path = "../../../hw-model/types" }
+caliptra-registers = { path = "../../../registers" }
 tock-registers = { git = "https://github.com/tock/tock.git"}
 smlang="0.6.0"
 lazy_static = "1.4.0"

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -13,25 +13,16 @@ Abstract:
 --*/
 use smlang::statemachine;
 
-use caliptra_emu_bus::{Bus, Ram};
+use caliptra_emu_bus::{Bus, BusMmio, Ram};
 use caliptra_emu_bus::{BusError, ReadOnlyRegister, ReadWriteRegister, WriteOnlyRegister};
 use caliptra_emu_derive::Bus;
 use caliptra_emu_types::{RvAddr, RvData, RvSize};
 use std::{cell::RefCell, rc::Rc};
-use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
-use tock_registers::registers::InMemoryRegister;
+use tock_registers::interfaces::Writeable;
 use tock_registers::{register_bitfields, LocalRegisterCopy};
 
 /// Maximum mailbox capacity.
 const MAX_MAILBOX_CAPACITY_BYTES: usize = 128 << 10;
-const OFFSET_LOCK: RvAddr = 0x00;
-const OFFSET_CMD: RvAddr = 0x08;
-const OFFSET_DLEN: RvAddr = 0x0C;
-const OFFSET_DATAIN: RvAddr = 0x10;
-const OFFSET_DATAOUT: RvAddr = 0x14;
-const OFFSET_EXECUTE: RvAddr = 0x18;
-const OFFSET_STATUS: RvAddr = 0x1C;
-const OFFSET_UNLOCK: RvAddr = 0x20;
 
 register_bitfields! [
     u32,
@@ -100,6 +91,16 @@ impl Default for MailboxRam {
 pub struct MailboxExternal {
     regs: Rc<RefCell<MailboxRegs>>,
 }
+impl MailboxExternal {
+    pub fn regs(&mut self) -> caliptra_registers::mbox::RegisterBlock<BusMmio<Self>> {
+        unsafe {
+            caliptra_registers::mbox::RegisterBlock::new_with_mmio(
+                std::ptr::null_mut::<u32>(),
+                BusMmio::new(self.clone()),
+            )
+        }
+    }
+}
 
 impl Bus for MailboxExternal {
     /// Read data of specified size from given address
@@ -135,184 +136,19 @@ impl MailboxInternal {
         }
     }
 
+    pub fn regs(&mut self) -> caliptra_registers::mbox::RegisterBlock<BusMmio<Self>> {
+        unsafe {
+            caliptra_registers::mbox::RegisterBlock::new_with_mmio(
+                std::ptr::null_mut::<u32>(),
+                BusMmio::new(self.clone()),
+            )
+        }
+    }
+
     pub fn as_external(&self) -> MailboxExternal {
         MailboxExternal {
             regs: self.regs.clone(),
         }
-    }
-
-    // Release the lock by writing to the  unlock register.
-    /// Only the uC can release the lock.
-    pub fn try_force_unlock(&mut self) -> Result<(), BusError> {
-        self.regs.borrow_mut().write(RvSize::Word, OFFSET_UNLOCK, 1)
-    }
-
-    pub fn read_dlen(&mut self) -> Result<u32, BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().read(RvSize::Word, OFFSET_DLEN)
-    }
-
-    pub fn write_dlen(&mut self, dlen: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs
-            .borrow_mut()
-            .write(RvSize::Word, OFFSET_DLEN, dlen)
-    }
-
-    pub fn read_cmd(&mut self) -> Result<u32, BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().read(RvSize::Word, OFFSET_CMD)
-    }
-
-    pub fn write_cmd(&mut self, cmd: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().write(RvSize::Word, OFFSET_CMD, cmd)
-    }
-
-    pub fn read_datain(&mut self) -> Result<u32, BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().read(RvSize::Word, OFFSET_DATAIN)
-    }
-
-    pub fn write_datain(&mut self, val: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs
-            .borrow_mut()
-            .write(RvSize::Word, OFFSET_DATAIN, val)
-    }
-
-    pub fn read_dataout(&mut self) -> Result<u32, BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().read(RvSize::Word, OFFSET_DATAOUT)
-    }
-
-    pub fn write_dataout(&mut self, val: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs
-            .borrow_mut()
-            .write(RvSize::Word, OFFSET_DATAOUT, val)
-    }
-
-    pub fn try_acquire_lock(&mut self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        let result = self.regs.borrow_mut().read(RvSize::Word, OFFSET_LOCK);
-        matches!(result, Ok(0))
-    }
-
-    pub fn is_locked(&mut self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow().state_machine.context().locked == 1
-    }
-
-    pub fn read_execute(&mut self) -> Result<u32, BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs.borrow_mut().read(RvSize::Word, OFFSET_EXECUTE)
-    }
-
-    pub fn write_execute(&mut self, val: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.regs
-            .borrow_mut()
-            .write(RvSize::Word, OFFSET_EXECUTE, val)?;
-        Ok(())
-    }
-
-    pub fn is_command_exec_set_requested(&self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        matches!(self.regs.borrow_mut().state_machine.state, States::ExecUc)
-    }
-
-    pub fn is_status_cmd_busy(&mut self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.match_status(Status::STATUS::CMD_BUSY.value)
-    }
-
-    pub fn is_status_data_ready(&mut self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.match_status(Status::STATUS::DATA_READY.value)
-    }
-
-    pub fn is_status_cmd_complete(&mut self) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.match_status(Status::STATUS::CMD_COMPLETE.value)
-    }
-
-    fn match_status(&mut self, status: u32) -> bool {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        let val = self
-            .regs
-            .borrow_mut()
-            .read(RvSize::Word, OFFSET_STATUS)
-            .unwrap();
-        let reg = InMemoryRegister::<u32, Status::Register>::new(val);
-        reg.read(Status::STATUS) == status
-    }
-
-    fn set_status(&mut self, status_in: u32) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        let status = self
-            .regs
-            .borrow_mut()
-            .read(RvSize::Word, OFFSET_STATUS)
-            .unwrap();
-
-        let status_reg: ReadWriteRegister<u32, Status::Register> = ReadWriteRegister::new(status);
-        status_reg.reg.modify(Status::STATUS.val(status_in));
-
-        self.regs
-            .borrow_mut()
-            .write(RvSize::Word, OFFSET_STATUS, status_reg.reg.get())?;
-        Ok(())
-    }
-
-    pub fn set_status_cmd_complete(&mut self) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.set_status(Status::STATUS::CMD_COMPLETE.value)
-    }
-
-    pub fn set_status_data_ready(&mut self) -> Result<(), BusError> {
-        self.regs
-            .borrow_mut()
-            .set_request(MailboxRequester::Caliptra);
-        self.set_status(Status::STATUS::DATA_READY.value)
     }
 }
 
@@ -773,10 +609,6 @@ impl Fifo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caliptra_emu_bus::Bus;
-    use caliptra_emu_types::RvAddr;
-
-    const OFFSET_USER: RvAddr = 0x04;
 
     pub fn get_mailbox() -> MailboxInternal {
         // Acquire lock
@@ -787,16 +619,15 @@ mod tests {
     fn test_sm_arc_rdyfordata_unlock() {
         // Acquire lock
         let mut mb = get_mailbox();
-        assert_eq!(mb.read(RvSize::Word, OFFSET_LOCK).unwrap(), 0);
+        let uc_regs = mb.regs();
+        assert!(!uc_regs.lock().read().lock());
         // Confirm it is locked
-        let lock = mb.read(RvSize::Word, OFFSET_LOCK).unwrap();
-        assert_eq!(lock, 1);
+        assert!(uc_regs.lock().read().lock());
 
-        let user = mb.read(RvSize::Word, OFFSET_USER).unwrap();
-        assert_eq!(user, 0);
+        assert_eq!(uc_regs.user().read(), 0);
 
         // Write command
-        assert_eq!(mb.write(RvSize::Word, OFFSET_CMD, 0x55).ok(), Some(()));
+        uc_regs.cmd().write(|_| 0x55);
         // Confirm it is locked
         assert_eq!(mb.regs.borrow().state_machine.context.locked, 1);
 
@@ -850,15 +681,15 @@ mod tests {
     fn test_soc_to_caliptra_lock() {
         let mut caliptra = MailboxInternal::new(MailboxRam::new());
         let mut soc = caliptra.as_external();
+        let soc_regs = soc.regs();
 
-        assert_eq!(soc.read(RvSize::Word, OFFSET_LOCK).unwrap(), 0);
+        assert!(!soc_regs.lock().read().lock());
         // Confirm it is locked
-        let soc_has_lock = soc.read(RvSize::Word, OFFSET_LOCK).unwrap();
-        assert_eq!(soc_has_lock, 1);
+        assert!(soc_regs.lock().read().lock());
 
         // Confirm caliptra has lock
-        let caliptra_has_lock = caliptra.read(RvSize::Word, OFFSET_LOCK).unwrap();
-        assert_eq!(caliptra_has_lock, 1);
+        let caliptra_has_lock = caliptra.regs().lock().read().lock();
+        assert!(caliptra_has_lock);
     }
 
     #[test]
@@ -867,49 +698,38 @@ mod tests {
 
         let mut caliptra = MailboxInternal::new(MailboxRam::new());
         let mut soc = caliptra.as_external();
+        let soc_regs = soc.regs();
+        let uc_regs = caliptra.regs();
 
-        assert_eq!(soc.read(RvSize::Word, OFFSET_LOCK).unwrap(), 0);
+        assert!(!soc_regs.lock().read().lock());
         // Confirm it is locked
-        let lock = soc.read(RvSize::Word, OFFSET_LOCK).unwrap();
-        assert_eq!(lock, 1);
+        assert!(soc_regs.lock().read().lock());
 
-        let user = soc.read(RvSize::Word, OFFSET_USER).unwrap();
-        assert_eq!(user, MailboxRequester::Soc as u32);
+        assert_eq!(soc_regs.user().read(), MailboxRequester::Soc as u32);
 
         // Write command
-        assert_eq!(soc.write(RvSize::Word, OFFSET_CMD, 0x55).ok(), Some(()));
+        soc_regs.cmd().write(|_| 0x55);
         // Confirm it is locked
         assert_eq!(soc.regs.borrow().state_machine.context.locked, 1);
 
         let dlen = request_to_send.len() as u32;
         let dlen = dlen * 4;
         // Write dlen
-        assert_eq!(soc.write(RvSize::Word, OFFSET_DLEN, dlen).ok(), Some(()));
+        soc_regs.dlen().write(|_| dlen);
 
         // Confirm it is locked
         assert_eq!(soc.regs.borrow().state_machine.context.locked, 1);
 
         for data_in in request_to_send.iter() {
             // Write datain
-            assert_eq!(
-                soc.write(RvSize::Word, OFFSET_DATAIN, *data_in).ok(),
-                Some(())
-            );
+            soc_regs.datain().write(|_| *data_in);
             // Confirm it is locked
             assert_eq!(soc.regs.borrow().state_machine.context.locked, 1);
         }
-        assert_eq!(
-            soc.write(
-                RvSize::Word,
-                OFFSET_STATUS,
-                Status::STATUS::DATA_READY.value
-            )
-            .ok(),
-            Some(())
-        );
+        soc_regs.status().write(|w| w.status(|w| w.data_ready()));
 
         // Write exec
-        assert_eq!(soc.write(RvSize::Word, OFFSET_EXECUTE, 0x55).ok(), Some(()));
+        soc_regs.execute().write(|w| w.execute(true));
         // Confirm it is locked
         assert_eq!(soc.regs.borrow().state_machine.context.locked, 1);
 
@@ -918,37 +738,26 @@ mod tests {
             States::ExecUc
         ));
 
-        let status = caliptra.read(RvSize::Word, OFFSET_STATUS).unwrap();
         assert_eq!(
-            status,
+            u32::from(uc_regs.status().read()),
             (Status::STATUS::DATA_READY + Status::MBOX_FSM_PS::MBOX_EXECUTE_UC).value
         );
 
-        let cmd = caliptra.read(RvSize::Word, OFFSET_CMD).unwrap();
-        assert_eq!(cmd, 0x55);
+        assert_eq!(uc_regs.cmd().read(), 0x55);
 
-        let dlen = caliptra.read(RvSize::Word, OFFSET_DLEN).unwrap();
+        let dlen = uc_regs.dlen().read();
         assert_eq!(dlen, (request_to_send.len() * 4) as u32);
 
         request_to_send.iter().for_each(|data_in| {
             // Read dataout
-            let data_out = caliptra.read(RvSize::Word, OFFSET_DATAOUT).unwrap();
+            let data_out = uc_regs.dataout().read();
             // compare with queued data.
             assert_eq!(*data_in, data_out);
         });
-        assert_eq!(
-            caliptra
-                .write(
-                    RvSize::Word,
-                    OFFSET_STATUS,
-                    Status::STATUS::CMD_COMPLETE.value
-                )
-                .ok(),
-            Some(())
-        );
+        uc_regs.status().write(|w| w.status(|w| w.cmd_complete()));
 
         // Requester resets exec register
-        assert_eq!(soc.write(RvSize::Word, OFFSET_EXECUTE, 0).ok(), Some(()));
+        soc_regs.execute().write(|w| w.execute(false));
         // Confirm it is unlocked
         assert_eq!(caliptra.regs.borrow().state_machine.context.locked, 0);
 
@@ -1031,95 +840,67 @@ mod tests {
     fn test_send_receive_max_limit() {
         // Acquire lock
         let mut mb = get_mailbox();
-        assert_eq!(mb.read(RvSize::Word, OFFSET_LOCK).unwrap(), 0);
-        // Confirm it is locked
-        let lock = mb.read(RvSize::Word, OFFSET_LOCK).unwrap();
-        assert_eq!(lock, 1);
+        let uc_regs = mb.regs();
 
-        let user = mb.read(RvSize::Word, OFFSET_USER).unwrap();
+        assert!(!uc_regs.lock().read().lock());
+        // Confirm it is locked
+        assert!(uc_regs.lock().read().lock());
+
+        let user = uc_regs.user().read();
         assert_eq!(user, MailboxRequester::Caliptra as u32);
 
         // Write command
-        assert_eq!(mb.write(RvSize::Word, OFFSET_CMD, 0x55).ok(), Some(()));
+        uc_regs.cmd().write(|_| 0x55);
 
         // Write dlen
-        assert_eq!(
-            mb.write(
-                RvSize::Word,
-                OFFSET_DLEN,
-                (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32
-            )
-            .ok(),
-            Some(())
-        );
+        uc_regs
+            .dlen()
+            .write(|_| (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32);
 
         for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES).step_by(4) {
             // Write datain
-            assert_eq!(
-                mb.write(RvSize::Word, OFFSET_DATAIN, data_in as u32).ok(),
-                Some(())
-            );
+            uc_regs.datain().write(|_| data_in as u32);
         }
 
         // Write an additional DWORD. This should be a no-op.
-        assert_eq!(
-            mb.write(RvSize::Word, OFFSET_DATAIN, 0xDEADBEEF).ok(),
-            Some(())
-        );
+        uc_regs.datain().write(|_| 0xDEADBEEF);
 
-        assert_eq!(
-            mb.write(
-                RvSize::Word,
-                OFFSET_STATUS,
-                Status::STATUS::DATA_READY.value
-            )
-            .ok(),
-            Some(())
-        );
+        uc_regs.status().write(|w| w.status(|w| w.data_ready()));
 
-        // Write exec
-        assert_eq!(mb.write(RvSize::Word, OFFSET_EXECUTE, 0x55).ok(), Some(()));
+        uc_regs.execute().write(|w| w.execute(true));
 
         assert!(matches!(
             mb.regs.borrow().state_machine.state(),
             States::ExecSoc
         ));
 
-        let status = mb.read(RvSize::Word, OFFSET_STATUS).unwrap();
         assert_eq!(
-            status,
+            u32::from(uc_regs.status().read()),
             (Status::STATUS::DATA_READY + Status::MBOX_FSM_PS::MBOX_EXECUTE_SOC).value
         );
 
-        let cmd = mb.read(RvSize::Word, OFFSET_CMD).unwrap();
-        assert_eq!(cmd, 0x55);
+        assert_eq!(uc_regs.cmd().read(), 0x55);
 
-        let dlen = mb.read(RvSize::Word, OFFSET_DLEN).unwrap();
-        assert_eq!(dlen, (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32);
+        assert_eq!(
+            uc_regs.dlen().read(),
+            (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32
+        );
 
         let mut data_out = 0;
         for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES).step_by(4) {
             // Read dataout
-            data_out = mb.read(RvSize::Word, OFFSET_DATAOUT).unwrap();
+            data_out = uc_regs.dataout().read();
             // compare with queued data.
             assert_eq!(data_in as u32, data_out);
         }
 
         // Read an additional DWORD. This should return the last word
-        assert_eq!(mb.read(RvSize::Word, OFFSET_DATAOUT).unwrap(), data_out);
+        assert_eq!(uc_regs.dataout().read(), data_out);
 
-        assert_eq!(
-            mb.write(
-                RvSize::Word,
-                OFFSET_STATUS,
-                Status::STATUS::CMD_COMPLETE.value
-            )
-            .ok(),
-            Some(())
-        );
+        uc_regs.status().write(|w| w.status(|w| w.cmd_complete()));
 
         // Receiver resets exec register
-        assert_eq!(mb.write(RvSize::Word, OFFSET_EXECUTE, 0).ok(), Some(()));
+        uc_regs.execute().write(|w| w.execute(false));
         // Confirm it is unlocked
         assert_eq!(mb.regs.borrow().state_machine.context.locked, 0);
 

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -733,14 +733,12 @@ impl SocRegistersImpl {
         }
 
         if self.timer.fired(&mut self.op_fw_read_complete_action) {
-            // Receiver sets status as CMD_COMPLETE after reading the mailbox data.
-            if !self.mailbox.regs().status().read().status().cmd_busy() {
+            let soc_mbox = self.mailbox.as_external().regs();
+            // uC will set status to CMD_COMPLETE after reading the
+            // mailbox data; we can't clear the execute bit until that is done.`
+            if !soc_mbox.status().read().status().cmd_busy() {
                 // Reset the execute bit
-                self.mailbox
-                    .as_external()
-                    .regs()
-                    .execute()
-                    .write(|w| w.execute(false));
+                soc_mbox.execute().write(|w| w.execute(false));
             } else {
                 self.op_fw_read_complete_action =
                     Some(self.timer.schedule_poll_in(Self::FW_READ_TICKS));


### PR DESCRIPTION
This reduces the amount of boilerplate code in emulator tests and glue
code.