### PR TITLE
[fix] Additional checks for FMC and Runtime in the Verifier library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "bitflags 2.0.2",
  "caliptra-drivers",
  "caliptra-image-types",
+ "caliptra_common",
  "memoffset",
  "zerocopy",
 ]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -232,6 +232,10 @@ impl CaliptraError {
     pub const RUNTIME_HANDOFF_FHT_NOT_LOADED: CaliptraError = CaliptraError::new_const(0x000b0039);
     pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_REVOKED: CaliptraError =
         CaliptraError::new_const(0x000b0003a);
+    pub const IMAGE_VERIFIER_ERR_FMC_SIZE_ZERO: CaliptraError =
+        CaliptraError::new_const(0x000b003b);
+    pub const IMAGE_VERIFIER_ERR_RUNTIME_SIZE_ZERO: CaliptraError =
+        CaliptraError::new_const(0x000b003c);
 
     /// Driver Error: LMS
     pub const DRIVER_LMS_INVALID_LMS_ALGO_TYPE: CaliptraError =

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -15,6 +15,9 @@ caliptra-image-types = { workspace = true, default-features = false }
 memoffset.workspace = true
 zerocopy.workspace = true
 
+[dev-dependencies]
+caliptra_common = { path = "../../common", default-features = false }
+
 [features]
 default = ["std"]
 std = ["caliptra-image-types/std"]

--- a/rom/dev/doc/test-coverage/test-coverage.md
+++ b/rom/dev/doc/test-coverage/test-coverage.md
@@ -37,12 +37,14 @@ IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
 **test_header_verify_owner_ecc_sig_invalid_signature_s** | Image Verification - Header | Checks if owner ECC signature.s from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID
 **test_toc_invalid_entry_count** | Image Verification - TOC | Checks if header.toc_count equals MAX_TOC_ENTRY_COUNT (2) | IMAGE_VERIFIER_ERR_TOC_ENTRY_COUNT_INVALID
 **test_toc_invalid_toc_digest** | Image Verification - TOC | Checks if digest of [manifest.fmc_toc | manifest.rt_toc] matches header.toc_digest | IMAGE_VERIFIER_ERR_TOC_DIGEST_MISMATCH
+**test_toc_fmc_size_zero** | Image Verification - TOC | Checks if FMC size if zero | IMAGE_VERIFIER_ERR_FMC_SIZE_ZERO
 **test_toc_fmc_range_overlap** | Image Verification - TOC | Checks if FMC and Runtime images don't overlap in the image bundle | IMAGE_VERIFIER_ERR_FMC_RUNTIME_OVERLAP
 **test_toc_fmc_range_incorrect_order** | Image Verification - TOC | Checks if FMC image is before Runtime image in the image bundle | IMAGE_VERIFIER_ERR_FMC_RUNTIME_INCORRECT_ORDER
 **test_fmc_rt_load_address_range_overlap** | Image Verification - TOC | Checks if FMC and Runtime image load address range don't overlap | IMAGE_VERIFIER_ERR_FMC_RUNTIME_LOAD_ADDR_OVERLAP
 **test_fmc_digest_mismatch** | Image Verification - FMC | Checks if manifest.fmc_toc.digest matches FMC image digest | IMAGE_VERIFIER_ERR_FMC_DIGEST_MISMATCH
 **test_fmc_invalid_load_addr_before_iccm** | Image Verification - FMC | Checks if FMC load address is within ICCM range | IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_INVALID
 **test_fmc_invalid_load_addr_after_iccm** | Image Verification - FMC | Checks if FMC load address is within ICCM range | IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_INVALID
+**test_fmc_not_contained_in_iccm** | Image Verification - FMC | Checks if FMC is fully contained in the ICCM | IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_INVALID
 **test_fmc_load_addr_unaligned** | Image Verification - FMC | Checks if FMC load address is DWORD aligned | IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_UNALIGNED
 **test_fmc_invalid_entry_point_before_iccm** | Image Verification - FMC | Checks if FMC entry point is within ICCM range  | IMAGE_VERIFIER_ERR_FMC_ENTRY_POINT_INVALID
 **test_fmc_invalid_entry_point_after_iccm** | Image Verification - FMC | Checks if FMC entry point is within ICCM range  | IMAGE_VERIFIER_ERR_FMC_ENTRY_POINT_INVALID
@@ -50,9 +52,11 @@ IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
 **test_fmc_svn_greater_than_32** | Image Verification - FMC | Checks if FMC SVN is greater than max (32) | IMAGE_VERIFIER_ERR_FMC_SVN_GREATER_THAN_MAX_SUPPORTED
 **test_fmc_svn_less_than_min_svn** | Image Verification - FMC | Checks if FMC SVN is less than toc_fmc.min_svn | IMAGE_VERIFIER_ERR_FMC_SVN_LESS_THAN_MIN_SUPPORTED
 **test_fmc_svn_less_than_fuse_svn** | Image Verification - FMC | Checks if FMC SVN is less than fuse svn | IMAGE_VERIFIER_ERR_FMC_SVN_LESS_THAN_FUSE
+**test_toc_rt_size_zero** | Image Verification - RT | Checks if RT size if 0 | IMAGE_VERIFIER_ERR_RUNTIME_SIZE_ZERO
 **test_runtime_digest_mismatch** | Image Verification - RT | Checks if manifest.rt_toc.digest matches Runtime image digest | IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH
 **test_runtime_invalid_load_addr_before_iccm** | Image Verification - RT | Checks if RT load address is within ICCM range | IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_INVALID
 **test_runtime_invalid_load_addr_after_iccm** | Image Verification - RT | Checks if RT load address is within ICCM range | IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_INVALID
+**test_runtime_not_contained_in_iccm** | Image Verification - RT | Checks if RT is fully contained in the ICCM | IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_INVALID
 **test_runtime_load_addr_unaligned** | Image Verification - RT | Checks if RT load address is DWORD aligned | IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_UNALIGNED
 **test_runtime_invalid_entry_point_before_iccm** | Image Verification - RT | Checks if RT entry point is within ICCM range  | IMAGE_VERIFIER_ERR_RUNTIME_ENTRY_POINT_INVALID
 **test_runtime_invalid_entry_point_after_iccm** | Image Verification - RT | Checks if RT entry point is within ICCM range  | IMAGE_VERIFIER_ERR_RUNTIME_ENTRY_POINT_INVALID

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,6 +16,7 @@ Abstract:
 --*/
 
 use crate::fht::FhtDataStore;
+use caliptra_common::memory_layout::*;
 use caliptra_drivers::{
     DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
     Sha384, Sha384Acc, SocIfc, Trng,
@@ -27,9 +28,6 @@ use caliptra_registers::{
     sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 use core::ops::Range;
-
-const ICCM_START: u32 = 0x40000000;
-const ICCM_SIZE: u32 = 128 << 10;
 
 /// Rom Context
 pub struct RomEnv {
@@ -81,8 +79,8 @@ pub struct RomEnv {
 
 impl RomEnv {
     pub const ICCM_RANGE: Range<u32> = Range {
-        start: ICCM_START,
-        end: ICCM_START + ICCM_SIZE,
+        start: ICCM_ORG,
+        end: ICCM_ORG + ICCM_SIZE,
     };
 
     pub unsafe fn new_from_registers() -> CaliptraResult<Self> {


### PR DESCRIPTION
This change adds the following checks to the Firmware Image Verifier Library:
	1. Checks if FMC and Runtime sizes are not zero in the TOCs.
	2. Checks if FMC and Runtime are fully contained in the ICCM.