### PR TITLE
Checksum utilities

### DIFF
--- a/common/src/checksum.rs
+++ b/common/src/checksum.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache-2.0 license
+
+/// Verify checksum
+pub fn verify_checksum(checksum: i32, cmd: u32, data: &[u8]) -> bool {
+    calc_checksum(cmd, data) - checksum == 0
+}
+
+/// Calculate the checksum
+/// 0 - (SUM(command code bytes) + SUM(request/response bytes))
+pub fn calc_checksum(cmd: u32, data: &[u8]) -> i32 {
+    let mut checksum = 0i32;
+    for c in cmd.to_le_bytes().iter() {
+        checksum += *c as i32;
+    }
+    for d in data {
+        checksum += *d as i32;
+    }
+
+    checksum
+}
+
+#[cfg(all(test, target_family = "unix"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_checksum() {
+        let cmd = 0x00000001u32;
+        let data = [0x00000000u32; 1];
+        let checksum = calc_checksum(cmd, data[0].to_le_bytes().as_ref());
+        assert!(verify_checksum(checksum, cmd, &data[0].to_le_bytes()));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod hand_off;
 #[macro_use]
 pub mod printer;
 pub mod boot_status;
+pub mod checksum;
 pub mod fuse;
 pub mod pcr;
 
@@ -18,6 +19,7 @@ pub use hand_off::{
 };
 
 pub use boot_status::RomBootStatus;
+pub use checksum::{calc_checksum, verify_checksum};
 pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId};
 pub use printer::HexBytes;

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -1,0 +1,21 @@
+// License by Apache-2.0
+
+pub struct Packet {
+    cmd: u32,
+    data: &[u8],
+    checksum: u32,
+}
+
+impl Packet {
+    pub fn new(cmd: u32, data: &[u8]) -> Self {
+        let checksum = crate::calc_checksum(cmd, data.to_le_bytes());
+        Self {
+            cmd,
+            data,
+            checksum,
+        }
+    }
+    pub fn verify(&self) -> bool {
+        crate::verify_checksum(self.checksum, self.cmd, self.data)
+    }
+}


### PR DESCRIPTION
This PR implements the checksum as per RT specification:

For every command input/output arguments which have a "chksum" field, the request and response feature a checksum. This mitigates glitches between clients and Caliptra.

The Checksum is a little-endian 32-bit value, defined as:
0 - (SUM(command code bytes) + SUM(request/response bytes))