### PR TITLE
[feat] Move firmware download and validation into a separate layer

### DIFF
--- a/common/src/boot_status.rs
+++ b/common/src/boot_status.rs
@@ -14,7 +14,8 @@ Abstract:
 
 const IDEVID_BOOT_STATUS_BASE: u32 = 1;
 const LDEVID_BOOT_STATUS_BASE: u32 = 65;
-const FMCALIAS_BOOT_STATUS_BASE: u32 = 129;
+const FWPROCESSOR_BOOT_STATUS_BASE: u32 = 129;
+const FMCALIAS_BOOT_STATUS_BASE: u32 = 193;
 
 /// Statuses used by ROM to log dice derivation progress.
 #[repr(u32)]
@@ -40,20 +41,23 @@ pub enum RomBootStatus {
     LDevIdCertSigGenerationComplete = LDEVID_BOOT_STATUS_BASE + 4,
     LDevIdDerivationComplete = LDEVID_BOOT_STATUS_BASE + 5,
 
+    // Firmware Processor Statuses
+    FwProcessorDownloadImageComplete = FWPROCESSOR_BOOT_STATUS_BASE,
+    FwProcessorManifestLoadComplete = FWPROCESSOR_BOOT_STATUS_BASE + 1,
+    FwProcessorImageVerificationComplete = FWPROCESSOR_BOOT_STATUS_BASE + 2,
+    FwProcessorPopulateDataVaultComplete = FWPROCESSOR_BOOT_STATUS_BASE + 3,
+    FwProcessorExtendPcrComplete = FWPROCESSOR_BOOT_STATUS_BASE + 4,
+    FwProcessorLoadImageComplete = FWPROCESSOR_BOOT_STATUS_BASE + 5,
+    FwProcessorFirmwareDownloadTxComplete = FWPROCESSOR_BOOT_STATUS_BASE + 6,
+    FwProcessorComplete = FWPROCESSOR_BOOT_STATUS_BASE + 7,
+
     // FmcAlias Statuses
-    FmcAliasDownloadImageComplete = FMCALIAS_BOOT_STATUS_BASE,
-    FmcAliasManifestLoadComplete = FMCALIAS_BOOT_STATUS_BASE + 1,
-    FmcAliasImageVerificationComplete = FMCALIAS_BOOT_STATUS_BASE + 2,
-    FmcAliasPopulateDataVaultComplete = FMCALIAS_BOOT_STATUS_BASE + 3,
-    FmcAliasExtendPcrComplete = FMCALIAS_BOOT_STATUS_BASE + 4,
-    FmcAliasLoadImageComplete = FMCALIAS_BOOT_STATUS_BASE + 5,
-    FmcAliasFirmwareDownloadTxComplete = FMCALIAS_BOOT_STATUS_BASE + 6,
-    FmcAliasDeriveCdiComplete = FMCALIAS_BOOT_STATUS_BASE + 7,
-    FmcAliasKeyPairDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 8,
-    FmcAliasSubjIdSnGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 9,
-    FmcAliasSubjKeyIdGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 10,
-    FmcAliasCertSigGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 11,
-    FmcAliasDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 12,
+    FmcAliasDeriveCdiComplete = FMCALIAS_BOOT_STATUS_BASE,
+    FmcAliasKeyPairDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 1,
+    FmcAliasSubjIdSnGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 2,
+    FmcAliasSubjKeyIdGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 3,
+    FmcAliasCertSigGenerationComplete = FMCALIAS_BOOT_STATUS_BASE + 4,
+    FmcAliasDerivationComplete = FMCALIAS_BOOT_STATUS_BASE + 5,
 }
 
 impl From<RomBootStatus> for u32 {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -295,39 +295,41 @@ impl CaliptraError {
     pub const ROM_LDEVID_CSR_VERIFICATION_FAILURE: CaliptraError =
         CaliptraError::new_const(0x01010001);
 
+    /// Firmware Processor Errors
+    pub const FW_PROC_MANIFEST_READ_FAILURE: CaliptraError = CaliptraError::new_const(0x01020001);
+    pub const FW_PROC_INVALID_IMAGE_SIZE: CaliptraError = CaliptraError::new_const(0x01020002);
+    pub const FW_PROC_MAILBOX_STATE_INCONSISTENT: CaliptraError =
+        CaliptraError::new_const(0x01020003);
+
     /// FMC Alias Layer : Certificate Verification Failure.
-    pub const FMC_ALIAS_CERT_VERIFY: CaliptraError = CaliptraError::new_const(0x01020001);
-    pub const FMC_ALIAS_MANIFEST_READ_FAILURE: CaliptraError = CaliptraError::new_const(0x01020002);
-    pub const FMC_ALIAS_INVALID_IMAGE_SIZE: CaliptraError = CaliptraError::new_const(0x01020003);
-    pub const FMC_ALIAS_MAILBOX_STATE_INCONSISTENT: CaliptraError =
-        CaliptraError::new_const(0x01020004);
+    pub const FMC_ALIAS_CERT_VERIFY: CaliptraError = CaliptraError::new_const(0x01030001);
 
     /// Update Reset Errors
     pub const ROM_UPDATE_RESET_FLOW_MANIFEST_READ_FAILURE: CaliptraError =
-        CaliptraError::new_const(0x01030002);
+        CaliptraError::new_const(0x01040002);
     pub const ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND: CaliptraError =
-        CaliptraError::new_const(0x01030003);
+        CaliptraError::new_const(0x01040003);
     pub const ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE: CaliptraError =
-        CaliptraError::new_const(0x01030004);
+        CaliptraError::new_const(0x01040004);
 
     /// ROM Global Errors
-    pub const ROM_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x01040001);
-    pub const ROM_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x01040002);
-    pub const ROM_GLOBAL_PANIC: CaliptraError = CaliptraError::new_const(0x01040003);
+    pub const ROM_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x01050001);
+    pub const ROM_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x01050002);
+    pub const ROM_GLOBAL_PANIC: CaliptraError = CaliptraError::new_const(0x01050003);
     pub const ROM_GLOBAL_PCR_LOG_INVALID_ENTRY_ID: CaliptraError =
