### PR TITLE
RE: #391 C API Package (libcaliptra)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,3 +117,6 @@ jobs:
           git submodule update --init
           (cd hw-model/c-binding/examples && make run)
 
+      - name: Caliptra C API Build/Link Test
+        run: |
+          (cd libcaliptra && make && make if_run)

--- a/libcaliptra/.gitignore
+++ b/libcaliptra/.gitignore
@@ -1,0 +1,2 @@
+inc/caliptra_model.h
+src/caliptra_api.o

--- a/libcaliptra/Makefile
+++ b/libcaliptra/Makefile
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Western Digital Corporation or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set Q= on the command line for verbosity
+Q=@
+
+# Set build targets, flags, and a defaultr
+ifeq ($(findstring "debug",$(MAKECMDGOALS)),"debug")
+CARGO_OUT = $(abspath ../target/debug)
+CARGO_FLAG =
+else ifeq ($(findstring "release,$(MAKECMDGOALS)),"release")
+CARGO_OUT = $(abspath ../target/release)
+CARGO_FLAG = --release
+else
+CARGO_OUT = $(abspath ../target/debug)
+endif
+
+RTL_SOC_IFC_INCLUDE_PATH = ../hw-latest/caliptra-rtl/src/soc_ifc/rtl
+CFLAGS += -I$(RTL_SOC_IFC_INCLUDE_PATH) -I$(CARGO_OUT) -I$(abspath inc)
+
+SOURCE += src/caliptra_api.c
+
+OBJS := $(patsubst %.c,%.o, $(filter %.c,$(SOURCE)))
+
+TESTS = $(sort $(notdir $(wildcard test/*)))
+CLEAN_TESTS = $(addprefix clean-, $(TESTS))
+
+.PHONY:%_test %_run clean $(CLEAN_TESTS)
+
+debug: all
+release: all
+tests: $(TESTS)
+all: $(OBJS) $(TESTS)
+
+$(OBJS): $(SOURCE)
+	@echo [CC] $@
+	$(Q)$(CC) ${CFLAGS} -c $< -o $@
+
+$(CLEAN_TESTS): FORCE
+	@echo [CLEAN] $@
+	@$(Q)$(MAKE) Q=$(Q) -C test/$(subst clean-,,$@) -f $(subst clean-,,$@).mk clean
+
+FORCE:
+
+clean: $(CLEAN_TESTS)
+	@echo [CLEAN] $(CARGO_OUT) $(OBJS)
+	$(Q)$(RM) -r $(CARGO_OUT)
+	$(Q)$(RM) $(OBJS)
+
+export CARGO_OUT
+export MODEL_HEADER
+export CFLAGS
+
+%_test: $(MODEL_HEADER)
+	$(Q)$(MAKE) Q=$(Q) -C test/$*_test -f $*_test.mk
+
+%_run:
+	$(Q)$(MAKE) Q=$(Q) -C test/$*_test -f $*_test.mk run

--- a/libcaliptra/README.md
+++ b/libcaliptra/README.md
@@ -1,0 +1,44 @@
+# libcaliptra
+
+## Purpose
+
+libcaliptra is an abstraction layer between SoC applications and the Caliptra implementation in hardware.
+
+## Structure
+
+libcaliptra exists in two parts:
+
+### Caliptra API
+
+Specified in caliptra_api.h and defined in caliptra_api.c
+
+Provides abstract APIs and functionality to SoC applications, independent of hardware details.
+
+### Caliptra IF
+
+Specified in caliptra_if.h and used by caliptra_api.c
+
+The caliptra implementation must supply the definitions for the functions named in caliptra_if.h
+
+## Build
+
+The top level Makefile has a few targets:
+
+debug
+release
+
+The default is debug (note: there is no difference between the two at this time)
+
+## Linking
+Applications will need to compile and link caliptra_api.c and the definitions for caliptra_if.hardware
+
+# Notes
+
+This is an early check-in to ensure its presence upstream and to generate feedback going forward.
+
+* Expand available APIs
+* Interrupts?
+** Handling thereof?
+* Add a demonstration interface connecting to the hardware model
+* Add a demonstration interface to the software simulator (?)
+* Add support for building the caliptra interface implementation if present?

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -1,0 +1,59 @@
+// Licensed under the Apache-2.0 license
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * caliptra_buffer
+ *
+ * Transfer buffer for Caliptra mailbox commands
+ */
+typedef struct caliptra_buffer {
+  const uint8_t *data; //< Pointer to a buffer with data to send/space to receive
+  uintptr_t len;       //< Size of the buffer
+} caliptra_buffer;
+
+/**
+ * DeviceLifecycle
+ *
+ * Device life cycle states
+ */
+enum DeviceLifecycle {
+    Unprovisioned = 0,
+    Manufacturing = 1,
+    Reserved2 = 2,
+    Production = 3,
+};
+
+/**
+ * caliptra_fuses
+ *
+ * Fuse data to be written to Caliptra registers
+ */
+struct caliptra_fuses {
+    uint32_t uds_seed[12];
+    uint32_t field_entropy[8];
+    uint32_t key_manifest_pk_hash[12];
+    uint32_t key_manifest_pk_hash_mask : 4;
+    uint32_t rsvd : 28;
+    uint32_t owner_pk_hash[12];
+    uint32_t fmc_key_manifest_svn;
+    uint32_t runtime_svn[4];
+    bool anti_rollback_disable;
+    uint32_t idevid_cert_attr[24];
+    uint32_t idevid_manuf_hsm_id[4];
+    enum DeviceLifecycle life_cycle;
+};
+
+// Initialize Caliptra fuses prior to boot
+int caliptra_init_fuses(struct caliptra_fuses *fuses);
+
+// Write into Caliptra BootFSM Go Register
+int caliptra_bootfsm_go();
+
+// Upload Caliptra Firmware
+int caliptra_upload_fw(struct caliptra_buffer *fw_buffer);
+
+// Execute Mailbox Command
+int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);

--- a/libcaliptra/inc/caliptra_if.h
+++ b/libcaliptra/inc/caliptra_if.h
@@ -1,0 +1,40 @@
+//Licensed under the Apache-2.0 license
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CALIPTRA_STATUS_OK 0
+
+// Memory
+
+/**
+ * caliptra_write_u32
+ *
+ * Writes a uint32_t value to the specified offset.
+ *
+ * @param[in] offset Memory offset to write
+ * @param[in] data   Data to write at offset
+ *
+ * @return 0 if successful, other if error (TBD)
+ */
+int caliptra_write_u32(uint32_t offset, uint32_t data);
+
+/**
+ * caliptra_read_u32
+ *
+ * Writes a uint32_t value to the specified offset.
+ *
+ * @param[in] offset Memory offset to read
+ * @param[in] data   Pointer to a uint32_t to store the data
+ *
+ * @return 0 if successful, other if error (TBD)
+ */
+int caliptra_read_u32(uint32_t offset, uint32_t *data);
+
+/**
+ * caliptra_wait
+ *
+ * Pend the current operation.
+ */
+void caliptra_wait(void);

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1,0 +1,256 @@
+// Licensed under the Apache-2.0 license
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <caliptra_top_reg.h>
+#include "caliptra_if.h"
+#include "caliptra_api.h"
+#include "caliptra_fuses.h"
+#include "caliptra_mbox.h"
+
+#define CALIPTRA_STATUS_NOT_READY 0
+
+static inline uint32_t caliptra_read_status(void)
+{
+    uint32_t status;
+
+    caliptra_read_u32(CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS, &status);
+}
+
+/**
+ * caliptra_ready_for_fuses
+ *
+ * Reports if the Caliptra hardware is ready for fuse data
+ *
+ * @return bool True if ready, false otherwise
+ */
+bool caliptra_ready_for_fuses(void)
+{
+    uint32_t status;
+
+    while (((status = caliptra_read_status()) & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_MASK) == CALIPTRA_STATUS_NOT_READY)
+    {
+        caliptra_wait();
+    }
+
+    return true;
+}
+
+/**
+ * caliptra_init_fuses
+ *
+ * Initialize fuses based on contents of "fuses" argument
+ *
+ * @param[in] fuses Valid caliptra_fuses structure
+ *
+ * @return int 0 if successful, -EINVAL if fuses is null, -EPERM if caliptra is not ready for fuses, -EIO if still ready after fuses are written
+ */
+int caliptra_init_fuses(struct caliptra_fuses *fuses)
+{
+    // Parameter check
+    if (!fuses) {
+        return -EINVAL;
+    }
+
+    // Check whether caliptra is ready for fuses
+    if (!caliptra_ready_for_fuses())
+        return -EPERM;
+
+    // Write Fuses
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_UDS_SEED_0, fuses->uds_seed, sizeof(fuses->uds_seed));
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_FIELD_ENTROPY_0, fuses->field_entropy, sizeof(fuses->field_entropy));
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_KEY_MANIFEST_PK_HASH_0, fuses->key_manifest_pk_hash, sizeof(fuses->key_manifest_pk_hash));
+    caliptra_fuse_write(GENERIC_AND_FUSE_REG_FUSE_KEY_MANIFEST_PK_HASH_MASK, fuses->key_manifest_pk_hash_mask);
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_OWNER_PK_HASH_0, fuses->owner_pk_hash, sizeof(fuses->owner_pk_hash));
+    caliptra_fuse_write(GENERIC_AND_FUSE_REG_FUSE_FMC_KEY_MANIFEST_SVN, fuses->fmc_key_manifest_svn);
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_FMC_KEY_MANIFEST_SVN, fuses->runtime_svn, sizeof(fuses->runtime_svn));
+    caliptra_fuse_write(GENERIC_AND_FUSE_REG_FUSE_ANTI_ROLLBACK_DISABLE, (uint32_t)fuses->anti_rollback_disable);
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_IDEVID_CERT_ATTR_0, fuses->idevid_cert_attr, sizeof(fuses->idevid_cert_attr));
+    caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_IDEVID_MANUF_HSM_ID_0, fuses->idevid_manuf_hsm_id, sizeof(fuses->idevid_manuf_hsm_id));
+    caliptra_fuse_write(GENERIC_AND_FUSE_REG_FUSE_LIFE_CYCLE, (uint32_t)fuses->life_cycle);
+
+    // Write to Caliptra Fuse Done
+    caliptra_write_u32(CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_CPTRA_FUSE_WR_DONE, 1);
+
+    // It shouldn`t be longer ready for fuses
+    if (caliptra_ready_for_fuses())
+        return -EIO;
+
+    return 0;
+}
+
+/**
+ * caliptra_bootfsm_go
+ *
+ * Initiate caliptra hw startup
+ *
+ * @return 0 if successful
+ */
+int caliptra_bootfsm_go()
+{
+    // Write BOOTFSM_GO Register
+    caliptra_write_u32(CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_CPTRA_BOOTFSM_GO, 1);
+
+    //TODO: Check registers/provide async completion mechanism
+
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_write_fifo
+ *
+ * Transfer contents of buffer into the mailbox FIFO
+ *
+ * @param[in] buffer Pointer to a valid caliptra_buffer struct
+ *
+ * @return int -EINVAL if the buffer is too large.
+ */
+static int caliptra_mailbox_write_fifo(struct caliptra_buffer *buffer)
+{
+    // Check against max size
+    const uint32_t MBOX_SIZE = (128u * 1024u);
+
+    if (buffer->len > MBOX_SIZE) {
+        return -EINVAL;
+    }
+
+    // Write DLEN
+    caliptra_mbox_write_dlen(buffer->len);
+
+    uint32_t remaining_len = buffer->len;
+    uint32_t *data_dw = (uint32_t *)buffer->data;
+
+    // Copy DWord multiples
+    while (remaining_len > sizeof(uint32_t)) {
+        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, *data_dw++);
+        remaining_len -= sizeof(uint32_t);
+    }
+
+    // if un-aligned dword reminder...
+    if (remaining_len) {
+        uint32_t data = 0;
+        memcpy(&data, data_dw, remaining_len);
+        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, data);
+    }
+
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_read_buffer
+ *
+ * Read a mailbxo FIFO into a buffer
+ *
+ * @param[in] buffer A pointer to a valid caliptra_buffer struct
+ *
+ * @return int 0 if successful, -EINVAL if the buffer is too small or the buffer pointer is invalid.
+ */
+static int caliptra_mailbox_read_buffer(struct caliptra_buffer *buffer)
+{
+    uint32_t remaining_len = caliptra_mbox_read_dlen();
+
+    // Check we have enough room in the buffer
+    if (buffer->len < remaining_len || !buffer->data)
+       return -EINVAL;
+
+    uint32_t *data_dw = (uint32_t *)buffer->data;
+
+    // Copy DWord multiples
+    while (remaining_len > sizeof(uint32_t)) {
+        *data_dw++ = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
+        remaining_len -= sizeof(uint32_t);
+    }
+
+    // if un-aligned dword reminder...
+    if (remaining_len) {
+        uint32_t data = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
+        memcpy(data_dw, &data, remaining_len);
+    }
+
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_execute
+ *
+ * Execute a mailbox command and send/retrieve a buffer
+ *
+ * @param[in] cmd Caliptra command opcode
+ * @param[in] mbox_tx_buffer Transmit buffer
+ * @param[in] mbox_rx_buffer Receive buffer
+ *
+ * @return 0 if successful, -EBUSY if the mailbox is locked, -EIO if the command has failed or data is not available or the FSM is not include
+ */
+int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer)
+{
+    // If mbox already locked return
+    if (caliptra_mbox_is_lock()) {
+        return -EBUSY;
+    }
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
+    // Write Cmd and Tx Buffer
+    caliptra_mbox_write_cmd(cmd);
+    caliptra_mailbox_write_fifo(mbox_tx_buffer);
+
+    // Set Execute bit and wait
+    caliptra_mbox_write_execute_wait(true);
+
+    // Check the Mailbox Status
+    uint32_t status = caliptra_mbox_read_status();
+    if (status == CALIPTRA_MBOX_STATUS_CMD_FAILURE) {
+        caliptra_mbox_write_execute(false);
+        return -EIO;
+    } else if(status == CALIPTRA_MBOX_STATUS_CMD_COMPLETE) {
+        caliptra_mbox_write_execute(false);
+        return 0;
+    } else if (status != CALIPTRA_MBOX_STATUS_DATA_READY) {
+        return -EIO;
+    }
+
+    // Read Buffer
+    caliptra_mailbox_read_buffer(mbox_rx_buffer);
+
+    // Execute False and wait
+    caliptra_mbox_write_execute_wait(false);
+
+    if (caliptra_mbox_read_status_fsm() != CALIPTRA_MBOX_STATUS_FSM_IDLE)
+        return -EIO;
+
+    return 0;
+}
+
+/**
+ * caliptra_ready_for_firmware
+ *
+ * Reports if the Caliptra hardware is ready for firmware upload 
+ *
+ * @return bool True if ready, false otherwise
+ */
+bool caliptra_ready_for_firmware(void)
+{
+    uint32_t status;
+
+    while (((status = caliptra_read_status()) & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FW_MASK) == CALIPTRA_STATUS_NOT_READY)
+    {
+        caliptra_wait();
+    }
+
+    return true;
+}
+
+/**
+ * caliptra_upload_fw
+ *
+ * Upload firmware to the Caliptra device
+ * 
+ * @param[in] fw_buffer Buffer containing Caliptra firmware
+ *
+ * @return See caliptra_mailbox_execute for possible results.
+ */
+int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
+{
+    const uint32_t FW_LOAD_CMD_OPCODE = 0x46574C44u;
+    return caliptra_mailbox_execute(FW_LOAD_CMD_OPCODE, fw_buffer, NULL);
+}

