### PR TITLE
[FIX] Corrected The Update Reset Part Of Design Document

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -674,19 +674,24 @@ The following are the pre-conditions that should be satisfied:
     - Validation of the entire image is done using the steps described above.
     - Save the hash of the FMC portion of the image in a separate register.
     - Copy the FMC and RT image's text and data section in the appropriate ICCM and DCCM memory regions.
+    - The data vault is saved with the following values:-
+        - Vendor public key index in the preamble is save in the data vault. 
+        - Digest of the owner public key portion of preamble. 
+        - Digest of the FMC part of the image.
 - Warm Boot Mode
     - In this mode there is no validation or load required for any parts of the image.
     - All the contents of ICCM and DCCM are preserved since this is a warm reboot.
 - Update Reset Mode
-    - The image is exactly the same as the initial image which was verified on the cold boot, except that
-      the RT part of the image is changed.
-    - This also implies that the TOC hash in the header will not match anymore and this will need to be skipped.
+    - The image is exactly the same as the initial image which was verified on the cold boot, except that the RT part of the image is changed.
+    - We need to validate the entire image exactly as described in the cold boot flow. In addition to that, also validate the image to make sure that no other part (except the RT image section) is altered. 
     - The validation flow will look like the following:
-        - Validate the preamble
-        - Validate the header
-        - The TOC hash will NOT match, skip the TOC hash validation.
-        - We still need to make sure that the hash of the FMC which was stored in the data vault register at cold boot
-          still matches the FMC code. This is the hash of the FMC image portion.
+        - Validate the preamble exactly like in cold boot flow. 
+            - Validate the vendor public key index from the value in data vault (value saved during cold boot). Fail the validation if there is a mismatch. This is done to make sure that the key being used is the same key that was used during cold boot.
+            -  Validate the owner public key digest against the owner public key digest in data vault (value saved during cold boot). This makes sure that the owner key is not changed since last cold boot.
+        - Validate the header exactly like in cold boot.
+        - Validate the toc exactly like in cold boot.
+        - We still need to make sure that the digest of the FMC which was stored in the data vault register at cold boot
+          still matches the FMC image section. 
     - If validation fails during ROM boot, the new image will not be copied from
       the mailbox. ROM will boot the existing FMC/Runtime images. Validation
       errors will be reported via the CPTRA_FW_ERROR_NON_FATAL register.


### PR DESCRIPTION
The update reset part of the design document was incorrect and required update. This PR updates the design document to reflect the actual implementation.