### PR TITLE
[feat] Move firmware download and validation into a separate layer

### DIFF
--- a/common/src/boot_status.rs
+++ b/common/src/boot_status.rs
@@ -14,7 +14,8 @@ Abstract:
 
 const IDEVID_BOOT_STATUS_BASE: u32 = 1;
 const LDEVID_BOOT_STATUS_BASE: u32 = 65;
-const FMCALIAS_BOOT_STATUS_BASE: u32 = 129;
+const FWPROCESSOR_BOOT_STATUS_BASE: u32 = 129;
+const FMCALIAS_BOOT_STATUS_BASE: u32 = 193;
 
 /// Statuses used by ROM to log dice derivation progress.
 #[repr(u32)]
@@ -40,20 +41,22 @@ pub enum RomBootStatus {
     LDevIdCertSigGenerationComplete = LDEVID_BOOT_STATUS_BASE + 4,
     LDevIdDerivationComplete = LDEVID_BOOT_STATUS_BASE + 5,
 
+    // Firmware Processor Statuses
+    FwProcessorDownloadImageComplete = FWPROCESSOR_BOOT_STATUS_BASE,
+    FwProcessorManifestLoadComplete = FWPROCESSOR_BOOT_STATUS_BASE + 1,
+    FwProcessorImageVerificationComplete = FWPROCESSOR_BOOT_STATUS_BASE + 2,
+    FwProcessorPopulateDataVaultComplete = FWPROCESSOR_BOOT_STATUS_BASE + 3,
+    FwProcessorExtendPcrComplete = FWPROCESSOR_BOOT_STATUS_BASE + 4,
+    FwProcessorLoadImageComplete = FWPROCESSOR_BOOT_STATUS_BASE + 5,
+    FwProcessorComplete = FWPROCESSOR_BOOT_STATUS_BASE + 6,
+
     // FmcAlias Statuses
-    FmcAliasDownloadImageComplete = FMCALIAS_BOOT_STATUS_BASE,
-    FmcAliasManifestLoadComplete = FMCALIAS_BOOT_STATUS_BASE + 1,
-    FmcAliasImageVerificationComplete = FMCALIAS_BOOT_STATUS_BASE + 2,
-    FmcAliasPopulateDataVaultComplete = FMCALIAS_BOOT_STATUS_BASE + 3,
-    FmcAliasExtendPcrComplete = FMCALIAS_BOOT_STATUS_BASE + 4,
-    FmcAliasLoadImageComplete = FMCALIAS_BOOT_STATUS_BASE + 5,
-    FmcAliasFirmwareDownloadTxComplete = FMCALIAS_BOOT_STATUS_BASE + 6,
-    FmcAliasDeriveCdiComplete = FMCALIAS_BOOT_STATUS_BASE + 7,
-    FmcAliasKeyPairDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 8,
-    FmcAliasSubjIdSnGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 9,
-    FmcAliasSubjKeyIdGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 10,
-    FmcAliasCertSigGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 11,
-    FmcAliasDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 12,
+    FmcAliasDeriveCdiComplete = FMCALIAS_BOOT_STATUS_BASE,
+    FmcAliasKeyPairDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 1,
+    FmcAliasSubjIdSnGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 2,
+    FmcAliasSubjKeyIdGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 3,
+    FmcAliasCertSigGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 4,
+    FmcAliasDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 5,
 }
 
 impl From<RomBootStatus> for u32 {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -267,29 +267,31 @@ impl CaliptraError {
     pub const ROM_LDEVID_CSR_VERIFICATION_FAILURE: CaliptraError =
         CaliptraError::new_const(0x01010001);
 
+    /// Firmware Processor Errors
+    pub const FW_PROC_MANIFEST_READ_FAILURE: CaliptraError = CaliptraError::new_const(0x01020001);
+    pub const FW_PROC_INVALID_IMAGE_SIZE: CaliptraError = CaliptraError::new_const(0x01020002);
+    pub const FW_PROC_MAILBOX_STATE_INCONSISTENT: CaliptraError =
+        CaliptraError::new_const(0x01020003);
+
     /// FMC Alias Layer : Certificate Verification Failure.
-    pub const FMC_ALIAS_CERT_VERIFY: CaliptraError = CaliptraError::new_const(0x01020001);
-    pub const FMC_ALIAS_MANIFEST_READ_FAILURE: CaliptraError = CaliptraError::new_const(0x01020002);
-    pub const FMC_ALIAS_INVALID_IMAGE_SIZE: CaliptraError = CaliptraError::new_const(0x01020003);
-    pub const FMC_ALIAS_MAILBOX_STATE_INCONSISTENT: CaliptraError =
-        CaliptraError::new_const(0x01020004);
+    pub const FMC_ALIAS_CERT_VERIFY: CaliptraError = CaliptraError::new_const(0x01030001);
 
     /// Update Reset Errors
     pub const ROM_UPDATE_RESET_FLOW_MANIFEST_READ_FAILURE: CaliptraError =
-        CaliptraError::new_const(0x01030002);
+        CaliptraError::new_const(0x01040001);
     pub const ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND: CaliptraError =
-        CaliptraError::new_const(0x01030003);
+        CaliptraError::new_const(0x01040002);
     pub const ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE: CaliptraError =
-        CaliptraError::new_const(0x01030004);
+        CaliptraError::new_const(0x01040003);
 
     /// ROM Global Errors
-    pub const ROM_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x01040001);
-    pub const ROM_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x01040002);
-    pub const ROM_GLOBAL_PANIC: CaliptraError = CaliptraError::new_const(0x01040003);
+    pub const ROM_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x01050001);
+    pub const ROM_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x01050002);
+    pub const ROM_GLOBAL_PANIC: CaliptraError = CaliptraError::new_const(0x01050003);
     pub const ROM_GLOBAL_PCR_LOG_INVALID_ENTRY_ID: CaliptraError =
