### PR TITLE
[feat] Add IV to the ECC384 key generation for SCA countermeasures.

### DIFF
--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -12,9 +12,13 @@ Abstract:
 
 --*/
 
+use core::iter::zip;
+use core::num::NonZeroUsize;
+
 use crate::kv_access::{KvAccess, KvAccessErr};
 use crate::{
-    array_concat3, caliptra_err_def, wait, Array4x12, CaliptraResult, KeyReadArgs, KeyWriteArgs,
+    array_concat3, caliptra_err_def, wait, Array4x12, CaliptraResult, Csrng, KeyReadArgs,
+    KeyWriteArgs,
 };
 use caliptra_registers::ecc::EccReg;
 
@@ -161,6 +165,7 @@ impl Ecc384 {
     ///
     /// * `seed` - Seed for deterministic ECC Key Pair generation
     /// * `nonce` - Nonce for deterministic ECC Key Pair generation
+    /// * `csrng` - CSRNG driver instance
     /// * `priv_key` - Generate ECC-384 Private key
     ///
     /// # Returns
@@ -170,6 +175,7 @@ impl Ecc384 {
         &mut self,
         seed: Ecc384Seed,
         nonce: &Array4x12,
+        csrng: &mut Csrng,
         mut priv_key: Ecc384PrivKeyOut,
     ) -> CaliptraResult<Ecc384PubKey> {
         let ecc = self.ecc.regs_mut();
@@ -198,6 +204,14 @@ impl Ecc384 {
 
         // Copy nonce to the hardware
         KvAccess::copy_from_arr(nonce, ecc.nonce())?;
+
+        // Generate an IV.
+        let mut iv: [u32; 12] = [0u32; 12];
+        let num_words = NonZeroUsize::new(iv.len()).unwrap();
+        for (dst, src) in zip(&mut iv, csrng.generate(num_words)?) {
+            *dst = src;
+        }
+        KvAccess::copy_from_arr(&Array4x12::from(iv), ecc.iv())?;
 
         // Program the command register for key generation
         ecc.ctrl().write(|w| w.ctrl(|w| w.keygen()));

--- a/drivers/test-fw/src/bin/ecc384_tests.rs
+++ b/drivers/test-fw/src/bin/ecc384_tests.rs
@@ -15,13 +15,15 @@ Abstract:
 #![no_std]
 #![no_main]
 
+use caliptra_drivers::Csrng;
 use caliptra_drivers::{
-    Array4x12, Array4xN, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar,
-    Ecc384Seed, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
+    Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar, Ecc384Seed,
+    KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 use caliptra_kat::Ecc384Kat;
+use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::ecc::EccReg;
-
+use caliptra_registers::entropy_src::EntropySrcReg;
 use caliptra_test_harness::test_suite;
 
 const PRIV_KEY: [u8; 48] = [
@@ -56,12 +58,13 @@ const SIGNATURE_S: [u8; 48] = [
 
 fn test_gen_key_pair() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut priv_key = Array4x12::default();
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(&mut priv_key),
     );
     assert!(result.is_ok());
@@ -75,6 +78,56 @@ fn test_gen_key_pair() {
     der[01..49].copy_from_slice(&PUB_KEY_X);
     der[49..97].copy_from_slice(&PUB_KEY_Y);
     assert_eq!(pub_key.to_der(), der);
+}
+
+fn test_gen_key_pair_with_iv() {
+    let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
+    let seed = [
+        0x8F, 0xA8, 0x54, 0x1C, 0x82, 0xA3, 0x92, 0xCA, 0x74, 0xF2, 0x3E, 0xD1, 0xDB, 0xFD, 0x73,
+        0x54, 0x1C, 0x59, 0x66, 0x39, 0x1B, 0x97, 0xEA, 0x73, 0xD7, 0x44, 0xB0, 0xE3, 0x4B, 0x9D,
+        0xF5, 0x9E, 0xD0, 0x15, 0x80, 0x63, 0xE3, 0x9C, 0x09, 0xA5, 0xA0, 0x55, 0x37, 0x1E, 0xDF,
+        0x7A, 0x54, 0x41,
+    ];
+
+    let nonce = [
+        0x1B, 0x7E, 0xC5, 0xE5, 0x48, 0xE8, 0xAA, 0xA9, 0x2E, 0xC7, 0x70, 0x97, 0xCA, 0x95, 0x51,
+        0xC9, 0x78, 0x3C, 0xE6, 0x82, 0xCA, 0x18, 0xFB, 0x1E, 0xDB, 0xD9, 0xF1, 0xE5, 0x0B, 0xC3,
+        0x82, 0xDB, 0x8A, 0xB3, 0x94, 0x96, 0xC8, 0xEE, 0x42, 0x3F, 0x8C, 0xA1, 0x05, 0xCB, 0xBA,
+        0x7B, 0x65, 0x88,
+    ];
+
+    let priv_key_exp = [
+        0xF2, 0x74, 0xF6, 0x9D, 0x16, 0x3B, 0x0C, 0x9F, 0x1F, 0xC3, 0xEB, 0xF4, 0x29, 0x2A, 0xD1,
+        0xC4, 0xEB, 0x3C, 0xEC, 0x1C, 0x5A, 0x7D, 0xDE, 0x6F, 0x80, 0xC1, 0x42, 0x92, 0x93, 0x4C,
+        0x20, 0x55, 0xE0, 0x87, 0x74, 0x8D, 0x0A, 0x16, 0x9C, 0x77, 0x24, 0x83, 0xAD, 0xEE, 0x5E,
+        0xE7, 0x0E, 0x17,
+    ];
+    let pub_key_x_exp = [
+        0xD7, 0x9C, 0x6D, 0x97, 0x2B, 0x34, 0xA1, 0xDF, 0xC9, 0x16, 0xA7, 0xB6, 0xE0, 0xA9, 0x9B,
+        0x6B, 0x53, 0x87, 0xB3, 0x4D, 0xA2, 0x18, 0x76, 0x07, 0xC1, 0xAD, 0x0A, 0x4D, 0x1A, 0x8C,
+        0x2E, 0x41, 0x72, 0xAB, 0x5F, 0xA5, 0xD9, 0xAB, 0x58, 0xFE, 0x45, 0xE4, 0x3F, 0x56, 0xBB,
+        0xB6, 0x6B, 0xA4,
+    ];
+    let pub_key_y_exp = [
+        0x5A, 0x73, 0x63, 0x93, 0x2B, 0x06, 0xB4, 0xF2, 0x23, 0xBE, 0xF0, 0xB6, 0x0A, 0x63, 0x90,
+        0x26, 0x51, 0x12, 0xDB, 0xBD, 0x0A, 0xAE, 0x67, 0xFE, 0xF2, 0x6B, 0x46, 0x5B, 0xE9, 0x35,
+        0xB4, 0x8E, 0x45, 0x1E, 0x68, 0xD1, 0x6F, 0x11, 0x18, 0xF2, 0xB3, 0x2B, 0x4C, 0x28, 0x60,
+        0x87, 0x49, 0xED,
+    ];
+
+    let mut priv_key = Array4x12::default();
+    let result = ecc.key_pair(
+        Ecc384Seed::from(&Ecc384Scalar::from(seed)),
+        &Array4x12::from(nonce),
+        &mut csrng,
+        Ecc384PrivKeyOut::from(&mut priv_key),
+    );
+    assert!(result.is_ok());
+    let pub_key = result.unwrap();
+    assert_eq!(priv_key, Ecc384Scalar::from(priv_key_exp));
+    assert_eq!(pub_key.x, Ecc384Scalar::from(pub_key_x_exp));
+    assert_eq!(pub_key.y, Ecc384Scalar::from(pub_key_y_exp));
 }
 
 fn test_sign() {
@@ -120,11 +173,11 @@ fn test_verify_failure() {
 
 fn test_kv_seed_from_input_msg_from_input() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Generate a key pair and store private key in kv slot 2.
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_ecc_private_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -133,7 +186,8 @@ fn test_kv_seed_from_input_msg_from_input() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -167,6 +221,7 @@ fn test_kv_seed_from_input_msg_from_input() {
 
 fn test_kv_seed_from_kv_msg_from_input() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Generate a key-pair. Store private key in kv slot 0.
     // Mark the key as ecc_key_gen_seed as it will be used as a seed for key generation.
@@ -178,7 +233,6 @@ fn test_kv_seed_from_kv_msg_from_input() {
     //  0x89, 0x46, 0xd6,]
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_ecc_key_gen_seed(true);
     let key_out_1 = KeyWriteArgs {
@@ -187,7 +241,8 @@ fn test_kv_seed_from_kv_msg_from_input() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -226,7 +281,8 @@ fn test_kv_seed_from_kv_msg_from_input() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(key_in_seed),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_priv_key),
     );
     assert!(result.is_ok());
@@ -286,6 +342,7 @@ fn test_kat() {
 test_suite! {
     test_kat,
     test_gen_key_pair,
+    test_gen_key_pair_with_iv,
     test_sign,
     test_verify,
     test_verify_failure,

--- a/drivers/test-fw/src/bin/hmac384_tests.rs
+++ b/drivers/test-fw/src/bin/hmac384_tests.rs
@@ -16,11 +16,13 @@ Abstract:
 #![no_main]
 
 use caliptra_drivers::{
-    Array4x12, Array4xN, Ecc384, Ecc384PrivKeyOut, Ecc384Scalar, Ecc384Seed, Hmac384, KeyId,
+    Array4x12, Csrng, Ecc384, Ecc384PrivKeyOut, Ecc384Scalar, Ecc384Seed, Hmac384, KeyId,
     KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 use caliptra_kat::Hmac384Kat;
+use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::ecc::EccReg;
+use caliptra_registers::entropy_src::EntropySrcReg;
 use caliptra_registers::hmac::HmacReg;
 
 use caliptra_test_harness::test_suite;
@@ -89,11 +91,11 @@ fn test_hmac1() {
 fn test_hmac3() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -102,7 +104,8 @@ fn test_hmac3() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -133,11 +136,11 @@ fn test_hmac3() {
 fn test_hmac4() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -146,7 +149,8 @@ fn test_hmac4() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -182,11 +186,11 @@ fn test_hmac4() {
 fn test_hmac5() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -195,7 +199,8 @@ fn test_hmac5() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -245,6 +250,7 @@ fn test_hmac5() {
 fn test_hmac6() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
@@ -253,7 +259,6 @@ fn test_hmac6() {
     //          0x87, 0x1c, 0x1a, 0xec, 0x3, 0x2c, 0x7a, 0x8b, 0x10, 0xb9, 0x3e, 0xe, 0xab, 0x89, 0x46, 0xd6,];
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -262,7 +267,8 @@ fn test_hmac6() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut csrng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());

--- a/rom/dev/src/flow/cold_reset/crypto.rs
+++ b/rom/dev/src/flow/cold_reset/crypto.rs
@@ -136,7 +136,6 @@ impl Crypto {
         seed: KeyId,
         priv_key: KeyId,
     ) -> CaliptraResult<Ecc384KeyPair> {
-        // [TODO] Add Nonce to the ecc384_key_gen function
         let seed = Ecc384Seed::Key(KeyReadArgs::new(seed));
 
         let mut usage = KeyUsage::default();
@@ -146,7 +145,9 @@ impl Crypto {
 
         Ok(Ecc384KeyPair {
             priv_key,
-            pub_key: env.ecc384.key_pair(seed, &Array4x12::default(), key_out)?,
+            pub_key: env
+                .ecc384
+                .key_pair(seed, &Array4x12::default(), &mut env.csrng, key_out)?,
         })
     }
 

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -54,7 +54,10 @@ Running Caliptra ROM ...
 pub extern "C" fn rom_entry() -> ! {
     cprintln!("{}", BANNER);
 
-    let mut env = unsafe { rom_env::RomEnv::new_from_registers() };
+    let mut env = match unsafe { rom_env::RomEnv::new_from_registers() } {
+        Ok(env) => env,
+        Err(e) => report_error(e.into()),
+    };
 
     let _lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,12 +16,14 @@ Abstract:
 --*/
 
 use caliptra_drivers::{
-    DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
-    Sha384, Sha384Acc, SocIfc,
+    Csrng, DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1,
+    Sha256, Sha384, Sha384Acc, SocIfc,
 };
+use caliptra_error::CaliptraResult;
 use caliptra_registers::{
-    doe::DoeReg, dv::DvReg, ecc::EccReg, hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg,
-    sha256::Sha256Reg, sha512::Sha512Reg, sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg,
+    csrng::CsrngReg, doe::DoeReg, dv::DvReg, ecc::EccReg, entropy_src::EntropySrcReg,
+    hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
+    sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg,
 };
 use core::ops::Range;
 
@@ -68,6 +70,9 @@ pub struct RomEnv {
 
     /// PCR Bank
     pub pcr_bank: PcrBank,
+
+    /// Cryptographically Secure Random Number Generator
+    pub csrng: Csrng,
 }
 
 impl RomEnv {
@@ -76,8 +81,10 @@ impl RomEnv {
         end: ICCM_START + ICCM_SIZE,
     };
 
-    pub unsafe fn new_from_registers() -> Self {
-        Self {
+    pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
+        let csrng = Csrng::new(CsrngReg::new(), EntropySrcReg::new())?;
+
+        Ok(Self {
             doe: DeobfuscationEngine::new(DoeReg::new()),
             sha1: Sha1::default(),
             sha256: Sha256::new(Sha256Reg::new()),
@@ -91,6 +98,7 @@ impl RomEnv {
             soc_ifc: SocIfc::new(SocIfcReg::new()),
             mbox: Mailbox::new(MboxCsr::new()),
             pcr_bank: PcrBank::new(PvReg::new()),
-        }
+            csrng,
+        })
     }
 }


### PR DESCRIPTION
This change uses the CSRNG driver to generate a nonce; the same is provided as an IV input to the key generation function of the ECC384 driver.