### PR TITLE
FIPS Shutdown command

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -32,4 +32,4 @@ pub const FMC_SIZE: u32 = 16 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 96 * 1024;
 
-pub use memory_layout::{FHT_ORG, FHT_SIZE};
+pub use memory_layout::{DATA_ORG, FHT_ORG, FHT_SIZE, MAN1_ORG};

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -278,6 +278,7 @@ impl CaliptraError {
     pub const RUNTIME_FIPS_UNIMPLEMENTED: CaliptraError = CaliptraError::new_const(0x000E0006);
     pub const RUNTIME_UNEXPECTED_UPDATE_RETURN: CaliptraError =
         CaliptraError::new_const(0x000E0007);
+    pub const RUNTIME_SHUTDOWN: CaliptraError = CaliptraError::new_const(0x000E0008);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -20,8 +20,15 @@ impl FipsModule {
         Err(CaliptraError::RUNTIME_FIPS_UNIMPLEMENTED)
     }
 
-    pub fn shutdown(_env: &Drivers) -> CaliptraResult<MboxStatusE> {
-        cprintln!("[rt] FIPS shutdown");
-        Err(CaliptraError::RUNTIME_FIPS_UNIMPLEMENTED)
+    pub fn shutdown(env: &mut Drivers) -> CaliptraResult<MboxStatusE> {
+        Self::zeroize(env);
+        env.mbox.set_status(MboxStatusE::CmdComplete);
+
+        Err(CaliptraError::RUNTIME_SHUTDOWN)
+    }
+
+    /// Clear data structures in DCCM.  
+    fn zeroize(env: &mut Drivers) {
+        env.regions.zeroize();
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,6 +16,11 @@ pub mod packet;
 pub use fips::FipsModule;
 use packet::Packet;
 
+use caliptra_common::memory_layout::{
+    FHT_ORG, FHT_SIZE, FMCALIAS_TBS_ORG, FMCALIAS_TBS_SIZE, FUSE_LOG_ORG, FUSE_LOG_SIZE,
+    LDEVID_TBS_ORG, LDEVID_TBS_SIZE, MAN1_ORG, MAN1_SIZE, MAN2_ORG, MAN2_SIZE, PCR_LOG_ORG,
+    PCR_LOG_SIZE,
+};
 use caliptra_common::{cprintln, FirmwareHandoffTable};
 use caliptra_drivers::{CaliptraError, CaliptraResult, DataVault, Ecc384};
 use caliptra_registers::{
@@ -26,6 +31,23 @@ use caliptra_registers::{
     soc_ifc::SocIfcReg,
 };
 use zerocopy::{AsBytes, FromBytes};
+
+const RUNTIME_BOOT_STATUS_BASE: u32 = 0x600;
+
+/// Statuses used by ROM to log dice derivation progress.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RtBootStatus {
+    // RtAlias Statuses
+    RtReadyForCommands = RUNTIME_BOOT_STATUS_BASE,
+}
+
+impl From<RtBootStatus> for u32 {
+    /// Converts to this type from the input type.
+    fn from(status: RtBootStatus) -> u32 {
+        status as u32
+    }
+}
 
 #[derive(PartialEq, Eq)]
 pub struct CommandId(pub u32);
@@ -66,6 +88,7 @@ pub struct Drivers<'a> {
     pub ecdsa: Ecc384,
     pub data_vault: DataVault,
     pub soc_ifc: SocIfcReg,
+    pub regions: MemoryRegions,
     pub fht: &'a mut FirmwareHandoffTable,
 }
 impl<'a> Drivers<'a> {
@@ -81,6 +104,7 @@ impl<'a> Drivers<'a> {
             ecdsa: Ecc384::new(EccReg::new()),
             data_vault: DataVault::new(DvReg::new()),
             soc_ifc: SocIfcReg::new(),
+            regions: MemoryRegions::new(),
             fht,
         }
     }
@@ -174,6 +198,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
 }
 
 pub fn handle_mailbox_commands(drivers: &mut Drivers) {
+    caliptra_drivers::report_boot_status(RtBootStatus::RtReadyForCommands.into());
     loop {
         wait_for_cmd(&mut drivers.mbox);
 
@@ -189,4 +214,44 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) {
             }
         }
     }
+}
+
+pub struct MemoryRegions {
+    man1: &'static mut [u8],
+    man2: &'static mut [u8],
+    fht: &'static mut [u8],
+    ldevid_tbs: &'static mut [u8],
+    fmcalias_tbs: &'static mut [u8],
+    pcr_log: &'static mut [u8],
+    fuse_log: &'static mut [u8],
+}
+
+impl MemoryRegions {
+    // Create a new instance of MemoryRegions with slices based on memory addresses and sizes
+    fn new() -> Self {
+        Self {
+            man1: unsafe { create_slice(MAN1_ORG, MAN1_SIZE as usize) },
+            man2: unsafe { create_slice(MAN2_ORG, MAN2_SIZE as usize) },
+            fht: unsafe { create_slice(FHT_ORG, FHT_SIZE as usize) },
+            ldevid_tbs: unsafe { create_slice(LDEVID_TBS_ORG, LDEVID_TBS_SIZE as usize) },
+            fmcalias_tbs: unsafe { create_slice(FMCALIAS_TBS_ORG, FMCALIAS_TBS_SIZE as usize) },
+            pcr_log: unsafe { create_slice(PCR_LOG_ORG, PCR_LOG_SIZE) },
+            fuse_log: unsafe { create_slice(FUSE_LOG_ORG, FUSE_LOG_SIZE) },
+        }
+    }
+    fn zeroize(&mut self) {
+        self.man1.fill(0);
+        self.man2.fill(0);
+        self.fht.fill(0);
+        self.ldevid_tbs.fill(0);
+        self.fmcalias_tbs.fill(0);
+        self.pcr_log.fill(0);
+        self.fuse_log.fill(0);
+    }
+}
+
+// Helper function to create a mutable slice from a memory region
+unsafe fn create_slice(org: u32, size: usize) -> &'static mut [u8] {
+    let ptr = org as *mut u8;
+    core::slice::from_raw_parts_mut(ptr, size)
 }


### PR DESCRIPTION
This commit implements the FIPS shutdown command : it zeroes data structures in  DCCM and transitions Caliptra to a SHUTDOWN state. When in SHUTDOWN state, the runtime module rejects mailbox commands and reports it is in SHUTDOWN mode to the SoC via non fatal error register.  