--- a/libcaliptra/src/caliptra_fuses.h
+++ b/libcaliptra/src/caliptra_fuses.h
@@ -1,0 +1,20 @@
+// Licensed under the Apache-2.0 license
+
+#pragma once
+
+#include "caliptra_api.h"
+
+// WARNING: THOSE APIS ARE INTENTED FOR SIMULATION ONLY.
+//          SOC FW MUST HAVE NO ACCESS TO THOSE APIS.
+//          A HW STATE MACHINE SHOULD BE USED TO SEND FUSE VALUES TO CALIPTRA OVER APB BUS
+
+static inline void caliptra_fuse_write(uint32_t offset, uint32_t data)
+{
+    caliptra_write_u32((offset + CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_BASE_ADDR), data);
+}
+
+static inline void caliptra_fuse_array_write(uint32_t offset, uint32_t *data, uint32_t size)
+{
+    for (uint32_t idx= 0; idx < size; idx +=sizeof(uint32_t))
+        caliptra_fuse_write((offset + idx ), data[idx]);
+}

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -1,0 +1,82 @@
+// Licensed under the Apache-2.0 license
+#pragma once
+
+/**
+ * Mailbox helper functions
+ *
+ * All of the below functions map to register reads and writes.
+ *
+ * TODO: Investigate interrupts for notification on mailbox
+ *       command completion.
+ */
+
+#define CALIPTRA_MBOX_STATUS_BUSY               0
+#define CALIPTRA_MBOX_STATUS_DATA_READY         1
+#define CALIPTRA_MBOX_STATUS_CMD_COMPLETE       2
+#define CALIPTRA_MBOX_STATUS_CMD_FAILURE        3
+
+#define CALIPTRA_MBOX_STATUS_FSM_IDLE           0
+#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_CMD  1
+#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DATA 2
+#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DLEN 3
+#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_SOC    4
+#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_UC     6
+
+static inline void caliptra_mbox_write(uint32_t offset, uint32_t data)
+{
+    caliptra_write_u32((offset + CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR), data);
+}
+
+static inline uint32_t caliptra_mbox_read(uint32_t offset)
+{
+    uint32_t data;
+    caliptra_read_u32((offset + CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR), &data);
+    return data;
+}
+
+static inline bool caliptra_mbox_is_lock()
+{
+    return (caliptra_mbox_read(MBOX_CSR_MBOX_LOCK) & MBOX_CSR_MBOX_LOCK_LOCK_MASK);
+}
+
+static inline void caliptra_mbox_write_cmd(uint32_t cmd)
+{
+    caliptra_mbox_write(MBOX_CSR_MBOX_CMD, cmd);
+}
+
+static inline void caliptra_mbox_write_execute(bool ex)
+{
+    caliptra_mbox_write(MBOX_CSR_MBOX_EXECUTE, ex);
+}
+
+static inline uint8_t caliptra_mbox_write_execute_wait(bool ex)
+{
+    caliptra_mbox_write(MBOX_CSR_MBOX_EXECUTE, ex);
+    uint8_t status;
+    while((status = (uint8_t)(caliptra_mbox_read(MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_STATUS_MASK)) == CALIPTRA_MBOX_STATUS_BUSY)
+    {
+        caliptra_wait();
+    }
+
+    return status;
+}
+
+static inline uint8_t caliptra_mbox_read_status(void)
+{
+    return (uint8_t)(caliptra_mbox_read(MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_STATUS_MASK);
+}
+
+static inline uint8_t caliptra_mbox_read_status_fsm(void)
+{
+    return (uint8_t)(caliptra_mbox_read(MBOX_CSR_MBOX_STATUS) >> 16 & MBOX_CSR_MBOX_STATUS_STATUS_MASK);
+}
+
+static inline uint32_t caliptra_mbox_read_dlen(void)
+{
+    return caliptra_mbox_read(MBOX_CSR_MBOX_DLEN);
+}
+
+static inline void caliptra_mbox_write_dlen(uint32_t dlen)
+{
+    caliptra_mbox_write(MBOX_CSR_MBOX_DLEN, dlen);
+}

--- a/libcaliptra/test/if_test/if_test.c
+++ b/libcaliptra/test/if_test/if_test.c
@@ -1,0 +1,21 @@
+//Licensed under the Apache-2.0 license
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "caliptra_api.h"
+
+int main(int argc, char **argv)
+{
+    int r = caliptra_bootfsm_go();
+
+    if (r)
+    {
+        printf("BOOTFSM_GO was not successful\n");
+        return 1;
+    }
+    
+    printf("OK\n");
+    return 0;
+}

--- a/libcaliptra/test/if_test/if_test.mk
+++ b/libcaliptra/test/if_test/if_test.mk
@@ -1,0 +1,26 @@
+Q=@
+
+SOURCE = if_test.c if_test_impl.c
+OBJS := $(patsubst %.c,%.o, $(filter %.c,$(SOURCE)))
+
+CALIPTRA_API = ../../src/caliptra_api.o
+
+.PHONY = run clean
+
+TARGET = if_test
+
+INCLUDE = ../../inc/
+
+$(TARGET): $(OBJS)
+	$(Q)$(CC) -o $(TARGET) $(CFLAGS) $(CALIPTRA_API) $(OBJS)
+
+%.o: %.c
+	@echo [CC] $< \-\> $@
+	$(Q)$(CC) ${CFLAGS} -c $< -o $@
+
+run:
+	$(Q)./$(TARGET)
+
+clean:
+	@echo [CLEAN] $(OBJS) $(TARGET)
+	$(Q)rm -f $(OBJS) $(TARGET)

--- a/libcaliptra/test/if_test/if_test_impl.c
+++ b/libcaliptra/test/if_test/if_test_impl.c
@@ -1,0 +1,26 @@
+//Licensed under the Apache-2.0 license
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "caliptra_api.h"
+#include "caliptra_if.h"
+
+// Memory
+int caliptra_write_u32(uint32_t offset, uint32_t data)
+{
+    return CALIPTRA_STATUS_OK;
+}
+
+int caliptra_read_u32(uint32_t offset, uint32_t *data)
+{
+    return 0x0ACEFACE;
+}
+
+// Control
+
+void caliptra_wait(void)
+{
+    // Execute some desired stall step, such as yield()
+}


### PR DESCRIPTION
Derived from the api example in hw-model/c-binding/examples/api, this is the initial skeleton of a more generic client API for Caliptra, intended to abstract away the details of the implementation.

Client applications will include caliptra_api.h and implementations will provide definitions to the functions declared in caliptra_if.h, check the README.md for more information.