### PR TITLE
[feat] RT Alias Layer must update  FHT data structure fields

### DIFF
--- a/common/src/hand_off.rs
+++ b/common/src/hand_off.rs
@@ -252,12 +252,6 @@ pub struct FirmwareHandoffTable {
     /// Index of RT Public Alias Key Y Coordinate in the Data Vault.
     pub rt_pub_key_y_dv_hdl: HandOffDataHandle,
 
-    /// Index of RT Certificate Signature R Component in the Data Vault.
-    pub rt_cert_sig_r_dv_hdl: HandOffDataHandle,
-
-    /// Index of RT Certificate Signature S Component in the Data Vault.
-    pub rt_cert_sig_s_dv_hdl: HandOffDataHandle,
-
     /// Index of RT SVN value in the Data Vault
     pub rt_svn_dv_hdl: HandOffDataHandle,
 
@@ -279,8 +273,10 @@ pub struct FirmwareHandoffTable {
     /// Fuse log Address
     pub fuse_log_addr: u32,
 
+    pub rt_dice_sign: [u8; core::mem::size_of::<caliptra_drivers::Ecc384Signature>()],
+
     /// Reserved for future use.
-    pub reserved: [u8; 32],
+    pub reserved: [u8; 60],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -306,16 +302,15 @@ impl Default for FirmwareHandoffTable {
             rt_priv_key_kv_hdl: FHT_INVALID_HANDLE,
             rt_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
             rt_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
-            rt_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
-            rt_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
             rt_svn_dv_hdl: FHT_INVALID_HANDLE,
             ldevid_tbs_size: 0,
             fmcalias_tbs_size: 0,
-            reserved: [0; 32],
+            reserved: [0u8; 60],
             ldevid_tbs_addr: 0,
             fmcalias_tbs_addr: 0,
             pcr_log_addr: 0,
             fuse_log_addr: 0,
+            rt_dice_sign: [0; core::mem::size_of::<caliptra_drivers::Ecc384Signature>()],
         }
     }
 }
