### PR TITLE
Fix #401 - Debug bit backwards in fmc_alias x509 certificate

### DIFF
--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -219,7 +219,7 @@ impl FmcAliasLayer {
             _ => 0,
         };
 
-        if debug_locked {
+        if !debug_locked {
             flags |= dice::FLAG_BIT_DEBUG;
         }
 


### PR DESCRIPTION
Fixes #401 