-        CaliptraError::new_const(0x01040004);
+        CaliptraError::new_const(0x01050004);
     pub const ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH: CaliptraError =
-        CaliptraError::new_const(0x01040005);
+        CaliptraError::new_const(0x01050005);
 
     pub const ROM_GLOBAL_FUSE_LOG_INVALID_ENTRY_ID: CaliptraError =
-        CaliptraError::new_const(0x01040006);
+        CaliptraError::new_const(0x01050006);
     pub const ROM_GLOBAL_FUSE_LOG_UNSUPPORTED_DATA_LENGTH: CaliptraError =
-        CaliptraError::new_const(0x01040007);
+        CaliptraError::new_const(0x01050007);
 
     pub const ROM_GLOBAL_UNSUPPORTED_LDEVID_TBS_SIZE: CaliptraError =
-        CaliptraError::new_const(0x01040008);
+        CaliptraError::new_const(0x01050008);
     pub const ROM_GLOBAL_UNSUPPORTED_FMCALIAS_TBS_SIZE: CaliptraError =
-        CaliptraError::new_const(0x01040009);
+        CaliptraError::new_const(0x01050009);
 
     /// ROM KAT Errors
     pub const ROM_KAT_SHA256_DIGEST_FAILURE: CaliptraError = CaliptraError::new_const(0x90010001);

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -66,7 +66,7 @@ impl DiceLayer for RtAliasLayer {
         let nf = NotAfter::default();
 
         // Generate Rt Alias Certificate
-        Self::generate_cert_sig(env, hand_off, input, &output, &nb.not_before, &nf.not_after)?;
+        Self::generate_cert_sig(env, hand_off, input, &output, &nb.value, &nf.value)?;
         Ok(output)
     }
 }

--- a/rom/dev/src/flow/cold_reset/dice.rs
+++ b/rom/dev/src/flow/cold_reset/dice.rs
@@ -13,9 +13,6 @@ Abstract:
 
 --*/
 
-use crate::rom_env::RomEnv;
-use caliptra_drivers::{okref, Array4x12, CaliptraResult, Ecc384PubKey, KeyId};
-
 use super::crypto::Ecc384KeyPair;
 
 /// DICE Layer Input
@@ -31,23 +28,6 @@ pub struct DiceInput<'a> {
     pub auth_key_id: &'a [u8; 20],
 }
 
-impl DiceInput<'_> {
-    pub fn default() -> Self {
-        const DEFAULT_KEY_PAIR: Ecc384KeyPair = Ecc384KeyPair {
-            priv_key: KeyId::KeyId0,
-            pub_key: Ecc384PubKey {
-                x: Array4x12::new([0; 12]),
-                y: Array4x12::new([0; 12]),
-            },
-        };
-        DiceInput {
-            auth_key_pair: &DEFAULT_KEY_PAIR,
-            auth_sn: &[0u8; 64],
-            auth_key_id: &[0u8; 20],
-        }
-    }
-}
-
 /// DICE Layer Output
 #[derive(Debug)]
 pub struct DiceOutput {
@@ -59,45 +39,4 @@ pub struct DiceOutput {
 
     /// Subject Key Identifier
     pub subj_key_id: [u8; 20],
-}
-
-/// DICE Layer Interface
-pub trait DiceLayer {
-    /// Perform derivations for the DICE layer
-    ///
-    /// # Arguments
-    ///
-    /// * `env`   - ROM Environment
-    /// * `input` - DICE layer input
-    ///
-    /// # Returns
-    ///
-    /// * `DiceOutput` - DICE layer output
-    fn derive(env: &mut RomEnv, input: &DiceInput) -> CaliptraResult<DiceOutput>;
-}
-
-/// Compose two dice layers into one
-///
-/// # Arguments
-///
-/// * `f` - Dice Layer 1
-/// * `g` - Dice Layer 2
-pub fn compose_layers<F, G>(
-    f: F,
-    g: G,
-) -> impl Fn(&mut RomEnv, &DiceInput) -> CaliptraResult<DiceOutput>
-where
-    F: Fn(&mut RomEnv, &DiceInput) -> CaliptraResult<DiceOutput>,
-    G: Fn(&mut RomEnv, &DiceInput) -> CaliptraResult<DiceOutput>,
-{
-    move |env, i| {
-        let output = f(env, i);
-        let output = okref(&output)?;
-        let input = DiceInput {
-            auth_key_pair: &output.subj_key_pair,
-            auth_sn: &output.subj_sn,
-            auth_key_id: &output.subj_key_id,
-        };
-        g(env, &input)
-    }
 }

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -14,40 +14,33 @@ Abstract:
 --*/
 
 use super::crypto::{Crypto, Ecc384KeyPair};
-use super::dice::{DiceInput, DiceLayer, DiceOutput};
+use super::dice::{DiceInput, DiceOutput};
+use super::fw_processor::FwProcInfo;
 use super::x509::X509;
+use crate::cprintln;
 use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::flow::cold_reset::{KEY_ID_CDI, KEY_ID_FMC_PRIV_KEY};
-use crate::fuse::log_fuse_data;
 use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
-use crate::verifier::RomImageVerificationEnv;
-use crate::{cprint, cprintln, pcr};
 use caliptra_common::dice;
-use caliptra_common::fuse::FuseLogEntryId;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::{
-    okref, report_boot_status, Array4x12, CaliptraResult, ColdResetEntry4, ColdResetEntry48,
-    DataVault, Hmac384Data, Hmac384Key, KeyId, KeyReadArgs, Lifecycle, Mailbox, MailboxRecvTxn,
-    ResetReason, SocIfc, WarmResetEntry4, WarmResetEntry48,
+    okref, report_boot_status, Array4x12, CaliptraResult, Hmac384Data, Hmac384Key, KeyId,
+    KeyReadArgs, Lifecycle,
 };
 use caliptra_error::CaliptraError;
-use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
-use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier};
-use caliptra_x509::{FmcAliasCertTbs, FmcAliasCertTbsParams, NotAfter, NotBefore};
-use core::mem::ManuallyDrop;
-use zerocopy::{AsBytes, FromBytes};
-
-extern "C" {
-    static mut MAN1_ORG: u32;
-}
+use caliptra_x509::{FmcAliasCertTbs, FmcAliasCertTbsParams};
 
 #[derive(Default)]
 pub struct FmcAliasLayer {}
 
