### PR TITLE
[feat] Lock the SHA Accelerator on a fatal error

### DIFF
--- a/drivers/src/sha384acc.rs
+++ b/drivers/src/sha384acc.rs
@@ -69,6 +69,21 @@ impl Sha384Acc {
         let mut sha512_acc = Sha512AccCsr::new();
         sha512_acc.regs_mut().control().write(|w| w.zeroize(true));
     }
+
+    /// Lock the accelerator.
+    ///
+    /// This is useful to call from a fatal-error-handling routine.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be certain that the results of any pending cryptographic
+    /// operations will not be used after this function is called.
+    ///
+    /// This function is safe to call from a trap handler.
+    pub unsafe fn lock() {
+        let mut sha512_acc = Sha512AccCsr::new();
+        sha512_acc.regs_mut().lock().write(|w| w.lock(false)); // Writing 0 locks the accelerator.
+    }
 }
 
 pub struct Sha384AccOp<'a> {

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -186,13 +186,16 @@ fn report_error(code: u32) -> ! {
     cprintln!("ROM Fatal Error: 0x{:08X}", code);
     report_fw_error_fatal(code);
 
-    // Zeroize the crypto blocks.
     unsafe {
+        // Zeroize the crypto blocks.
         Ecc384::zeroize();
         Hmac384::zeroize();
         Sha256::zeroize();
         Sha384::zeroize();
         Sha384Acc::zeroize();
+
+        // Lock the SHA Accelerator.
+        Sha384Acc::lock();
 
         // Stop the watchdog timer.
         // Note: This is an idempotent operation.

--- a/sw-emulator/lib/periph/src/sha512_acc.rs
+++ b/sw-emulator/lib/periph/src/sha512_acc.rs
@@ -229,11 +229,8 @@ impl Sha512AcceleratorRegs {
             self.execute.reg.set(0);
             self.data_in.reg.set(0);
             self.mode.reg.set(0);
-
-            Ok(())
-        } else {
-            Err(BusError::StoreAccessFault)?
         }
+        Ok(())
     }
 
     /// On Write callback for `mode` register


### PR DESCRIPTION
This change is for the FIPS requirement: https://github.com/chipsalliance/caliptra-sw/issues/394