### PR TITLE
Document firmware error reporting

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -407,6 +407,7 @@ The following is the sequence of the steps that are required to download the par
 - Read N dwords from the mailbox DATAOUT register.  Execute the command.
 - Once the entire data is processed, clear the execute bit.
     - This should be the last step. Clearing this bit transfers the control back to the originator of the command.
+- On failure, a non-zero status code will be reported in the `CPTRA_FW_ERROR_NON_FATAL` register
 
 ![DATA FROM MBOX FLOW](doc/svg/data-from-mbox.svg)
 
@@ -548,6 +549,7 @@ The basic flow for validating the firmware involves the following:
 - Validate the RT Image against the hash in the TOC entry for the RT.
 - If all the above validations are complete, the entire image is validated.
 - Let the SOC know that the firmware download command is complete.
+- On failure, a non-zero status code will be reported in the `CPTRA_FW_ERROR_NON_FATAL` register
 
 
 ### 13.1 **Overall Validation Flow**

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -73,10 +73,12 @@ Table: Mailbox command "result" codes:
 | `BAD_IMAGE`      | `0x4249_4D47` ("BIMG") | Malformed input image
 | `BAD_CHKSUM`     | `0x4243_484B` ("BCHK") | Checksum check failed on input arguments
 
-Relevant Mailbox Registers:
+Relevant Registers:
 
-* COMMAND: Command code to execute
-* DLEN: Number of bytes written to mailbox
+* mbox\_csr -> COMMAND: Command code to execute
+* mbox\_csr -> DLEN: Number of bytes written to mailbox
+* CPTRA\_FW\_ERROR\_NON\_FATAL: Status code of mailbox command. Any result
+  other than `SUCCESS` signifies a mailbox command failure.
 
 ### CALIPTRA\_FW\_LOAD
 
@@ -101,12 +103,7 @@ Table: `CALIPTRA_FW_LOAD` input arguments
 | --------  | --------      | ---------------
 | data      | u8[...]       | Firmware image to load.
 
-Table: `CALIPTRA_FW_LOAD` output arguments
-
-| **Name** | **Type** | **Description**
-| -------- | -------- | ---------------
-| chksum   | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| result   | u32      | Result code. Little endian.
+`CALIPTRA_FW_LOAD` returns no output arguments.
 
 ### GET\_IDEV\_CSR
 
@@ -155,13 +152,7 @@ Table: `ECDSA384_SIGNATURE_VERIFY` input arguments
 | signature\_r | u8[48]   | R portion of signature to verify
 | signature\_s | u8[48]   | S portion of signature to verify
 
-
-Table: `ECDSA384_SIGNATURE_VERIFY` output arguments
-
-| **Name** | **Type** | **Description**
-| -------- | -------- | ---------------
-| chksum   | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| result   | u32      | Result code. Little endian.
+`ECDSA384_SIGNATURE_VERIFY` returns no output arguments.
 
 ### STASH\_MEASUREMENT
 
@@ -186,7 +177,6 @@ Table: `STASH_MEASUREMENT` output arguments
 | **Name**    | **Type** | **Description**
 | --------    | -------- | ---------------
 | chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| result      | u32      | Result code. Little endian.
 | dpe\_result | u32      | Result code of DPE DeriveChild command. Little endian.
 
 ### DISABLE\_ATTESTATION
@@ -202,12 +192,8 @@ Command Code: `0x4453_424C` ("DSBL")
 
 `DISABLE_ATTESTATION` takes no input arguments.
 
-Table: `DISABLE_ATTESTATION` output arguments
+`DISABLE_ATTESTATION` returns no output arguments.
 
-| **Name**    | **Type** | **Description**
-| --------    | -------- | ---------------
-| chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| result      | u32      | Result code. Little endian.
 
 ### INVOKE\_DPE\_COMMAND
 
@@ -226,7 +212,6 @@ Table: `INVOKE_DPE_COMMAND` output arguments
 | **Name**    | **Type**      | **Description**
 | --------    | --------      | ---------------
 | chksum      | u32           | Checksum over other output arguments, computed by Caliptra. Little endian.