-        CaliptraError::new_const(0x01040004);
+        CaliptraError::new_const(0x01050004);
     pub const ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH: CaliptraError =
-        CaliptraError::new_const(0x01040005);
+        CaliptraError::new_const(0x01050005);
 
     /// ROM KAT Errors
     pub const ROM_KAT_SHA256_DIGEST_FAILURE: CaliptraError = CaliptraError::new_const(0x90010001);

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -16,29 +16,19 @@ Abstract:
 use super::crypto::{Crypto, Ecc384KeyPair};
 use super::dice::{DiceInput, DiceLayer, DiceOutput};
 use super::x509::X509;
+use crate::cprintln;
 use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::flow::cold_reset::{KEY_ID_CDI, KEY_ID_FMC_PRIV_KEY};
 use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
-use crate::verifier::RomImageVerificationEnv;
-use crate::{cprint, cprintln, pcr};
 use caliptra_common::dice;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::{
-    okref, report_boot_status, Array4x12, CaliptraResult, ColdResetEntry4, ColdResetEntry48,
-    DataVault, Hmac384Data, Hmac384Key, KeyId, KeyReadArgs, Lifecycle, Mailbox, MailboxRecvTxn,
-    ResetReason, SocIfc, WarmResetEntry4, WarmResetEntry48,
+    okref, report_boot_status, Array4x12, CaliptraResult, Hmac384Data, Hmac384Key, KeyId,
+    KeyReadArgs, Lifecycle,
 };
 use caliptra_error::CaliptraError;
-use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
-use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
-use caliptra_x509::{FmcAliasCertTbs, FmcAliasCertTbsParams, NotAfter, NotBefore};
-use core::mem::ManuallyDrop;
-use zerocopy::{AsBytes, FromBytes};
-
-extern "C" {
-    static mut MAN1_ORG: u32;
-}
+use caliptra_x509::{FmcAliasCertTbs, FmcAliasCertTbsParams};
 
 #[derive(Default)]
 pub struct FmcAliasLayer {}
@@ -53,40 +43,6 @@ impl DiceLayer for FmcAliasLayer {
             "[afmc] AUTHORITY.KEYID = {}",
             input.auth_key_pair.priv_key as u8
         );
-
-        // Download the image
-        let mut txn = Self::download_image(&mut env.soc_ifc, &mut env.mbox)?;
-
-        // Load the manifest
-        let manifest = Self::load_manifest(&mut txn);
-        let manifest = okref(&manifest)?;
-
-        let mut venv = RomImageVerificationEnv {
-            sha384: &mut env.sha384,
-            sha384_acc: &mut env.sha384_acc,
-            soc_ifc: &mut env.soc_ifc,
-            ecc384: &mut env.ecc384,
-            data_vault: &mut env.data_vault,
-            pcr_bank: &mut env.pcr_bank,
-        };
-
-        // Verify the image
-        let info = Self::verify_image(&mut venv, manifest, txn.dlen());
-        let info = okref(&info)?;
-
-        // populate data vault
-        Self::populate_data_vault(venv.data_vault, info);
-
-        // Extend PCR0
-        pcr::extend_pcr0(&mut venv, info)?;
-        report_boot_status(FmcAliasExtendPcrComplete.into());
-
-        // Load the image
-        Self::load_image(manifest, &mut txn)?;
-
-        // Complete the mailbox transaction indicating success.
-        txn.complete(true)?;
-        report_boot_status(FmcAliasFirmwareDownloadTxComplete.into());
 
         // At this point PCR0 & PCR1 must have the same value. We use the value
         // of PCR1 as the measurement for deriving the CDI
@@ -116,30 +72,8 @@ impl DiceLayer for FmcAliasLayer {
             subj_key_id,
         };
 
