### PR TITLE
Document error handling for Impactless Update

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -687,3 +687,6 @@ The following are the pre-conditions that should be satisfied:
         - The TOC hash will NOT match, skip the TOC hash validation.
         - We still need to make sure that the hash of the FMC which was stored in the data vault register at cold boot
           still matches the FMC code. This is the hash of the FMC image portion.
+    - If validation fails during ROM boot, the new image will not be copied from
+      the mailbox. ROM will boot the existing FMC/Runtime images. Validation
+      errors will be reported via the CPTRA_FW_ERROR_NON_FATAL register.


### PR DESCRIPTION
Document in both Runtime and ROM documentation what happens in impactless firmware update fails.

Additionally, provide more documentation on usage of DISABLE_ATTESTATION.