### PR TITLE
sw-emulator,ureg: Update proc-macro2 to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/sw-emulator/lib/derive/Cargo.toml
+++ b/sw-emulator/lib/derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 caliptra-emu-bus = { path = "../bus"}
 caliptra-emu-types = { path = "../types"}
 quote = "1.0"
-proc-macro2 = "1.0.43"
+proc-macro2 = "1.0.66"

--- a/ureg/lib/codegen/Cargo.toml
+++ b/ureg/lib/codegen/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 [dependencies]
 ureg-schema = { path = "../schema" }
 quote = "1.0"
-proc-macro2 = "1.0.40"
+proc-macro2 = "1.0.66"


### PR DESCRIPTION
Compilation of the older version with the nightly compiler failed after the feature `proc_macro_span_shrink` was removed. Update the crate to resolve this issue.