-impl DiceLayer for FmcAliasLayer {
+impl FmcAliasLayer {
     /// Perform derivations for the DICE layer
-    fn derive(env: &mut RomEnv, input: &DiceInput) -> CaliptraResult<DiceOutput> {
+    pub fn derive(
+        env: &mut RomEnv,
+        input: &DiceInput,
+        fw_proc_info: &FwProcInfo,
+    ) -> CaliptraResult<()> {
         cprintln!("[afmc] ++");
         cprintln!("[afmc] CDI.KEYID = {}", KEY_ID_CDI as u8);
         cprintln!("[afmc] SUBJECT.KEYID = {}", KEY_ID_FMC_PRIV_KEY as u8);
@@ -55,43 +48,6 @@ impl DiceLayer for FmcAliasLayer {
             "[afmc] AUTHORITY.KEYID = {}",
             input.auth_key_pair.priv_key as u8
         );
-
-        // Download the image
-        let mut txn = Self::download_image(&mut env.soc_ifc, &mut env.mbox)?;
-
-        // Load the manifest
-        let manifest = Self::load_manifest(&mut txn);
-        let manifest = okref(&manifest)?;
-
-        let mut venv = RomImageVerificationEnv {
-            sha256: &mut env.sha256,
-            sha384: &mut env.sha384,
-            sha384_acc: &mut env.sha384_acc,
-            soc_ifc: &mut env.soc_ifc,
-            ecc384: &mut env.ecc384,
-            data_vault: &mut env.data_vault,
-            pcr_bank: &mut env.pcr_bank,
-        };
-
-        // Verify the image
-        let info = Self::verify_image(&mut venv, manifest, txn.dlen());
-        let info = okref(&info)?;
-
-        Self::update_fuse_log(&info.log_info)?;
-
-        // populate data vault
-        Self::populate_data_vault(venv.data_vault, info);
-
-        // Extend PCR0
-        pcr::extend_pcr0(&mut venv, info)?;
-        report_boot_status(FmcAliasExtendPcrComplete.into());
-
-        // Load the image
-        Self::load_image(manifest, &mut txn)?;
-
-        // Complete the mailbox transaction indicating success.
-        txn.complete(true)?;
-        report_boot_status(FmcAliasFirmwareDownloadTxComplete.into());
 
         // We use the value of PCR0 as the measurement for deriving the CDI.
         let measurement = env.pcr_bank.read_pcr(caliptra_drivers::PcrId::PcrId0);
@@ -120,271 +76,13 @@ impl DiceLayer for FmcAliasLayer {
             subj_key_id,
         };
 
-        // if there is a valid value in the manifest for the not_before and not_after
-        // we take it from there.
-
-        let mut nb = NotBefore::default();
-        let mut nf = NotAfter::default();
-        let null_time = [0u8; 15];
-
-        if manifest.header.vendor_data.vendor_not_after != null_time
-            && manifest.header.vendor_data.vendor_not_before != null_time
-        {
-            nf.not_after = manifest.header.vendor_data.vendor_not_after;
-            nb.not_before = manifest.header.vendor_data.vendor_not_before;
-        }
-
-        //The owner values takes preference
-        if manifest.header.owner_data.owner_not_after != null_time
-            && manifest.header.owner_data.owner_not_before != null_time
-        {
-            nf.not_after = manifest.header.owner_data.owner_not_after;
-            nb.not_before = manifest.header.owner_data.owner_not_before;
-        }
-
         // Generate Local Device ID Certificate
-        Self::generate_cert_sig(env, info, input, &output, &nb.not_before, &nf.not_after)?;
+        Self::generate_cert_sig(env, input, &output, fw_proc_info)?;
 
         report_boot_status(FmcAliasDerivationComplete.into());
         cprintln!("[afmc] --");
 
-        Ok(output)
-    }
-}
-
-impl FmcAliasLayer {
-    /// Download firmware mailbox command ID.
-    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
-
-    /// Download the image
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    ///
-    /// # Returns
-    ///
-    /// Mailbox transaction handle. This transaction is ManuallyDrop because we
-    /// don't want the transaction to be completed with failure until after
-    /// report_error is called. This prevents a race condition where the SoC
-    /// reads FW_ERROR_NON_FATAL immediately after the mailbox transaction
-    /// fails, but before caliptra has set the FW_ERROR_NON_FATAL register.
-    fn download_image<'a>(
-        soc_ifc: &mut SocIfc,
-        mbox: &'a mut Mailbox,
-    ) -> CaliptraResult<ManuallyDrop<MailboxRecvTxn<'a>>> {
-        soc_ifc.flow_status_set_ready_for_firmware();
-
-        cprint!("[afmc] Waiting for Image ");
-        loop {
-            if let Some(txn) = mbox.peek_recv() {
-                if txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
-                    cprintln!("Invalid command 0x{:08x} received", txn.cmd());
-                    txn.start_txn().complete(false)?;
-                    continue;
-                }
-
-                // Re-borrow mailbox to work around https://github.com/rust-lang/rust/issues/54663
-                let txn = mbox
-                    .peek_recv()
-                    .ok_or(CaliptraError::FMC_ALIAS_MAILBOX_STATE_INCONSISTENT)?;
-
-                // This is a download-firmware command; don't drop this, as the
-                // transaction will be completed by either report_error() (on
-                // failure) or by a manual complete call upon success.
-                let txn = ManuallyDrop::new(txn.start_txn());
-                if txn.dlen() == 0 || txn.dlen() > IMAGE_BYTE_SIZE as u32 {
-                    cprintln!("Invalid Image of size {} bytes" txn.dlen());
-                    return Err(CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE);
-                }
-
-                cprintln!("");
-                cprintln!("[afmc] Received Image of size {} bytes" txn.dlen());
-                report_boot_status(FmcAliasDownloadImageComplete.into());
-                return Ok(txn);
-            }
-        }
-    }
-
-    /// Load the manifest
-    ///
-    /// # Returns
-    ///
-    /// * `Manifest` - Caliptra Image Bundle Manifest
-    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
-        let slice = unsafe {
-            let ptr = &mut MAN1_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        txn.copy_request(slice)?;
-
-        if let Some(result) = ImageManifest::read_from(slice.as_bytes()) {
-            report_boot_status(FmcAliasManifestLoadComplete.into());
-            Ok(result)
-        } else {
-            Err(CaliptraError::FMC_ALIAS_MANIFEST_READ_FAILURE)
-        }
-    }
-
-    /// Verify the image
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    fn verify_image(
-        venv: &mut RomImageVerificationEnv,
-        manifest: &ImageManifest,
-        img_bundle_sz: u32,
-    ) -> CaliptraResult<ImageVerificationInfo> {
-        let mut verifier = ImageVerifier::new(venv);
-        let info = verifier.verify(manifest, img_bundle_sz, ResetReason::ColdReset)?;
-
-        cprintln!(
-            "[afmc] Image verified using Vendor ECC Key Index {}",
-            info.vendor_ecc_pub_key_idx,
-        );
-        report_boot_status(FmcAliasImageVerificationComplete.into());
-        Ok(info)
-    }
-
-    /// Update the fuse log
-    ///
-    /// # Arguments
-    /// * `log_info` - Image Verification Log Info
-    ///
-    /// # Returns
-    /// * CaliptraResult
-    fn update_fuse_log(log_info: &ImageVerificationLogInfo) -> CaliptraResult<()> {
-        // Log VendorPubKeyIndex
-        log_fuse_data(
-            FuseLogEntryId::VendorPubKeyIndex,
-            log_info.vendor_ecc_pub_key_idx.as_bytes(),
-        )?;
-
-        // Log VendorPubKeyRevocation
-        log_fuse_data(
-            FuseLogEntryId::VendorPubKeyRevocation,
-            log_info.fuse_vendor_pub_key_revocation.bits().as_bytes(),
-        )?;
-
-        // Log ManifestFmcSvn
-        log_fuse_data(
-            FuseLogEntryId::ManifestFmcSvn,
-            log_info.fmc_log_info.manifest_svn.as_bytes(),
-        )?;
-
-        // Log ManifestFmcMinSvn
-        log_fuse_data(
-            FuseLogEntryId::ManifestFmcMinSvn,
-            log_info.fmc_log_info.manifest_min_svn.as_bytes(),
-        )?;
-
-        // Log FuseFmcSvn
-        log_fuse_data(
-            FuseLogEntryId::FuseFmcSvn,
-            log_info.fmc_log_info.fuse_svn.as_bytes(),
-        )?;
-
-        // Log ManifestRtSvn
-        log_fuse_data(
-            FuseLogEntryId::ManifestRtSvn,
-            log_info.rt_log_info.manifest_svn.as_bytes(),
-        )?;
-
-        // Log ManifestRtMinSvn
-        log_fuse_data(
-            FuseLogEntryId::ManifestRtMinSvn,
-            log_info.rt_log_info.manifest_min_svn.as_bytes(),
-        )?;
-
-        // Log FuseRtSvn
-        log_fuse_data(
-            FuseLogEntryId::FuseRtSvn,
-            log_info.rt_log_info.fuse_svn.as_bytes(),
-        )?;
         Ok(())
-    }
-
-    /// Load the image to ICCM & DCCM
-    ///
-    /// # Arguments
-    ///
-    /// * `env`      - ROM Environment
-    /// * `manifest` - Manifest
-    /// * `txn`      - Mailbox Receive Transaction
-    fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
-        cprintln!(
-            "[afmc] Loading FMC at address 0x{:08x} len {}",
-            manifest.fmc.load_addr,
-            manifest.fmc.size
-        );
-
-        let fmc_dest = unsafe {
-            let addr = (manifest.fmc.load_addr) as *mut u32;
-            core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
-        };
-
-        txn.copy_request(fmc_dest)?;
-
-        cprintln!(
-            "[afmc] Loading Runtime at address 0x{:08x} len {}",
-            manifest.runtime.load_addr,
-            manifest.runtime.size
-        );
-
-        let runtime_dest = unsafe {
-            let addr = (manifest.runtime.load_addr) as *mut u32;
-            core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
-        };
-
-        txn.copy_request(runtime_dest)?;
-
-        report_boot_status(FmcAliasLoadImageComplete.into());
-        Ok(())
-    }
-
-    /// Populate data vault
-    ///
-    /// # Arguments
-    ///
-    /// * `env`  - ROM Environment
-    /// * `info` - Image Verification Info
-    fn populate_data_vault(data_vault: &mut DataVault, info: &ImageVerificationInfo) {
-        data_vault.write_cold_reset_entry48(ColdResetEntry48::FmcTci, &info.fmc.digest.into());
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcSvn, info.fmc.svn);
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr, info.fmc.load_addr);
-
-        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint, info.fmc.entry_point);
-
-        data_vault.write_cold_reset_entry48(
-            ColdResetEntry48::OwnerPubKeyHash,
-            &info.owner_pub_keys_digest.into(),
-        );
-
-        data_vault.write_cold_reset_entry4(
-            ColdResetEntry4::VendorPubKeyIndex,
-            info.vendor_ecc_pub_key_idx,
-        );
-
-        data_vault.write_warm_reset_entry48(WarmResetEntry48::RtTci, &info.runtime.digest.into());
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtSvn, info.runtime.svn);
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtLoadAddr, info.runtime.load_addr);
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtEntryPoint, info.runtime.entry_point);
-
-        // TODO: Need a better way to get the Manifest address
-        let slice = unsafe {
-            let ptr = &MAN1_ORG as *const u32;
-            ptr as u32
-        };
-
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, slice);
-        report_boot_status(FmcAliasPopulateDataVaultComplete.into());
     }
 
     /// Derive Composite Device Identity (CDI) from FMC measurements
