### PR TITLE
Unify Lifecycle enum between drivers and hardware.

### DIFF
--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -37,9 +37,9 @@ impl From<DeviceLifecycleE> for Lifecycle {
     /// Converts to this type from the input type.
     fn from(value: DeviceLifecycleE) -> Self {
         match value {
-            DeviceLifecycleE::DeviceUnprovisioned => Lifecycle::Unprovisioned,
-            DeviceLifecycleE::DeviceManufacturing => Lifecycle::Manufacturing,
-            DeviceLifecycleE::DeviceProduction => Lifecycle::Production,
+            DeviceLifecycleE::Unprovisioned => Lifecycle::Unprovisioned,
+            DeviceLifecycleE::Manufacturing => Lifecycle::Manufacturing,
+            DeviceLifecycleE::Production => Lifecycle::Production,
             _ => Lifecycle::Unknown,
         }
     }

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -17,33 +17,7 @@ use caliptra_registers::soc_ifc::{self, SocIfcReg};
 
 use crate::FuseBank;
 
-/// Device Life Cycle State
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Lifecycle {
-    /// Unprovisioned
-    Unprovisioned = 0x0,
-
-    /// Manufacturing
-    Manufacturing = 0x1,
-
-    /// Production
-    Production = 0x2,
-
-    /// Unknown
-    Unknown = 0x3,
-}
-
-impl From<DeviceLifecycleE> for Lifecycle {
-    /// Converts to this type from the input type.
-    fn from(value: DeviceLifecycleE) -> Self {
-        match value {
-            DeviceLifecycleE::Unprovisioned => Lifecycle::Unprovisioned,
-            DeviceLifecycleE::Manufacturing => Lifecycle::Manufacturing,
-            DeviceLifecycleE::Production => Lifecycle::Production,
-            _ => Lifecycle::Unknown,
-        }
-    }
-}
+pub type Lifecycle = DeviceLifecycleE;
 
 pub fn report_boot_status(val: u32) {
     let mut soc_ifc = unsafe { soc_ifc::SocIfcReg::new() };
@@ -66,7 +40,6 @@ impl SocIfc {
             .cptra_security_state()
             .read()
             .device_lifecycle()
-            .into()
     }
 
     /// Check if device is locked for debug

--- a/registers/bin/generator/src/main.rs
+++ b/registers/bin/generator/src/main.rs
@@ -184,6 +184,13 @@ fn real_main() -> Result<(), Box<dyn Error>> {
                 &format!("{}_", block.name.to_ascii_lowercase()),
             );
         }
+        if block.name == "soc_ifc" {
+            block.rename_enum_variants(&[
+                ("DEVICE_UNPROVISIONED", "UNPROVISIONED"),
+                ("DEVICE_MANUFACTURING", "MANUFACTURING"),
+                ("DEVICE_PRODUCTION", "PRODUCTION"),
+            ]);
+        }
         let mut block = block.validate_and_dedup()?;
 
         if block.block().name == "ecc" {

--- a/registers/src/soc_ifc.rs
+++ b/registers/src/soc_ifc.rs
@@ -3044,23 +3044,23 @@ pub mod enums {
     #[derive(Clone, Copy, Eq, PartialEq)]
     #[repr(u32)]
     pub enum DeviceLifecycleE {
-        DeviceUnprovisioned = 0,
-        DeviceManufacturing = 1,
+        Unprovisioned = 0,
+        Manufacturing = 1,
         Reserved2 = 2,
-        DeviceProduction = 3,
+        Production = 3,
     }
     impl DeviceLifecycleE {
         #[inline(always)]
-        pub fn device_unprovisioned(&self) -> bool {
-            *self == Self::DeviceUnprovisioned
+        pub fn unprovisioned(&self) -> bool {
+            *self == Self::Unprovisioned
         }
         #[inline(always)]
-        pub fn device_manufacturing(&self) -> bool {
-            *self == Self::DeviceManufacturing
+        pub fn manufacturing(&self) -> bool {
+            *self == Self::Manufacturing
         }
         #[inline(always)]
-        pub fn device_production(&self) -> bool {
-            *self == Self::DeviceProduction
+        pub fn production(&self) -> bool {
+            *self == Self::Production
         }
     }
     impl TryFrom<u32> for DeviceLifecycleE {
@@ -3083,16 +3083,16 @@ pub mod enums {
         pub struct DeviceLifecycleESelector();
         impl DeviceLifecycleESelector {
             #[inline(always)]
-            pub fn device_unprovisioned(&self) -> super::DeviceLifecycleE {
-                super::DeviceLifecycleE::DeviceUnprovisioned
+            pub fn unprovisioned(&self) -> super::DeviceLifecycleE {
+                super::DeviceLifecycleE::Unprovisioned
             }
             #[inline(always)]
-            pub fn device_manufacturing(&self) -> super::DeviceLifecycleE {
-                super::DeviceLifecycleE::DeviceManufacturing
+            pub fn manufacturing(&self) -> super::DeviceLifecycleE {
+                super::DeviceLifecycleE::Manufacturing
             }
             #[inline(always)]
-            pub fn device_production(&self) -> super::DeviceLifecycleE {
-                super::DeviceLifecycleE::DeviceProduction
+            pub fn production(&self) -> super::DeviceLifecycleE {
+                super::DeviceLifecycleE::Production
             }
         }
     }

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -51,7 +51,7 @@ pub extern "C" fn rom_entry() -> ! {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",
         caliptra_drivers::Lifecycle::Manufacturing => "Manufacturing",
         caliptra_drivers::Lifecycle::Production => "Production",
-        caliptra_drivers::Lifecycle::Unknown => "Unknown",
+        caliptra_drivers::Lifecycle::Reserved2 => "Unknown",
     };
     cprintln!("[state] LifecycleState = {}", _lifecyle);
 


### PR DESCRIPTION
This redefines the value of Lifecycle::Production from 2 to 3, to
match the hardware.

Also, this shaves 40 bytes off the UART ROM build.

Fixes #404