@@ -376,14 +371,6 @@ pub fn print_fht(fht: &FirmwareHandoffTable) {
     crate::cprintln!(
         "RT Public Key Y DV Handle: 0x{:08x}",
         fht.rt_pub_key_y_dv_hdl.0
-    );
-    crate::cprintln!(
-        "RT Certificate Signature R DV Handle: 0x{:08x}",
-        fht.rt_cert_sig_r_dv_hdl.0
-    );
-    crate::cprintln!(
-        "RT Certificate Signature S DV Handle: 0x{:08x}",
-        fht.rt_cert_sig_s_dv_hdl.0
     );
     crate::cprintln!("RT SVN DV Handle: 0x{:08x}", fht.rt_svn_dv_hdl.0);
 
@@ -451,7 +438,7 @@ pub fn report_handoff_error_and_halt(msg: &str, code: u32) -> ! {
 mod tests {
     use super::*;
     use core::mem;
-    const FHT_SIZE: usize = 140;
+    const FHT_SIZE: usize = 256;
 
     fn rt_tci_store() -> HandOffDataHandle {
         HandOffDataHandle::from(DataStore::DataVaultNonSticky48(WarmResetEntry48::RtTci))

--- a/drivers/src/array.rs
+++ b/drivers/src/array.rs
@@ -14,6 +14,13 @@ Abstract:
 --*/
 
 use core::mem::MaybeUninit;
+use zerocopy::{AsBytes, FromBytes};
+
+macro_rules! static_assert {
+    ($expression:expr) => {
+        const _: () = assert!($expression);
+    };
+}
 
 /// The `Array4xN` type represents large arrays in the native format of the Caliptra
 /// cryptographic hardware, and provides From traits for converting to/from byte arrays.
@@ -30,6 +37,18 @@ impl<const W: usize, const B: usize> Default for Array4xN<W, B> {
     fn default() -> Self {
         Self([0u32; W])
     }
+}
+
+//// Ensure there is no padding in the struct
+static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
+unsafe impl<const W: usize, const B: usize> AsBytes for Array4xN<W, B> {
+    fn only_derive_is_allowed_to_implement_this_trait() {}
+}
+
+//// Ensure there is no padding in the struct
+static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
+unsafe impl<const W: usize, const B: usize> FromBytes for Array4xN<W, B> {
+    fn only_derive_is_allowed_to_implement_this_trait() {}
 }
 
 impl<const W: usize, const B: usize> Array4xN<W, B> {

--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -11,12 +11,12 @@ Abstract:
     File contains API for ECC-384 Cryptography operations
 
 --*/
-
 use crate::kv_access::{KvAccess, KvAccessErr};
 use crate::{
     array_concat3, wait, Array4x12, CaliptraError, CaliptraResult, KeyReadArgs, KeyWriteArgs,
 };
 use caliptra_registers::ecc::EccReg;
+use zerocopy::{AsBytes, FromBytes};
 
 /// ECC-384 Coordinate
 pub type Ecc384Scalar = Array4x12;
@@ -93,7 +93,8 @@ impl From<KeyReadArgs> for Ecc384PrivKeyIn<'_> {
 }
 
 /// ECC-384 Public Key
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct Ecc384PubKey {
     /// X coordinate
     pub x: Ecc384Scalar,
@@ -111,7 +112,8 @@ impl Ecc384PubKey {
 }
 
 /// ECC-384 Signature
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[repr(C)]
+#[derive(Debug, Default, AsBytes, FromBytes, Copy, Clone, Eq, PartialEq)]
 pub struct Ecc384Signature {
     /// Random point
     pub r: Ecc384Scalar,

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -126,13 +126,12 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | rt_tci_dv_hdl         | 1            | ROM        | Handle of RT TCI value in the Data Vault.                                                                 |
 | rt_cdi_kv_hdl         | 1            | FMC        | Handle of RT CDI value in the Key Vault.                                                                  |
 | rt_priv_key_kv_hdl    | 1            | FMC        | Handle of RT Private Alias Key in the Key Vault.                                                          |
-| rt_pub_key_x_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key X Coordinate in the Data Vault.                                             |
-| rt_pub_key_y_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
+Key Y Coordinate in the Data Vault.                                             |
 | rt_svn_dv_hdl         | 1            | FMC        | Handle of RT SVN value in the Data Vault.                                                                 |
 | rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.
 | reserved              | 52           |            | Reserved for future use.                                                                                 |
 
-*FHT is currently defined to be 256 bytes in length.*
+*FHT is currently defined to be 512 bytes in length.*
 
 ### fht_marker
 
@@ -199,10 +198,6 @@ This field provides the Handle into the Key Vault where the CDI<sub>RT</sub> is 
 ### rt_priv_key_kv_hdl
 
 This field provides the Handle into the Key Vault where the PrivateKey<sub>RT</sub> is stored.
-
-### rt_pub_key_x_dv_hdl, rt_pub_key_y_dv_hdl
-
-These fields provide the indices into the Data Vault where the PublicKey<sub>RT</sub> X and Y coordinates are stored.
 
 ### rt_cert_sig_r_dv_hdl, rt_cert_sig_s_dv_hdl
 

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -128,12 +128,11 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | rt_priv_key_kv_hdl    | 1            | FMC        | Handle of RT Private Alias Key in the Key Vault.                                                          |
 | rt_pub_key_x_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key X Coordinate in the Data Vault.                                             |
 | rt_pub_key_y_dv_hdl   | 1            | FMC        | Handle of RT Public Alias Key Y Coordinate in the Data Vault.                                             |
-| rt_cert_sig_r_dv_hdl  | 1            | FMC        | Handle of RT Certificate Signature R Component in the Data Vault.                                         |
-| rt_cert_sig_s_dv_hdl  | 1            | FMC        | Handle of RT Certificate Signature S Component in the Data Vault.                                         |
 | rt_svn_dv_hdl         | 1            | FMC        | Handle of RT SVN value in the Data Vault.                                                                 |
-| reserved              | 20           |            | Reserved for future use.                                                                                 |
+| rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.
+| reserved              | 52           |            | Reserved for future use.                                                                                 |
 
-*FHT is currently defined to be 60 bytes in length.*
+*FHT is currently defined to be 256 bytes in length.*
 
 ### fht_marker
 
@@ -184,10 +183,6 @@ This field provides the Handle into the Key Vault where the PrivateKey<sub>FMC</
 ### fmc_pub_key_x_dv_hdl, fmc_pub_key_y_dv_hdl
 
 These fields provide the indices into the Data Vault where the PublicKey<sub>FMC</sub> X and Y coordinates are stored.
-
-### fmc_cert_sig_r_dv_hdl, fmc_cert_sig_s_dv_hdl
-
-These fields provide the indices into the Data Vault where the Cert<sub>FMC</sub> signature R and S components are stored.
 
 ### fmc_svn_dv_hdl
 

--- a/fmc/src/flow/dice.rs
+++ b/fmc/src/flow/dice.rs
@@ -93,7 +93,7 @@ pub trait DiceLayer {
     /// * `DiceOutput` - DICE layer output
     fn derive(
         env: &mut FmcEnv,
-        hand_off: &HandOff,
+        hand_off: &mut HandOff,
         input: &DiceInput,
     ) -> CaliptraResult<DiceOutput>;
 }

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -41,7 +41,7 @@ impl DiceLayer for RtAliasLayer {
     /// Perform derivations for the DICE layer
     fn derive(
         env: &mut FmcEnv,
-        hand_off: &HandOff,
+        hand_off: &mut HandOff,
         input: &DiceInput,
     ) -> CaliptraResult<DiceOutput> {
         cprintln!("[fmc] Derive CDI");
@@ -73,7 +73,7 @@ impl DiceLayer for RtAliasLayer {
 
 impl RtAliasLayer {
     #[inline(never)]
-    pub fn run(env: &mut FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
+    pub fn run(env: &mut FmcEnv, hand_off: &mut HandOff) -> CaliptraResult<()> {
         cprintln!("[fmc] Extend RT PCRs");
         Self::extend_pcrs(env, hand_off)?;
         cprintln!("[fmc] Extend RT PCRs Done");
@@ -187,7 +187,7 @@ impl RtAliasLayer {
     /// * `output` - DICE Output
     fn generate_cert_sig(
         env: &mut FmcEnv,
-        hand_off: &HandOff,
+        hand_off: &mut HandOff,
         input: &DiceInput,
         output: &DiceOutput,
         not_before: &[u8; RtAliasCertTbsParams::NOT_BEFORE_LEN],

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -176,10 +176,15 @@ impl HandOff {
         }
     }
 
-    pub fn set_rt_dice_signature(&self, _sig: &Ecc384Signature) {
-        // TODO - implement
-        // Where should this be stored?
-        // No DV slots avaiable anymore.
+    /// Store runtime Dice Signature
+    pub fn set_rt_dice_signature(&mut self, sig: &Ecc384Signature) {
+        let data = unsafe {
+            core::slice::from_raw_parts(
+                sig as *const Ecc384Signature as *const u8,
+                core::mem::size_of::<Ecc384Signature>(),
+            )
+        };
+        self.fht.rt_dice_sign.copy_from_slice(data);
     }
 
     /// Retrieve image manifest load address in DCCM

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -167,8 +167,6 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         rt_priv_key_kv_hdl: FHT_INVALID_HANDLE,
         rt_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
         rt_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
-        rt_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
-        rt_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
         rt_tci_dv_hdl: FhtDataStore::rt_tci_data_store(),
         rt_svn_dv_hdl: FhtDataStore::rt_svn_data_store(),
         ldevid_tbs_size: env.fht_data_store.ldevid_tbs_size,

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -165,8 +165,6 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         fmc_svn_dv_hdl: FhtDataStore::fmc_svn_store(),
         rt_cdi_kv_hdl: FHT_INVALID_HANDLE,
         rt_priv_key_kv_hdl: FHT_INVALID_HANDLE,
-        rt_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
-        rt_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
         rt_tci_dv_hdl: FhtDataStore::rt_tci_data_store(),
         rt_svn_dv_hdl: FhtDataStore::rt_svn_data_store(),
         ldevid_tbs_size: env.fht_data_store.ldevid_tbs_size,


### PR DESCRIPTION
- Add FHT field to store the RT Alias key pair.
- Update the newly created FHT field during FMC's RT Alias DICE flow.
- Update FMC's README.md with new FHT field.