@@ -432,11 +130,9 @@ impl FmcAliasLayer {
     /// * `output` - DICE Output
     fn generate_cert_sig(
         env: &mut RomEnv,
-        info: &ImageVerificationInfo,
         input: &DiceInput,
         output: &DiceOutput,
-        not_before: &[u8; FmcAliasCertTbsParams::NOT_BEFORE_LEN],
-        not_after: &[u8; FmcAliasCertTbsParams::NOT_AFTER_LEN],
+        fw_proc_info: &FwProcInfo,
     ) -> CaliptraResult<()> {
         let auth_priv_key = input.auth_key_pair.priv_key;
         let auth_pub_key = &input.auth_key_pair.pub_key;
@@ -445,7 +141,7 @@ impl FmcAliasLayer {
         let flags = Self::make_flags(env.soc_ifc.lifecycle(), env.soc_ifc.debug_locked());
 
         let svn = env.data_vault.fmc_svn() as u8;
-        let fuse_svn = info.fmc.effective_fuse_svn as u8;
+        let fuse_svn = fw_proc_info.fmc_effective_fuse_svn as u8;
 
         // Certificate `To Be Signed` Parameters
         let params = FmcAliasCertTbsParams {
@@ -461,8 +157,8 @@ impl FmcAliasLayer {
             tcb_info_flags: &flags,
             tcb_info_fmc_svn: &svn.to_be_bytes(),
             tcb_info_fmc_svn_fuses: &fuse_svn.to_be_bytes(),
-            not_before,
-            not_after,
+            not_before: &fw_proc_info.fmc_cert_valid_not_before.value,
+            not_after: &fw_proc_info.fmc_cert_valid_not_after.value,
         };
 
         // Generate the `To Be Signed` portion of the CSR

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -1,0 +1,359 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    fw_processor.rs
+
+Abstract:
+
+    File contains the code to download and validate the firmware.
+
+--*/
+
+use crate::fuse::log_fuse_data;
+use crate::pcr;
+use crate::rom_env::RomEnv;
+use crate::{cprintln, verifier::RomImageVerificationEnv};
+use caliptra_common::{cprint, FuseLogEntryId, RomBootStatus::*};
+use caliptra_drivers::*;
+use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
+use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier};
+use caliptra_x509::{NotAfter, NotBefore};
+use core::mem::ManuallyDrop;
+use zerocopy::{AsBytes, FromBytes};
+
+extern "C" {
+    static mut MAN1_ORG: u32;
+}
+
+#[derive(Debug, Default)]
+pub struct FwProcInfo {
+    pub fmc_cert_valid_not_before: NotBefore,
+
+    pub fmc_cert_valid_not_after: NotAfter,
+
+    pub fmc_effective_fuse_svn: u32,
+}
+
+pub struct FirmwareProcessor {}
+
+impl FirmwareProcessor {
+    /// Download firmware mailbox command ID.
+    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
+
+    pub fn process(env: &mut RomEnv) -> CaliptraResult<FwProcInfo> {
+        // Download the image
+        let mut txn = Self::download_image(&mut env.soc_ifc, &mut env.mbox)?;
+
+        // Load the manifest
+        let manifest = Self::load_manifest(&mut txn);
+        let manifest = okref(&manifest)?;
+
+        let mut venv = RomImageVerificationEnv {
+            sha256: &mut env.sha256,
+            sha384: &mut env.sha384,
+            sha384_acc: &mut env.sha384_acc,
+            soc_ifc: &mut env.soc_ifc,
+            ecc384: &mut env.ecc384,
+            data_vault: &mut env.data_vault,
+            pcr_bank: &mut env.pcr_bank,
+        };
+
+        // Verify the image
+        let info = Self::verify_image(&mut venv, manifest, txn.dlen());
+        let info = okref(&info)?;
+
+        Self::update_fuse_log(&info.log_info)?;
+
+        // Populate data vault
+        Self::populate_data_vault(venv.data_vault, info);
+
+        // Extend PCR0
+        pcr::extend_pcr0(&mut venv, info)?;
+        report_boot_status(FwProcessorExtendPcrComplete.into());
+
+        // Load the image
+        Self::load_image(manifest, &mut txn)?;
+
+        // Complete the mailbox transaction indicating success.
+        txn.complete(true)?;
+        report_boot_status(FwProcessorFirmwareDownloadTxComplete.into());
+
+        // Get the certificate validity info
+        let (nb, nf) = Self::get_cert_validity_info(manifest);
+
+        report_boot_status(FwProcessorComplete.into());
+        Ok(FwProcInfo {
+            fmc_cert_valid_not_before: nb,
+            fmc_cert_valid_not_after: nf,
+            fmc_effective_fuse_svn: info.fmc.effective_fuse_svn,
+        })
+    }
+
+    /// Download the image
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - ROM Environment
+    ///
+    /// # Returns
+    ///
+    /// Mailbox transaction handle. This transaction is ManuallyDrop because we
+    /// don't want the transaction to be completed with failure until after
+    /// report_error is called. This prevents a race condition where the SoC
+    /// reads FW_ERROR_NON_FATAL immediately after the mailbox transaction
+    /// fails, but before caliptra has set the FW_ERROR_NON_FATAL register.
+    fn download_image<'a>(
+        soc_ifc: &mut SocIfc,
+        mbox: &'a mut Mailbox,
+    ) -> CaliptraResult<ManuallyDrop<MailboxRecvTxn<'a>>> {
+        soc_ifc.flow_status_set_ready_for_firmware();
+
+        cprint!("[afmc] Waiting for Image ");
+        loop {
+            if let Some(txn) = mbox.peek_recv() {
+                if txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
+                    cprintln!("Invalid command 0x{:08x} received", txn.cmd());
+                    txn.start_txn().complete(false)?;
+                    continue;
+                }
+
+                // Re-borrow mailbox to work around https://github.com/rust-lang/rust/issues/54663
+                let txn = mbox
+                    .peek_recv()
+                    .ok_or(CaliptraError::FW_PROC_MAILBOX_STATE_INCONSISTENT)?;
+
+                // This is a download-firmware command; don't drop this, as the
+                // transaction will be completed by either report_error() (on
+                // failure) or by a manual complete call upon success.
+                let txn = ManuallyDrop::new(txn.start_txn());
+                if txn.dlen() == 0 || txn.dlen() > IMAGE_BYTE_SIZE as u32 {
+                    cprintln!("Invalid Image of size {} bytes" txn.dlen());
+                    return Err(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE);
+                }
+
+                cprintln!("");
+                cprintln!("[afmc] Received Image of size {} bytes" txn.dlen());
+                report_boot_status(FwProcessorDownloadImageComplete.into());
+                return Ok(txn);
+            }
+        }
+    }
+
+    /// Load the manifest
+    ///
+    /// # Returns
+    ///
+    /// * `Manifest` - Caliptra Image Bundle Manifest
+    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
+        let slice = unsafe {
+            let ptr = &mut MAN1_ORG as *mut u32;
+            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
+        };
+
+        txn.copy_request(slice)?;
+
+        if let Some(result) = ImageManifest::read_from(slice.as_bytes()) {
+            report_boot_status(FwProcessorManifestLoadComplete.into());
+            Ok(result)
+        } else {
+            Err(CaliptraError::FW_PROC_MANIFEST_READ_FAILURE)
+        }
+    }
+
+    /// Verify the image
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - ROM Environment
+    fn verify_image(
+        venv: &mut RomImageVerificationEnv,
+        manifest: &ImageManifest,
+        img_bundle_sz: u32,
+    ) -> CaliptraResult<ImageVerificationInfo> {
+        let mut verifier = ImageVerifier::new(venv);
+        let info = verifier.verify(manifest, img_bundle_sz, ResetReason::ColdReset)?;
+
+        cprintln!(
+            "[afmc] Image verified using Vendor ECC Key Index {}",
+            info.vendor_ecc_pub_key_idx,
+        );
+        report_boot_status(FwProcessorImageVerificationComplete.into());
+        Ok(info)
+    }
+
+    /// Update the fuse log
+    ///
+    /// # Arguments
+    /// * `log_info` - Image Verification Log Info
+    ///
+    /// # Returns
+    /// * CaliptraResult
+    fn update_fuse_log(log_info: &ImageVerificationLogInfo) -> CaliptraResult<()> {
+        // Log VendorPubKeyIndex
+        log_fuse_data(
+            FuseLogEntryId::VendorPubKeyIndex,
+            log_info.vendor_ecc_pub_key_idx.as_bytes(),
+        )?;
+
+        // Log VendorPubKeyRevocation
+        log_fuse_data(
+            FuseLogEntryId::VendorPubKeyRevocation,
+            log_info.fuse_vendor_pub_key_revocation.bits().as_bytes(),
+        )?;
+
+        // Log ManifestFmcSvn
+        log_fuse_data(
+            FuseLogEntryId::ManifestFmcSvn,
+            log_info.fmc_log_info.manifest_svn.as_bytes(),
+        )?;
+
+        // Log ManifestFmcMinSvn
+        log_fuse_data(
+            FuseLogEntryId::ManifestFmcMinSvn,
+            log_info.fmc_log_info.manifest_min_svn.as_bytes(),
+        )?;
+
+        // Log FuseFmcSvn
+        log_fuse_data(
+            FuseLogEntryId::FuseFmcSvn,
+            log_info.fmc_log_info.fuse_svn.as_bytes(),
+        )?;
+
+        // Log ManifestRtSvn
+        log_fuse_data(
+            FuseLogEntryId::ManifestRtSvn,
+            log_info.rt_log_info.manifest_svn.as_bytes(),
+        )?;
+
+        // Log ManifestRtMinSvn
+        log_fuse_data(
+            FuseLogEntryId::ManifestRtMinSvn,
+            log_info.rt_log_info.manifest_min_svn.as_bytes(),
+        )?;
+
+        // Log FuseRtSvn
+        log_fuse_data(
+            FuseLogEntryId::FuseRtSvn,
+            log_info.rt_log_info.fuse_svn.as_bytes(),
+        )?;
+        Ok(())
+    }
+
+    /// Load the image to ICCM & DCCM
+    ///
+    /// # Arguments
+    ///
+    /// * `env`      - ROM Environment
+    /// * `manifest` - Manifest
+    /// * `txn`      - Mailbox Receive Transaction
+    fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
+        cprintln!(
+            "[afmc] Loading FMC at address 0x{:08x} len {}",
+            manifest.fmc.load_addr,
+            manifest.fmc.size
+        );
+
+        let fmc_dest = unsafe {
+            let addr = (manifest.fmc.load_addr) as *mut u32;
+            core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
+        };
+
+        txn.copy_request(fmc_dest)?;
+
+        cprintln!(
+            "[afmc] Loading Runtime at address 0x{:08x} len {}",
+            manifest.runtime.load_addr,
+            manifest.runtime.size
+        );
+
+        let runtime_dest = unsafe {
+            let addr = (manifest.runtime.load_addr) as *mut u32;
+            core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
+        };
+
+        txn.copy_request(runtime_dest)?;
+
+        report_boot_status(FwProcessorLoadImageComplete.into());
+        Ok(())
+    }
+
+    /// Populate data vault
+    ///
+    /// # Arguments
+    ///
+    /// * `env`  - ROM Environment
+    /// * `info` - Image Verification Info
+    fn populate_data_vault(data_vault: &mut DataVault, info: &ImageVerificationInfo) {
+        data_vault.write_cold_reset_entry48(ColdResetEntry48::FmcTci, &info.fmc.digest.into());
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcSvn, info.fmc.svn);
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcLoadAddr, info.fmc.load_addr);
+
+        data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcEntryPoint, info.fmc.entry_point);
+
+        data_vault.write_cold_reset_entry48(
+            ColdResetEntry48::OwnerPubKeyHash,
+            &info.owner_pub_keys_digest.into(),
+        );
+
+        data_vault.write_cold_reset_entry4(
+            ColdResetEntry4::VendorPubKeyIndex,
+            info.vendor_ecc_pub_key_idx,
+        );
+
+        data_vault.write_warm_reset_entry48(WarmResetEntry48::RtTci, &info.runtime.digest.into());
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtSvn, info.runtime.svn);
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtLoadAddr, info.runtime.load_addr);
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::RtEntryPoint, info.runtime.entry_point);
+
+        // TODO: Need a better way to get the Manifest address
+        let slice = unsafe {
+            let ptr = &MAN1_ORG as *const u32;
+            ptr as u32
+        };
+
+        data_vault.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, slice);
+        report_boot_status(FwProcessorPopulateDataVaultComplete.into());
+    }
+
+    /// Process the certificate validity info
+    ///
+    /// # Arguments
+    /// * `manifest` - Manifest
+    ///
+    /// # Returns
+    /// * `NotBefore` - Valid Not Before Time
+    /// * `NotAfter`  - Valid Not After Time
+    ///
+    fn get_cert_validity_info(manifest: &ImageManifest) -> (NotBefore, NotAfter) {
+        // If there is a valid value in the manifest for the not_before and not_after times,
+        // use those. Otherwise use the default values.
+        let mut nb = NotBefore::default();
+        let mut nf = NotAfter::default();
+        let null_time = [0u8; 15];
+
+        if manifest.header.vendor_data.vendor_not_after != null_time
+            && manifest.header.vendor_data.vendor_not_before != null_time
+        {
+            nf.value = manifest.header.vendor_data.vendor_not_after;
+            nb.value = manifest.header.vendor_data.vendor_not_before;
+        }
+
+        // Owner values take preference.
+        if manifest.header.owner_data.owner_not_after != null_time
+            && manifest.header.owner_data.owner_not_before != null_time
+        {
+            nf.value = manifest.header.owner_data.owner_not_after;
+            nb.value = manifest.header.owner_data.owner_not_before;
+        }
+
+        (nb, nf)
+    }
+}

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -44,18 +44,17 @@ const MAX_CSR_SIZE: usize = 512;
 /// Dice Initial Device Identity (IDEVID) Layer
 pub enum InitDevIdLayer {}
 