-        // if there is a valid value in the manifest for the not_before and not_after
-        // we take it from there.
-
-        let mut nb = NotBefore::default();
-        let mut nf = NotAfter::default();
-        let null_time = [0u8; 15];
-
-        if manifest.header.vendor_data.vendor_not_after != null_time
-            && manifest.header.vendor_data.vendor_not_before != null_time
-        {
-            nf.not_after = manifest.header.vendor_data.vendor_not_after;
-            nb.not_before = manifest.header.vendor_data.vendor_not_before;
-        }
-
-        //The owner values takes preference
-        if manifest.header.owner_data.owner_not_after != null_time
-            && manifest.header.owner_data.owner_not_before != null_time
-        {
-            nf.not_after = manifest.header.owner_data.owner_not_after;
-            nb.not_before = manifest.header.owner_data.owner_not_before;
-        }
-
-        // Generate Local Device ID Certificate
-        Self::generate_cert_sig(env, info, input, &output, &nb.not_before, &nf.not_after)?;
+        // Generate FMC Alias Certificate signature
+        Self::generate_cert_sig(env, input, &output)?;
 
         report_boot_status(FmcAliasDerivationComplete.into());
         cprintln!("[afmc] --");
@@ -149,182 +83,6 @@ impl DiceLayer for FmcAliasLayer {
 }
 
 impl FmcAliasLayer {
-    /// Download firmware mailbox command ID.
-    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
-
-    /// Download the image
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    ///
-    /// # Returns
-    ///
-    /// Mailbox transaction handle. This transaction is ManuallyDrop because we
-    /// don't want the transaction to be completed with failure until after
-    /// report_error is called. This prevents a race condition where the SoC
-    /// reads FW_ERROR_NON_FATAL immediately after the mailbox transaction
-    /// fails, but before caliptra has set the FW_ERROR_NON_FATAL register.
-    fn download_image<'a>(
-        soc_ifc: &mut SocIfc,
-        mbox: &'a mut Mailbox,
-    ) -> CaliptraResult<ManuallyDrop<MailboxRecvTxn<'a>>> {
-        soc_ifc.flow_status_set_ready_for_firmware();
-
-        cprint!("[afmc] Waiting for Image ");
-        loop {
-            if let Some(txn) = mbox.peek_recv() {
-                if txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
-                    cprintln!("Invalid command 0x{:08x} received", txn.cmd());
-                    txn.start_txn().complete(false)?;
-                    continue;
-                }
-
-                // Re-borrow mailbox to work around https://github.com/rust-lang/rust/issues/54663
-                let txn = mbox
-                    .peek_recv()
-                    .ok_or(CaliptraError::FMC_ALIAS_MAILBOX_STATE_INCONSISTENT)?;
-
-                // This is a download-firmware command; don't drop this, as the
-                // transaction will be completed by either report_error() (on
-                // failure) or by a manual complete call upon success.
-                let txn = ManuallyDrop::new(txn.start_txn());
-                if txn.dlen() == 0 || txn.dlen() > IMAGE_BYTE_SIZE as u32 {
-                    cprintln!("Invalid Image of size {} bytes" txn.dlen());
-                    return Err(CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE);
-                }
-
-                cprintln!("");
-                cprintln!("[afmc] Received Image of size {} bytes" txn.dlen());
-                report_boot_status(FmcAliasDownloadImageComplete.into());
-                return Ok(txn);
-            }
-        }
-    }
-
-    /// Load the manifest
-    ///
-    /// # Returns
-    ///
-    /// * `Manifest` - Caliptra Image Bundle Manifest
-    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
-        let slice = unsafe {
-            let ptr = &mut MAN1_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        txn.copy_request(slice)?;
-
-        if let Some(result) = ImageManifest::read_from(slice.as_bytes()) {
-            report_boot_status(FmcAliasManifestLoadComplete.into());
-            Ok(result)
-        } else {
-            Err(CaliptraError::FMC_ALIAS_MANIFEST_READ_FAILURE)
-        }
-    }
-
-    /// Verify the image
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    fn verify_image(
-        venv: &mut RomImageVerificationEnv,
-        manifest: &ImageManifest,
-        img_bundle_sz: u32,
-    ) -> CaliptraResult<ImageVerificationInfo> {
-        let mut verifier = ImageVerifier::new(venv);
-        let info = verifier.verify(manifest, img_bundle_sz, ResetReason::ColdReset)?;
-
-        cprintln!(
-            "[afmc] Image verified using Vendor ECC Key Index {}",
-            info.vendor_ecc_pub_key_idx
-        );
-        report_boot_status(FmcAliasImageVerificationComplete.into());
-        Ok(info)
-    }
-
-    /// Load the image to ICCM & DCCM
-    ///
-    /// # Arguments
-    ///
-    /// * `env`      - ROM Environment
-    /// * `manifest` - Manifest
-    /// * `txn`      - Mailbox Receive Transaction
-    fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
-        cprintln!(
-            "[afmc] Loading FMC at address 0x{:08x} len {}",
-            manifest.fmc.load_addr,
-            manifest.fmc.size
-        );
-
-        let fmc_dest = unsafe {
-            let addr = (manifest.fmc.load_addr) as *mut u32;
-            core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
-        };
-
-        txn.copy_request(fmc_dest)?;
-
-        cprintln!(
-            "[afmc] Loading Runtime at address 0x{:08x} len {}",
-            manifest.runtime.load_addr,
-            manifest.runtime.size
-        );
-
-        let runtime_dest = unsafe {
-            let addr = (manifest.runtime.load_addr) as *mut u32;
-            core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
-        };
-
-        txn.copy_request(runtime_dest)?;
-
-        report_boot_status(FmcAliasLoadImageComplete.into());
-        Ok(())
-    }
-
-    /// Populate data vault
-    ///
-    /// # Arguments
-    ///
-    /// * `env`  - ROM Environment
-    /// * `info` - Image Verification Info
-    fn populate_data_vault(data_vault: &mut DataVault, info: &ImageVerificationInfo) {
-        data_vault.write_cold_reset_entry48(ColdResetEntry48::FmcTci, &info.fmc.digest.into());
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcSvn, info.fmc.svn);
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr, info.fmc.load_addr);
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint, info.fmc.entry_point);
-
-        data_vault.write_cold_reset_entry48(
-            ColdResetEntry48::OwnerPubKeyHash,
-            &info.owner_pub_keys_digest.into(),
-        );
-
-        data_vault.write_cold_reset_entry4(
-            ColdResetEntry4::VendorPubKeyIndex,
-            info.vendor_ecc_pub_key_idx,
-        );
-
-        data_vault.write_warm_reset_entry48(WarmResetEntry48::RtTci, &info.runtime.digest.into());
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtSvn, info.runtime.svn);
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtLoadAddr, info.runtime.load_addr);
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtEntryPoint, info.runtime.entry_point);
-
-        // TODO: Need a better way to get the Manifest address
-        let slice = unsafe {
-            let ptr = &MAN1_ORG as *const u32;
-            ptr as u32
-        };
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, slice);
-        report_boot_status(FmcAliasPopulateDataVaultComplete.into());
-    }
-
     /// Derive Composite Device Identity (CDI) from FMC measurements
     ///
     /// # Arguments
