### PR TITLE
RT FIPS Self-Test : verify Caliptra image in ICCM using the manifest stored in DCCM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "caliptra-image-openssl",
  "caliptra-image-serde",
  "caliptra-image-types",
+ "caliptra-image-verify",
  "caliptra-kat",
  "caliptra-registers",
  "caliptra-x509",
@@ -598,6 +599,7 @@ dependencies = [
  "caliptra-builder",
  "caliptra-hw-model",
  "caliptra-hw-model-types",
+ "caliptra-runtime",
  "openssl",
  "zerocopy",
 ]

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -147,6 +147,27 @@ impl SocIfc {
         }
     }
 
+    pub fn internal_fw_update_reset_wait_cycles(&self) -> u32 {
+        self.soc_ifc
+            .regs()
+            .internal_fw_update_reset_wait_cycles()
+            .read()
+            .into()
+    }
+    pub fn assert_fw_update_reset(&mut self) {
+        self.soc_ifc
+            .regs_mut()
+            .internal_fw_update_reset()
+            .write(|w| w.core_rst(true));
+    }
+
+    pub fn assert_ready_for_runtime(&mut self) {
+        self.soc_ifc
+            .regs_mut()
+            .cptra_flow_status()
+            .write(|w| w.ready_for_runtime(true));
+    }
+
     /// Sets WDT1 timeout
     ///
     /// # Arguments

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -15,6 +15,7 @@ caliptra-image-types = { path = "../image/types", default-features = false }
 ufmt = { workspace = true }
 zerocopy = "0.6.1"
 caliptra-kat = { version = "0.1.0", path = "../kat" }
+caliptra-image-verify = { version = "0.1.0", path = "../image/verify", default-features = false }
 
 [build-dependencies]
 cfg-if = "1.0.0"

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -1,9 +1,36 @@
 // Licensed under the Apache-2.0 license
 
+use core::ops::Range;
+
 use caliptra_common::cprintln;
+use caliptra_common::memory_layout::ICCM_ORG;
+use caliptra_common::memory_layout::ICCM_SIZE;
+use caliptra_drivers::Array4x12;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
-use caliptra_kat::{Ecc384Kat, Hmac384Kat, Sha256Kat, Sha384AccKat, Sha384Kat};
+use caliptra_drivers::DataVault;
+use caliptra_drivers::Ecc384;
+use caliptra_drivers::Ecc384PubKey;
+use caliptra_drivers::Ecc384Result;
+use caliptra_drivers::Ecc384Signature;
+use caliptra_drivers::Lifecycle;
+use caliptra_drivers::Lms;
+use caliptra_drivers::LmsResult;
+use caliptra_drivers::LmsVerifyConfig;
+use caliptra_drivers::ResetReason;
+use caliptra_drivers::Sha256;
+use caliptra_drivers::Sha384Acc;
+use caliptra_drivers::SocIfc;
+use caliptra_drivers::VendorPubKeyRevocation;
+use caliptra_image_types::ImageDigest;
+use caliptra_image_types::ImageEccPubKey;
+use caliptra_image_types::ImageEccSignature;
+use caliptra_image_types::ImageLmsPublicKey;
+use caliptra_image_types::ImageLmsSignature;
+use caliptra_image_types::SHA384_DIGEST_BYTE_SIZE;
+use caliptra_image_verify::ImageVerificationEnv;
+use caliptra_image_verify::ImageVerifier;
+use caliptra_kat::{Ecc384Kat, Hmac384Kat, LmsKat, Sha1Kat, Sha256Kat, Sha384AccKat, Sha384Kat};
 use caliptra_registers::mbox::enums::MboxStatusE;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -50,6 +77,22 @@ impl FipsModule {
         cprintln!("[rt] FIPS self test");
         Self::execute_kats(env)?;
 
+        let venv = FipsTestEnv {
+            sha384_acc: &mut env.sha384_acc,
+            ecc384: &mut env.ecc384,
+            sha256: &mut env.sha256,
+            soc_ifc: &mut env.soc_ifc,
+            data_vault: &env.data_vault,
+        };
+
+        let mut verifier = ImageVerifier::new(venv);
+        //Verify Caliptra image loaded to ICCM by ROM using the manifest stored in DCCM.
+        verifier.verify(
+            &env.manifest,
+            caliptra_common::memory_layout::MBOX_SIZE,
+            ResetReason::ColdReset,
+        )?;
+
         Ok(MboxStatusE::CmdComplete)
     }
 
