### PR TITLE
Make all Cargo deps workspace deps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,80 @@ members = [
 ]
 
 [workspace.dependencies]
+aes = "0.8.2"
+anyhow = "1.0.70"
+arrayref = "0.3.6"
+asn1 = "0.13.0"
+bitfield = "0.14.0"
+bitflags = "2.0.1"
+caliptra_common = { path = "common", default-features = false }
+caliptra-builder = { path = "builder" }
+caliptra-cpu = { path = "cpu" }
+caliptra-drivers = { path = "drivers" }
+caliptra-drivers-test-bin = { path = "drivers/test-fw" }
+caliptra-emu-bus = { path = "sw-emulator/lib/bus" }
+caliptra-emu-cpu = { path = "sw-emulator/lib/cpu" }
+caliptra-emu-crypto = { path = "sw-emulator/lib/crypto" }
+caliptra-emu-derive = { path = "sw-emulator/lib/derive" }
+caliptra-emu-periph = { path = "sw-emulator/lib/periph" }
+caliptra-emu-types = { path = "sw-emulator/lib/types" }
+caliptra-error = { path = "error", default-features = false }
+caliptra-gen-linker-scripts = { path = "cpu/gen" }
+caliptra-hw-model = { path = "hw-model" }
+caliptra-hw-model-types = { path = "hw-model/types" }
+caliptra-image-elf = { path = "image/elf" }
+caliptra-image-fake-keys = { path = "image/fake-keys" }
+caliptra-image-gen = { path = "image/gen" }
+caliptra-image-openssl = { path = "image/openssl" }
+caliptra-image-serde = { path = "image/serde" }
+caliptra-image-types = { path = "image/types", default-features = false }
+caliptra-image-verify = { path = "image/verify", default-features = false }
+caliptra-kat = { path = "kat" }
+caliptra-lms-types = { path = "lms-types" }
+caliptra-registers = { path = "registers" }
+caliptra-runtime = { path = "runtime", default-features = false }
+caliptra-systemrdl = { path = "systemrdl" }
+caliptra-test = { path = "test" }
+caliptra-test-harness = { path = "test-harness" }
+caliptra-test-harness-types = { path = "test-harness/types" }
+caliptra-verilated = { path = "hw-latest/verilated",  features = ["verilator"] }
+caliptra-x509 = { path = "x509", default-features = false }
+cbc = "0.1.2"
+cbindgen = "0.24.0"
+cfg-if = "1.0.0"
+chrono = "0.4.24"
+clap = { version = "3.2.14", default-features = false, features = ["std"] }
+convert_case = "0.6.0"
+elf = "0.7.2"
+gdbstub = "0.6.3"  
+gdbstub_arch = "0.2.4"
+getrandom = "0.2"
+hex = "0.4.3"
+lazy_static = "1.4.0"
+memoffset = "0.8.0"
+once_cell = "1.13"
+openssl = { version = "0.10", features = ["vendored"] }
+p384 = "0.11.2"
+proc-macro2 = "1.0.66"
+quote = "1.0"
+rand = "0.8"
+rfc6979 = "0.3.0"
+serde = "1.0"
+serde_derive = "1.0.136"
+serde_json = "1.0"
+sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
+smlang = "0.6.0"
+syn = "1.0.107"
+tinytemplate = "1.1"
+tock-registers = { git = "https://github.com/tock/tock.git"}
+toml = "0.7.0"
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
+uio = { version = "0.2.0" }
+ureg = { path = "ureg" }
+ureg-codegen = { path = "ureg/lib/codegen" }
+ureg-schema = { path = "ureg/lib/schema" }
+ureg-systemrdl = { path = "ureg/lib/systemrdl" }
+zerocopy = "0.6.1"
 
 [profile.firmware]
 inherits = "release"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-elf.workspace = true
+anyhow.workspace = true
 caliptra-image-elf.workspace= true
 caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-openssl.workspace = true
 caliptra-image-types.workspace = true
 clap.workspace = true
+elf.workspace = true
 hex.workspace = true
-anyhow.workspace = true
 once_cell.workspace = true
 
 [[bin]]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-elf = "0.7.2"
-caliptra-image-elf = { path = "../image/elf" }
-caliptra-image-fake-keys = { path = "../image/fake-keys" }
-caliptra-image-gen = { path = "../image/gen" }
-caliptra-image-openssl = { path = "../image/openssl" }
-caliptra-image-types = { path = "../image/types" }
-clap = { version = "3.2.14", default-features = false, features = ["std"] }
-hex = "0.4.3"
-anyhow = "1.0.70"
-once_cell = "1.13"
+elf.workspace = true
+caliptra-image-elf.workspace= true
+caliptra-image-fake-keys.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-openssl.workspace = true
+caliptra-image-types.workspace = true
+clap.workspace = true
+hex.workspace = true
+anyhow.workspace = true
+once_cell.workspace = true
 
 [[bin]]
 name = "image"

