### PR TITLE
[feat] Enable SCA countermeasures.

### DIFF
--- a/drivers/src/hmac384_kdf.rs
+++ b/drivers/src/hmac384_kdf.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use caliptra_error::CaliptraResult;
 
-use crate::{Hmac384, Hmac384Key, Hmac384Tag};
+use crate::{Hmac384, Hmac384Key, Hmac384Tag, Trng};
 
 /// Calculate HMAC-384-KDF
 ///
@@ -29,15 +29,17 @@ use crate::{Hmac384, Hmac384Key, Hmac384Tag};
 ///             the fixed input data.
 /// * `context` - Context for KDF. If present, a NULL byte is included between
 ///               the label and context.
+/// * `trng` - TRNG driver instance
 /// * `output` - Location to store the output
 pub fn hmac384_kdf(
     hmac: &mut Hmac384,
     key: Hmac384Key,
     label: &[u8],
     context: Option<&[u8]>,
+    trng: &mut Trng,
     output: Hmac384Tag,
 ) -> CaliptraResult<()> {
-    let mut hmac_op = hmac.hmac_init(key, output)?;
+    let mut hmac_op = hmac.hmac_init(key, trng, output)?;
 
     hmac_op.update(&1_u32.to_be_bytes())?;
     hmac_op.update(label)?;

--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -17,11 +17,15 @@ Abstract:
 
 use caliptra_drivers::{
     Array4x12, Array4x4, DeobfuscationEngine, Hmac384, Hmac384Data, Hmac384Key, Hmac384Tag, KeyId,
-    KeyReadArgs, Mailbox,
+    KeyReadArgs, Mailbox, Trng,
 };
 use caliptra_drivers_test_bin::{DoeTestResults, DOE_TEST_HMAC_KEY, DOE_TEST_IV};
 
-use caliptra_registers::{doe::DoeReg, hmac::HmacReg, mbox::MboxCsr};
+use caliptra_registers::soc_ifc::SocIfcReg;
+use caliptra_registers::soc_ifc_trng::SocIfcTrngReg;
+use caliptra_registers::{
+    csrng::CsrngReg, doe::DoeReg, entropy_src::EntropySrcReg, hmac::HmacReg, mbox::MboxCsr,
+};
 use caliptra_test_harness::test_suite;
 use zerocopy::AsBytes;
 
@@ -30,6 +34,15 @@ fn test_decrypt() {
 
     let mut hmac384 = Hmac384::new(unsafe { HmacReg::new() });
     let mut doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     assert_eq!(
         doe.decrypt_uds(&Array4x4::from(DOE_TEST_IV), KeyId::KeyId0)
             .ok(),
@@ -41,6 +54,7 @@ fn test_decrypt() {
         .hmac(
             Hmac384Key::Key(KeyReadArgs { id: KeyId::KeyId0 }),
             Hmac384Data::Slice("Hello world!".as_bytes()),
+            &mut trng,
             Hmac384Tag::Array4x12(&mut result),
         )
         .unwrap();
@@ -52,6 +66,7 @@ fn test_decrypt() {
         .hmac(
             Hmac384Key::Array4x12(&Array4x12::new(DOE_TEST_HMAC_KEY)),
             Hmac384Data::Key(KeyReadArgs { id: KeyId::KeyId0 }),
+            &mut trng,
             Hmac384Tag::Array4x12(&mut result),
         )
         .unwrap();
@@ -66,6 +81,7 @@ fn test_decrypt() {
         .hmac(
             Hmac384Key::Key(KeyReadArgs { id: KeyId::KeyId1 }),
             Hmac384Data::Slice("Hello world!".as_bytes()),
+            &mut trng,
             Hmac384Tag::Array4x12(&mut result),
         )
         .unwrap();
@@ -77,6 +93,7 @@ fn test_decrypt() {
         .hmac(
             Hmac384Key::Array4x12(&Array4x12::new(DOE_TEST_HMAC_KEY)),
             Hmac384Data::Key(KeyReadArgs { id: KeyId::KeyId1 }),
+            &mut trng,
             Hmac384Tag::Array4x12(&mut result),
         )
         .unwrap();

--- a/drivers/test-fw/src/bin/ecc384_tests.rs
+++ b/drivers/test-fw/src/bin/ecc384_tests.rs
@@ -16,12 +16,15 @@ Abstract:
 #![no_main]
 
 use caliptra_drivers::{
-    Array4x12, Array4xN, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar,
-    Ecc384Seed, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
+    Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Scalar, Ecc384Seed,
+    KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, Trng,
 };
 use caliptra_kat::Ecc384Kat;
+use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::ecc::EccReg;
-
+use caliptra_registers::entropy_src::EntropySrcReg;
+use caliptra_registers::soc_ifc::SocIfcReg;
+use caliptra_registers::soc_ifc_trng::SocIfcTrngReg;
 use caliptra_test_harness::test_suite;
 
 const PRIV_KEY: [u8; 48] = [
@@ -56,12 +59,21 @@ const SIGNATURE_S: [u8; 48] = [
 
 fn test_gen_key_pair() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let mut priv_key = Array4x12::default();
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut trng,
         Ecc384PrivKeyOut::from(&mut priv_key),
     );
     assert!(result.is_ok());
@@ -77,10 +89,81 @@ fn test_gen_key_pair() {
     assert_eq!(pub_key.to_der(), der);
 }
 
+fn test_gen_key_pair_with_iv() {
+    let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
+    let seed = [
+        0x8F, 0xA8, 0x54, 0x1C, 0x82, 0xA3, 0x92, 0xCA, 0x74, 0xF2, 0x3E, 0xD1, 0xDB, 0xFD, 0x73,
+        0x54, 0x1C, 0x59, 0x66, 0x39, 0x1B, 0x97, 0xEA, 0x73, 0xD7, 0x44, 0xB0, 0xE3, 0x4B, 0x9D,
+        0xF5, 0x9E, 0xD0, 0x15, 0x80, 0x63, 0xE3, 0x9C, 0x09, 0xA5, 0xA0, 0x55, 0x37, 0x1E, 0xDF,
+        0x7A, 0x54, 0x41,
+    ];
+
+    let nonce = [
+        0x1B, 0x7E, 0xC5, 0xE5, 0x48, 0xE8, 0xAA, 0xA9, 0x2E, 0xC7, 0x70, 0x97, 0xCA, 0x95, 0x51,
+        0xC9, 0x78, 0x3C, 0xE6, 0x82, 0xCA, 0x18, 0xFB, 0x1E, 0xDB, 0xD9, 0xF1, 0xE5, 0x0B, 0xC3,
+        0x82, 0xDB, 0x8A, 0xB3, 0x94, 0x96, 0xC8, 0xEE, 0x42, 0x3F, 0x8C, 0xA1, 0x05, 0xCB, 0xBA,
+        0x7B, 0x65, 0x88,
+    ];
+
+    let priv_key_exp = [
+        0xF2, 0x74, 0xF6, 0x9D, 0x16, 0x3B, 0x0C, 0x9F, 0x1F, 0xC3, 0xEB, 0xF4, 0x29, 0x2A, 0xD1,
+        0xC4, 0xEB, 0x3C, 0xEC, 0x1C, 0x5A, 0x7D, 0xDE, 0x6F, 0x80, 0xC1, 0x42, 0x92, 0x93, 0x4C,
+        0x20, 0x55, 0xE0, 0x87, 0x74, 0x8D, 0x0A, 0x16, 0x9C, 0x77, 0x24, 0x83, 0xAD, 0xEE, 0x5E,
+        0xE7, 0x0E, 0x17,
+    ];
+    let pub_key_x_exp = [
+        0xD7, 0x9C, 0x6D, 0x97, 0x2B, 0x34, 0xA1, 0xDF, 0xC9, 0x16, 0xA7, 0xB6, 0xE0, 0xA9, 0x9B,
+        0x6B, 0x53, 0x87, 0xB3, 0x4D, 0xA2, 0x18, 0x76, 0x07, 0xC1, 0xAD, 0x0A, 0x4D, 0x1A, 0x8C,
+        0x2E, 0x41, 0x72, 0xAB, 0x5F, 0xA5, 0xD9, 0xAB, 0x58, 0xFE, 0x45, 0xE4, 0x3F, 0x56, 0xBB,
+        0xB6, 0x6B, 0xA4,
+    ];
+    let pub_key_y_exp = [
+        0x5A, 0x73, 0x63, 0x93, 0x2B, 0x06, 0xB4, 0xF2, 0x23, 0xBE, 0xF0, 0xB6, 0x0A, 0x63, 0x90,
+        0x26, 0x51, 0x12, 0xDB, 0xBD, 0x0A, 0xAE, 0x67, 0xFE, 0xF2, 0x6B, 0x46, 0x5B, 0xE9, 0x35,
+        0xB4, 0x8E, 0x45, 0x1E, 0x68, 0xD1, 0x6F, 0x11, 0x18, 0xF2, 0xB3, 0x2B, 0x4C, 0x28, 0x60,
+        0x87, 0x49, 0xED,
+    ];
+
+    let mut priv_key = Array4x12::default();
+    let result = ecc.key_pair(
+        Ecc384Seed::from(&Ecc384Scalar::from(seed)),
+        &Array4x12::from(nonce),
+        &mut trng,
+        Ecc384PrivKeyOut::from(&mut priv_key),
+    );
+    assert!(result.is_ok());
+    let pub_key = result.unwrap();
+    assert_eq!(priv_key, Ecc384Scalar::from(priv_key_exp));
+    assert_eq!(pub_key.x, Ecc384Scalar::from(pub_key_x_exp));
+    assert_eq!(pub_key.y, Ecc384Scalar::from(pub_key_y_exp));
+}
+
 fn test_sign() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     let digest = Array4x12::new([0u32; 12]);
-    let result = ecc.sign(Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)), &digest);
+    let result = ecc.sign(
+        Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)),
+        &digest,
+        &mut trng,
+    );
     assert!(result.is_ok());
     let signature = result.unwrap();
     assert_eq!(signature.r, Ecc384Scalar::from(SIGNATURE_R));
@@ -89,8 +172,21 @@ fn test_sign() {
 
 fn test_verify() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     let digest = Array4x12::new([0u32; 12]);
-    let result = ecc.sign(Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)), &digest);
+    let result = ecc.sign(
+        Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)),
+        &digest,
+        &mut trng,
+    );
     assert!(result.is_ok());
     let signature = result.unwrap();
     let pub_key = Ecc384PubKey {
@@ -104,8 +200,21 @@ fn test_verify() {
 
 fn test_verify_failure() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     let digest = Array4x12::new([0u32; 12]);
-    let result = ecc.sign(Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)), &digest);
+    let result = ecc.sign(
+        Ecc384PrivKeyIn::from(&Array4x12::from(PRIV_KEY)),
+        &digest,
+        &mut trng,
+    );
     assert!(result.is_ok());
     let signature = result.unwrap();
     let pub_key = Ecc384PubKey {
@@ -120,18 +229,27 @@ fn test_verify_failure() {
 
 fn test_kv_seed_from_input_msg_from_input() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     //
     // Step 1: Generate a key pair and store private key in kv slot 2.
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let key_out_1 = KeyWriteArgs {
         id: KeyId::KeyId2,
         usage: KeyUsage::default().set_ecc_private_key_en(),
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut trng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -145,7 +263,7 @@ fn test_kv_seed_from_input_msg_from_input() {
     let digest = Array4x12::new([0u32; 12]);
     let key_in_1 = KeyReadArgs::new(KeyId::KeyId2);
 
-    let result = ecc.sign(key_in_1.into(), &digest);
+    let result = ecc.sign(key_in_1.into(), &digest, &mut trng);
     assert!(result.is_ok());
     let signature = result.unwrap();
     assert_eq!(signature.r, Ecc384Scalar::from(SIGNATURE_R));
@@ -165,6 +283,15 @@ fn test_kv_seed_from_input_msg_from_input() {
 
 fn test_kv_seed_from_kv_msg_from_input() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
     //
     // Step 1: Generate a key-pair. Store private key in kv slot 0.
     // Mark the key as ecc_key_gen_seed as it will be used as a seed for key generation.
@@ -176,14 +303,14 @@ fn test_kv_seed_from_kv_msg_from_input() {
     //  0x89, 0x46, 0xd6,]
     //
     let seed = [0u8; 48];
-    let nonce = Array4xN::default();
     let key_out_1 = KeyWriteArgs {
         id: KeyId::KeyId0,
         usage: KeyUsage::default().set_ecc_key_gen_seed_en(),
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(&Ecc384Scalar::from(seed)),
-        &nonce,
+        &Array4x12::default(),
+        &mut trng,
         Ecc384PrivKeyOut::from(key_out_1),
     );
     assert!(result.is_ok());
@@ -220,7 +347,8 @@ fn test_kv_seed_from_kv_msg_from_input() {
     };
     let result = ecc.key_pair(
         Ecc384Seed::from(key_in_seed),
-        &nonce,
+        &Array4x12::default(),
+        &mut trng,
         Ecc384PrivKeyOut::from(key_out_priv_key),
     );
     assert!(result.is_ok());
@@ -255,7 +383,7 @@ fn test_kv_seed_from_kv_msg_from_input() {
         0xe8, 0x8c, 0x10,
     ];
     let key_in_priv_key = KeyReadArgs::new(KeyId::KeyId1);
-    let result = ecc.sign(key_in_priv_key.into(), &Array4x12::from(msg));
+    let result = ecc.sign(key_in_priv_key.into(), &Array4x12::from(msg), &mut trng);
     assert!(result.is_ok());
     let signature = result.unwrap();
     assert_eq!(signature.r, Ecc384Scalar::from(sig_r));
@@ -274,12 +402,25 @@ fn test_kv_seed_from_kv_msg_from_input() {
 
 fn test_kat() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
-    assert_eq!(Ecc384Kat::default().execute(&mut ecc).is_ok(), true);
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        Ecc384Kat::default().execute(&mut ecc, &mut trng).is_ok(),
+        true
+    );
 }
 
 test_suite! {
     test_kat,
     test_gen_key_pair,
+    test_gen_key_pair_with_iv,
     test_sign,
     test_verify,
     test_verify_failure,

--- a/fmc/src/flow/crypto.rs
+++ b/fmc/src/flow/crypto.rs
@@ -86,7 +86,7 @@ impl Crypto {
         ));
 
         // Calculate the CDI
-        env.hmac384.hmac(key, data, tag_args)?;
+        env.hmac384.hmac(key, data, &mut env.trng, tag_args)?;
 
         Ok(tag)
     }
@@ -116,7 +116,9 @@ impl Crypto {
 
         Ok(Ecc384KeyPair {
             priv_key,
-            pub_key: env.ecc384.key_pair(seed, &Array4x12::default(), key_out)?,
+            pub_key: env
+                .ecc384
+                .key_pair(seed, &Array4x12::default(), &mut env.trng, key_out)?,
         })
     }
 
@@ -142,7 +144,7 @@ impl Crypto {
         let digest = okref(&digest)?;
         let priv_key_args = KeyReadArgs::new(priv_key);
         let priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
-        env.ecc384.sign(priv_key, digest)
+        env.ecc384.sign(priv_key, digest, &mut env.trng)
     }
 
     /// Verify the ECC Signature

--- a/kat/src/ecc384_kat.rs
+++ b/kat/src/ecc384_kat.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use caliptra_drivers::{
     Array4x12, Array4xN, CaliptraError, CaliptraResult, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey,
-    Ecc384Signature,
+    Ecc384Signature, Trng,
 };
 
 const PRIV_KEY: Array4x12 = Array4x12::new([
@@ -60,15 +60,15 @@ impl Ecc384Kat {
     /// # Returns
     ///
     /// * `CaliptraResult` - Result denoting the KAT outcome.
-    pub fn execute(&self, ecc: &mut Ecc384) -> CaliptraResult<()> {
-        self.kat_signature_generate(ecc)?;
+    pub fn execute(&self, ecc: &mut Ecc384, trng: &mut Trng) -> CaliptraResult<()> {
+        self.kat_signature_generate(ecc, trng)?;
         self.kat_signature_verify(ecc)
     }
 
-    fn kat_signature_generate(&self, ecc: &mut Ecc384) -> CaliptraResult<()> {
+    fn kat_signature_generate(&self, ecc: &mut Ecc384, trng: &mut Trng) -> CaliptraResult<()> {
         let digest = Array4x12::new([0u32; 12]);
         let signature = ecc
-            .sign(Ecc384PrivKeyIn::from(&PRIV_KEY), &digest)
+            .sign(Ecc384PrivKeyIn::from(&PRIV_KEY), &digest, trng)
             .map_err(|_| CaliptraError::ROM_KAT_ECC384_SIGNATURE_GENERATE_FAILURE)?;
 
         if signature != SIGNATURE {

--- a/kat/src/hmac384_kat.rs
+++ b/kat/src/hmac384_kat.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult, Hmac384};
+use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult, Hmac384, Trng};
 
 const KEY: Array4x12 = Array4x12::new([
     0xb57dc523, 0x54afee11, 0xedb4c905, 0x2a528344, 0x348b2c6b, 0x6c39f321, 0x33ed3bb7, 0x2035a4ab,
@@ -44,12 +44,13 @@ impl Hmac384Kat {
     /// # Arguments
     ///
     /// * `hmac` - HMAC-384 Driver
+    /// * `trng` - TRNG Driver
     ///
     /// # Returns
     ///
     /// * `CaliptraResult` - Result denoting the KAT outcome.
-    pub fn execute(&self, hmac: &mut Hmac384) -> CaliptraResult<()> {
-        self.kat_nist_vector(hmac)?;
+    pub fn execute(&self, hmac: &mut Hmac384, trng: &mut Trng) -> CaliptraResult<()> {
+        self.kat_nist_vector(hmac, trng)?;
         Ok(())
     }
 
@@ -58,14 +59,15 @@ impl Hmac384Kat {
     /// # Arguments
     ///
     /// * `hmac` - HMAC-384 Driver
+    /// * `trng` - TRNG Driver
     ///
     /// # Returns
     ///
     /// * `CaliptraResult` - Result denoting the KAT outcome.
-    fn kat_nist_vector(&self, hmac: &mut Hmac384) -> CaliptraResult<()> {
+    fn kat_nist_vector(&self, hmac: &mut Hmac384, trng: &mut Trng) -> CaliptraResult<()> {
         let mut out = Array4x12::default();
 
-        hmac384_kdf(hmac, (&KEY).into(), &LABEL, None, (&mut out).into())
+        hmac384_kdf(hmac, (&KEY).into(), &LABEL, None, trng, (&mut out).into())
             .map_err(|_| CaliptraError::ROM_KAT_HMAC384_FAILURE)?;
 
         if EXPECTED_OUT != <[u8; 48]>::from(out)[..EXPECTED_OUT.len()] {

--- a/rom/dev/src/flow/cold_reset/crypto.rs
+++ b/rom/dev/src/flow/cold_reset/crypto.rs
@@ -117,7 +117,7 @@ impl Crypto {
         ));
 
         // Calculate the CDI
-        env.hmac384.hmac(key, data, tag_args)?;
+        env.hmac384.hmac(key, data, &mut env.trng, tag_args)?;
 
         Ok(tag)
     }
@@ -138,7 +138,6 @@ impl Crypto {
         seed: KeyId,
         priv_key: KeyId,
     ) -> CaliptraResult<Ecc384KeyPair> {
-        // [TODO] Add Nonce to the ecc384_key_gen function
         let seed = Ecc384Seed::Key(KeyReadArgs::new(seed));
 
         let key_out = Ecc384PrivKeyOut::Key(KeyWriteArgs::new(
@@ -148,7 +147,9 @@ impl Crypto {
 
         Ok(Ecc384KeyPair {
             priv_key,
-            pub_key: env.ecc384.key_pair(seed, &Array4x12::default(), key_out)?,
+            pub_key: env
+                .ecc384
+                .key_pair(seed, &Array4x12::default(), &mut env.trng, key_out)?,
         })
     }
 
@@ -174,7 +175,7 @@ impl Crypto {
         let digest = okref(&digest)?;
         let priv_key_args = KeyReadArgs::new(priv_key);
         let priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
-        env.ecc384.sign(priv_key, digest)
+        env.ecc384.sign(priv_key, digest, &mut env.trng)
     }
 
     /// Verify the ECC Signature

--- a/rom/dev/src/kat.rs
+++ b/rom/dev/src/kat.rs
@@ -38,10 +38,10 @@ pub fn execute_kat(env: &mut RomEnv) -> CaliptraResult<()> {
     Sha384AccKat::default().execute(&mut env.sha384_acc)?;
 
     cprintln!("[kat] Executing ECC-384 Engine KAT");
-    Ecc384Kat::default().execute(&mut env.ecc384)?;
+    Ecc384Kat::default().execute(&mut env.ecc384, &mut env.trng)?;
 
     cprintln!("[kat] Executing HMAC-384 Engine KAT");
-    Hmac384Kat::default().execute(&mut env.hmac384)?;
+    Hmac384Kat::default().execute(&mut env.hmac384, &mut env.trng)?;
 
     cprintln!("[kat] Executing LMS Engine KAT");
     LmsKat::default().execute(&mut env.sha256, &env.lms)?;

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -50,7 +50,10 @@ Running Caliptra ROM ...
 pub extern "C" fn rom_entry() -> ! {
     cprintln!("{}", BANNER);
 
-    let mut env = unsafe { rom_env::RomEnv::new_from_registers() };
+    let mut env = match unsafe { rom_env::RomEnv::new_from_registers() } {
+        Ok(env) => env,
+        Err(e) => report_error(e.into()),
+    };
 
     let _lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -18,11 +18,13 @@ Abstract:
 use crate::fht::FhtDataStore;
 use caliptra_drivers::{
     DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
-    Sha384, Sha384Acc, SocIfc,
+    Sha384, Sha384Acc, SocIfc, Trng,
 };
+use caliptra_error::CaliptraResult;
 use caliptra_registers::{
-    doe::DoeReg, dv::DvReg, ecc::EccReg, hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg,
-    sha256::Sha256Reg, sha512::Sha512Reg, sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg,
+    csrng::CsrngReg, doe::DoeReg, dv::DvReg, ecc::EccReg, entropy_src::EntropySrcReg,
+    hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
+    sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 use core::ops::Range;
 
@@ -72,6 +74,9 @@ pub struct RomEnv {
 
     /// FHT Data Store
     pub fht_data_store: FhtDataStore,
+
+    /// Cryptographically Secure Random Number Generator
+    pub trng: Trng,
 }
 
 impl RomEnv {
@@ -80,8 +85,15 @@ impl RomEnv {
         end: ICCM_START + ICCM_SIZE,
     };
 
-    pub unsafe fn new_from_registers() -> Self {
-        Self {
+    pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
+        let trng = Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        )?;
+
+        Ok(Self {
             doe: DeobfuscationEngine::new(DoeReg::new()),
             sha1: Sha1::default(),
             sha256: Sha256::new(Sha256Reg::new()),
@@ -96,6 +108,7 @@ impl RomEnv {
             mbox: Mailbox::new(MboxCsr::new()),
             pcr_bank: PcrBank::new(PvReg::new()),
             fht_data_store: FhtDataStore::default(),
-        }
+            trng,
+        })
     }
 }

--- a/sw-emulator/lib/periph/src/hmac_sha384.rs
+++ b/sw-emulator/lib/periph/src/hmac_sha384.rs
@@ -103,6 +103,9 @@ const UPDATE_TICKS: u64 = 1000;
 /// The number of CPU clock cycles read and write keys from key vault
 const KEY_RW_TICKS: u64 = 100;
 
+/// LSFR Seed Size.
+const HMAC_LFSR_SEED_SIZE: usize = 20;
+
 /// HMAC-SHA-384 Peripheral
 #[derive(Bus)]
 #[poll_fn(poll)]
@@ -144,6 +147,10 @@ pub struct HmacSha384 {
     /// HMAC Tag Register
     #[peripheral(offset = 0x0000_0100, mask = 0x0000_00ff)]
     tag: ReadOnlyMemory<HMAC_TAG_SIZE>,
+
+    /// LSFR Seed Register
+    #[register_array(offset = 0x0000_0130)]
+    lfsr_seed: [u32; HMAC_LFSR_SEED_SIZE / 4],
 
     /// Key Read Control Register
     #[register(offset = 0x0000_0600, write_fn = on_write_key_read_control)]
@@ -226,6 +233,7 @@ impl HmacSha384 {
             key: WriteOnlyMemory::new(),
             block: ReadWriteMemory::new(),
             tag: ReadOnlyMemory::new(),
+            lfsr_seed: Default::default(),
             key_read_ctrl: ReadWriteRegister::new(0),
             key_read_status: ReadOnlyRegister::new(KeyReadStatus::READY::SET.value),
             block_read_ctrl: ReadWriteRegister::new(0),


### PR DESCRIPTION
This change uses the CSRNG driver to generate a random IV and an LFSR seed; the IV is provided as an input to the key generation and signing functions of the ECC384 driver, the LFSR seed is provided as an input to the MAC generation functions of HMAC384 driver.