@@ -82,6 +125,139 @@ impl FipsModule {
         cprintln!("[kat] Executing HMAC-384 Engine KAT");
         Hmac384Kat::default().execute(&mut env.hmac384, &mut env.trng)?;
 
+        cprintln!("[kat] sha1");
+        Sha1Kat::default().execute(&mut env.sha1)?;
+
+        cprintln!("[kat] LMS");
+        LmsKat::default().execute(&mut env.sha256, &env.lms)?;
+
         Ok(())
+    }
+}
+
+struct FipsTestEnv<'a> {
+    pub(crate) sha384_acc: &'a mut Sha384Acc,
+    pub(crate) ecc384: &'a mut Ecc384,
+    pub(crate) sha256: &'a mut Sha256,
+    pub(crate) soc_ifc: &'a mut SocIfc,
+    pub(crate) data_vault: &'a DataVault,
+}
+
+impl ImageVerificationEnv for FipsTestEnv<'_> {
+    fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest> {
+        loop {
+            if let Some(mut txn) = self.sha384_acc.try_start_operation() {
+                let mut digest = Array4x12::default();
+                txn.digest(len, offset, false, &mut digest)?;
+                return Ok(digest.0);
+            }
+        }
+    }
+
+    /// ECC-384 Verification routine
+    fn ecc384_verify(
+        &mut self,
+        digest: &ImageDigest,
+        pub_key: &ImageEccPubKey,
+        sig: &ImageEccSignature,
+    ) -> CaliptraResult<Ecc384Result> {
+        // TODO: Remove following conversions after refactoring the driver ECC384PubKey
+        // for use across targets
+        let pub_key = Ecc384PubKey {
+            x: pub_key.x.into(),
+            y: pub_key.y.into(),
+        };
+
+        // TODO: Remove following conversions after refactoring the driver SHA384Digest
+        // for use across targets
+        let digest: Array4x12 = digest.into();
+
+        // TODO: Remove following conversions after refactoring the driver ECC384Signature
+        // for use across targets
+        let sig = Ecc384Signature {
+            r: sig.r.into(),
+            s: sig.s.into(),
+        };
+
+        self.ecc384.verify(&pub_key, &digest, &sig)
+    }
+
+    fn lms_verify(
+        &mut self,
+        digest: &ImageDigest,
+        pub_key: &ImageLmsPublicKey,
+        sig: &ImageLmsSignature,
+    ) -> CaliptraResult<LmsResult> {
+        let mut message = [0u8; SHA384_DIGEST_BYTE_SIZE];
+        for i in 0..digest.len() {
+            message[i * 4..][..4].copy_from_slice(&digest[i].to_be_bytes());
+        }
+        Lms::default().verify_lms_signature(self.sha256, &message, pub_key, sig)
+    }
+
+    /// Retrieve Vendor Public Key Digest
+    fn vendor_pub_key_digest(&self) -> ImageDigest {
+        self.soc_ifc.fuse_bank().vendor_pub_key_hash().into()
+    }
+
+    /// Retrieve Vendor ECC Public Key Revocation Bitmask
+    fn vendor_ecc_pub_key_revocation(&self) -> VendorPubKeyRevocation {
+        self.soc_ifc.fuse_bank().vendor_ecc_pub_key_revocation()
+    }
+
+    /// Retrieve Vendor LMS Public Key Revocation Bitmask
+    fn vendor_lms_pub_key_revocation(&self) -> u32 {
+        self.soc_ifc.fuse_bank().vendor_lms_pub_key_revocation()
+    }
+
+    /// Retrieve Owner Public Key Digest from fuses
+    fn owner_pub_key_digest_fuses(&self) -> ImageDigest {
+        self.soc_ifc.fuse_bank().owner_pub_key_hash().into()
+    }
+
+    /// Retrieve Anti-Rollback disable fuse value
+    fn anti_rollback_disable(&self) -> bool {
+        self.soc_ifc.fuse_bank().anti_rollback_disable()
+    }
+
+    /// Retrieve Device Lifecycle state
+    fn dev_lifecycle(&self) -> Lifecycle {
+        self.soc_ifc.lifecycle()
+    }
+
+    /// Get the vendor key index saved in data vault on cold boot
+    fn vendor_pub_key_idx_dv(&self) -> u32 {
+        self.data_vault.ecc_vendor_pk_index()
+    }
+
+    /// Get the owner public key digest saved in the dv on cold boot
+    fn owner_pub_key_digest_dv(&self) -> ImageDigest {
+        self.data_vault.owner_pk_hash().into()
+    }
+
+    // Get the fmc digest from the data vault on cold boot
+    fn get_fmc_digest_dv(&self) -> ImageDigest {
+        self.data_vault.fmc_tci().into()
+    }
+
+    // Get Fuse FMC Key Manifest SVN
+    fn fmc_fuse_svn(&self) -> u32 {
+        self.soc_ifc.fuse_bank().fmc_fuse_svn()
+    }
+
+    // Get Runtime fuse SVN
+    fn runtime_fuse_svn(&self) -> u32 {
+        self.soc_ifc.fuse_bank().runtime_fuse_svn()
+    }
+
+    fn iccm_range(&self) -> Range<u32> {
+        Range {
+            start: ICCM_ORG,
+            end: ICCM_ORG + ICCM_SIZE,
+        }
+    }
+
+    fn lms_verify_enabled(&self) -> bool {
+        self.soc_ifc.fuse_bank().lms_verify() == LmsVerifyConfig::EcdsaAndLms
     }
 }

