### PR TITLE
Add impactless update command to RT

### DIFF
--- a/drivers/test-fw/src/bin/mailbox_driver_responder.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_responder.rs
@@ -54,6 +54,20 @@ extern "C" fn main() {
             0x8000_0000 => {
                 txn.complete(false).unwrap();
             }
+            // Test dropping first half of words and then printing the remaining words
+            0x9000_0000 => {
+                let dlen = txn.dlen() as usize;
+                let dlen_words = (dlen + 3) / 4;
+                println!("dlen: {dlen}");
+                txn.drop_words(dlen_words / 2).unwrap();
+                let rem_words = dlen_words / 2;
+                let mut buf = [0u32; 1];
+                for _ in 0..rem_words {
+                    txn.copy_request(&mut buf).unwrap();
+                    println!("buf: {:08x?}", buf);
+                }
+                txn.complete(true).unwrap();
+            }
             // Test transaction dropped immediately
             _ => {}
         }

--- a/drivers/tests/integration_tests.rs
+++ b/drivers/tests/integration_tests.rs
@@ -434,6 +434,22 @@ fn test_mailbox_soc_to_uc() {
              buf: [04050607, 00000003]\n"
         );
     }
+
+    // Test drop_words
+    {
+        model
+            .mailbox_execute(
+                0x9000_0000,
+                &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+            )
+            .unwrap();
+        assert_eq!(
+            model.output().take(usize::MAX),
+            "cmd: 0x90000000\n\
+             dlen: 8\n\
+             buf: [08070605]\n"
+        );
+    }
 }
 
 #[test]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -109,7 +109,7 @@ impl CaliptraError {
     pub const DRIVER_MAILBOX_INVALID_DATA_LEN: CaliptraError = CaliptraError::new_const(0x00080002);
     pub const DRIVER_MAILBOX_ENQUEUE_ERR: CaliptraError = CaliptraError::new_const(0x00080004);
 
-    /// SHA384ACC Errors.   
+    /// SHA384ACC Errors.
     pub const DRIVER_SHA384ACC_INDEX_OUT_OF_BOUNDS: CaliptraError =
         CaliptraError::new_const(0x00090003);
     /// SHA1 Errors.
