### PR TITLE
[fix] Change DeobfuscationEngine.clear_secrets return type to void.

### DIFF
--- a/drivers/src/doe.rs
+++ b/drivers/src/doe.rs
@@ -79,7 +79,7 @@ impl DeobfuscationEngine {
     /// * Deobfuscation Key
     /// * Encrypted UDS
     /// * Encrypted Field entropy
-    pub fn clear_secrets(&mut self) -> CaliptraResult<()> {
+    pub fn clear_secrets(&mut self) {
         let doe = self.doe.regs_mut();
 
         // Wait for hardware ready
@@ -90,7 +90,5 @@ impl DeobfuscationEngine {
 
         // Wait for command to complete
         wait::until(|| doe.status().read().valid());
-
-        Ok(())
     }
 }

--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -108,7 +108,7 @@ fn test_decrypt() {
 
 fn test_clear_secrets() {
     let mut doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
-    doe.clear_secrets().unwrap();
+    doe.clear_secrets();
 }
 
 test_suite! {

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -61,7 +61,7 @@ impl InitDevIdLayer {
         Self::decrypt_field_entropy(env, KEY_ID_FE)?;
 
         // Clear Deobfuscation Engine Secrets
-        Self::clear_doe_secrets(env)?;
+        Self::clear_doe_secrets(env);
 
         // Derive the DICE CDI from decrypted UDS
         Self::derive_cdi(env, KEY_ID_UDS, KEY_ID_ROM_FMC_CDI)?;
@@ -129,12 +129,9 @@ impl InitDevIdLayer {
     /// # Arguments
     ///
     /// * `env` - ROM Environment
-    fn clear_doe_secrets(env: &mut RomEnv) -> CaliptraResult<()> {
-        let result = env.doe.clear_secrets();
-        if result.is_ok() {
-            report_boot_status(IDevIdClearDoeSecretsComplete.into());
-        }
-        result
+    fn clear_doe_secrets(env: &mut RomEnv) {
+        env.doe.clear_secrets();
+        report_boot_status(IDevIdClearDoeSecretsComplete.into());
     }
 
     /// Derive Composite Device Identity (CDI) from Unique Device Secret (UDS)


### PR DESCRIPTION
Since DeobfuscationEngine.clear_secrets cannot fail, there isn't any value of having a return type of CalitpraResult on the clear_secrets API.