### PR TITLE
Make CI 2x faster: Try to avoid invalidating cargo cache.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,7 +101,9 @@ jobs:
       # build.
       - name: Clippy lint check
         run: |
-          cargo clippy --locked --all-targets -- -D warnings
+          # Clippy doesn't look at --config, so manually set RUSTFLAGS to the
+          # same as the build steps to avoid invalidating the cargo cache.
+          RUSTFLAGS="-Dwarnings" cargo clippy --locked --all-targets -- -D warnings
 
       - name: Run tests
         run: |
@@ -112,7 +114,7 @@ jobs:
         run: |
           sudo apt-get install gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf
           (cd /tmp/ && git clone --depth 1 --branch old-framework-2.x https://github.com/riscv-non-isa/riscv-arch-test)
-          cargo run --locked -p compliance-test -- --test_root_path /tmp/riscv-arch-test
+          cargo --config "$EXTRA_CARGO_CONFIG" run --locked -p compliance-test -- --test_root_path /tmp/riscv-arch-test
 
       - name: ROM Makefile
         run: |

--- a/hw-model/c-binding/examples/Makefile
+++ b/hw-model/c-binding/examples/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+EXTRA_CARGO_CONFIG = target.'cfg(all())'.rustflags = [\"-Dwarnings\"]
 OUT = out
 TARGET = $(OUT)/smoke_test
 RTL_SOC_IFC_INCLUDE_PATH = ../../../hw-latest/caliptra-rtl/src/soc_ifc/rtl
@@ -28,7 +28,9 @@ OBJS := $(patsubst %.c,%.o, $(filter %.c,$(SOURCE)))
 
 all: $(TARGET)
 $(OUT)/caliptra_model.h:
-	cargo build --target-dir $(OUT)
+	cargo --config="$(EXTRA_CARGO_CONFIG)" build
+	mkdir -p $(OUT)/debug
+	cp ../../../target/debug/libcaliptra_hw_model_c_binding.a $(OUT)/debug/
 
 $(OUT)/%.o: $(SOURCE)
 	$(MKDIR)
@@ -41,6 +43,6 @@ clean:
 	$(RM) -rf $(OUT)
 
 run: $(TARGET)
-	cargo run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom $(OUT)/caliptra_rom.bin --fw $(OUT)/image_bundle.bin
+	cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom $(OUT)/caliptra_rom.bin --fw $(OUT)/image_bundle.bin
 	$(TARGET) -r $(OUT)/caliptra_rom.bin -f $(OUT)/image_bundle.bin
 

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -15,44 +15,55 @@
 TARGET_DIR=../../target/riscv32imc-unknown-none-elf/firmware
 CURRENT_DIR = $(shell pwd)
 GIT_REV = $(shell git rev-parse HEAD)
+EXTRA_CARGO_CONFIG = target.'cfg(all())'.rustflags = [\"-Dwarnings\"]
 
 default: build
 
 build:
-	cargo build \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		build \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
 
 build-emu:
-	cargo build \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		build \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features emu
 
 build-test-fmc:
-	cargo build \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		build \
 		--profile firmware \
 		--manifest-path tools/test-fmc/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features emu
 
 build-test-rt:
-	cargo build \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		build \
 		--profile firmware \
 		--manifest-path tools/test-rt/Cargo.toml \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
-		--features emu \
+		--features emu
 
 gen-certs:
 	$(shell bash $(CURRENT_DIR)/tools/scripts/gen_test_certs.sh $(TARGET_DIR))
 	$(shell cp $(CURRENT_DIR)/tools/keys.toml $(TARGET_DIR))
 
 build-fw-image: gen-certs build-test-fmc build-test-rt
-	cargo run \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		run \
 		--manifest-path ../../image/app/Cargo.toml \
 		-- \
 		create \
@@ -70,18 +81,22 @@ build-fw-image: gen-certs build-test-fmc build-test-rt
 		--out $(TARGET_DIR)/caliptra-rom-test-fw \
 
 bloat: build
-	 cargo bloat \
+	 cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		bloat \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
 		-n 1000 \
 
 objdump:
-	 cargo objdump \
+	 cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		objdump \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
- 		-- \
+		-- \
 		-d \
 		--no-print-imm-hex \
 		--disassembler-options=no-aliases \
@@ -97,7 +112,9 @@ objcopy:
   		$(TARGET_DIR)/caliptra-rom.bin \
 
 run: build-emu build-fw-image objcopy
-	cargo run \
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		run \
 		-p caliptra-emu \
 		-- \
 		--req-idevid-csr \
@@ -107,7 +124,9 @@ run: build-emu build-fw-image objcopy
 		--device-lifecycle unprovisioned \
 
 run-update: build-emu build-fw-image objcopy
-		cargo run \
+		cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		run \
 		-p caliptra-emu \
 		-- \
 		--req-idevid-csr \
@@ -119,13 +138,17 @@ run-update: build-emu build-fw-image objcopy
 
 
 size:
-	 cargo size \
+	 cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		size \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
 
 nm:
-	 cargo nm \
+	 cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		nm \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \

--- a/rom/dev/tools/scripts/gen_test_certs.sh
+++ b/rom/dev/tools/scripts/gen_test_certs.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-cargo test -p caliptra-image-fake-keys test_write_lms_keys -- --ignored >/dev/null
+cargo --config="target.'cfg(all())'.rustflags = [\"-Dwarnings\"]" test -p caliptra-image-fake-keys test_write_lms_keys -- --ignored >/dev/null
 
 for value in {0..3}
 do


### PR DESCRIPTION
When compiling for the host, try to use the same RUSTFLAGS everywhere to
avoid invalidating the cargo cache.

Also, in the hw-model c binding tests, don't change the target
directory, so we can use the cached artifacts built earlier in the
workflow.

Together, these changes should reduce the total time from ~16 minutes to
~8 minutes.