### PR TITLE
Update CI to use ubuntu 22.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       RUST_TOOLCHAIN_VERSION: 1.68.0


### PR DESCRIPTION
Update to a version of ubuntu with OpenSSL 3.x.x support for CI