@@ -268,6 +268,8 @@ impl CaliptraError {
     pub const RUNTIME_ECDSA_VERIFY_FAILED: CaliptraError = CaliptraError::new_const(0x000E0004);
     pub const RUNTIME_INVALID_CHECKSUM: CaliptraError = CaliptraError::new_const(0x000E0005);
     pub const RUNTIME_FIPS_UNIMPLEMENTED: CaliptraError = CaliptraError::new_const(0x000E0006);
+    pub const RUNTIME_UNEXPECTED_UPDATE_RETURN: CaliptraError =
+        CaliptraError::new_const(0x000E0007);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);
@@ -317,6 +319,8 @@ impl CaliptraError {
         CaliptraError::new_const(0x01040003);
     pub const ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE: CaliptraError =
         CaliptraError::new_const(0x01040004);
+    pub const ROM_UPDATE_RESET_READ_FHT_FAILURE: CaliptraError =
+        CaliptraError::new_const(0x01040005);
 
     /// Unknown Reset Error
     pub const ROM_UNKNOWN_RESET_FLOW: CaliptraError = CaliptraError::new_const(0x01040020);

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -48,7 +48,7 @@ impl ColdResetFlow {
     ///
     /// * `env` - ROM Environment
     #[inline(never)]
-    pub fn run(env: &mut RomEnv) -> CaliptraResult<FirmwareHandoffTable> {
+    pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
         cprintln!("[cold-reset] ++");
         report_boot_status(ColdResetStarted.into());
 
@@ -73,7 +73,7 @@ impl ColdResetFlow {
         cprintln!("[cold-reset] --");
         report_boot_status(ColdResetComplete.into());
 
-        Ok(fht::make_fht(env))
+        Ok(Some(fht::make_fht(env)))
     }
 }
 

--- a/rom/dev/src/flow/mod.rs
+++ b/rom/dev/src/flow/mod.rs
@@ -26,7 +26,7 @@ use caliptra_error::CaliptraError;
 /// # Arguments
 ///
 /// * `env` - ROM Environment
-pub fn run(env: &mut RomEnv) -> CaliptraResult<FirmwareHandoffTable> {
+pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
     let reset_reason = env.soc_ifc.reset_reason();
     match reset_reason {
         // Cold Reset Flow

--- a/rom/dev/src/flow/warm_reset.rs
+++ b/rom/dev/src/flow/warm_reset.rs
@@ -28,7 +28,7 @@ impl WarmResetFlow {
     ///
     /// * `env` - ROM Environment
     #[inline(never)]
-    pub fn run(env: &mut RomEnv) -> CaliptraResult<FirmwareHandoffTable> {
+    pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
         cprintln!("[warm-reset] ++");
 
         // [TODO] Remove this when RTL bug is fixed.
@@ -49,7 +49,7 @@ impl WarmResetFlow {
 
         cprintln!("[warm-reset] --");
 
-        Ok(fht)
+        Ok(None)
     }
 
     fn load_manifest(manifest_load_addr: u32) -> CaliptraResult<ImageManifest> {

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -86,10 +86,10 @@ pub extern "C" fn rom_entry() -> ! {
 
     let result = flow::run(&mut env);
     match result {
-        Ok(fht) => {
+        Ok(Some(fht)) => {
             fht::store(fht);
         }
-
+        Ok(None) => {}
         Err(err) => {
             //
             // For the update reset case, when we fail the image validation

--- a/runtime/src/update.rs
+++ b/runtime/src/update.rs
@@ -1,0 +1,22 @@
+// Licensed under the Apache-2.0 license
+
+use crate::Drivers;
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+
+pub(crate) fn handle_impactless_update(drivers: &mut Drivers) -> CaliptraResult<()> {
+    let cycles = drivers
+        .soc_ifc
+        .regs_mut()
+        .internal_fw_update_reset_wait_cycles()
+        .read()
+        .into();
+    for _ in 0..cycles {
+        drivers
+            .soc_ifc
+            .regs_mut()
+            .internal_fw_update_reset()
+            .write(|w| w.core_rst(true));
+    }
+
+    Err(CaliptraError::RUNTIME_UNEXPECTED_UPDATE_RETURN)
+}

--- a/sw-emulator/lib/periph/src/key_vault.rs
+++ b/sw-emulator/lib/periph/src/key_vault.rs
@@ -448,6 +448,8 @@ impl KeyVaultRegs {
         Ok(())
     }
 
+    // Does not write to usage, usage bits aren't directly writable outside of
+    // key creation.
     fn write_key_ctrl(&mut self, _size: RvSize, index: usize, val: u32) -> Result<(), BusError> {
         let val = LocalRegisterCopy::<u32, KV_CONTROL::Register>::new(val);
         let key_ctrl_reg = &mut self.key_control[index];
@@ -461,8 +463,6 @@ impl KeyVaultRegs {
             KV_CONTROL::USE_LOCK
                 .val(key_ctrl_reg.read(KV_CONTROL::USE_LOCK) | val.read(KV_CONTROL::USE_LOCK)),
         );
-
-        key_ctrl_reg.modify(KV_CONTROL::USAGE.val(val.read(KV_CONTROL::USAGE)));
 
         if key_ctrl_reg.read(KV_CONTROL::WRITE_LOCK) == 0 && val.is_set(KV_CONTROL::CLEAR) {
             let key_min = index * KeyVault::KEY_SIZE;

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -630,7 +630,7 @@ impl SocRegistersImpl {
             internal_obf_key: args.cptra_obf_key,
             internal_iccm_lock: ReadWriteRegister::new(0),
             internal_fw_update_reset: ReadWriteRegister::new(0),
-            internal_fw_update_reset_wait_cycles: ReadWriteRegister::new(0),
+            internal_fw_update_reset_wait_cycles: ReadWriteRegister::new(5),
             internal_nmi_vector: ReadWriteRegister::new(0),
             mailbox,
             iccm,


### PR DESCRIPTION
1. Add impactless update mailbox command
2. Fix a keyvault emulation bug which was clearing usage bits
3. Make ROM use the old FHT on update reset