--- a/ci-tools/size-history/Cargo.toml
+++ b/ci-tools/size-history/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-builder = { path = "../../builder" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tinytemplate = "1.1"
+caliptra-builder.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tinytemplate.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,16 +7,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ufmt = { workspace = true }
-zerocopy = "0.6.1"
-caliptra-drivers = { path = "../drivers" }
-caliptra-registers = { path = "../registers" }
-caliptra-image-types = { path = "../image/types", default-features = false }
-bitfield = "0.14.0"
+ufmt.workspace = true
+zerocopy.workspace = true
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra-image-types = { workspace = true, default-features = false }
+bitfield.workspace = true
 
 
 [features]
 default = ["std"]
 std = []
-emu = []
-
+emu = ["caliptra-drivers/emu"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,15 +7,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitfield.workspace = true
+caliptra-drivers.workspace = true
+caliptra-image-types = { workspace = true, default-features = false }
+caliptra-registers.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
-caliptra-drivers.workspace = true
-caliptra-registers.workspace = true
-caliptra-image-types = { workspace = true, default-features = false }
-bitfield.workspace = true
-
 
 [features]
 default = ["std"]
-std = []
 emu = ["caliptra-drivers/emu"]
+std = []

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -22,8 +22,8 @@ required-features = ["riscv"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-drivers = { path = "../drivers" }
-caliptra-registers = { path = "../registers" }
-cfg-if = "1.0.0"
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+cfg-if.workspace = true
 
 [build-dependencies]

--- a/cpu/gen/Cargo.toml
+++ b/cpu/gen/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra_common = { path = "../../common", default-features = false }
+caliptra_common = { workspace = true, default-features = false }

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -9,25 +9,25 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-lms-types.workspace = true
-caliptra-registers.workspace = true
-ureg.workspace = true
-zerocopy.workspace = true
-cfg-if.workspace = true
 bitfield.workspace = true
 bitflags.workspace = true
 caliptra-error = { workspace = true, default-features = false }
+caliptra-lms-types.workspace = true
+caliptra-registers.workspace = true
+cfg-if.workspace = true
+ureg.workspace = true
+zerocopy.workspace = true
 
 [features]
 emu = []
+fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
-fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 
 [dev-dependencies]
-caliptra-drivers-test-bin.workspace = true
-caliptra-hw-model.workspace = true
-caliptra-hw-model-types.workspace = true
 caliptra-builder.workspace = true
+caliptra-drivers-test-bin.workspace = true
+caliptra-hw-model-types.workspace = true
+caliptra-hw-model.workspace = true
 caliptra-test.workspace = true
 openssl.workspace = true

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-lms-types = { path = "../lms-types" }
-caliptra-registers = { path = "../registers" }
-ureg = { path = "../ureg" }
-zerocopy = "0.6.1"
-cfg-if = "1.0.0"
-bitfield = "0.14.0"
-bitflags = "2.0.1"
-caliptra-error = { version = "0.1.0", path = "../error" , default-features=false}
+caliptra-lms-types.workspace = true
+caliptra-registers.workspace = true
+ureg.workspace = true
+zerocopy.workspace = true
+cfg-if.workspace = true
+bitfield.workspace = true
+bitflags.workspace = true
+caliptra-error = { workspace = true, default-features = false }
 
 [features]
 emu = []
@@ -25,9 +25,9 @@ verilator = ["caliptra-hw-model/verilator"]
 fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 
 [dev-dependencies]
-caliptra-drivers-test-bin = { path = "test-fw" }
-caliptra-hw-model = { path = "../hw-model" }
-caliptra-hw-model-types = { path = "../hw-model/types" }
-caliptra-builder = { path = "../builder" }
-caliptra-test = { path = "../test" }
-openssl = { version = "0.10", features = ["vendored"] }
+caliptra-drivers-test-bin.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-hw-model-types.workspace = true
+caliptra-builder.workspace = true
+caliptra-test.workspace = true
+openssl.workspace = true

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -7,14 +7,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers = { path = "..", features=["emu"] }
-caliptra-error = { path = "../../error", default_features = false }
-caliptra-registers = { path = "../../registers" }
-caliptra-kat = { path = "../../kat" }
-caliptra-lms-types = { path = "../../lms-types" }
-caliptra-test-harness = { path = "../../test-harness" }
-cfg-if = "1.0.0"
-zerocopy = "0.6.1"
+caliptra-drivers = { workspace = true, features=["emu"] }
+caliptra-error = { workspace = true, default-features = false }
+caliptra-registers = { workspace = true }
+caliptra-kat = { workspace = true }
+caliptra-lms-types = { workspace = true }
+caliptra-test-harness = { workspace = true }
+cfg-if.workspace = true
+zerocopy.workspace = true
 
 [features]
 emu = ["caliptra-test-harness/emu"]

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 [dependencies]
 caliptra-drivers = { workspace = true, features=["emu"] }
 caliptra-error = { workspace = true, default-features = false }
-caliptra-registers = { workspace = true }
 caliptra-kat = { workspace = true }
 caliptra-lms-types = { workspace = true }
+caliptra-registers = { workspace = true }
 caliptra-test-harness = { workspace = true }
 cfg-if.workspace = true
 zerocopy.workspace = true

--- a/drivers/test-fw/scripts/vector_gen/Cargo.toml
+++ b/drivers/test-fw/scripts/vector_gen/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-openssl = "0.10.48"
+openssl.workspace = true

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -6,25 +6,25 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-cpu = { version = "0.1.0", path = "../cpu" }
-caliptra-drivers = { path = "../drivers" }
-caliptra-error = { version = "0.1.0", path = "../error" , default-features=false}
-caliptra-registers = { path = "../registers" }
-caliptra-x509 = { version = "0.1.0", path = "../x509" , default-features = false }
-caliptra_common = { path = "../common", default-features = false }
-caliptra-image-types = { path = "../image/types",  default-features = false  }
-ufmt = { workspace = true }
-zerocopy = "0.6.1"
+caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
+caliptra-error = { workspace = true, default-features = false }
+caliptra-registers.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
+caliptra_common = { workspace = true, default-features = false }
+caliptra-image-types = { workspace = true, default-features = false  }
+ufmt.workspace = true
+zerocopy.workspace = true
 
 [build-dependencies]
-cfg-if = "1.0.0"
-caliptra-gen-linker-scripts = { version = "0.1.0", path = "../cpu/gen" }
-caliptra_common = { path = "../common", default-features = false }
+cfg-if.workspace = true
+caliptra-gen-linker-scripts.workspace = true
+caliptra_common = { workspace = true, default-features = false }
 
 [dev-dependencies]
-caliptra-builder = { path = "../builder" }
-caliptra-hw-model = { path = "../hw-model" }
-caliptra-image-types = { path = "../image/types" }
+caliptra-builder.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-image-types.workspace = true
 
 [features]
 riscv = ["caliptra-cpu/riscv"]

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -6,20 +6,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
 caliptra-error = { workspace = true, default-features = false }
+caliptra-image-types = { workspace = true, default-features = false  }
 caliptra-registers.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
-caliptra_common = { workspace = true, default-features = false }
-caliptra-image-types = { workspace = true, default-features = false  }
 ufmt.workspace = true
 zerocopy.workspace = true
 
 [build-dependencies]
-cfg-if.workspace = true
-caliptra-gen-linker-scripts.workspace = true
 caliptra_common = { workspace = true, default-features = false }
+caliptra-gen-linker-scripts.workspace = true
+cfg-if.workspace = true
 
 [dev-dependencies]
 caliptra-builder.workspace = true
@@ -27,8 +27,8 @@ caliptra-hw-model.workspace = true
 caliptra-image-types.workspace = true
 
 [features]
-riscv = ["caliptra-cpu/riscv"]
 default = ["std"]
-std = ["ufmt/std", "caliptra_common/std"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
+riscv = ["caliptra-cpu/riscv"]
+std = ["ufmt/std", "caliptra_common/std"]

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -6,18 +6,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-cpu = { version = "0.1.0", path = "../../../cpu" }
-caliptra-drivers = { path = "../../../drivers" }
-caliptra-registers = { version = "0.1.0", path = "../../../registers" }
-caliptra_common = { path = "../../../common", default-features = false }
-ufmt = { workspace = true }
-zerocopy = "0.6.1"
+caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+ufmt.workspace = true
+zerocopy.workspace = true
 
 [build-dependencies]
-cfg-if = "1.0.0"
+cfg-if.workspace = true
 
 [dev-dependencies]
-caliptra-builder = { path = "../../../builder" }
+caliptra-builder.workspace = true
 
 [features]
 riscv = ["caliptra-cpu/riscv"]

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -6,10 +6,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
-caliptra_common = { workspace = true, default-features = false }
 ufmt.workspace = true
 zerocopy.workspace = true
 
@@ -20,7 +20,7 @@ cfg-if.workspace = true
 caliptra-builder.workspace = true
 
 [features]
-riscv = ["caliptra-cpu/riscv"]
 default = ["std"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
+riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -14,20 +14,20 @@ fpga_realtime = ["dep:uio"]
 itrng = ["caliptra-verilated?/itrng"]
 
 [dependencies]
-caliptra-emu-bus = { path = "../sw-emulator/lib/bus" }
-caliptra-emu-cpu = { path = "../sw-emulator/lib/cpu" }
-caliptra-emu-periph = { path = "../sw-emulator/lib/periph" }
-caliptra-emu-types = { path = "../sw-emulator/lib/types" }
-caliptra-hw-model-types = { path = "types" }
-caliptra-registers = { path = "../registers" }
-uio = { version = "0.2.0", optional = true }
-ureg = { path = "../ureg" }
-caliptra-verilated = { path = "../hw-latest/verilated", optional = true, features = ["verilator"] }
-rand = "0.8"
-zerocopy = "0.6.1"
-bitfield = "0.14.0"
+caliptra-emu-bus.workspace = true
+caliptra-emu-cpu.workspace = true
+caliptra-emu-periph.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-hw-model-types.workspace = true
+caliptra-registers.workspace = true
+uio = { workspace = true, optional = true }
+ureg.workspace = true
+caliptra-verilated = { workspace = true, optional = true }
+rand.workspace = true
+zerocopy.workspace = true
+bitfield.workspace = true
 
 [dev-dependencies]
-caliptra-builder = { path = "../builder" }
-caliptra-registers = { path = "../registers" }
-caliptra-test-harness-types = { path = "../test-harness/types" }
+caliptra-builder.workspace = true
+caliptra-registers.workspace = true
+caliptra-test-harness-types.workspace = true

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -14,18 +14,18 @@ fpga_realtime = ["dep:uio"]
 itrng = ["caliptra-verilated?/itrng"]
 
 [dependencies]
+bitfield.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-registers.workspace = true
-uio = { workspace = true, optional = true }
-ureg.workspace = true
 caliptra-verilated = { workspace = true, optional = true }
 rand.workspace = true
+uio = { workspace = true, optional = true }
+ureg.workspace = true
 zerocopy.workspace = true
-bitfield.workspace = true
 
 [dev-dependencies]
 caliptra-builder.workspace = true

--- a/hw-model/c-binding/Cargo.toml
+++ b/hw-model/c-binding/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-hw-model.workspace = true
-caliptra-emu-types.workspace = true
 caliptra-emu-bus.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-hw-model.workspace = true
 
 [lib]
 crate-type = ["staticlib"]

--- a/hw-model/c-binding/Cargo.toml
+++ b/hw-model/c-binding/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-hw-model = { path = "../" }
-caliptra-emu-types = { path = "../../sw-emulator/lib/types" }
-caliptra-emu-bus = { path = "../../sw-emulator/lib/bus" }
+caliptra-hw-model.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-emu-bus.workspace = true
 
 [lib]
 crate-type = ["staticlib"]
@@ -18,4 +18,4 @@ itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 
 [build-dependencies]
-cbindgen = "0.24.0"
+cbindgen.workspace = true

--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -11,9 +11,9 @@ riscv = ["caliptra-test-harness/riscv"]
 emu = ["caliptra-test-harness/emu"]
 
 [dependencies]
-caliptra-test-harness.workspace = true
-caliptra-registers.workspace = true
 caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra-test-harness.workspace = true
 
 [[bin]]
 name = "test_iccm_unaligned_write"

--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -11,9 +11,9 @@ riscv = ["caliptra-test-harness/riscv"]
 emu = ["caliptra-test-harness/emu"]
 
 [dependencies]
-caliptra-test-harness = { path = "../../test-harness" }
-caliptra-registers = { path = "../../registers" }
-caliptra-drivers = { path = "../../drivers" }
+caliptra-test-harness.workspace = true
+caliptra-registers.workspace = true
+caliptra-drivers.workspace = true
 
 [[bin]]
 name = "test_iccm_unaligned_write"

--- a/hw-model/types/Cargo.toml
+++ b/hw-model/types/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8"
+rand.workspace = true

--- a/image/app/Cargo.toml
+++ b/image/app/Cargo.toml
@@ -6,18 +6,18 @@ version = "0.5.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers = { path = "../../drivers" }
-caliptra-image-types = { path = "../types", features = ["std"] }
-caliptra-image-elf = { path = "../elf" }
-caliptra-image-gen = { path = "../gen" }
-caliptra-image-openssl = { path = "../openssl" }
-caliptra-image-serde = { path = "../serde" }
-serde = "1.0"
-toml = "0.7.0"
-serde_derive = "1.0.136"
-clap = { version = "3.2.14", default-features = false, features = ["std"] }
-openssl = { version = "0.10", features = ["vendored"] }
-zerocopy = "0.6.1"
-anyhow = "1.0.70"
-hex = "0.4.3"
-chrono = "0.4.24"
+caliptra-drivers.workspace = true
+caliptra-image-types = { workspace = true, features = ["std"] }
+caliptra-image-elf.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-openssl.workspace = true
+caliptra-image-serde.workspace = true
+serde.workspace = true
+toml.workspace = true
+serde_derive.workspace = true
+clap.workspace = true
+openssl.workspace = true
+zerocopy.workspace = true
+anyhow.workspace = true
+hex.workspace = true
+chrono.workspace = true

--- a/image/app/Cargo.toml
+++ b/image/app/Cargo.toml
@@ -6,18 +6,18 @@ version = "0.5.0"
 edition = "2021"
 
 [dependencies]
+anyhow.workspace = true
 caliptra-drivers.workspace = true
-caliptra-image-types = { workspace = true, features = ["std"] }
 caliptra-image-elf.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-openssl.workspace = true
 caliptra-image-serde.workspace = true
+caliptra-image-types = { workspace = true, features = ["std"] }
+chrono.workspace = true
+clap.workspace = true
+hex.workspace = true
+openssl.workspace = true
+serde_derive.workspace = true
 serde.workspace = true
 toml.workspace = true
-serde_derive.workspace = true
-clap.workspace = true
-openssl.workspace = true
 zerocopy.workspace = true
-anyhow.workspace = true
-hex.workspace = true
-chrono.workspace = true

--- a/image/elf/Cargo.toml
+++ b/image/elf/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-image-gen = { path = "../gen" }
-caliptra-image-types = { path = "../types" }
-anyhow = "1.0.70"
-elf = "0.7.1"
+caliptra-image-gen.workspace = true
+caliptra-image-types.workspace = true
+anyhow.workspace = true
+elf.workspace = true

--- a/image/elf/Cargo.toml
+++ b/image/elf/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true
-anyhow.workspace = true
 elf.workspace = true

--- a/image/fake-keys/Cargo.toml
+++ b/image/fake-keys/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-image-gen = { path = "../gen" }
-caliptra-image-types = { path = "../types" }
-caliptra-lms-types = { path = "../../lms-types" }
-zerocopy = "0.6.1"
+caliptra-image-gen.workspace = true
+caliptra-image-types.workspace = true
+caliptra-lms-types.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
-caliptra-image-openssl = { path = "../openssl" }
+caliptra-image-openssl.workspace = true

--- a/image/gen/Cargo.toml
+++ b/image/gen/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-image-types = { path = "../types", features = ["std"] }
-caliptra-lms-types = { path = "../../lms-types" }
-bitflags = "2.0.1"
-zerocopy = "0.6.1"
-anyhow = "1.0.70"
-memoffset = "0.8.0"
+caliptra-image-types = { workspace = true, features = ["std"] }
+caliptra-lms-types.workspace = true
+bitflags.workspace = true
+zerocopy.workspace = true
+anyhow.workspace = true
+memoffset.workspace = true

--- a/image/gen/Cargo.toml
+++ b/image/gen/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 doctest = false
 
 [dependencies]
+anyhow.workspace = true
+bitflags.workspace = true
 caliptra-image-types = { workspace = true, features = ["std"] }
 caliptra-lms-types.workspace = true
-bitflags.workspace = true
-zerocopy.workspace = true
-anyhow.workspace = true
 memoffset.workspace = true
+zerocopy.workspace = true

--- a/image/openssl/Cargo.toml
+++ b/image/openssl/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-image-gen = { path = "../gen" }
-caliptra-image-types = { path = "../types" }
-caliptra-lms-types = { path = "../../lms-types" }
-openssl = { version = "0.10", features = ["vendored"] }
-anyhow = "1.0.70"
-zerocopy = "0.6.1"
+caliptra-image-gen.workspace = true
+caliptra-image-types.workspace = true
+caliptra-lms-types.workspace = true
+openssl.workspace = true
+anyhow.workspace = true
+zerocopy.workspace = true

--- a/image/openssl/Cargo.toml
+++ b/image/openssl/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true
 caliptra-lms-types.workspace = true
 openssl.workspace = true
-anyhow.workspace = true
 zerocopy.workspace = true

--- a/image/serde/Cargo.toml
+++ b/image/serde/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-image-types = { path = "../types", features = ["std"] }
-zerocopy = "0.6.1"
-anyhow = "1.0.70"
+caliptra-image-types = { workspace = true, features = ["std"] }
+zerocopy.workspace = true
+anyhow.workspace = true
 

--- a/image/serde/Cargo.toml
+++ b/image/serde/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
+anyhow.workspace = true
 caliptra-image-types = { workspace = true, features = ["std"] }
 zerocopy.workspace = true
-anyhow.workspace = true
 

--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-lms-types = { path = "../../lms-types" }
-zerocopy = "0.6.1"
-memoffset = "0.8.0"
+caliptra-lms-types.workspace = true
+zerocopy.workspace = true
+memoffset.workspace = true
 
 [features]
 default = ["std"]

--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [dependencies]
 caliptra-lms-types.workspace = true
-zerocopy.workspace = true
 memoffset.workspace = true
+zerocopy.workspace = true
 
 [features]
 default = ["std"]

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-image-types = { path = "../types", default-features = false }
-caliptra-drivers = { path = "../../drivers" }
-bitflags = "2.0.1"
-zerocopy = "0.6.1"
-memoffset = "0.8.0"
+caliptra-image-types = { workspace = true, default-features = false }
+caliptra-drivers.workspace = true
+bitflags.workspace = true
+zerocopy.workspace = true
+memoffset.workspace = true
 
 [features]
 default = ["std"]

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra-image-types = { workspace = true, default-features = false }
-caliptra-drivers.workspace = true
 bitflags.workspace = true
-zerocopy.workspace = true
+caliptra-drivers.workspace = true
+caliptra-image-types = { workspace = true, default-features = false }
 memoffset.workspace = true
+zerocopy.workspace = true
 
 [features]
 default = ["std"]

--- a/kat/Cargo.toml
+++ b/kat/Cargo.toml
@@ -10,6 +10,6 @@ test = false
 doctest = false
 
 [dependencies]
-caliptra-drivers = { path = "../drivers" }
-caliptra-lms-types = { path = "../lms-types" }
-zerocopy = "0.6.1"
+caliptra-drivers.workspace = true
+caliptra-lms-types.workspace = true
+zerocopy.workspace = true

--- a/lms-types/Cargo.toml
+++ b/lms-types/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.6.1"
+zerocopy.workspace = true

--- a/registers/Cargo.toml
+++ b/registers/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ureg = { path = "../ureg" }
+ureg.workspace = true

--- a/registers/bin/generator/Cargo.toml
+++ b/registers/bin/generator/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ureg-codegen = { path = "../../../ureg/lib/codegen" }
-ureg-schema = { path = "../../../ureg/lib/schema" }
-ureg-systemrdl = { path = "../../../ureg/lib/systemrdl" }
-caliptra-systemrdl = { path = "../../../systemrdl" }
-quote = "1.0"
+ureg-codegen.workspace = true
+ureg-schema.workspace = true
+ureg-systemrdl.workspace = true
+caliptra-systemrdl.workspace = true
+quote.workspace = true

--- a/registers/bin/generator/Cargo.toml
+++ b/registers/bin/generator/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+caliptra-systemrdl.workspace = true
+quote.workspace = true
 ureg-codegen.workspace = true
 ureg-schema.workspace = true
 ureg-systemrdl.workspace = true
-caliptra-systemrdl.workspace = true
-quote.workspace = true

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -7,35 +7,35 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
-caliptra-drivers = { path = "../../drivers" }
-caliptra-kat = { path = "../../kat" }
-caliptra-lms-types = { path = "../../lms-types" }
-caliptra-x509 = { path = "../../x509", default-features = false }
-caliptra-image-types = { path = "../../image/types", default-features = false }
-caliptra-image-verify = { path = "../../image/verify", default-features = false }
-caliptra_common = { path = "../../common", default-features = false }
-caliptra-registers = { path = "../../registers" }
-ufmt = { workspace = true }
-zerocopy = "0.6.1"
-caliptra-error = { version = "0.1.0", path = "../../error", default_features = false }
+caliptra-drivers.workspace = true
+caliptra-kat.workspace = true
+caliptra-lms-types.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
+caliptra-image-types = { workspace = true, default-features = false }
+caliptra-image-verify = { workspace = true, default-features = false }
+caliptra_common = { workspace = true, default-features = false }
+caliptra-registers.workspace = true
+ufmt.workspace = true
+zerocopy.workspace = true
+caliptra-error = { workspace = true, default-features = false }
 
 
 [build-dependencies]
-cfg-if = "1.0.0"
-hex = "0.4.3"
+cfg-if.workspace = true
+hex.workspace = true
 
 
 [dev-dependencies]
-caliptra-builder = { path = "../../builder" }
-caliptra-hw-model = { path = "../../hw-model" }
-caliptra-image-gen = { path = "../../image/gen" }
-caliptra-image-openssl = { path = "../../image/openssl" }
-caliptra-image-elf = { path = "../../image/elf" }
-caliptra-image-fake-keys = { path = "../../image/fake-keys" }
-caliptra-image-types = { path = "../../image/types" }
-hex = "0.4.3"
-openssl = { version = "0.10", features = ["vendored"] }
-memoffset = "0.8.0"
+caliptra-builder.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-openssl.workspace = true
+caliptra-image-elf.workspace = true
+caliptra-image-fake-keys.workspace = true
+caliptra-image-types.workspace = true
+hex.workspace = true
+openssl.workspace = true
+memoffset.workspace = true
 
 [features]
 riscv = []

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -7,45 +7,43 @@ edition = "2021"
 rust-version = "1.70"
 
 [dependencies]
+caliptra_common = { workspace = true, default-features = false }
 caliptra-drivers.workspace = true
-caliptra-kat.workspace = true
-caliptra-lms-types.workspace = true
-caliptra-x509 = { workspace = true, default-features = false }
+caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false }
 caliptra-image-verify = { workspace = true, default-features = false }
-caliptra_common = { workspace = true, default-features = false }
+caliptra-kat.workspace = true
+caliptra-lms-types.workspace = true
 caliptra-registers.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
 ufmt.workspace = true
 zerocopy.workspace = true
-caliptra-error = { workspace = true, default-features = false }
-
 
 [build-dependencies]
 cfg-if.workspace = true
 hex.workspace = true
 
-
 [dev-dependencies]
 caliptra-builder.workspace = true
 caliptra-hw-model.workspace = true
-caliptra-image-gen.workspace = true
-caliptra-image-openssl.workspace = true
 caliptra-image-elf.workspace = true
 caliptra-image-fake-keys.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-openssl.workspace = true
 caliptra-image-types.workspace = true
 hex.workspace = true
-openssl.workspace = true
 memoffset.workspace = true
+openssl.workspace = true
 
 [features]
 riscv = []
 default = ["std"]
 emu = ["caliptra-drivers/emu"]
 std = [
-  "caliptra-x509/std",
+  "caliptra_common/std",
   "caliptra-image-types/std",
   "caliptra-image-verify/std",
-  "caliptra_common/std",
+  "caliptra-x509/std",
   "ufmt/std",
 ]
 no-fmc = []

--- a/rom/dev/tools/test-fmc/Cargo.toml
+++ b/rom/dev/tools/test-fmc/Cargo.toml
@@ -6,14 +6,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers.workspace = true
 caliptra_common = { workspace = true, default-features = false }
+caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
 ufmt.workspace = true
 ureg.workspace = true
 zerocopy.workspace = true
-caliptra-x509 = { workspace = true, default-features = false }
-caliptra-cpu.workspace = true
-caliptra-registers.workspace = true
 
 [build-dependencies]
 cfg-if.workspace = true
@@ -21,6 +21,6 @@ cfg-if.workspace = true
 [features]
 default = ["std"]
 emu = ["caliptra-drivers/emu"]
+interactive_test_fmc = []
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
-interactive_test_fmc = []

--- a/rom/dev/tools/test-fmc/Cargo.toml
+++ b/rom/dev/tools/test-fmc/Cargo.toml
@@ -6,17 +6,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers = { path = "../../../../drivers" }
-caliptra_common = { path = "../../../../common", default-features = false }
-ufmt = { workspace = true }
-ureg = { path = "../../../../ureg" }
-zerocopy = "0.6.1"
-caliptra-x509 = { version = "0.1.0", path = "../../../../x509" , default-features = false }
-caliptra-cpu = { version = "0.1.0", path = "../../../../cpu" }
-caliptra-registers = { path = "../../../../registers" }
+caliptra-drivers.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+ufmt.workspace = true
+ureg.workspace = true
+zerocopy.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
+caliptra-cpu.workspace = true
+caliptra-registers.workspace = true
 
 [build-dependencies]
-cfg-if = "1.0.0"
+cfg-if.workspace = true
 
 [features]
 default = ["std"]

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -6,12 +6,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-drivers = { path = "../../../../drivers" }
-ufmt = { workspace = true }
-caliptra-cpu = { version = "0.1.0", path = "../../../../cpu" }
+caliptra-drivers.workspace = true
+ufmt.workspace = true
+caliptra-cpu.workspace = true
 
 [build-dependencies]
-cfg-if = "1.0.0"
+cfg-if.workspace = true
 
 [features]
 default = ["std"]

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
 ufmt.workspace = true
-caliptra-cpu.workspace = true
 
 [build-dependencies]
 cfg-if.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,30 +6,30 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-caliptra-cpu = { version = "0.1.0", path = "../cpu" }
-caliptra-drivers = { path = "../drivers" }
-caliptra-registers = { path = "../registers" }
-caliptra_common = { path = "../common", default-features = false }
-caliptra-x509 = { path = "../x509", default-features = false }
-caliptra-image-types = { path = "../image/types", default-features = false }
-ufmt = { workspace = true }
-zerocopy = "0.6.1"
-caliptra-kat = { version = "0.1.0", path = "../kat" }
+caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+caliptra-image-types = { workspace = true, default-features = false }
+caliptra-x509 = { workspace = true, default-features = false }
+ufmt.workspace = true
+zerocopy.workspace = true
+caliptra-kat.workspace = true
 
 [build-dependencies]
-cfg-if = "1.0.0"
-caliptra_common = { path = "../common", default-features = false }
-caliptra-gen-linker-scripts = { version = "0.1.0", path = "../cpu/gen" }
+cfg-if.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+caliptra-gen-linker-scripts.workspace = true
 
 [dev-dependencies]
-caliptra-hw-model = { path = "../hw-model" }
-caliptra-builder = { path = "../builder" }
-caliptra-image-elf = { path = "../image/elf" }
-caliptra-image-fake-keys = { path = "../image/fake-keys" }
-caliptra-image-gen = { path = "../image/gen" }
-caliptra-image-openssl = { path = "../image/openssl" }
-caliptra-image-serde = { path = "../image/serde" }
-openssl = { version = "0.10", features = ["vendored"] }
+caliptra-hw-model.workspace = true
+caliptra-builder.workspace = true
+caliptra-image-elf.workspace = true
+caliptra-image-fake-keys.workspace = true
+caliptra-image-gen.workspace = true
+caliptra-image-openssl.workspace = true
+caliptra-image-serde.workspace = true
+openssl.workspace = true
 
 [features]
 riscv = ["caliptra-cpu/riscv"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,24 +6,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
-caliptra-registers.workspace = true
-caliptra_common = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false }
+caliptra-kat.workspace = true
+caliptra-registers.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
 ufmt.workspace = true
 zerocopy.workspace = true
-caliptra-kat.workspace = true
 
 [build-dependencies]
-cfg-if.workspace = true
 caliptra_common = { workspace = true, default-features = false }
 caliptra-gen-linker-scripts.workspace = true
+cfg-if.workspace = true
 
 [dev-dependencies]
-caliptra-hw-model.workspace = true
 caliptra-builder.workspace = true
+caliptra-hw-model.workspace = true
 caliptra-image-elf.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
@@ -32,11 +32,11 @@ caliptra-image-serde.workspace = true
 openssl.workspace = true
 
 [features]
-riscv = ["caliptra-cpu/riscv"]
 default = ["std", "test_only_commands"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
+itrng = ["caliptra-hw-model/itrng"]
+riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 test_only_commands = []
-itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]

--- a/runtime/test-fw/Cargo.toml
+++ b/runtime/test-fw/Cargo.toml
@@ -34,16 +34,16 @@ path = "src/cert_tests.rs"
 required-features = ["riscv"]
 
 [build-dependencies]
-cfg-if = "1.0.0"
-caliptra_common = { path = "../../common", default-features = false }
-caliptra-gen-linker-scripts = { version = "0.1.0", path = "../../cpu/gen" }
+cfg-if.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+caliptra-gen-linker-scripts.workspace = true
 
 [dependencies]
-caliptra-test-harness = { path = "../../test-harness" }
-caliptra-cpu = { version = "0.1.0", path = "../../cpu" }
-caliptra-registers = { path = "../../registers" }
-caliptra-runtime = { path = "..", default-features = false }
-caliptra-drivers = { path = "../../drivers" }
-caliptra_common = { path = "../../common", default-features = false }
-cfg-if = "1.0.0"
-zerocopy = "0.6.1"
+caliptra-test-harness.workspace = true
+caliptra-cpu.workspace = true
+caliptra-registers.workspace = true
+caliptra-runtime = { workspace = true, default-features = false }
+caliptra-drivers.workspace = true
+caliptra_common = { workspace = true, default-features = false }
+cfg-if.workspace = true
+zerocopy.workspace = true

--- a/runtime/test-fw/Cargo.toml
+++ b/runtime/test-fw/Cargo.toml
@@ -34,16 +34,16 @@ path = "src/cert_tests.rs"
 required-features = ["riscv"]
 
 [build-dependencies]
-cfg-if.workspace = true
 caliptra_common = { workspace = true, default-features = false }
 caliptra-gen-linker-scripts.workspace = true
+cfg-if.workspace = true
 
 [dependencies]
-caliptra-test-harness.workspace = true
+caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
 caliptra-runtime = { workspace = true, default-features = false }
-caliptra-drivers.workspace = true
-caliptra_common = { workspace = true, default-features = false }
+caliptra-test-harness.workspace = true
 cfg-if.workspace = true
 zerocopy.workspace = true

--- a/sw-emulator/app/Cargo.toml
+++ b/sw-emulator/app/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap.workspace = true
-caliptra-registers.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
-caliptra-hw-model.workspace = true
 caliptra-hw-model-types.workspace = true
-gdbstub.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-registers.workspace = true
+clap.workspace = true
 gdbstub_arch.workspace = true
+gdbstub.workspace = true
 hex.workspace = true
 tock-registers.workspace = true

--- a/sw-emulator/app/Cargo.toml
+++ b/sw-emulator/app/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.14", default-features = false, features = ["std"] }
-caliptra-registers = { path = "../../registers" }
-caliptra-emu-bus = { path = "../lib/bus" }
-caliptra-emu-cpu = { path = "../lib/cpu" }
-caliptra-emu-periph = { path = "../lib/periph" }
-caliptra-emu-types = { path = "../lib/types" }
-caliptra-hw-model = { path = "../../hw-model" }
-caliptra-hw-model-types = { path = "../../hw-model/types" }
-gdbstub = "0.6.3"
-gdbstub_arch = "0.2.4"
-hex = "0.4.3"
-tock-registers = { git = "https://github.com/tock/tock.git"}
+clap.workspace = true
+caliptra-registers.workspace = true
+caliptra-emu-bus.workspace = true
+caliptra-emu-cpu.workspace = true
+caliptra-emu-periph.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-hw-model.workspace = true
+caliptra-hw-model-types.workspace = true
+gdbstub.workspace = true
+gdbstub_arch.workspace = true
+hex.workspace = true
+tock-registers.workspace = true

--- a/sw-emulator/compliance-test/Cargo.toml
+++ b/sw-emulator/compliance-test/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap.workspace = true
-getrandom.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-types.workspace = true
+clap.workspace = true
+getrandom.workspace = true

--- a/sw-emulator/compliance-test/Cargo.toml
+++ b/sw-emulator/compliance-test/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.2.14", default-features = false, features = ["std"] }
-getrandom = "0.2"
-caliptra-emu-bus = { path = "../lib/bus" }
-caliptra-emu-cpu = { path = "../lib/cpu" }
-caliptra-emu-types = { path = "../lib/types" }
+clap.workspace = true
+getrandom.workspace = true
+caliptra-emu-bus.workspace = true
+caliptra-emu-cpu.workspace = true
+caliptra-emu-types.workspace = true

--- a/sw-emulator/lib/bus/Cargo.toml
+++ b/sw-emulator/lib/bus/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 
 [dependencies]
 caliptra-emu-types.workspace = true
-ureg.workspace = true
 tock-registers.workspace = true
+ureg.workspace = true

--- a/sw-emulator/lib/bus/Cargo.toml
+++ b/sw-emulator/lib/bus/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-emu-types = { path = "../types" }
-ureg = { path = "../../../ureg" }
-tock-registers = { git = "https://github.com/tock/tock.git"}
+caliptra-emu-types.workspace = true
+ureg.workspace = true
+tock-registers.workspace = true

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 bitfield.workspace = true
-lazy_static.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-types.workspace = true
+lazy_static.workspace = true

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitfield = "0.14.0"
-lazy_static = "1.4.0"
-caliptra-emu-bus = { path = "../bus" }
-caliptra-emu-types = { path = "../types" }
+bitfield.workspace = true
+lazy_static.workspace = true
+caliptra-emu-bus.workspace = true
+caliptra-emu-types.workspace = true

--- a/sw-emulator/lib/crypto/Cargo.toml
+++ b/sw-emulator/lib/crypto/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
-p384 = "0.11.2"
-rfc6979 = "0.3.0"
-aes = "0.8.2"
-cbc = "0.1.2"
+sha2.workspace = true
+p384.workspace = true
+rfc6979.workspace = true
+aes.workspace = true
+cbc.workspace = true

--- a/sw-emulator/lib/crypto/Cargo.toml
+++ b/sw-emulator/lib/crypto/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sha2.workspace = true
-p384.workspace = true
-rfc6979.workspace = true
 aes.workspace = true
 cbc.workspace = true
+p384.workspace = true
+rfc6979.workspace = true
+sha2.workspace = true

--- a/sw-emulator/lib/derive/Cargo.toml
+++ b/sw-emulator/lib/derive/Cargo.toml
@@ -11,7 +11,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-emu-bus = { path = "../bus"}
-caliptra-emu-types = { path = "../types"}
-quote = "1.0"
-proc-macro2 = "1.0.66"
+caliptra-emu-bus.workspace = true
+caliptra-emu-types.workspace = true
+quote.workspace = true
+proc-macro2.workspace = true

--- a/sw-emulator/lib/derive/Cargo.toml
+++ b/sw-emulator/lib/derive/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 [dependencies]
 caliptra-emu-bus.workspace = true
 caliptra-emu-types.workspace = true
-quote.workspace = true
 proc-macro2.workspace = true
+quote.workspace = true

--- a/sw-emulator/lib/periph/Cargo.toml
+++ b/sw-emulator/lib/periph/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aes.workspace = true
+arrayref.workspace = true
+bitfield.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true
 caliptra-emu-crypto.workspace = true
@@ -15,9 +18,6 @@ caliptra-emu-derive.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-registers.workspace = true
-tock-registers.workspace = true
-smlang.workspace = true
 lazy_static.workspace = true
-arrayref.workspace = true
-bitfield.workspace = true
-aes.workspace = true
+smlang.workspace = true
+tock-registers.workspace = true

--- a/sw-emulator/lib/periph/Cargo.toml
+++ b/sw-emulator/lib/periph/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-caliptra-emu-bus = { path = "../bus"}
-caliptra-emu-cpu = { path = "../cpu"}
-caliptra-emu-crypto = { path = "../crypto"}
-caliptra-emu-derive = { path = "../derive" }
-caliptra-emu-types = { path = "../types" }
-caliptra-hw-model-types = { path = "../../../hw-model/types" }
-caliptra-registers = { path = "../../../registers" }
-tock-registers = { git = "https://github.com/tock/tock.git"}
-smlang="0.6.0"
-lazy_static = "1.4.0"
-arrayref = "0.3.6"
-bitfield = "0.14.0"
-aes = "0.8.2"
+caliptra-emu-bus.workspace = true
+caliptra-emu-cpu.workspace = true
+caliptra-emu-crypto.workspace = true
+caliptra-emu-derive.workspace = true
+caliptra-emu-types.workspace = true
+caliptra-hw-model-types.workspace = true
+caliptra-registers.workspace = true
+tock-registers.workspace = true
+smlang.workspace = true
+lazy_static.workspace = true
+arrayref.workspace = true
+bitfield.workspace = true
+aes.workspace = true

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -13,5 +13,5 @@ riscv = []
 runtime = []
 
 [dependencies]
-cfg-if.workspace = true
 caliptra-drivers = { workspace = true, features=["emu"] }
+cfg-if.workspace = true

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -13,5 +13,5 @@ riscv = []
 runtime = []
 
 [dependencies]
-cfg-if = "1.0.0"
-caliptra-drivers = { path = "../drivers", features=["emu"] }
+cfg-if.workspace = true
+caliptra-drivers = { workspace = true, features=["emu"] }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy.workspace = true
-openssl.workspace = true
-caliptra-hw-model-types.workspace = true
 asn1.workspace = true
+caliptra-hw-model-types.workspace = true
+openssl.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 caliptra-builder.workspace = true

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zerocopy = "0.6.1"
-openssl = { version = "0.10", features = ["vendored"] }
-caliptra-hw-model-types = { path = "../hw-model/types" }
-asn1 = "0.13.0"
+zerocopy.workspace = true
+openssl.workspace = true
+caliptra-hw-model-types.workspace = true
+asn1.workspace = true
 
 [dev-dependencies]
-caliptra-builder = { path = "../builder" }
-caliptra-hw-model = { path = "../hw-model" }
-openssl = { version = "0.10", features = ["vendored"] }
+caliptra-builder.workspace = true
+caliptra-hw-model.workspace = true
+openssl.workspace = true
 
 [features]
 fpga_realtime = ["caliptra-hw-model/fpga_realtime", "caliptra-builder/fpga_realtime"]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -12,18 +12,18 @@ doctest = false
 [dependencies]
 
 [build-dependencies]
-caliptra_common.workspace = true
-openssl.workspace = true
-hex.workspace = true
-bitfield.workspace = true
 asn1.workspace = true
-syn.workspace = true
+bitfield.workspace = true
+caliptra_common.workspace = true
 convert_case.workspace = true
+hex.workspace = true
+openssl.workspace = true
 quote.workspace = true
+syn.workspace = true
 
 [dev-dependencies]
-openssl.workspace = true
 hex.workspace = true
+openssl.workspace = true
 
 [features]
 default = ["std"]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -12,18 +12,18 @@ doctest = false
 [dependencies]
 
 [build-dependencies]
-caliptra_common = { path = "../common" }
-openssl = { version = "0.10", features = ["vendored"] }
-hex = "0.4.3"
-bitfield = "0.14.0"
-asn1 = "0.13.0"
-syn = "1.0.107"
-convert_case = "0.6.0"
-quote = "1.0.23"
+caliptra_common.workspace = true
+openssl.workspace = true
+hex.workspace = true
+bitfield.workspace = true
+asn1.workspace = true
+syn.workspace = true
+convert_case.workspace = true
+quote.workspace = true
 
 [dev-dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-hex = "0.4.3"
+openssl.workspace = true
+hex.workspace = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This makes it significantly easier to manage dependency versions, and reduces the chance that we use multiple versions of the same crate.