### PR TITLE
Update rust toolchain from 1.68 to 1.70 (-2076 bytes)

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -22,7 +22,7 @@ jobs:
       SCCACHE_GHA_CACHE_TO: sccache-verilator-10000
       SCCACHE_GHA_CACHE_FROM: sccache-verilator-
       # Change this to a new random value if you suspect the cache is corrupted
-      SCCACHE_C_CUSTOM_CACHE_BUSTER: f3e6951f0c1d
+      SCCACHE_C_CUSTOM_CACHE_BUSTER: 3962471045e8
 
       # Compiler warnings should fail to compile
       EXTRA_CARGO_CONFIG: "target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
@@ -31,21 +31,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-
-      - name: Set Rust ${{ env.RUST_TOOLCHAIN_VERSION }} as the default toolchain.
-        run: |
-          rustup default ${RUST_TOOLCHAIN_VERSION}
-          rustup component add rustfmt clippy
-          rustc --version
-          cargo fmt --version
-          cargo clippy --version
-
-      - name: Restore Cargo index from cache
-        uses: actions/cache/restore@v3
-        id: cargo_index_restore
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-index-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Restore sccache binary
         uses: actions/cache/restore@v3
@@ -103,23 +88,12 @@ jobs:
         run: |
           echo /opt/verilator/bin >> $GITHUB_PATH
 
-      - name: Install risv32imc target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
-
       - name: Update Cargo index
         run: |
           cargo tree --locked > /dev/null || (
             echo "Please include required changes to Cargo.lock in your pull request"
             exit 1
           )
-
-      - name: Save Cargo index to cache
-        uses: actions/cache/save@v3
-        if: steps.cargo_index_restore.outputs.cache-hit != 'true'
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-index-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Check that generated register code matches caliptra-rtl submodule
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,27 +14,19 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      RUST_TOOLCHAIN_VERSION: 1.68.0
       CARGO_INCREMENTAL: 0
       SCCACHE_VERSION: 0.3.3
       SCCACHE_GHA_CACHE_TO: sccache-caliptra-sw
       SCCACHE_GHA_CACHE_FROM: sccache-caliptra-sw
 
       # Change this to a new random value if you suspect the cache is corrupted
-      SCCACHE_C_CUSTOM_CACHE_BUSTER: 68a6835b420c
+      SCCACHE_C_CUSTOM_CACHE_BUSTER: 4eeb97ca753a
 
       # Compiler warnings should fail to compile
       EXTRA_CARGO_CONFIG: "target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Restore Cargo index from cache
-        uses: actions/cache/restore@v3
-        id: cargo_index_restore
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-index-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Restore sccache binary
         uses: actions/cache/restore@v3
@@ -65,14 +57,6 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Set Rust ${{ env.RUST_TOOLCHAIN_VERSION }} as the default toolchain.
-        run: |
-          rustup default ${RUST_TOOLCHAIN_VERSION}
-          rustup component add rustfmt clippy
-          rustc --version
-          cargo fmt --version
-          cargo clippy --version
-
       - name: Check that Cargo.lock doesn't need to be updated
           # Note: this isn't the same as checking that Cargo.lock is up to date
           # (cargo update --locked), which makes sure that every package is the
@@ -90,13 +74,6 @@ jobs:
             exit 1
           )
 
-      - name: Save Cargo index to cache
-        uses: actions/cache/save@v3
-        if: steps.cargo_index_restore.outputs.cache-hit != 'true'
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-index-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}-${{ hashFiles('Cargo.lock') }}
-
       - name: Check source-code formatting (run "cargo fmt" if this fails)
         run: |
           cargo fmt --check --all
@@ -104,10 +81,6 @@ jobs:
       - name: Check license headers
         run: |
           cargo run -p file-header-fix --locked -- --check
-
-      - name: Install risv32imc target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
 
       - name: Build
         run: |

--- a/.github/workflows/nightly-verilator.yml
+++ b/.github/workflows/nightly-verilator.yml
@@ -5,7 +5,6 @@ on:
     # 2:11 AM PST tuesday-saturday
     - cron: '11 10 * * 2-6'
 
-
 jobs:
   smoke_test:
     name: Smoke Test
@@ -13,7 +12,6 @@ jobs:
     timeout-minutes: 360
 
     env:
-      RUST_TOOLCHAIN_VERSION: 1.68.0
       VERILATOR_VERSION: v5.006
       PKG_CONFIG_PATH: /opt/verilator/share/pkgconfig
         # Change this to a new random value if you suspect the cache is corrupted
@@ -23,14 +21,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-
-      - name: Set Rust ${{ env.RUST_TOOLCHAIN_VERSION }} as the default toolchain.
-        run: |
-          rustup default ${RUST_TOOLCHAIN_VERSION}
-          rustup component add rustfmt clippy
-          rustc --version
-          cargo fmt --version
-          cargo clippy --version
 
       - name: Restore verilator dir
         uses: actions/cache/restore@v3
@@ -61,10 +51,6 @@ jobs:
       - name: Setup verilator path
         run: |
           echo /opt/verilator/bin >> $GITHUB_PATH
-
-      - name: Install risv32imc target
-        run: |
-          rustup target add riscv32imc-unknown-none-elf
 
       - name: Run smoke test inside verilator (will take hours)
         run: |

--- a/.github/workflows/size-history.yml
+++ b/.github/workflows/size-history.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      RUST_TOOLCHAIN_VERSION: 1.68.0
       CARGO_INCREMENTAL: 0
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       PR_TITLE: ${{github.event.pull_request.title}}
@@ -34,11 +33,6 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Set Rust ${{ env.RUST_TOOLCHAIN_VERSION }} as the default toolchain.
-        run: |
-          rustup default ${RUST_TOOLCHAIN_VERSION}
-          rustup target add riscv32imc-unknown-none-elf
 
       - name: Run size analysis (look at workflow "Summary" tab for results)
         run: |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ used by firmware running on Caliptra's RISC-V cpu.
 To build Caliptra firmware or tools, you need a Linux installation with a recent
 Rust toolchain. See [Getting started with
 Rust](https://www.rust-lang.org/learn/get-started) for more information on
-installing an up-to-date Rust toolchain. We use version 1.68 of the Rust
+installing an up-to-date Rust toolchain. We use version 1.70 of the Rust
 toolchain for all continuous integration.
 
 ## Checkout and build

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -4,6 +4,7 @@
 name = "caliptra-rom"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.70"
 
 [dependencies]
 caliptra-drivers = { path = "../../drivers" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Licensed under the Apache-2.0 license
+
+[toolchain]
+channel = "1.70"
+targets = ["riscv32imc-unknown-none-elf"]
+profile = "minimal"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Set the desired toolchain in rust-toolchain.toml, so everyone uses the same toolchain by default.

[Size analysis](https://github.com/chipsalliance/caliptra-sw/actions/runs/5206880511)

The improved risc-v codegen in this release reduces the size of the ROM
by 2076 bytes.

As part of this change, we can remove the cargo index cache, as in 1.70
cargo [switched to](https://github.com/rust-lang/rust/blob/642c92e63008ffb49f6ad8344e07bfa7d5b0d9bb/RELEASES.md?plain=1#L101) the [sparse index protocol](https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html#background), which is much faster.

