### PR TITLE
sw-emulator: Fix bug in c.slli instruction.

### DIFF
--- a/sw-emulator/lib/cpu/src/instr/compression.rs
+++ b/sw-emulator/lib/cpu/src/instr/compression.rs
@@ -675,7 +675,7 @@ mod rv16 {
             result
         }
         pub fn rs1rd(&self) -> XReg {
-            XReg::from(bit_range(self.0, 9, 7) + 8)
+            XReg::from(bit_range(self.0, 11, 7))
         }
     }
 


### PR DESCRIPTION
We were incorrectly parsing c.slli's rd/rs1 field as a 3-bit register
(as used  by most compressed instructions), rather than as a 5-bit
register as the spec defines.

Unfortunately, the test suite at
https://github.com/riscv-non-isa/riscv-arch-test/blob/old-framework-2.x/riscv-test-suite/rv32i_m/C/src/cslli-01.S
only tests with 3-bit values (x8 through x15), so this was not caught.