@@ -361,7 +119,7 @@ impl FmcAliasLayer {
         Crypto::ecc384_key_gen(env, cdi, priv_key)
     }
 
-    /// Generate Local Device ID Certificate Signature
+    /// Generate FMC Alias Certificate Signature
     ///
     /// # Arguments
     ///
@@ -370,11 +128,8 @@ impl FmcAliasLayer {
     /// * `output` - DICE Output
     fn generate_cert_sig(
         env: &mut RomEnv,
-        info: &ImageVerificationInfo,
         input: &DiceInput,
         output: &DiceOutput,
-        not_before: &[u8; FmcAliasCertTbsParams::NOT_BEFORE_LEN],
-        not_after: &[u8; FmcAliasCertTbsParams::NOT_AFTER_LEN],
     ) -> CaliptraResult<()> {
         let auth_priv_key = input.auth_key_pair.priv_key;
         let auth_pub_key = &input.auth_key_pair.pub_key;
@@ -383,7 +138,7 @@ impl FmcAliasLayer {
         let flags = Self::make_flags(env.soc_ifc.lifecycle(), env.soc_ifc.debug_locked());
 
         let svn = env.data_vault.fmc_svn() as u8;
-        let fuse_svn = info.fmc.effective_fuse_svn as u8;
+        let fuse_svn = input.fw_proc_info.fmc_effective_fuse_svn as u8;
 
         // Certificate `To Be Signed` Parameters
         let params = FmcAliasCertTbsParams {
@@ -399,8 +154,8 @@ impl FmcAliasLayer {
             tcb_info_flags: &flags,
             tcb_info_fmc_svn: &svn.to_be_bytes(),
             tcb_info_fmc_svn_fuses: &fuse_svn.to_be_bytes(),
-            not_before,
-            not_after,
+            not_before: &input.fw_proc_info.fmc_cert_valid_not_before.value,
+            not_after: &input.fw_proc_info.fmc_cert_valid_not_after.value,
         };
 
         // Generate the `To Be Signed` portion of the CSR

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -1,0 +1,309 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    fw_processor.rs
+
+Abstract:
+
+    File contains the code to download and validate the firmware.
+
+--*/
+
+use core::mem::ManuallyDrop;
+
+use crate::pcr;
+use crate::rom_env::RomEnv;
+use crate::{cprintln, verifier::RomImageVerificationEnv};
+use caliptra_common::{cprint, RomBootStatus::*};
+use caliptra_drivers::*;
+use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
+use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
+use caliptra_x509::{NotAfter, NotBefore};
+use zerocopy::{AsBytes, FromBytes};
+
+extern "C" {
+    static mut MAN1_ORG: u32;
+}
+
+#[derive(Debug, Default)]
+pub struct FwProcInfo {
+    pub fmc_cert_valid_not_before: NotBefore,
+
+    pub fmc_cert_valid_not_after: NotAfter,
+
+    pub fmc_effective_fuse_svn: u32,
+}
+
+pub enum FirmwareProcessor {}
+
+impl FirmwareProcessor {
+    /// Download firmware mailbox command ID.
+    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
+
+    pub fn process(env: &mut RomEnv) -> CaliptraResult<FwProcInfo> {
+        // Download the image
+        let mut txn = Self::download_image(&mut env.soc_ifc, &mut env.mbox)?;
+
+        // Load the manifest
+        let manifest = Self::load_manifest(&mut txn);
+        let manifest = okref(&manifest)?;
+
+        let mut venv = RomImageVerificationEnv {
+            sha384: &mut env.sha384,
+            sha384_acc: &mut env.sha384_acc,
+            soc_ifc: &mut env.soc_ifc,
+            ecc384: &mut env.ecc384,
+            data_vault: &mut env.data_vault,
+            pcr_bank: &mut env.pcr_bank,
+        };
+
+        // Verify the image
+        let info = Self::verify_image(&mut venv, manifest, txn.dlen());
+        let info = okref(&info)?;
+
+        // Populate data vault
+        Self::populate_data_vault(venv.data_vault, info);
+
+        // Extend PCR0
+        pcr::extend_pcr0(&mut venv, info)?;
+        report_boot_status(FwProcessorExtendPcrComplete.into());
+
+        // Load the image
+        Self::load_image(manifest, &mut txn)?;
+
+        // Complete the mailbox transaction indicating success.
+        txn.complete(true)?;
+
+        // Get the certificate validity info
+        let (nb, nf) = Self::get_cert_validity_info(manifest);
+
+        report_boot_status(FwProcessorComplete.into());
+        Ok(FwProcInfo {
+            fmc_cert_valid_not_before: nb,
+            fmc_cert_valid_not_after: nf,
+            fmc_effective_fuse_svn: info.fmc.effective_fuse_svn,
+        })
+    }
+
+    /// Download the image
+    ///
+    /// # Arguments
+    ///
+    ///    soc_ifc - SOC Interface
+    ///    mbox    - Mailbox
+    ///
+    /// # Returns
+    ///
+    /// Mailbox transaction handle. This transaction is ManuallyDrop because we
+    /// don't want the transaction to be completed with failure until after
+    /// report_error is called. This prevents a race condition where the SoC
+    /// reads FW_ERROR_NON_FATAL immediately after the mailbox transaction
+    /// fails, but before caliptra has set the FW_ERROR_NON_FATAL register.
+    fn download_image<'a>(
+        soc_ifc: &mut SocIfc,
+        mbox: &'a mut Mailbox,
+    ) -> CaliptraResult<ManuallyDrop<MailboxRecvTxn<'a>>> {
+        soc_ifc.flow_status_set_ready_for_firmware();
+
+        cprint!("[fwproc] Waiting for Image ");
+        loop {
+            if let Some(txn) = mbox.peek_recv() {
+                if txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
+                    cprintln!("Invalid command 0x{:08x} received", txn.cmd());
+                    txn.start_txn().complete(false)?;
+                    continue;
+                }
+
+                // Re-borrow mailbox to work around https://github.com/rust-lang/rust/issues/54663
+                let txn = mbox
+                    .peek_recv()
+                    .ok_or(CaliptraError::FW_PROC_MAILBOX_STATE_INCONSISTENT)?;
+
+                // This is a download-firmware command; don't drop this, as the
+                // transaction will be completed by either report_error() (on
+                // failure) or by a manual complete call upon success.
+                let txn = ManuallyDrop::new(txn.start_txn());
+                if txn.dlen() == 0 || txn.dlen() > IMAGE_BYTE_SIZE as u32 {
+                    cprintln!("Invalid Image of size {} bytes" txn.dlen());
+                    return Err(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE);
+                }
+
+                cprintln!("");
+                cprintln!("[fwproc] Received Image of size {} bytes" txn.dlen());
+                report_boot_status(FwProcessorDownloadImageComplete.into());
+                return Ok(txn);
+            }
+        }
+    }
+
+    /// Load the manifest
+    ///
+    /// # Arguments
+    ///     txn - Mailbox transaction handle
+    ///
+    /// # Returns
+    ///
+    /// * `Manifest` - Caliptra Image Bundle Manifest
+    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
+        let slice = unsafe {
+            let ptr = &mut MAN1_ORG as *mut u32;
+            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
+        };
+
+        txn.copy_request(slice)?;
+
+        if let Some(result) = ImageManifest::read_from(slice.as_bytes()) {
+            report_boot_status(FwProcessorManifestLoadComplete.into());
+            Ok(result)
+        } else {
+            Err(CaliptraError::FW_PROC_MANIFEST_READ_FAILURE)
+        }
+    }
+
+    /// Verify the image
+    ///
+    /// # Arguments
+    ///   venv - Verification Environment
+    ///   manifest - Manifest
+    ///   img_bundle_sz - Image Bundle Size
+    ///
+    /// # Returns
+    ///   Image Verification Info  
+    ///
+    fn verify_image(
+        venv: &mut RomImageVerificationEnv,
+        manifest: &ImageManifest,
+        img_bundle_sz: u32,
+    ) -> CaliptraResult<ImageVerificationInfo> {
+        let mut verifier = ImageVerifier::new(venv);
+        let info = verifier.verify(manifest, img_bundle_sz, ResetReason::ColdReset)?;
+
+        cprintln!(
+            "[fwproc] Image verified using Vendor ECC Key Index {}",
+            info.vendor_ecc_pub_key_idx
+        );
+        report_boot_status(FwProcessorImageVerificationComplete.into());
+        Ok(info)
+    }
+
+    /// Populate data vault
+    ///
+    /// # Arguments
+    ///
+    /// * `env`  - ROM Environment
+    /// * `info` - Image Verification Info
+    fn populate_data_vault(data_vault: &mut DataVault, info: &ImageVerificationInfo) {
+        data_vault.write_cold_reset_entry48(ColdResetEntry48::FmcTci, &info.fmc.digest.into());
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcSvn, info.fmc.svn);
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr, info.fmc.load_addr);
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint, info.fmc.entry_point);
+
+        data_vault.write_cold_reset_entry48(
+            ColdResetEntry48::OwnerPubKeyHash,
+            &info.owner_pub_keys_digest.into(),
+        );
+
+        data_vault.write_cold_reset_entry4(
+            ColdResetEntry4::VendorPubKeyIndex,
+            info.vendor_ecc_pub_key_idx,
+        );
+
+        data_vault.write_warm_reset_entry48(WarmResetEntry48::RtTci, &info.runtime.digest.into());
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtSvn, info.runtime.svn);
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtLoadAddr, info.runtime.load_addr);
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtEntryPoint, info.runtime.entry_point);
+
+        // TODO: Need a better way to get the Manifest address
+        let slice = unsafe {
+            let ptr = &MAN1_ORG as *const u32;
+            ptr as u32
+        };
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, slice);
+        report_boot_status(FwProcessorPopulateDataVaultComplete.into());
+    }
+
+    /// Load the image to ICCM & DCCM
+    ///
+    /// # Arguments
+    ///
+    /// * `env`      - ROM Environment
+    /// * `manifest` - Manifest
+    /// * `txn`      - Mailbox Receive Transaction
+    ///
+    /// # Returns
+    ///  Caliptra Result
+    fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
+        cprintln!(
+            "[fwproc] Loading FMC at address 0x{:08x} len {}",
+            manifest.fmc.load_addr,
+            manifest.fmc.size
+        );
+
+        let fmc_dest = unsafe {
+            let addr = (manifest.fmc.load_addr) as *mut u32;
+            core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
+        };
+
+        txn.copy_request(fmc_dest)?;
+
+        cprintln!(
+            "[fwproc] Loading Runtime at address 0x{:08x} len {}",
+            manifest.runtime.load_addr,
+            manifest.runtime.size
+        );
+
+        let runtime_dest = unsafe {
+            let addr = (manifest.runtime.load_addr) as *mut u32;
+            core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
+        };
+
+        txn.copy_request(runtime_dest)?;
+
+        report_boot_status(FwProcessorLoadImageComplete.into());
+        Ok(())
+    }
+
+    /// Process the certificate validity info
+    ///
+    /// # Arguments
+    /// * `manifest` - Manifest
+    ///
+    /// # Returns
+    /// * `NotBefore` - Valid Not Before Time
+    /// * `NotAfter`  - Valid Not After Time
+    ///
+    fn get_cert_validity_info(manifest: &ImageManifest) -> (NotBefore, NotAfter) {
+        // If there is a valid value in the manifest for the not_before and not_after times,
+        // use those. Otherwise use the default values.
+        let mut nb = NotBefore::default();
+        let mut nf = NotAfter::default();
+        let null_time = [0u8; 15];
+
+        if manifest.header.vendor_data.vendor_not_after != null_time
+            && manifest.header.vendor_data.vendor_not_before != null_time
+        {
+            nf.value = manifest.header.vendor_data.vendor_not_after;
+            nb.value = manifest.header.vendor_data.vendor_not_before;
+        }
+
+        // Owner values take preference.
+        if manifest.header.owner_data.owner_not_after != null_time
+            && manifest.header.owner_data.owner_not_before != null_time
+        {
+            nf.value = manifest.header.owner_data.owner_not_after;
+            nb.value = manifest.header.owner_data.owner_not_before;
+        }
+
+        (nb, nf)
+    }
+}

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -157,8 +157,8 @@ impl LocalDevIdLayer {
             authority_key_id: input.auth_key_id,
             serial_number,
             public_key: &pub_key.to_der(),
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         // Generate the `To Be Signed` portion of the CSR

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -15,6 +15,7 @@ Abstract:
 mod crypto;
 mod dice;
 mod fmc_alias;
+mod fw_processor;
 mod idev_id;
 mod ldev_id;
 mod x509;
@@ -22,6 +23,7 @@ mod x509;
 use crate::fht;
 use crate::flow::cold_reset::dice::*;
 use crate::flow::cold_reset::fmc_alias::FmcAliasLayer;
+use crate::flow::cold_reset::fw_processor::FirmwareProcessor;
 use crate::flow::cold_reset::idev_id::InitDevIdLayer;
 use crate::flow::cold_reset::ldev_id::LocalDevIdLayer;
 use crate::{cprintln, rom_env::RomEnv};
@@ -57,15 +59,21 @@ impl ColdResetFlow {
     pub fn run(env: &mut RomEnv) -> CaliptraResult<FirmwareHandoffTable> {
         cprintln!("[cold-reset] ++");
 
-        // Compose the three dice layers into one function
-        let dice_fn = compose_layers(
-            InitDevIdLayer::derive,
-            compose_layers(LocalDevIdLayer::derive, FmcAliasLayer::derive),
-        );
-
         let input = DiceInput::default();
 
-        let _ = dice_fn(env, &input)?;
+        // Execute IDEVID layer
+        let idevid_layer_output = InitDevIdLayer::derive(env, &input)?;
+        let ldevid_layer_input = dice_input_from_output(&idevid_layer_output);
+
+        // Execute LDEVID layer
+        let ldevid_layer_output = LocalDevIdLayer::derive(env, &ldevid_layer_input)?;
+        let mut fmc_layer_input = dice_input_from_output(&ldevid_layer_output);
+
+        // Download and validate firmware.
+        fmc_layer_input.fw_proc_info = FirmwareProcessor::process(env)?;
+
+        // Execute FMCALIAS layer
+        let _ = FmcAliasLayer::derive(env, &fmc_layer_input)?;
 
         cprintln!("[cold-reset] --");
 
@@ -87,4 +95,13 @@ pub fn copy_tbs(tbs: &[u8], tbs_type: TbsType) -> CaliptraResult<()> {
 
     dst[..tbs.len()].copy_from_slice(tbs);
     Ok(())
+}
+
+fn dice_input_from_output(dice_output: &DiceOutput) -> DiceInput {
+    DiceInput {
+        auth_key_pair: &dice_output.subj_key_pair,
+        auth_sn: &dice_output.subj_sn,
+        auth_key_id: &dice_output.subj_key_id,
+        ..DiceInput::default()
+    }
 }

--- a/rom/dev/tests/test_dice_derivations.rs
+++ b/rom/dev/tests/test_dice_derivations.rs
@@ -71,13 +71,13 @@ fn test_status_reporting() {
         .is_ok());
 
     // [TODO] Don't use upload_firmware (whic returns only when the txn is complete); manually upload the firmware to test these boot statuses.
-    // step_until_boot_status(FmcAliasDownloadImageComplete);
-    // step_until_boot_status(FmcAliasManifestLoadComplete);
-    // step_until_boot_status(FmcAliasImageVerificationComplete);
-    // step_until_boot_status(FmcAliasPopulateDataVaultComplete);
-    // step_until_boot_status(FmcAliasExtendPcrComplete);
-    // step_until_boot_status(FmcAliasLoadImageComplete);
-    step_until_boot_status(&mut hw, FmcAliasFirmwareDownloadTxComplete);
+    // step_until_boot_status(FwProcessorDownloadImageComplete);
+    // step_until_boot_status(FwProcessorManifestLoadComplete);
+    // step_until_boot_status(FwProcessorImageVerificationComplete);
+    // step_until_boot_status(FwProcessorPopulateDataVaultComplete);
+    // step_until_boot_status(FwProcessorExtendPcrComplete);
+    // step_until_boot_status(FwProcessorLoadImageComplete);
+    step_until_boot_status(&mut hw, FwProcessorComplete);
     step_until_boot_status(&mut hw, FmcAliasDeriveCdiComplete);
     step_until_boot_status(&mut hw, FmcAliasKeyPairDerivationComplete);
     step_until_boot_status(&mut hw, FmcAliasSubjIdSnGenerationComplete);

--- a/rom/dev/tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/test_fmcalias_derivation.rs
@@ -3,6 +3,7 @@
 use caliptra_builder::{FwId, ImageOptions, APP_WITH_UART, ROM_WITH_UART};
 use caliptra_common::PcrLogEntry;
 use caliptra_common::PcrLogEntryId::*;
+use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, ModelError, SecurityState};
 use caliptra_image_fake_keys::VENDOR_CONFIG_KEY_1;
 use caliptra_image_gen::ImageGenerator;
@@ -12,9 +13,6 @@ use zerocopy::{AsBytes, FromBytes};
 
 pub mod helpers;
 
-// [TODO] Use the error codes from the common library.
-const INVALID_IMAGE_SIZE: u32 = 0x01020003;
-
 #[test]
 fn test_zero_firmware_size() {
     let (mut hw, _image_bundle) =
@@ -23,11 +21,11 @@ fn test_zero_firmware_size() {
     // Zero-sized firmware.
     assert_eq!(
         hw.upload_firmware(&[]).unwrap_err(),
-        ModelError::MailboxCmdFailed(0x01020003)
+        ModelError::MailboxCmdFailed(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into())
     );
     assert_eq!(
         hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        INVALID_IMAGE_SIZE
+        CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
     );
 }
 
@@ -56,7 +54,7 @@ fn test_firmware_gt_max_size() {
 
     assert_eq!(
         hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        INVALID_IMAGE_SIZE
+        CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
     );
 }
 

--- a/rom/dev/tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/test_mailbox_errors.rs
@@ -1,12 +1,10 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_builder::ImageOptions;
+use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
 
 pub mod helpers;
-
-// [TODO] Use the error codes from the common library.
-const INVALID_IMAGE_SIZE: u32 = 0x0102_0003;
 
 #[test]
 fn test_unknown_command_is_not_fatal() {
@@ -34,7 +32,9 @@ fn test_mailbox_command_aborted_after_report_error() {
     let (mut hw, image_bundle) =
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
     assert_eq!(
-        Err(ModelError::MailboxCmdFailed(INVALID_IMAGE_SIZE)),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
+        )),
         hw.upload_firmware(&[])
     );
 
@@ -44,6 +44,8 @@ fn test_mailbox_command_aborted_after_report_error() {
     // The original failure reason should still be in the register
     assert_eq!(
         hw.upload_firmware(&image_bundle.to_bytes().unwrap()),
-        Err(ModelError::MailboxCmdFailed(INVALID_IMAGE_SIZE))
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
+        ))
     );
 }

--- a/x509/src/fmc_alias_cert.rs
+++ b/x509/src/fmc_alias_cert.rs
@@ -59,8 +59,8 @@ mod tests {
             tcb_info_fmc_tci: &[0xB6u8; FmcAliasCertTbsParams::TCB_INFO_FMC_TCI_LEN],
             tcb_info_fmc_svn: &[0xB7],
             tcb_info_fmc_svn_fuses: &[0xB8],
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = FmcAliasCertTbs::new(&params);

--- a/x509/src/ldevid_cert.rs
+++ b/x509/src/ldevid_cert.rs
@@ -56,8 +56,8 @@ mod tests {
                     issuer_key.sha1(),
                 )
                 .unwrap(),
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = LocalDevIdCertTbs::new(&params);

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -27,34 +27,32 @@ pub use idevid_csr::{InitDevIdCsrTbs, InitDevIdCsrTbsParams};
 pub use ldevid_cert::{LocalDevIdCertTbs, LocalDevIdCertTbsParams};
 pub use rt_alias_cert::{RtAliasCertTbs, RtAliasCertTbsParams};
 
+#[derive(Debug)]
 pub struct NotBefore {
-    pub not_before: [u8; 15],
+    pub value: [u8; 15],
 }
 
 impl Default for NotBefore {
     fn default() -> Self {
         let not_before = "20230101000000Z";
-        let mut nb: NotBefore = NotBefore {
-            not_before: [0u8; 15],
-        };
+        let mut nb: NotBefore = NotBefore { value: [0u8; 15] };
 
-        nb.not_before.copy_from_slice(not_before.as_bytes());
+        nb.value.copy_from_slice(not_before.as_bytes());
         nb
     }
 }
 
+#[derive(Debug)]
 pub struct NotAfter {
-    pub not_after: [u8; 15],
+    pub value: [u8; 15],
 }
 
 impl Default for NotAfter {
     fn default() -> Self {
         let not_after = "99991231235959Z";
-        let mut nb: NotAfter = NotAfter {
-            not_after: [0u8; 15],
-        };
+        let mut nf: NotAfter = NotAfter { value: [0u8; 15] };
 
-        nb.not_after.copy_from_slice(not_after.as_bytes());
-        nb
+        nf.value.copy_from_slice(not_after.as_bytes());
+        nf
     }
 }

--- a/x509/src/rt_alias_cert.rs
+++ b/x509/src/rt_alias_cert.rs
@@ -56,8 +56,8 @@ mod tests {
             .unwrap(),
             tcb_info_rt_svn: &[0xE3],
             tcb_info_rt_tci: &[0xEFu8; RtAliasCertTbsParams::TCB_INFO_RT_TCI_LEN],
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = RtAliasCertTbs::new(&params);


### PR DESCRIPTION
This change moves the firmware download and validation code out of the
FmcAlias layer into a new non-DICE layer.