-| result      | u32           | Result code. Little endian.
 | data        | u8[...]       | DPE response structure as defined in the DPE iRoT profile.
 
 ## Checksum

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,6 +20,7 @@ caliptra_err_def! {
         InternalErr = 0x1,
         UnimplementedCommand = 0x2,
         InsufficientMemory = 0x3,
+        EcdsaVerificationFailed = 0x4,
     }
 }
 
@@ -67,13 +68,6 @@ impl Default for EcdsaVerifyCmd {
     }
 }
 
-#[repr(C)]
-#[derive(AsBytes, FromBytes)]
-pub struct EcdsaVerifyResponse {
-    pub chksum: u32,
-    pub result: u32,
-}
-
 fn wait_for_cmd() {
     // TODO: Enable interrupts?
     //#[cfg(feature = "riscv")]
@@ -110,7 +104,7 @@ fn handle_command() -> CaliptraResult<MboxStatusE> {
         CommandId::GET_LDEV_CERT => Err(err_u32!(UnimplementedCommand)),
         CommandId::ECDSA384_VERIFY => {
             verify::handle_ecdsa_verify(cmd_bytes)?;
-            Ok(MboxStatusE::DataReady)
+            Ok(MboxStatusE::CmdComplete)
         }
         CommandId::STASH_MEASUREMENT => Err(err_u32!(UnimplementedCommand)),
         CommandId::INVOKE_DPE => Err(err_u32!(UnimplementedCommand)),

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -20,7 +20,7 @@ impl Mailbox {
     }
 
     // Set the length of the current mailbox data in bytes
-    pub fn set_dlen(len: u32) {
+    pub fn _set_dlen(len: u32) {
         mbox::RegisterBlock::mbox_csr().dlen().write(|_| len);
     }
 
@@ -39,7 +39,7 @@ impl Mailbox {
         }
     }
 
-    pub fn copy_to_mbox(buf: &[Unalign<u32>]) {
+    pub fn _copy_to_mbox(buf: &[Unalign<u32>]) {
         for word in buf {
             mbox::RegisterBlock::mbox_csr()
                 .datain()
@@ -48,14 +48,14 @@ impl Mailbox {
     }
 
     /// Write a word-aligned `buf` to the mailbox
-    pub fn write_response(buf: &[u8]) -> CaliptraResult<()> {
+    pub fn _write_response(buf: &[u8]) -> CaliptraResult<()> {
         let Some(buf_words) = LayoutVerified::new_slice_unaligned(buf) else {
             // buf size is not a multiple of word size
             return Err(RuntimeErr::InternalErr.into());
         };
 
-        Self::set_dlen(buf.len() as u32);
-        Self::copy_to_mbox(&buf_words);
+        Self::_set_dlen(buf.len() as u32);
+        Self::_copy_to_mbox(&buf_words);
 
         Ok(())
     }

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -2,8 +2,8 @@
 
 use caliptra_builder::{FwId, ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
 use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams, ModelError};
-use caliptra_runtime::{CommandId, EcdsaVerifyCmd, EcdsaVerifyResponse};
-use zerocopy::{AsBytes, FromBytes};
+use caliptra_runtime::{CommandId, EcdsaVerifyCmd};
+use zerocopy::AsBytes;
 
 // Run test_bin as a ROM image. The is used for faster tests that can run
 // against verilator
@@ -138,11 +138,9 @@ fn test_verify_cmd() {
 
     let resp = model
         .mailbox_execute(u32::from(CommandId::ECDSA384_VERIFY), cmd.as_bytes())
-        .unwrap()
         .unwrap();
-    let resp_bytes: &[u8] = resp.as_bytes();
-    let response = EcdsaVerifyResponse::read_from(resp_bytes).unwrap();
-    assert_eq!(response.result, true as u32);
+    assert!(resp.is_none());
+    assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0);
 }
 
 #[test]


### PR DESCRIPTION
For any failed mailbox flows, document that errors are reported in the CPTRA_FW_ERROR_NON_FATAL register.