### PR TITLE
Do not write LDevID or FMC alias public keys to DV slots.

### DIFF
--- a/common/src/hand_off.rs
+++ b/common/src/hand_off.rs
@@ -223,12 +223,6 @@ pub struct FirmwareHandoffTable {
     /// Index of FMC Private Alias Key in the Key Vault.
     pub fmc_priv_key_kv_hdl: HandOffDataHandle,
 
-    /// Index of FMC Public Alias Key X Coordinate in the Data Vault.
-    pub fmc_pub_key_x_dv_hdl: HandOffDataHandle,
-
-    /// Index of FMC Public Alias Key Y Coordinate in the Data Vault.
-    pub fmc_pub_key_y_dv_hdl: HandOffDataHandle,
-
     /// Index of FMC Certificate Signature R Component in the Data Vault.
     pub fmc_cert_sig_r_dv_hdl: HandOffDataHandle,
 
@@ -276,7 +270,7 @@ pub struct FirmwareHandoffTable {
     pub idev_dice_pub_key: Ecc384PubKey,
 
     /// Reserved for future use.
-    pub reserved: [u8; 132],
+    pub reserved: [u8; 140],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -292,8 +286,6 @@ impl Default for FirmwareHandoffTable {
             fmc_tci_dv_hdl: FHT_INVALID_HANDLE,
             fmc_cdi_kv_hdl: FHT_INVALID_HANDLE,
             fmc_priv_key_kv_hdl: FHT_INVALID_HANDLE,
-            fmc_pub_key_x_dv_hdl: FHT_INVALID_HANDLE,
-            fmc_pub_key_y_dv_hdl: FHT_INVALID_HANDLE,
             fmc_cert_sig_r_dv_hdl: FHT_INVALID_HANDLE,
             fmc_cert_sig_s_dv_hdl: FHT_INVALID_HANDLE,
             fmc_svn_dv_hdl: FHT_INVALID_HANDLE,
@@ -303,7 +295,7 @@ impl Default for FirmwareHandoffTable {
             rt_svn_dv_hdl: FHT_INVALID_HANDLE,
             ldevid_tbs_size: 0,
             fmcalias_tbs_size: 0,
-            reserved: [0u8; 132],
+            reserved: [0u8; 140],
             ldevid_tbs_addr: 0,
             fmcalias_tbs_addr: 0,
             pcr_log_addr: 0,
@@ -342,14 +334,6 @@ pub fn print_fht(fht: &FirmwareHandoffTable) {
         fht.fmc_priv_key_kv_hdl.0
     );
     crate::cprintln!(
-        "FMC Public Key X DV Handle: 0x{:08x}",
-        fht.fmc_pub_key_x_dv_hdl.0
-    );
-    crate::cprintln!(
-        "FMC Public Key Y DV Handle: 0x{:08x}",
-        fht.fmc_pub_key_y_dv_hdl.0
-    );
-    crate::cprintln!(
         "FMC Certificate Signature R DV Handle: 0x{:08x}",
         fht.fmc_cert_sig_r_dv_hdl.0
     );
@@ -386,8 +370,6 @@ impl FirmwareHandoffTable {
         let mut valid = self.fht_marker == FHT_MARKER
             && self.fmc_cdi_kv_hdl != FHT_INVALID_HANDLE
             && self.manifest_load_addr != FHT_INVALID_ADDRESS
-            && self.fmc_pub_key_x_dv_hdl != FHT_INVALID_HANDLE
-            && self.fmc_pub_key_y_dv_hdl != FHT_INVALID_HANDLE
             && self.fmc_cert_sig_r_dv_hdl != FHT_INVALID_HANDLE
             && self.fmc_cert_sig_s_dv_hdl != FHT_INVALID_HANDLE
             && self.rt_fw_load_addr_hdl != FHT_INVALID_HANDLE
@@ -478,8 +460,6 @@ mod tests {
         let valid = fht.fht_marker == FHT_MARKER
             && fht.fmc_cdi_kv_hdl != FHT_INVALID_HANDLE
             && fht.manifest_load_addr != FHT_INVALID_ADDRESS
-            && fht.fmc_pub_key_x_dv_hdl != FHT_INVALID_HANDLE
-            && fht.fmc_pub_key_y_dv_hdl != FHT_INVALID_HANDLE
             && fht.fmc_cert_sig_r_dv_hdl != FHT_INVALID_HANDLE
             && fht.fmc_cert_sig_s_dv_hdl != FHT_INVALID_HANDLE
             && fht.rt_fw_load_addr_hdl != FHT_INVALID_HANDLE

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -14,18 +14,18 @@ Abstract:
 
 use caliptra_registers::dv::DvReg;
 
-use crate::{Array4x12, Ecc384PubKey, Ecc384Signature};
+use crate::{Array4x12, Ecc384Signature};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColdResetEntry48 {
     LDevDiceSigR = 0,
     LDevDiceSigS = 1,
-    LDevDicePubKeyX = 2,
-    LDevDicePubKeyY = 3,
+    Reserved0 = 2,
+    Reserved1 = 3,
     FmcDiceSigR = 4,
     FmcDiceSigS = 5,
-    FmcPubKeyX = 6,
-    FmcPubKeyY = 7,
+    Reserved2 = 6,
+    Reserved3 = 7,
     FmcTci = 8,
     OwnerPubKeyHash = 9,
 }
@@ -36,12 +36,8 @@ impl TryFrom<u8> for ColdResetEntry48 {
         match value {
             0 => Ok(ColdResetEntry48::LDevDiceSigR),
             1 => Ok(ColdResetEntry48::LDevDiceSigS),
-            2 => Ok(ColdResetEntry48::LDevDicePubKeyX),
-            3 => Ok(ColdResetEntry48::LDevDicePubKeyY),
             4 => Ok(ColdResetEntry48::FmcDiceSigR),
             5 => Ok(ColdResetEntry48::FmcDiceSigS),
-            6 => Ok(ColdResetEntry48::FmcPubKeyX),
-            7 => Ok(ColdResetEntry48::FmcPubKeyY),
             8 => Ok(ColdResetEntry48::FmcTci),
             9 => Ok(ColdResetEntry48::OwnerPubKeyHash),
             _ => Err(()),
@@ -211,28 +207,6 @@ impl DataVault {
         }
     }
 
-    /// Set the ldev dice public key.
-    ///
-    /// # Arguments
-    /// * `pub_key` - ldev dice public key
-    ///
-    pub fn set_ldev_dice_pub_key(&mut self, pub_key: &Ecc384PubKey) {
-        self.write_lock_cold_reset_entry48(ColdResetEntry48::LDevDicePubKeyX, &pub_key.x);
-        self.write_lock_cold_reset_entry48(ColdResetEntry48::LDevDicePubKeyY, &pub_key.y);
-    }
-
-    /// Get the ldev dice public key.
-    ///
-    /// # Returns
-    /// * ldev dice public key
-    ///
-    pub fn ldev_dice_pub_key(&self) -> Ecc384PubKey {
-        Ecc384PubKey {
-            x: self.read_cold_reset_entry48(ColdResetEntry48::LDevDicePubKeyX),
-            y: self.read_cold_reset_entry48(ColdResetEntry48::LDevDicePubKeyY),
-        }
-    }
-
     /// Set the fmc dice signature.
     ///
     /// # Arguments
@@ -252,28 +226,6 @@ impl DataVault {
         Ecc384Signature {
             r: self.read_cold_reset_entry48(ColdResetEntry48::FmcDiceSigR),
             s: self.read_cold_reset_entry48(ColdResetEntry48::FmcDiceSigS),
-        }
-    }
-
-    /// Set the fmc public key.
-    ///
-    /// # Arguments
-    /// * `pub_key` - fmc public key
-    ///
-    pub fn set_fmc_pub_key(&mut self, pub_key: &Ecc384PubKey) {
-        self.write_lock_cold_reset_entry48(ColdResetEntry48::FmcPubKeyX, &pub_key.x);
-        self.write_lock_cold_reset_entry48(ColdResetEntry48::FmcPubKeyY, &pub_key.y);
-    }
-
-    /// Get the fmc public key.
-    ///
-    /// # Returns
-    /// * fmc public key
-    ///
-    pub fn fmc_pub_key(&self) -> Ecc384PubKey {
-        Ecc384PubKey {
-            x: self.read_cold_reset_entry48(ColdResetEntry48::FmcPubKeyX),
-            y: self.read_cold_reset_entry48(ColdResetEntry48::FmcPubKeyY),
         }
     }
 

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -122,8 +122,6 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | fmc_tci_dv_hdl        | 4            | ROM        | Handle of FMC TCI value in the Data Vault.                                                               |
 | fmc_cdi_kv_hdl        | 4            | ROM        | Handle of FMC CDI value in the Key Vault. Value of 0xFF indicates not present.                           |
 | fmc_priv_key_kv_hdl   | 4            | ROM        | Handle of FMC Private Alias Key in the Key Vault.                                                        |
-| fmc_pub_key_x_dv_hdl  | 4            | ROM        | Handle of FMC Public Alias Key X Coordinate in the Data Vault.                                           |
-| fmc_pub_key_y_dv_hdl  | 4            | ROM        | Handle of FMC Public Alias Key Y Coordinate in the Data Vault                                            |
 | fmc_cert_sig_r_dv_hdl | 4            | ROM        | Handle of FMC Certificate Signature R Component in the Data Vault.                                       |
 | fmc_cert_sig_s_dv_hdl | 4            | ROM        | Handle of FMC Certificate Signature S Component in the Data Vault.                                       |
 | fmc_svn_dv_hdl        | 4            | ROM        | Handle of FMC SVN value in the Data Vault.                                                               |
@@ -140,7 +138,7 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | rt_dice_pub_key       | 96           | FMC        | RT Alias DICE Public Key.                                                                                |
 | rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.                                                                                 |
 | idev_dice_pub_key     | 96           | ROM        | Initial Device ID Public Key.                                                                            |
-| reserved              | 132          |            | Reserved for future use.                                                                                 |
+| reserved              | 140          |            | Reserved for future use.                                                                                 |
 
 *FHT is currently defined to be 512 bytes in length.*
 

--- a/fmc/src/flow/crypto.rs
+++ b/fmc/src/flow/crypto.rs
@@ -9,7 +9,7 @@ use crate::fmc_env::FmcEnv;
 use caliptra_common::{crypto::Ecc384KeyPair, keyids::KEY_ID_TMP};
 use caliptra_drivers::{
     hmac384_kdf, okref, Array4x12, Array4x5, Array4x8, CaliptraResult, Ecc384PrivKeyIn,
-    Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Signature, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
+    Ecc384PrivKeyOut, Ecc384Signature, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 
 pub enum Crypto {}
@@ -152,30 +152,5 @@ impl Crypto {
         let priv_key_args = KeyReadArgs::new(priv_key);
         let priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
         env.ecc384.sign(&priv_key, digest, &mut env.trng)
-    }
-
-    /// Verify the ECC Signature
-    ///
-    /// This routine calculates the digest and verifies the signature
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - ROM Environment
-    /// * `pub_key` - Public key to verify the signature
-    /// * `data` - Input data to hash
-    /// * `sig` - Signature to verify
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - True on success, false otherwise
-    pub fn ecdsa384_verify(
-        env: &mut FmcEnv,
-        pub_key: &Ecc384PubKey,
-        data: &[u8],
-        sig: &Ecc384Signature,
-    ) -> CaliptraResult<bool> {
-        let digest = Self::sha384_digest(env, data);
-        let digest = okref(&digest)?;
-        env.ecc384.verify(pub_key, digest, sig)
     }
 }

--- a/fmc/src/flow/dice.rs
+++ b/fmc/src/flow/dice.rs
@@ -27,8 +27,8 @@ pub struct DiceInput {
     /// * On output, this field will hold the CDI of the current layer.
     pub cdi: KeyId,
 
-    /// Authority Key Pair
-    pub auth_key_pair: Ecc384KeyPair,
+    /// Authority Private Key
+    pub auth_priv_key: KeyId,
 
     /// Authority Serial Number
     pub auth_sn: [u8; 64],

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -16,7 +16,6 @@ use crate::fmc_env::FmcEnv;
 use caliptra_common::DataStore::*;
 use caliptra_common::{DataStore, FirmwareHandoffTable, HandOffDataHandle, Vault};
 use caliptra_drivers::{Array4x12, Ecc384Signature, KeyId};
-use caliptra_drivers::{Ecc384PubKey, Ecc384Scalar};
 use caliptra_error::CaliptraResult;
 
 #[cfg(feature = "riscv")]
@@ -98,66 +97,6 @@ impl HandOff {
                 "Invalid KeySlot DV Entry",
                 caliptra_error::CaliptraError::FMC_HANDOFF_INVALID_PARAM.into(),
             ),
-        }
-    }
-
-    fn fmc_pub_key_x(&self, env: &FmcEnv) -> Ecc384Scalar {
-        let ds: DataStore = self
-            .fht
-            .fmc_pub_key_x_dv_hdl
-            .try_into()
-            .unwrap_or_else(|_| {
-                caliptra_common::report_handoff_error_and_halt(
-                    "Invalid FMC ALias Public Key X DV handle",
-                    caliptra_error::CaliptraError::FMC_HANDOFF_INVALID_PARAM.into(),
-                )
-            });
-
-        // The data store is either a warm reset entry or a cold reset entry.
-        match ds {
-            DataVaultNonSticky48(dv_entry) => env.data_vault.read_warm_reset_entry48(dv_entry),
-            DataVaultSticky48(dv_entry) => env.data_vault.read_cold_reset_entry48(dv_entry),
-            _ => {
-                crate::report_error(
-                    caliptra_error::CaliptraError::FMC_HANDOFF_INVALID_PARAM.into(),
-                );
-            }
-        }
-    }
-
-    fn fmc_pub_key_y(&self, env: &FmcEnv) -> Ecc384Scalar {
-        let ds: DataStore = self
-            .fht
-            .fmc_pub_key_y_dv_hdl
-            .try_into()
-            .unwrap_or_else(|_| {
-                caliptra_common::report_handoff_error_and_halt(
-                    "Invalid FMC ALias Public Key Y DV handle",
-                    caliptra_error::CaliptraError::FMC_HANDOFF_INVALID_PARAM.into(),
-                )
-            });
-
-        // The data store is either a warm reset entry or a cold reset entry.
-        match ds {
-            DataVaultNonSticky48(dv_entry) => env.data_vault.read_warm_reset_entry48(dv_entry),
-            DataVaultSticky48(dv_entry) => env.data_vault.read_cold_reset_entry48(dv_entry),
-            _ => {
-                crate::report_error(
-                    caliptra_error::CaliptraError::FMC_HANDOFF_INVALID_PARAM.into(),
-                );
-            }
-        }
-    }
-
-    /// Get the fmc public key.
-    ///
-    /// # Returns
-    /// * fmc public key
-    ///
-    pub fn fmc_pub_key(&self, env: &FmcEnv) -> Ecc384PubKey {
-        Ecc384PubKey {
-            x: self.fmc_pub_key_x(env),
-            y: self.fmc_pub_key_y(env),
         }
     }
 

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -360,32 +360,25 @@ Local Device ID Layer derives the Owner CDI & ECC Keys. This layer represents th
     `LDevIdPubKey = ecc384_keygen(KvSlot3, KvSlot5)`
     `kv_clear(KvSlot3)`
 
-4.	Store and lock (for write) the LDevID Public Key in Data Vault (48 bytes) Slot 0 & Slot 1
-
-    `dv48_store(LDevIdPubKey.X, Dv48Slot0)`
-    `dv48_lock_wr(Dv48Slot0)`
-    `dv48_store(LDevIdPubKey.Y, Dv48Slot1)`
-    `dv48_lock_wr(Dv48Slot1)`
-
-5.	Generate the `To Be Signed` DER Blob of the LDevId Certificate
+4.	Generate the `To Be Signed` DER Blob of the LDevId Certificate
 
 	`LDevIdTbs = gen_cert_tbs(LDEVID_CERT, IDevIdPubKey, LDevIdPubKey)`
 
-6.	Sign the LDevID `To Be Signed` DER Blob with IDevId Private Key in Key Vault Slot 7
+5.	Sign the LDevID `To Be Signed` DER Blob with IDevId Private Key in Key Vault Slot 7
 
 	`LDevIdTbsDigest = sha384_digest(LDevIdTbs)`
 	`LDevIdCertSig = ecc384_sign(KvSlot7, LDevIdTbsDigest)`
 
-7.	Clear the IDevId Private Key in Key Vault Slot 7
+6.	Clear the IDevId Private Key in Key Vault Slot 7
 
 	`kv_clear(KvSlot7)`
 
-8.	Verify the signature of LDevID `To Be Signed` Blob
+7.	Verify the signature of LDevID `To Be Signed` Blob
 
 	`LDevIdTbsDigest = sha384_digest(LDevIdTbs)`
 	`Result = ecc384_verify(LDevIdPubKey, LDevIdTbsDigest, LDevIdCertSig)`
 
-9.	Store and lock (for write) the LDevID Certificate Signature in the sticky Data Vault (48 bytes) Slot 2 & Slot 3
+8.	Store and lock (for write) the LDevID Certificate Signature in the sticky Data Vault (48 bytes) Slot 2 & Slot 3
 
 	`dv48_store(LDevIdCertSig.R, Dv48Slot2)`
     `dv48_lock_wr(Dv48Slot2)`
@@ -397,10 +390,8 @@ Local Device ID Layer derives the Owner CDI & ECC Keys. This layer represents th
 
 | Slot | Key Vault | PCR Bank | Data Vault 48 Byte (Sticky) | Data Vault 4 Byte (Sticky) |
 |------|-----------|----------|-----------------------------|----------------------------|
-| 0 | | | 🔒LDevID Pub Key X |
-| 1 | | | 🔒LDevID Pub Key Y |
-| 2 | | | 🔒LDevID Cert Signature R |
-| 3 | | | 🔒LDevID Cert Signature S |
+| 0 | | | 🔒LDevID Cert Signature R |
+| 1 | | | 🔒LDevID Cert Signature S |
 | 5 | LDevID Private Key (48 bytes) |
 | 6 | LDevID CDI (48 bytes) |
 
@@ -462,32 +453,25 @@ Alias FMC Layer includes the measurement of the FMC and other security states. T
     `AliasFmcPubKey = ecc384_keygen(KvSlot3, KvSlot7)`
     `kv_clear(KvSlot3)`
 
-4.	Store and lock (for write) the Alias FMC Public Key in Data Vault (48 bytes) Slot 4 & Slot 5
-
-    `dv48_store(AliasFmcPubKey.X, Dv48Slot4)`
-    `dv48_lock_wr(Dv48Slot4)`
-    `dv48_store(AliasFmcPubKey.Y, Dv48Slot5)`
-    `dv48_lock_wr(Dv48Slot5)`
-
-5.	Generate the `To Be Signed` DER Blob of the Alias FMC Certificate
+4.	Generate the `To Be Signed` DER Blob of the Alias FMC Certificate
 
 	`AliasFmcTbs = gen_cert_tbs(ALIAS_FMC_CERT, LDevIdPubKey, AliasFmcPubKey)`
 
-6.	Sign the Alias FMC `To Be Signed` DER Blob with LDevId Private Key in Key Vault Slot 5
+5.	Sign the Alias FMC `To Be Signed` DER Blob with LDevId Private Key in Key Vault Slot 5
 
 	`AliasFmcTbsDigest = sha384_digest(AliasFmcTbs)`
 	`AliasFmcTbsCertSig = ecc384_sign(KvSlot5, AliasFmcTbsDigest)`
 
-7.	Clear the LDevId Private Key in Key Vault Slot 5
+6.	Clear the LDevId Private Key in Key Vault Slot 5
 
 	`kv_clear(KvSlot5)`
 
-8.	Verify the signature of Alias FMC `To Be Signed` Blob
+7.	Verify the signature of Alias FMC `To Be Signed` Blob
 
 	`AliasFmcTbsDigest = sha384_digest(AliasFmcTbs)`
 	`Result = ecc384_verify(AliasFmcPubKey, AliasFmcDigest , AliasFmcTbsCertSig)`
 
-9.	Store and lock (for write) the LDevID Certificate Signature in the sticky Data Vault (48 bytes) Slot 6 & Slot 7
+8.	Store and lock (for write) the LDevID Certificate Signature in the sticky Data Vault (48 bytes) Slot 6 & Slot 7
 
     `dv48_store(AliasFmcTbsCertSig.R, Dv48Slot6)`
     `dv48_lock_wr(Dv48Slot6)`
@@ -495,7 +479,7 @@ Alias FMC Layer includes the measurement of the FMC and other security states. T
     `dv48_store(AliasFmcTbsCertSig.S, Dv48Slot7)`
     `dv48_lock_wr(Dv48Slot7)`
 
-10.	Lock critical state needed for warm and update reset in Data Vault
+9.	Lock critical state needed for warm and update reset in Data Vault
 
 	`dv48_store(FMC_DIGEST, Dv48Slot8)`
     `dv48_lock_wr(Dv48Slot8)`
@@ -515,14 +499,12 @@ Alias FMC Layer includes the measurement of the FMC and other security states. T
 
 | Slot | Key Vault | PCR Bank | Data Vault 48 Byte (Sticky) | Data Vault 4 Byte (Sticky) |
 |------|-----------|----------|-----------------------------|----------------------------|
-| 0 | | | 🔒LDevID Pub Key X | 🔒FMC SVN |
-| 1 | | | 🔒LDevID Pub Key Y | 🔒Manufacturer Public Key Index |
-| 2 | | | 🔒LDevID Cert Signature R |
-| 3 | | | 🔒LDevID Cert Signature S |
-| 4 | | | 🔒Alias FMC Pub Key X |
-| 5 | | | 🔒Alias FMC Pub Key Y |
-| 6 | Alias FMC CDI (48 bytes) | | 🔒Alias FMC Cert Signature R |
-| 7 | Alias FMC Private Key (48 bytes) | | 🔒Alias FMC Cert Signature S |
+| 0 | | | 🔒LDevID Cert Signature R |
+| 1 | | | 🔒LDevID Cert Signature S |
+| 4 | | | 🔒Alias FMC Cert Signature R |
+| 5 | | | 🔒Alias FMC Cert Signature S |
+| 6 | Alias FMC CDI (48 bytes) |
+| 7 | Alias FMC Private Key (48 bytes) |
 | 8 |  | | 🔒FMC Digest |
 | 9 |  | | 🔒Owner PK Hash |
 
@@ -700,7 +682,7 @@ The following are the pre-conditions that should be satisfied:
             -  Validate the owner public key digest against the owner public key digest in data vault (value saved during cold boot). This makes sure that the owner key is not changed since last cold boot.
         - Validate the header exactly like in cold boot.
         - Validate the toc exactly like in cold boot.
-        - We still need to make sure that the digest of the FMC which was stored in the data vault register at cold boot
+        - Validate that the digest of the FMC which was stored in the data vault register at cold boot
           still matches the FMC image section. 
     - If validation fails during ROM boot, the new image will not be copied from
       the mailbox. ROM will boot the existing FMC/Runtime images. Validation

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -85,24 +85,6 @@ impl FhtDataStore {
                 | ColdResetEntry48::FmcDiceSigS as u32,
         )
     }
-    /// The FMC public key X coordinate is stored in a 384-bit DataVault
-    /// sticky register.
-    pub const fn fmc_pub_key_x_store() -> HandOffDataHandle {
-        HandOffDataHandle(
-            (Vault::DataVault as u32) << 12
-                | (DataVaultRegister::Sticky384BitReg as u32) << 8
-                | ColdResetEntry48::FmcPubKeyX as u32,
-        )
-    }
-    /// FMC public key Y coordinate is stored in a 384-bit DataVault
-    /// sticky register.
-    pub const fn fmc_pub_key_y_store() -> HandOffDataHandle {
-        HandOffDataHandle(
-            (Vault::DataVault as u32) << 12
-                | (DataVaultRegister::Sticky384BitReg as u32) << 8
-                | ColdResetEntry48::FmcPubKeyY as u32,
-        )
-    }
     /// The RT SVN is stored in a 32-bit DataVault non-sticky register.
     pub const fn rt_svn_data_store() -> HandOffDataHandle {
         HandOffDataHandle(
@@ -146,8 +128,6 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         rt_fw_entry_point_hdl: FhtDataStore::rt_fw_entry_point(),
         fmc_cdi_kv_hdl: FhtDataStore::fmc_cdi_store(),
         fmc_priv_key_kv_hdl: FhtDataStore::fmc_priv_key_store(),
-        fmc_pub_key_x_dv_hdl: FhtDataStore::fmc_pub_key_x_store(),
-        fmc_pub_key_y_dv_hdl: FhtDataStore::fmc_pub_key_y_store(),
         fmc_cert_sig_r_dv_hdl: FhtDataStore::fmc_cert_sig_r_store(),
         fmc_cert_sig_s_dv_hdl: FhtDataStore::fmc_cert_sig_s_store(),
         fmc_tci_dv_hdl: FhtDataStore::fmc_tci_store(),

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -193,9 +193,6 @@ impl FmcAliasLayer {
         // Lock the FMC Certificate Signature in data vault until next boot
         env.data_vault.set_fmc_dice_signature(sig);
 
-        // Lock the FMC Public key in the data vault until next boot
-        env.data_vault.set_fmc_pub_key(pub_key);
-
         //  Copy TBS to DCCM.
         copy_tbs(tbs.tbs(), TbsType::FmcaliasTbs, env)?;
 

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -193,10 +193,6 @@ impl LocalDevIdLayer {
         env.data_vault.set_ldev_dice_signature(sig);
         sig.zeroize();
 
-        // Lock the Local Device ID public keys in data vault until
-        // cold reset
-        env.data_vault.set_ldev_dice_pub_key(pub_key);
-
         //  Copy TBS to DCCM.
         copy_tbs(tbs.tbs(), TbsType::LdevidTbs, env)?;
 

--- a/rom/dev/tests/test_image_validation.rs
+++ b/rom/dev/tests/test_image_validation.rs
@@ -1653,19 +1653,6 @@ fn ldevid_cert(idevd_cert: &X509, output: &str) -> X509 {
         str::from_utf8(&ldevid_cert.to_text().unwrap()).unwrap()
     );
 
-    // Get ldevid public key
-    let pub_key_from_dv =
-        hex::decode(helpers::get_data("[fmc] LDEVID PUBLIC KEY DER = ", output)).unwrap();
-
-    // Verify the signature on the cert is valid.
-    let pub_key_from_cert = ldevid_cert
-        .public_key()
-        .as_ref()
-        .unwrap()
-        .public_key_to_der()
-        .unwrap();
-    assert_eq!(pub_key_from_dv, pub_key_from_cert[23..]);
-
     // Verify the ldevid cert using idevid cert's public key.
     assert!(ldevid_cert
         .verify(idevd_cert.public_key().as_ref().unwrap())
@@ -1683,22 +1670,6 @@ fn fmcalias_cert(ldevid_cert: &X509, output: &str) -> X509 {
         "FMCALIAS Cert:\n {}",
         str::from_utf8(&fmcalias_cert.to_text().unwrap()).unwrap()
     );
-
-    // Get fmclias public key
-    let pub_key_from_dv = hex::decode(helpers::get_data(
-        "[fmc] FMCALIAS PUBLIC KEY DER = ",
-        output,
-    ))
-    .unwrap();
-
-    // Verify the signature on the cert is valid.
-    let pub_key_from_cert = fmcalias_cert
-        .public_key()
-        .as_ref()
-        .unwrap()
-        .public_key_to_der()
-        .unwrap();
-    assert_eq!(pub_key_from_dv, pub_key_from_cert[23..]);
 
     // Verify the ldevid cert using idevid cert's public key.
     assert!(fmcalias_cert

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -110,12 +110,8 @@ fn create_certs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
     // Create LDEVID cert.
     //
 
-    // Retrieve the public key and signature from the data vault.
+    // Retrieve the signature from the data vault.
     let data_vault = unsafe { DataVault::new(DvReg::new()) };
-    let ldevid_pub_key = data_vault.ldev_dice_pub_key();
-    let mut _pub_der: [u8; 97] = ldevid_pub_key.to_der();
-    cprint_slice!("[fmc] LDEVID PUBLIC KEY DER", _pub_der);
-
     let sig = data_vault.ldev_dice_signature();
 
     let ecdsa_sig = Ecdsa384Signature {
@@ -139,11 +135,7 @@ fn create_certs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
     // Create FMCALIAS cert.
     //
 
-    // Retrieve the public key and signature from the data vault.
-    let fmcalias_pub_key = data_vault.fmc_pub_key();
-    let _pub_der: [u8; 97] = fmcalias_pub_key.to_der();
-    cprint_slice!("[fmc] FMCALIAS PUBLIC KEY DER", _pub_der);
-
+    // Retrieve the signature from the data vault.
     let sig = data_vault.fmc_dice_signature();
     let ecdsa_sig = Ecdsa384Signature {
         r: sig.r.into(),


### PR DESCRIPTION
These are unnecessary, and this change frees up DV slots for future use by FMC.

This change also removes these entries in FHT, removes the explicit ECDSA verify from RT alias cert generation (will be done anyways as part of the driver), and removes a test that only checks to ensure the keys in DV match those in the cert.