--- a/runtime/src/update.rs
+++ b/runtime/src/update.rs
@@ -4,18 +4,9 @@ use crate::Drivers;
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 
 pub(crate) fn handle_impactless_update(drivers: &mut Drivers) -> CaliptraResult<()> {
-    let cycles = drivers
-        .soc_ifc
-        .regs_mut()
-        .internal_fw_update_reset_wait_cycles()
-        .read()
-        .into();
+    let cycles = drivers.soc_ifc.internal_fw_update_reset_wait_cycles();
     for _ in 0..cycles {
-        drivers
-            .soc_ifc
-            .regs_mut()
-            .internal_fw_update_reset()
-            .write(|w| w.core_rst(true));
+        drivers.soc_ifc.assert_fw_update_reset();
     }
 
     Err(CaliptraError::RUNTIME_UNEXPECTED_UPDATE_RETURN)

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -4,7 +4,7 @@ pub mod common;
 use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART};
 use caliptra_drivers::Ecc384PubKey;
 use caliptra_hw_model::{HwModel, ModelError, ShaAccMode};
-use caliptra_runtime::{info::FwInfoResp, CommandId, EcdsaVerifyCmd, VersionResponse};
+use caliptra_runtime::{info::FwInfoResp, CommandId, EcdsaVerifyCmd};
 use common::{run_rom_test, run_rt_test};
 use openssl::{
     bn::BigNum,
@@ -197,43 +197,6 @@ fn test_verify_cmd() {
         model.soc_ifc().cptra_fw_error_non_fatal().read(),
         caliptra_drivers::CaliptraError::RUNTIME_INVALID_CHECKSUM.into()
     );
-}
-
-#[test]
-fn test_fips_cmd_api() {
-    let mut model = run_rom_test("mbox");
-
-    model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
-
-    let cmd = [0u8; 4];
-
-    let resp = model.mailbox_execute(u32::from(CommandId::VERSION), &cmd);
-    assert!(resp.is_ok());
-    let fips_version_resp = model
-        .mailbox_execute(u32::from(CommandId::VERSION), &cmd)
-        .unwrap()
-        .unwrap();
-
-    // Check command size
-    let fips_version_bytes: &[u8] = fips_version_resp.as_bytes();
-
-    // Check values against expected.
-    let fips_version = VersionResponse::read_from(fips_version_bytes.as_bytes()).unwrap();
-    assert_eq!(fips_version.mode, VersionResponse::MODE);
-    assert_eq!(fips_version.fips_rev, [0x01, 0x00, 0x00]);
-    let name = &fips_version.name[..];
-    assert_eq!(name, VersionResponse::NAME.as_bytes());
-
-    let resp = model.mailbox_execute(u32::from(CommandId::SELF_TEST), &cmd);
-    assert!(resp.is_ok());
-
-    let resp = model.mailbox_execute(u32::from(CommandId::SHUTDOWN), &cmd);
-    assert!(resp.is_ok());
-
-    // Check we are rejecting additional commands with the shutdown error code.
-    let expected_err = Err(ModelError::MailboxCmdFailed(0x000E0008));
-    let resp = model.mailbox_execute(u32::from(CommandId::VERSION), &cmd);
-    assert_eq!(resp, expected_err);
 }
 
 #[test]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -12,6 +12,7 @@ zerocopy = "0.6.1"
 openssl = { version = "0.10", features = ["vendored"] }
 caliptra-hw-model-types = { path = "../hw-model/types" }
 asn1 = "0.13.0"
