### PR TITLE
Revert "[feat] Add random IV to ECC384 key generation for SCA counter…

### DIFF
--- a/drivers/test-fw/src/bin/hmac384_tests.rs
+++ b/drivers/test-fw/src/bin/hmac384_tests.rs
@@ -16,13 +16,11 @@ Abstract:
 #![no_main]
 
 use caliptra_drivers::{
-    Array4x12, Csrng, Ecc384, Ecc384PrivKeyOut, Ecc384Scalar, Ecc384Seed, Hmac384, KeyId,
+    Array4x12, Array4xN, Ecc384, Ecc384PrivKeyOut, Ecc384Scalar, Ecc384Seed, Hmac384, KeyId,
     KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 use caliptra_kat::Hmac384Kat;
-use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::ecc::EccReg;
-use caliptra_registers::entropy_src::EntropySrcReg;
 use caliptra_registers::hmac::HmacReg;
 
 use caliptra_test_harness::test_suite;
@@ -91,11 +89,11 @@ fn test_hmac1() {
 fn test_hmac3() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
-    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
+    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -104,8 +102,7 @@ fn test_hmac3() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &Array4x12::default(),
-        &mut csrng,
+        &nonce,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -136,11 +133,11 @@ fn test_hmac3() {
 fn test_hmac4() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
-    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
+    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -149,8 +146,7 @@ fn test_hmac4() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &Array4x12::default(),
-        &mut csrng,
+        &nonce,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -186,11 +182,11 @@ fn test_hmac4() {
 fn test_hmac5() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
-    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
     let seed = [0u8; 48];
+    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -199,8 +195,7 @@ fn test_hmac5() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &Array4x12::default(),
-        &mut csrng,
+        &nonce,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -250,7 +245,6 @@ fn test_hmac5() {
 fn test_hmac6() {
     let mut hmac384 = unsafe { Hmac384::new(HmacReg::new()) };
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
-    let mut csrng = unsafe { Csrng::new(CsrngReg::new(), EntropySrcReg::new()).unwrap() };
     //
     // Step 1: Place a key in the key-vault.
     //
@@ -259,6 +253,7 @@ fn test_hmac6() {
     //          0x87, 0x1c, 0x1a, 0xec, 0x3, 0x2c, 0x7a, 0x8b, 0x10, 0xb9, 0x3e, 0xe, 0xab, 0x89, 0x46, 0xd6,];
     //
     let seed = [0u8; 48];
+    let nonce = Array4xN::default();
     let mut key_usage = KeyUsage::default();
     key_usage.set_hmac_key(true);
     let key_out_1 = KeyWriteArgs {
@@ -267,8 +262,7 @@ fn test_hmac6() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &Array4x12::default(),
-        &mut csrng,
+        &nonce,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());

--- a/rom/dev/src/flow/cold_reset/crypto.rs
+++ b/rom/dev/src/flow/cold_reset/crypto.rs
@@ -136,6 +136,7 @@ impl Crypto {
         seed: KeyId,
         priv_key: KeyId,
     ) -> CaliptraResult<Ecc384KeyPair> {
+        // [TODO] Add Nonce to the ecc384_key_gen function
         let seed = Ecc384Seed::Key(KeyReadArgs::new(seed));
 
         let mut usage = KeyUsage::default();
@@ -145,9 +146,7 @@ impl Crypto {
 
         Ok(Ecc384KeyPair {
             priv_key,
-            pub_key: env
-                .ecc384
-                .key_pair(seed, &Array4x12::default(), &mut env.csrng, key_out)?,
+            pub_key: env.ecc384.key_pair(seed, &Array4x12::default(), key_out)?,
         })
     }
 

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -44,10 +44,7 @@ Running Caliptra ROM ...
 pub extern "C" fn rom_entry() -> ! {
     cprintln!("{}", BANNER);
 
-    let mut env = match unsafe { rom_env::RomEnv::new_from_registers() } {
-        Ok(env) => env,
-        Err(e) => report_error(e.into()),
-    };
+    let mut env = unsafe { rom_env::RomEnv::new_from_registers() };
 
     let _lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,14 +16,12 @@ Abstract:
 --*/
 
 use caliptra_drivers::{
-    Csrng, DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1,
-    Sha256, Sha384, Sha384Acc, SocIfc,
+    DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
+    Sha384, Sha384Acc, SocIfc,
 };
-use caliptra_error::CaliptraResult;
 use caliptra_registers::{
-    csrng::CsrngReg, doe::DoeReg, dv::DvReg, ecc::EccReg, entropy_src::EntropySrcReg,
-    hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
-    sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg,
+    doe::DoeReg, dv::DvReg, ecc::EccReg, hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg,
+    sha256::Sha256Reg, sha512::Sha512Reg, sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg,
 };
 use core::ops::Range;
 
@@ -70,9 +68,6 @@ pub struct RomEnv {
 
     /// PCR Bank
     pub pcr_bank: PcrBank,
-
-    /// Cryptographically Secure Random Number Generator
-    pub csrng: Csrng,
 }
 
 impl RomEnv {
@@ -81,10 +76,8 @@ impl RomEnv {
         end: ICCM_START + ICCM_SIZE,
     };
 
-    pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
-        let csrng = Csrng::new(CsrngReg::new(), EntropySrcReg::new())?;
-
-        Ok(Self {
+    pub unsafe fn new_from_registers() -> Self {
+        Self {
             doe: DeobfuscationEngine::new(DoeReg::new()),
             sha1: Sha1::default(),
             sha256: Sha256::new(Sha256Reg::new()),
@@ -98,7 +91,6 @@ impl RomEnv {
             soc_ifc: SocIfc::new(SocIfcReg::new()),
             mbox: Mailbox::new(MboxCsr::new()),
             pcr_bank: PcrBank::new(PvReg::new()),
-            csrng,
-        })
+        }
     }
 }


### PR DESCRIPTION
…measures. (#305)"

Unfortunately, that commit assumes that the CSRNG will always be enabled in the RTL, which isn't true (at HEAD, it's not enabled at all).

Will need to re-apply once we have a RNG abstraction that can handle the CSRNG being disabled.

This reverts commit 6793936ff0c6cabf8805ed26534f8a829cf39640.