-impl DiceLayer for InitDevIdLayer {
+impl InitDevIdLayer {
     /// Perform derivations for the DICE layer
     ///
     /// # Arguments
     ///
     /// * `env`   - ROM Environment
-    /// * `_input` - DICE layer input
     ///
     /// # Returns
     ///
     /// * `DiceOutput` - DICE layer output
-    fn derive(env: &mut RomEnv, _input: &DiceInput) -> CaliptraResult<DiceOutput> {
+    pub fn derive(env: &mut RomEnv) -> CaliptraResult<DiceOutput> {
         cprintln!("[idev] ++");
         cprintln!("[idev] CDI.KEYID = {}", KEY_ID_CDI as u8);
         cprintln!("[idev] SUBJECT.KEYID = {}", KEY_ID_IDEVID_PRIV_KEY as u8);
@@ -101,9 +100,7 @@ impl DiceLayer for InitDevIdLayer {
         // Return the DICE Layer Output
         Ok(output)
     }
-}
 
-impl InitDevIdLayer {
     /// Decrypt Unique Device Secret (UDS)
     ///
     /// # Arguments

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -29,7 +29,7 @@ use caliptra_x509::*;
 #[derive(Default)]
 pub struct LocalDevIdLayer {}
 
-impl DiceLayer for LocalDevIdLayer {
+impl LocalDevIdLayer {
     /// Perform derivations for the DICE layer
     ///
     /// # Arguments
@@ -40,7 +40,7 @@ impl DiceLayer for LocalDevIdLayer {
     /// # Returns
     ///
     /// * `DiceOutput` - key pair, subject identifier serial number, subject key identifier
-    fn derive(env: &mut RomEnv, input: &DiceInput) -> CaliptraResult<DiceOutput> {
+    pub fn derive(env: &mut RomEnv, input: &DiceInput) -> CaliptraResult<DiceOutput> {
         cprintln!("[ldev] ++");
         cprintln!("[ldev] CDI.KEYID = {}", KEY_ID_CDI as u8);
         cprintln!("[ldev] SUBJECT.KEYID = {}", KEY_ID_LDEVID_PRIV_KEY as u8);
@@ -84,9 +84,7 @@ impl DiceLayer for LocalDevIdLayer {
 
         Ok(output)
     }
-}
 
-impl LocalDevIdLayer {
     /// Derive Composite Device Identity (CDI) from field entropy
     ///
     /// # Arguments
@@ -157,8 +155,8 @@ impl LocalDevIdLayer {
             authority_key_id: input.auth_key_id,
             serial_number,
             public_key: &pub_key.to_der(),
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         // Generate the `To Be Signed` portion of the CSR

--- a/rom/dev/tests/test_dice_derivations.rs
+++ b/rom/dev/tests/test_dice_derivations.rs
@@ -71,17 +71,15 @@ fn test_status_reporting() {
         .is_ok());
 
     // [TODO] Don't use upload_firmware (whic returns only when the txn is complete); manually upload the firmware to test these boot statuses.
-    // step_until_boot_status(FmcAliasDownloadImageComplete);
-    // step_until_boot_status(FmcAliasManifestLoadComplete);
-    // step_until_boot_status(FmcAliasImageVerificationComplete);
-    // step_until_boot_status(FmcAliasPopulateDataVaultComplete);
-    // step_until_boot_status(FmcAliasExtendPcrComplete);
-    // step_until_boot_status(FmcAliasLoadImageComplete);
-    step_until_boot_status(&mut hw, FmcAliasFirmwareDownloadTxComplete);
+    // step_until_boot_status(FwProcessorDownloadImageComplete);
+    // step_until_boot_status(FwProcessorManifestLoadComplete);
+    // step_until_boot_status(FwProcessorImageVerificationComplete);
+    // step_until_boot_status(FwProcessorPopulateDataVaultComplete);
+    // step_until_boot_status(FwProcessorExtendPcrComplete);
+    // step_until_boot_status(FwProcessorLoadImageComplete);
+    step_until_boot_status(&mut hw, FwProcessorFirmwareDownloadTxComplete);
+    step_until_boot_status(&mut hw, FwProcessorComplete);
     step_until_boot_status(&mut hw, FmcAliasDeriveCdiComplete);
     step_until_boot_status(&mut hw, FmcAliasKeyPairDerivationComplete);
     step_until_boot_status(&mut hw, FmcAliasSubjIdSnGenerationComplete);
-    step_until_boot_status(&mut hw, FmcAliasSubjKeyIdGenerationComplete);
-    step_until_boot_status(&mut hw, FmcAliasCertSigGenerationComplete);
-    step_until_boot_status(&mut hw, FmcAliasDerivationComplete);
 }

--- a/rom/dev/tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/test_fmcalias_derivation.rs
@@ -21,11 +21,11 @@ fn test_zero_firmware_size() {
     // Zero-sized firmware.
     assert_eq!(
         hw.upload_firmware(&[]).unwrap_err(),
-        ModelError::MailboxCmdFailed(0x01020003)
+        ModelError::MailboxCmdFailed(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into())
     );
     assert_eq!(
         hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE.into()
+        CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
     );
 }
 
@@ -54,7 +54,7 @@ fn test_firmware_gt_max_size() {
 
     assert_eq!(
         hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE.into()
+        CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
     );
 }
 

--- a/rom/dev/tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/test_mailbox_errors.rs
@@ -33,7 +33,7 @@ fn test_mailbox_command_aborted_after_report_error() {
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
     assert_eq!(
         Err(ModelError::MailboxCmdFailed(
-            CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE.into()
+            CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
         )),
         hw.upload_firmware(&[])
     );
@@ -45,7 +45,7 @@ fn test_mailbox_command_aborted_after_report_error() {
     assert_eq!(
         hw.upload_firmware(&image_bundle.to_bytes().unwrap()),
         Err(ModelError::MailboxCmdFailed(
-            CaliptraError::FMC_ALIAS_INVALID_IMAGE_SIZE.into()
+            CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()
         ))
     );
 }

--- a/x509/src/fmc_alias_cert.rs
+++ b/x509/src/fmc_alias_cert.rs
@@ -59,8 +59,8 @@ mod tests {
             tcb_info_fmc_tci: &[0xB6u8; FmcAliasCertTbsParams::TCB_INFO_FMC_TCI_LEN],
             tcb_info_fmc_svn: &[0xB7],
             tcb_info_fmc_svn_fuses: &[0xB8],
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = FmcAliasCertTbs::new(&params);

--- a/x509/src/ldevid_cert.rs
+++ b/x509/src/ldevid_cert.rs
@@ -56,8 +56,8 @@ mod tests {
                     issuer_key.sha1(),
                 )
                 .unwrap(),
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = LocalDevIdCertTbs::new(&params);

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -27,34 +27,32 @@ pub use idevid_csr::{InitDevIdCsrTbs, InitDevIdCsrTbsParams};
 pub use ldevid_cert::{LocalDevIdCertTbs, LocalDevIdCertTbsParams};
 pub use rt_alias_cert::{RtAliasCertTbs, RtAliasCertTbsParams};
 
+#[derive(Debug)]
 pub struct NotBefore {
-    pub not_before: [u8; 15],
+    pub value: [u8; 15],
 }
 
 impl Default for NotBefore {
     fn default() -> Self {
         let not_before = "20230101000000Z";
-        let mut nb: NotBefore = NotBefore {
-            not_before: [0u8; 15],
-        };
+        let mut nb: NotBefore = NotBefore { value: [0u8; 15] };
 
-        nb.not_before.copy_from_slice(not_before.as_bytes());
+        nb.value.copy_from_slice(not_before.as_bytes());
         nb
     }
 }
 
+#[derive(Debug)]
 pub struct NotAfter {
-    pub not_after: [u8; 15],
+    pub value: [u8; 15],
 }
 
 impl Default for NotAfter {
     fn default() -> Self {
         let not_after = "99991231235959Z";
-        let mut nb: NotAfter = NotAfter {
-            not_after: [0u8; 15],
-        };
+        let mut nf: NotAfter = NotAfter { value: [0u8; 15] };
 
-        nb.not_after.copy_from_slice(not_after.as_bytes());
-        nb
+        nf.value.copy_from_slice(not_after.as_bytes());
+        nf
     }
 }

--- a/x509/src/rt_alias_cert.rs
+++ b/x509/src/rt_alias_cert.rs
@@ -56,8 +56,8 @@ mod tests {
             .unwrap(),
             tcb_info_rt_svn: &[0xE3],
             tcb_info_rt_tci: &[0xEFu8; RtAliasCertTbsParams::TCB_INFO_RT_TCI_LEN],
-            not_before: &NotBefore::default().not_before,
-            not_after: &NotAfter::default().not_after,
+            not_before: &NotBefore::default().value,
+            not_after: &NotAfter::default().value,
         };
 
         let cert = RtAliasCertTbs::new(&params);


### PR DESCRIPTION
This change moves the firmware download and validation code out of the FmcAlias layer into a new layer.