### PR TITLE
[feat] Make LMS verification dependent on a fuse.

### DIFF
--- a/common/src/fuse.rs
+++ b/common/src/fuse.rs
@@ -18,27 +18,33 @@ use zerocopy::{AsBytes, FromBytes};
 
 pub enum FuseLogEntryId {
     Invalid = 0,
-    VendorPubKeyIndex = 1,      // 4 bytes  (From Manifest)
-    VendorPubKeyRevocation = 2, // 4 bytes  (From Fuse)
-    ManifestFmcSvn = 3,         // 4 bytes
-    ManifestFmcMinSvn = 4,      // 4 bytes
-    FuseFmcSvn = 5,             // 4 bytes
-    ManifestRtSvn = 6,          // 4 bytes
-    ManifestRtMinSvn = 7,       // 4 bytes
-    FuseRtSvn = 8,              // 4 bytes
+    VendorEccPubKeyIndex = 1,       // 4 bytes  (From Manifest)
+    VendorEccPubKeyRevocation = 2,  // 4 bytes  (From Fuse)
+    ManifestFmcSvn = 3,             // 4 bytes
+    ManifestFmcMinSvn = 4,          // 4 bytes
+    FuseFmcSvn = 5,                 // 4 bytes
+    ManifestRtSvn = 6,              // 4 bytes
+    ManifestRtMinSvn = 7,           // 4 bytes
+    FuseRtSvn = 8,                  // 4 bytes
+    VendorLmsPubKeyIndex = 9,       // 4 bytes  (From Manifest)
+    VendorLmsPubKeyRevocation = 10, // 4 bytes  (From Fuse)
+    OwnerLmsPubKeyIndex = 11,       // 4 bytes  (From Manifest)
 }
 
 impl From<u32> for FuseLogEntryId {
     fn from(id: u32) -> FuseLogEntryId {
         match id {
-            1 => FuseLogEntryId::VendorPubKeyIndex,
-            2 => FuseLogEntryId::VendorPubKeyRevocation,
+            1 => FuseLogEntryId::VendorEccPubKeyIndex,
+            2 => FuseLogEntryId::VendorEccPubKeyRevocation,
             3 => FuseLogEntryId::ManifestFmcSvn,
             4 => FuseLogEntryId::ManifestFmcMinSvn,
             5 => FuseLogEntryId::FuseFmcSvn,
             6 => FuseLogEntryId::ManifestRtSvn,
             7 => FuseLogEntryId::ManifestRtMinSvn,
             8 => FuseLogEntryId::FuseRtSvn,
+            9 => FuseLogEntryId::VendorLmsPubKeyIndex,
+            10 => FuseLogEntryId::VendorLmsPubKeyRevocation,
+            11 => FuseLogEntryId::OwnerLmsPubKeyIndex,
             _ => FuseLogEntryId::Invalid,
         }
     }

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -54,6 +54,7 @@ impl From<IdevidCertAttr> for usize {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LmsVerifyConfig {
     EcdsaOnly = 0,
     EcdsaAndLms = 1,
@@ -167,19 +168,32 @@ impl FuseBank<'_> {
         Array4x12::read_from_reg(soc_ifc_regs.fuse_key_manifest_pk_hash())
     }
 
-    /// Get the vendor public key revocation mask.
+    /// Get the ecc vendor public key revocation mask.
     ///
     /// # Arguments
     /// * None
     ///
     /// # Returns
-    ///     vendor public key revocation mask
+    ///     ecc vendor public key revocation mask
     ///
-    pub fn vendor_pub_key_revocation(&self) -> VendorPubKeyRevocation {
+    pub fn vendor_ecc_pub_key_revocation(&self) -> VendorPubKeyRevocation {
         let soc_ifc_regs = self.soc_ifc.regs();
         VendorPubKeyRevocation::from_bits_truncate(
             soc_ifc_regs.fuse_key_manifest_pk_hash_mask().read().mask(),
         )
+    }
+
+    /// Get the lms vendor public key revocation mask.
+    ///
+    /// # Arguments
+    /// * None
+    ///
+    /// # Returns
+    ///     lms vendor public key revocation mask
+    ///
+    pub fn vendor_lms_pub_key_revocation(&self) -> VendorPubKeyRevocation {
+        let soc_ifc_regs = self.soc_ifc.regs();
+        VendorPubKeyRevocation::from_bits_truncate(soc_ifc_regs.fuse_lms_revocation().read())
     }
 
     /// Get the owner public key hash.

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -57,7 +57,9 @@ pub use ecc384::{
 };
 pub use error_reporter::{report_fw_error_fatal, report_fw_error_non_fatal};
 pub use exit_ctrl::ExitCtrl;
-pub use fuse_bank::{FuseBank, IdevidCertAttr, VendorPubKeyRevocation, X509KeyIdAlgo};
+pub use fuse_bank::{
+    FuseBank, IdevidCertAttr, LmsVerifyConfig, VendorPubKeyRevocation, X509KeyIdAlgo,
+};
 pub use hmac384::{Hmac384, Hmac384Data, Hmac384Key, Hmac384Op, Hmac384Tag};
 pub use hmac384_kdf::hmac384_kdf;
 pub use key_vault::{KeyId, KeyUsage, KeyVault};

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -167,7 +167,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b0017);
     pub const IMAGE_VERIFIER_ERR_FMC_RUNTIME_INCORRECT_ORDER: CaliptraError =
         CaliptraError::new_const(0x000b0018);
-    pub const IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG: CaliptraError =
+    pub const IMAGE_VERIFIER_ERR_OWNER_ECC_PUB_KEY_INVALID_ARG: CaliptraError =
         CaliptraError::new_const(0x000b0019);
     pub const IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG: CaliptraError =
         CaliptraError::new_const(0x000b001a);
@@ -215,7 +215,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b0030);
     pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_VERIFY_FAILURE: CaliptraError =
         CaliptraError::new_const(0x000b0031);
-    pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS: CaliptraError =
+    pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_INDEX_OUT_OF_BOUNDS: CaliptraError =
         CaliptraError::new_const(0x000b0032);
     pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_SIGNATURE_INVALID: CaliptraError =
         CaliptraError::new_const(0x000b0033);
@@ -225,11 +225,13 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b0035);
     pub const IMAGE_VERIFIER_ERR_OWNER_LMS_VERIFY_FAILURE: CaliptraError =
         CaliptraError::new_const(0x000b0036);
