### PR TITLE
[fix] FMC not saving data to the FHT memory region

### DIFF
--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -121,6 +121,8 @@ impl HandOff {
         extern "C" {
             fn transfer_control(entry: u32) -> !;
         }
+
+        FirmwareHandoffTable::save(&self.fht);
         // Retrieve runtime entry point
         let rt_entry = IccmAddress(self.rt_entry_point(env));
 


### PR DESCRIPTION
FHT is updating a  copy of the FHT but not saving it back to the FHT region.