+caliptra-runtime = { version = "0.1.0", path = "../runtime" }
 
 [dev-dependencies]
 caliptra-builder = { path = "../builder" }

--- a/test/tests/fips_cmd_api.rs
+++ b/test/tests/fips_cmd_api.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_hw_model::ModelError;
+use caliptra_hw_model::{BootParams, HwModel, InitParams};
+use caliptra_runtime::{CommandId, VersionResponse};
+use zerocopy::{AsBytes, FromBytes};
+
+#[test]
+fn test_fips_cmd_api() {
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    hw.step_until(|m| m.ready_for_fw());
+
+    let resp = hw.mailbox_execute(u32::from(CommandId::VERSION), &[]);
+    assert!(resp.is_ok());
+    let fips_version_resp = hw
+        .mailbox_execute(u32::from(CommandId::VERSION), &[])
+        .unwrap()
+        .unwrap();
+
+    // Check command size
+    let fips_version_bytes: &[u8] = fips_version_resp.as_bytes();
+
+    // Check values against expected.
+    let fips_version = VersionResponse::read_from(fips_version_bytes.as_bytes()).unwrap();
+    assert_eq!(fips_version.mode, VersionResponse::MODE);
+    assert_eq!(fips_version.fips_rev, [0x01, 0x00, 0x00]);
+    let name = &fips_version.name[..];
+    assert_eq!(name, VersionResponse::NAME.as_bytes());
+
+    let resp = hw.mailbox_execute(u32::from(CommandId::SELF_TEST), &[]);
+    assert!(resp.is_ok());
+
+    let resp = hw.mailbox_execute(u32::from(CommandId::SHUTDOWN), &[]);
+    assert!(resp.is_ok());
+
+    // Check we are rejecting additional commands with the shutdown error code.
+    let expected_err = Err(ModelError::MailboxCmdFailed(0x000E0008));
+    let resp = hw.mailbox_execute(u32::from(CommandId::VERSION), &[]);
+    assert_eq!(resp, expected_err);
+}


### PR DESCRIPTION
This commit adds firmware authentication to the FIP Self Test command handler.