-    pub const IMAGE_VERIFIER_ERR_OWNER_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS: CaliptraError =
+    pub const IMAGE_VERIFIER_ERR_OWNER_LMS_PUB_KEY_INDEX_OUT_OF_BOUNDS: CaliptraError =
         CaliptraError::new_const(0x000b0037);
     pub const IMAGE_VERIFIER_ERR_OWNER_LMS_SIGNATURE_INVALID: CaliptraError =
         CaliptraError::new_const(0x000b0038);
     pub const RUNTIME_HANDOFF_FHT_NOT_LOADED: CaliptraError = CaliptraError::new_const(0x000b0039);
+    pub const IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_REVOKED: CaliptraError =
+        CaliptraError::new_const(0x000b0003a);
 
     /// Driver Error: LMS
     pub const DRIVER_LMS_INVALID_LMS_ALGO_TYPE: CaliptraError =

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -443,6 +443,12 @@ pub trait HwModel {
         self.soc_ifc()
             .fuse_life_cycle()
             .write(|w| w.life_cycle(fuses.life_cycle.into()));
+        self.soc_ifc()
+            .fuse_lms_verify()
+            .write(|w| w.lms_verify(fuses.lms_verify));
+        self.soc_ifc()
+            .fuse_lms_revocation()
+            .write(|_| fuses.fuse_lms_revocation);
 
         self.soc_ifc().cptra_fuse_wr_done().write(|w| w.done(true));
         assert!(self.soc_ifc().cptra_fuse_wr_done().read().done());

--- a/hw-model/types/src/lib.rs
+++ b/hw-model/types/src/lib.rs
@@ -167,6 +167,8 @@ pub struct Fuses {
     pub idevid_cert_attr: [u32; 24],
     pub idevid_manuf_hsm_id: [u32; 4],
     pub life_cycle: DeviceLifecycle,
+    pub lms_verify: bool,
+    pub fuse_lms_revocation: u32,
 }
 impl Default for Fuses {
     fn default() -> Self {
@@ -182,6 +184,8 @@ impl Default for Fuses {
             idevid_cert_attr: Default::default(),
             idevid_manuf_hsm_id: Default::default(),
             life_cycle: Default::default(),
+            lms_verify: Default::default(),
+            fuse_lms_revocation: Default::default(),
         }
     }
 }

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -8,7 +8,7 @@ File Name:
 
 Abstract:
 
-    File contains data strucutres for the firmware image bundle.
+    File contains data structures for the firmware image bundle.
 
 --*/
 

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -54,11 +54,20 @@ pub struct ImageVerificationExeInfo {
 /// Information To Be Logged For The Verified Image
 #[derive(Default, Debug)]
 pub struct ImageVerificationLogInfo {
-    // Vendor Public Key Index To Log
+    // ECC Vendor Public Key Index To Log
     pub vendor_ecc_pub_key_idx: u32,
 
-    /// Vendor Public Key Revocation Fuse    
-    pub fuse_vendor_pub_key_revocation: VendorPubKeyRevocation,
+    /// Vendor ECC Public Key Revocation Fuse    
+    pub fuse_vendor_ecc_pub_key_revocation: VendorPubKeyRevocation,
+
+    // LMS Vendor Public Key Index
+    pub vendor_lms_pub_key_idx: Option<u32>,
+
+    // LMS Owner Public Key Index To Log
+    pub owner_lms_pub_key_idx: Option<u32>,
+
+    /// Vendor LMS Public Key Revocation Fuse
+    pub fuse_vendor_lms_pub_key_revocation: Option<VendorPubKeyRevocation>,
 
     /// First Mutable code's logging information
     pub fmc_log_info: ImageSvnLogInfo,
@@ -72,6 +81,12 @@ pub struct ImageVerificationLogInfo {
 pub struct ImageVerificationInfo {
     /// Vendor ECC public key index
     pub vendor_ecc_pub_key_idx: u32,
+
+    /// Vendor LMS public key index
+    pub vendor_lms_pub_key_idx: Option<u32>,
+
+    /// Owner LMS public key index
+    pub owner_lms_pub_key_idx: Option<u32>,
 
     /// Digest of vendor public keys that verified the image
     pub vendor_pub_keys_digest: ImageDigest,
@@ -113,8 +128,11 @@ pub trait ImageVerificationEnv {
     /// Get Vendor Public Key Digest
     fn vendor_pub_key_digest(&self) -> ImageDigest;
 
-    /// Get Vendor Public Key Revocation list
-    fn vendor_pub_key_revocation(&self) -> VendorPubKeyRevocation;
+    /// Get Vendor ECC Public Key Revocation list
+    fn vendor_ecc_pub_key_revocation(&self) -> VendorPubKeyRevocation;
+
+    /// Get Vendor LMS Public Key Revocation list
+    fn vendor_lms_pub_key_revocation(&self) -> VendorPubKeyRevocation;
 
     /// Get Owner Public Key Digest from fuses
     fn owner_pub_key_digest_fuses(&self) -> ImageDigest;
@@ -142,4 +160,7 @@ pub trait ImageVerificationEnv {
 
     // ICCM Range
     fn iccm_range(&self) -> Range<u32>;
+
+    // LMS Verification enabled
+    fn lms_verify_enabled(&self) -> bool;
 }

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -94,6 +94,7 @@ objdump:
 	 cargo \
 		"--config=$(EXTRA_CARGO_CONFIG)" \
 		objdump \
+		--bin caliptra-rom \
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
@@ -145,6 +146,7 @@ size:
 		--profile firmware \
 		--target=riscv32imc-unknown-none-elf \
 		--no-default-features \
+		--bin caliptra-rom \
 
 nm:
 	 cargo \

--- a/rom/dev/doc/test-coverage/test-coverage.md
+++ b/rom/dev/doc/test-coverage/test-coverage.md
@@ -6,26 +6,35 @@ Test Name | ROM Stage | Description | ROM Error Code
 **test_preamble_zero_vendor_pubkey_digest** | Image Verification - Preamble | Checks if vendor public key digest is not zero in the fuse | IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_INVALID
 **test_preamble_vendor_pubkey_digest_mismatch** | Image Verification - Preamble | Checks if the vendor public key hash from fuse matches the hash of the vendor public keys in the Preamble | IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_MISMATCH
 **test_preamble_owner_pubkey_digest_mismatch** | Image Verification - Preamble | Checks if the owner public key hash from fuse is not zero and matches the hash of the owner public key in the Preamble | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH
-**test_preamble_vendor_pubkey_revocation** | Image Verification - Preamble | * Checks revoking of key idx 0/1/2 <br> * Checks if last key (idx = 3) is revocable | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_REVOKED
-**test_preamble_vendor_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if key idx is >= 4 | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS
-**test_preamble_vendor_lms_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if LMS key idx is >= 4 | IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
-**test_preamble_owner_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if key idx is >= 4 | IMAGE_VERIFIER_ERR_OWNER_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS
+**test_preamble_vendor_ecc_pubkey_revocation** | Image Verification - Preamble | Checks revoking of key idx 0/1/2 <br> * Checks if last key (idx = 3) is revocable | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_REVOKED
+**test_preamble_vendor_lms_pubkey_revocation** | Image Verification - Preamble | Checks revoking of key idx 0/1/2 <br> * Checks if last key (idx = 3) is revocable | IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_REVOKED
+**test_preamble_vendor_lms_optional_no_pubkey_revocation_check** | Image Verification - Preamble | * Sets lms_verify fuse to false and checks vendor LMS key revocation | Success
+**test_preamble_vendor_ecc_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if vendor ECC key idx is >= 4 | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS
+**test_preamble_vendor_lms_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if vendor LMS key idx is >= 4 | 
+IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
+**test_preamble_vendor_lms_optional_no_pubkey_out_of_bounds_check** | Image Verification - Preamble | Sets lms_verify fuse to false and checks if vendor LMS key idx is >= 4 |  Success
+IMAGE_VERIFIER_ERR_VENDOR_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
 **test_preamble_owner_lms_pubkey_out_of_bounds** | Image Verification - Preamble | Checks if LMS key idx is >= 4 | IMAGE_VERIFIER_ERR_OWNER_LMS_PUBKEY_INDEX_OUT_OF_BOUNDS
-**test_header_verify_vendor_sig_zero_pubkey** | Image Verification - Header | Checks if vendor ECC public key is non-zero | IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_INVALID_ARG
-**test_header_verify_vendor_sig_zero_signature** | Image Verification - Header | Checks if vendor signature is non-zero | IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID_ARG
-**test_header_verify_vendor_sig_mismatch** | Image Verification - Header | Checks if vendor ECC signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID
+**test_preamble_owner_lms_optional_no_pubkey_out_of_bounds_check** | Image Verification - Preamble | Sets lms_verify fuse to false and checks if owner LMS key idx is >= 4 | Success
+**test_header_verify_vendor_sig_zero_ecc_pubkey** | Image Verification - Header | Checks if vendor ECC public key is non-zero | IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_INVALID_ARG
+**test_header_verify_vendor_sig_zero_ecc_signature** | Image Verification - Header | Checks if vendor signature is non-zero | IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID_ARG
+**test_header_verify_vendor_ecc_sig_mismatch** | Image Verification - Header | Checks if vendor ECC signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID
 **test_header_verify_vendor_lms_sig_mismatch** | Image Verification - Header | Checks if vendor LMS signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_VENDOR_LMS_SIGNATURE_INVALID
+**test_header_verify_vendor_lms_optional_no_sig_mismatch_check** | Image Verification - Header | Sets lms_verify fuse to false and checks if vendor LMS signature from Preamble and computed header signature match | Success
 **test_header_verify_owner_lms_sig_mismatch** | Image Verification - Header | Checks if owner LMS signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_LMS_SIGNATURE_INVALID
-**test_header_verify_vendor_pub_key_in_preamble_and_header** | Image Verification - Header | Checks if the vendor ECC public key index in Preamble and Header match | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_MISMATCH
+**test_header_verify_owner_lms_optional_no_sig_mismatch_check** | Image Verification - Header | Sets lms_verify fuse to false and checks if owner LMS signature from Preamble and computed header signature match | Success
+**test_header_verify_vendor_ecc_pub_key_in_preamble_and_header** | Image Verification - Header | Checks if the vendor ECC public key index in Preamble and Header match | IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_MISMATCH
 **test_header_verify_vendor_lms_pub_key_in_preamble_and_header** | Image Verification - Header | Checks if the vendor LMS public key index in Preamble and Header match | IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_INDEX_MISMATCH
+**test_header_verify_vendor_lms_optional_no_pub_key_in_preamble_and_header_check** | Image Verification - Header |  Sets lms_verify fuse to false and checks if the vendor LMS public key index in Preamble and Header match | Success
 **test_header_verify_owner_lms_pub_key_in_preamble_and_header** | Image Verification - Header | Checks if the owner LMS public key index in Preamble and Header match | IMAGE_VERIFIER_ERR_OWNER_LMS_PUB_KEY_INDEX_MISMATCH
+**test_header_verify_owner_lms_optional_no_pub_key_in_preamble_and_header_check** | Image Verification - Header | Sets lms_verify fuse to false and checks if the owner LMS public key index in Preamble and Header match | Success
 **test_header_verify_owner_sig_zero_fuses_zero_pubkey_x** | Image Verification - Header | Checks if the owner ECC public key in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG
-**test_header_verify_owner_sig_zero_pubkey_x** | Image Verification - Header | Checks if the owner ECC public key in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG
-**test_header_verify_owner_sig_zero_pubkey_y** | Image Verification - Header | Checks if the owner ECC public key in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG
-**test_header_verify_owner_sig_zero_signature_r** | Image Verification - Header | Checks if the owner ECC signature in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG
-**test_header_verify_owner_sig_zero_signature_s** | Image Verification - Header | Checks if the owner ECC signature in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG
-**test_header_verify_owner_sig_invalid_signature_r** | Image Verification - Header | Checks if owner ECC signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID
-**test_header_verify_owner_sig_invalid_signature_s** | Image Verification - Header | Checks if owner ECC signature from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID
+**test_header_verify_owner_ecc_sig_zero_pubkey_x** | Image Verification - Header | Checks if the owner ECC public key.x in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG
+**test_header_verify_owner_ecc_sig_zero_pubkey_y** | Image Verification - Header | Checks if the owner ECC public key.y in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_INVALID_ARG
+**test_header_verify_owner_ecc_sig_zero_signature_r** | Image Verification - Header | Checks if the owner ECC signature.r in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG
+**test_header_verify_owner_ecc_sig_zero_signature_s** | Image Verification - Header | Checks if the owner ECC signature.s in Preamble is zero | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG
+**test_header_verify_owner_ecc_sig_invalid_signature_r** | Image Verification - Header | Checks if owner ECC signature.r from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID
+**test_header_verify_owner_ecc_sig_invalid_signature_s** | Image Verification - Header | Checks if owner ECC signature.s from Preamble and computed header signature match | IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID
 **test_toc_invalid_entry_count** | Image Verification - TOC | Checks if header.toc_count equals MAX_TOC_ENTRY_COUNT (2) | IMAGE_VERIFIER_ERR_TOC_ENTRY_COUNT_INVALID
 **test_toc_invalid_toc_digest** | Image Verification - TOC | Checks if digest of [manifest.fmc_toc | manifest.rt_toc] matches header.toc_digest | IMAGE_VERIFIER_ERR_TOC_DIGEST_MISMATCH
 **test_toc_fmc_range_overlap** | Image Verification - TOC | Checks if FMC and Runtime images don't overlap in the image bundle | IMAGE_VERIFIER_ERR_FMC_RUNTIME_OVERLAP
@@ -64,10 +73,10 @@ Test Name | ROM Stage | Description | ROM Error Code
 # **Firmware Downloader Integration Tests**
 Test Name | ROM Stage | Description | ROM Error Code
 ---|---|---|---
-**test_zero_firmware_size** | FW Donwloader | Checks if firmware is zero-sized | FW_PROC_INVALID_IMAGE_SIZE
-**test_firmware_gt_max_size** | FW Donwloader |  Checks if firmware is not more than max. size (128K)  | FW_PROC_INVALID_IMAGE_SIZE
-**test_pcr_log** | FW Donwloader |  Checks if PCR log entries are correctly logged to DCCM  | N/A
-**ttest_fuse_log** | FW Donwloader |  Checks if Fuse log entries are correctly logged to DCCM  | N/A
+**test_zero_firmware_size** | FW Downloader | Checks if firmware is zero-sized | FW_PROC_INVALID_IMAGE_SIZE
+**test_firmware_gt_max_size** | FW Downloader |  Checks if firmware is not more than max. size (128K)  | FW_PROC_INVALID_IMAGE_SIZE
+**test_pcr_log** | FW Downloader |  Checks if PCR log entries are correctly logged to DCCM  | N/A
+**ttest_fuse_log** | FW Downloader |  Checks if Fuse log entries are correctly logged to DCCM  | N/A
 <br><br>
 ## **FMCALIAS Integration Tests**
 Test Name | ROM Stage | Description | ROM Error Code

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -204,14 +204,17 @@ impl FirmwareProcessor {
     fn update_fuse_log(log_info: &ImageVerificationLogInfo) -> CaliptraResult<()> {
         // Log VendorPubKeyIndex
         log_fuse_data(
-            FuseLogEntryId::VendorPubKeyIndex,
+            FuseLogEntryId::VendorEccPubKeyIndex,
             log_info.vendor_ecc_pub_key_idx.as_bytes(),
         )?;
 
         // Log VendorPubKeyRevocation
         log_fuse_data(
-            FuseLogEntryId::VendorPubKeyRevocation,
-            log_info.fuse_vendor_pub_key_revocation.bits().as_bytes(),
+            FuseLogEntryId::VendorEccPubKeyRevocation,
+            log_info
+                .fuse_vendor_ecc_pub_key_revocation
+                .bits()
+                .as_bytes(),
         )?;
 
         // Log ManifestFmcSvn
@@ -249,6 +252,33 @@ impl FirmwareProcessor {
             FuseLogEntryId::FuseRtSvn,
             log_info.rt_log_info.fuse_svn.as_bytes(),
         )?;
+
+        // Log VendorLmsPubKeyIndex
+        if let Some(vendor_lms_pub_key_idx) = log_info.vendor_lms_pub_key_idx {
+            log_fuse_data(
+                FuseLogEntryId::VendorLmsPubKeyIndex,
+                vendor_lms_pub_key_idx.as_bytes(),
+            )?;
+        }
+
+        // Log VendorLmsPubKeyRevocation
+        if let Some(fuse_vendor_lms_pub_key_revocation) =
+            log_info.fuse_vendor_lms_pub_key_revocation
+        {
+            log_fuse_data(
+                FuseLogEntryId::VendorLmsPubKeyRevocation,
+                fuse_vendor_lms_pub_key_revocation.bits().as_bytes(),
+            )?;
+        }
+
+        // Log OwnerLmsPubKeyIndex
+        if let Some(owner_lms_pub_key_idx) = log_info.owner_lms_pub_key_idx {
+            log_fuse_data(
+                FuseLogEntryId::OwnerLmsPubKeyIndex,
+                owner_lms_pub_key_idx.as_bytes(),
+            )?;
+        }
+
         Ok(())
     }
 
@@ -312,6 +342,8 @@ impl FirmwareProcessor {
             ColdResetEntry4::VendorPubKeyIndex,
             info.vendor_ecc_pub_key_idx,
         );
+
+        // [TODO] Write the Vendor and Owner Public key Indices of LMS keys.
 
         data_vault.write_warm_reset_entry48(WarmResetEntry48::RtTci, &info.runtime.digest.into());
 

--- a/rom/dev/src/verifier.rs
+++ b/rom/dev/src/verifier.rs
@@ -88,9 +88,14 @@ impl<'a> ImageVerificationEnv for &mut RomImageVerificationEnv<'a> {
         self.soc_ifc.fuse_bank().vendor_pub_key_hash().into()
     }
 
-    /// Retrieve Vendor Public Key Revocation Bitmask
-    fn vendor_pub_key_revocation(&self) -> VendorPubKeyRevocation {
-        self.soc_ifc.fuse_bank().vendor_pub_key_revocation()
+    /// Retrieve Vendor ECC Public Key Revocation Bitmask
+    fn vendor_ecc_pub_key_revocation(&self) -> VendorPubKeyRevocation {
+        self.soc_ifc.fuse_bank().vendor_ecc_pub_key_revocation()
+    }
+
+    /// Retrieve Vendor LMS Public Key Revocation Bitmask
+    fn vendor_lms_pub_key_revocation(&self) -> VendorPubKeyRevocation {
+        self.soc_ifc.fuse_bank().vendor_lms_pub_key_revocation()
     }
 
     /// Retrieve Owner Public Key Digest from fuses
@@ -135,5 +140,9 @@ impl<'a> ImageVerificationEnv for &mut RomImageVerificationEnv<'a> {
 
     fn iccm_range(&self) -> Range<u32> {
         RomEnv::ICCM_RANGE
+    }
+
+    fn lms_verify_enabled(&self) -> bool {
+        self.soc_ifc.fuse_bank().lms_verify() == LmsVerifyConfig::EcdsaAndLms
     }
 }


### PR DESCRIPTION
This change adds the following:
	1. LMS verification based on lms_verify fuse.
	2. LMS vendor public key revocation check.
	3. Logging of the LMS vendor and owner public key indices and vendor public key revocation fuse to fuse log.
	4. Tests.

Note: Updating vendor key count to 32 will come as a separate PR.