### PR TITLE
ROM: Use preprocessor for start.S.

### DIFF
--- a/rom/dev/build.rs
+++ b/rom/dev/build.rs
@@ -12,21 +12,49 @@ Abstract:
 
 --*/
 
+use std::process::Command;
+
+fn preprocess(filename: &str, defines: &[(String, String)]) -> Vec<u8> {
+    let mut cmd = Command::new("cc");
+    cmd.arg("-E");
+    for (key, val) in defines {
+        cmd.arg(format!("-D{key}={val}"));
+    }
+    cmd.arg(filename);
+    let out = cmd.output().unwrap();
+    if !out.status.success() {
+        panic!(
+            "failed to use cc preprocessor {} {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    out.stdout
+}
+
 fn main() {
-    cfg_if::cfg_if! {
-        if #[cfg(not(feature = "std"))] {
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+    if cfg!(not(feature = "std")) {
+        use std::env;
+        use std::fs;
+        use std::path::PathBuf;
 
-            let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-            fs::write(out_dir.join("rom.ld"), include_bytes!("src/rom.ld")).unwrap();
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        fs::write(out_dir.join("rom.ld"), include_bytes!("src/rom.ld")).unwrap();
 
-            println!("cargo:rustc-link-search={}", out_dir.display());
-            println!("cargo:rustc-link-arg=-Trom.ld");
-            println!("cargo:rerun-if-changed=src/rom.ld");
-            println!("cargo:rerun-if-changed=src/start.S");
-            println!("cargo:rerun-if-changed=build.rs");
-        }
+        let preprocessor_vars: Vec<_> = env::vars()
+            .filter(|(k, _)| k.starts_with("CARGO_"))
+            .collect();
+
+        std::fs::write(
+            out_dir.join("start_preprocessed.S"),
+            preprocess("src/start.S", &preprocessor_vars),
+        )
+        .unwrap();
+
+        println!("cargo:rustc-link-search={}", out_dir.display());
+        println!("cargo:rustc-link-arg=-Trom.ld");
+        println!("cargo:rerun-if-changed=src/rom.ld");
+        println!("cargo:rerun-if-changed=src/start.S");
+        println!("cargo:rerun-if-changed=build.rs");
     }
 }

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -21,7 +21,10 @@ use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, Mailbox};
 use rom_env::RomEnv;
 
 #[cfg(not(feature = "std"))]
-core::arch::global_asm!(include_str!("start.S"));
+core::arch::global_asm!(include_str!(concat!(
+    env!("OUT_DIR"),
+    "/start_preprocessed.S"
+)));
 
 mod exception;
 mod fht;


### PR DESCRIPTION
All of the CARGO_* environment variables are available as preprocessor variables:

https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts

`CARGO_FEATURE_<name>` would be particularly useful for conditional compilation.