### PR TITLE
[sw-emu] [fix] Access to unmapped mmio address does not trigger NMI

### DIFF
--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -29,6 +29,11 @@ name = "test_iccm_write_locked"
 path = "test_iccm_write_locked.rs"
 required-features = ["riscv"]
 
+[[bin]]
+name = "test_system_bus_invalid_access"
+path = "test_system_bus_invalid_access.rs"
+required-features = ["riscv"]
+
 
 [[bin]]
 name = "mailbox_responder"

--- a/hw-model/test-fw/test_system_bus_invalid_access.rs
+++ b/hw-model/test-fw/test_system_bus_invalid_access.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that sends mailbox transactions.
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::println;
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    unsafe {
+        let addr = 0xFFFF_0000_u32;
+        let ptr = addr as *mut u32;
+        *ptr = 0xdeadbeef;
+    }
+    loop {}
+}

--- a/hw-model/tests/model_tests.rs
+++ b/hw-model/tests/model_tests.rs
@@ -94,3 +94,22 @@ fn test_iccm_write_locked_nmi_failure() {
     let ext_info = harness::ExtErrorInfo::from(soc_ifc.cptra_fw_extended_error_info().read());
     assert_eq!(ext_info.mcause, harness::NMI_CAUSE_DBUS_STORE_ERROR);
 }
+
+#[test]
+fn test_rom_write_access() {
+    let elf = caliptra_builder::build_firmware_elf(&FwId {
+        bin_name: "test_system_bus_invalid_access",
+        ..BASE_FWID
+    })
+    .unwrap();
+
+    let mut model = run_fw_elf(&elf);
+    model.step_until_exit_success().unwrap_err();
+    let soc_ifc: caliptra_registers::soc_ifc::RegisterBlock<_> = model.soc_ifc();
+    assert_eq!(
+        soc_ifc.cptra_fw_error_non_fatal().read(),
+        harness::ERROR_NMI
+    );
+    let ext_info = harness::ExtErrorInfo::from(soc_ifc.cptra_fw_extended_error_info().read());
+    assert_eq!(ext_info.mcause, harness::NMI_CAUSE_DBUS_STORE_ERROR);
+}


### PR DESCRIPTION
Software emulator raises an exception instead of NMI upon access to unmapped address in the root bus.