### PR TITLE
Wycheproof: hmac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +564,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "openssl",
  "ufmt",
+ "wycheproof",
  "zerocopy",
 ]
 
@@ -2062,6 +2069,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wycheproof"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e639f57253b80c6584b378011aec0fed61c4c21d7a4b97c4d9d7eaf35ca77d12"
+dependencies = [
+ "base64",
+ "hex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -276,6 +276,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E0007);
     pub const RUNTIME_SHUTDOWN: CaliptraError = CaliptraError::new_const(0x000E0008);
     pub const RUNTIME_NO_MANIFEST: CaliptraError = CaliptraError::new_const(0x000E0009);
+    pub const RUNTIME_HMAC_VERIFY_FAILED: CaliptraError = CaliptraError::new_const(0x000E000A);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ caliptra-image-gen = { path = "../image/gen" }
 caliptra-image-openssl = { path = "../image/openssl" }
 caliptra-image-serde = { path = "../image/serde" }
 openssl = { version = "0.10", features = ["vendored"] }
+wycheproof = "0.5.1"
 
 [features]
 riscv = ["caliptra-cpu/riscv"]

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -1,10 +1,14 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{CommandId, Drivers, EcdsaVerifyCmd};
+use crate::{CommandId, Drivers, EcdsaVerifyCmd, HmacVerifyCmd};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
-    Ecc384Signature,
+    Ecc384Signature, Hmac384Data, Hmac384Key, Trng,
 };
+use caliptra_registers::csrng::CsrngReg;
+use caliptra_registers::entropy_src::EntropySrcReg;
+use caliptra_registers::soc_ifc::SocIfcReg;
+use caliptra_registers::soc_ifc_trng::SocIfcTrngReg;
 use zerocopy::FromBytes;
 
 /// Start of payload (skips checksum field).
@@ -40,6 +44,47 @@ pub(crate) fn handle_ecdsa_verify(drivers: &mut Drivers, cmd_args: &[u8]) -> Cal
         let success = drivers.ecdsa.verify(&pubkey, &digest, &sig)?;
         if success != Ecc384Result::Success {
             return Err(CaliptraError::RUNTIME_ECDSA_VERIFY_FAILED);
+        }
+    } else {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    };
+
+    Ok(())
+}
+
+/// Handle the `HMAC_SHA384_VERIFY` mailbox command
+pub(crate) fn handle_hmac_verify(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<()> {
+    if let Some(cmd) = HmacVerifyCmd::read_from(cmd_args) {
+        if !caliptra_common::checksum::verify_checksum(
+            cmd.chksum,
+            CommandId::TEST_ONLY_HMAC384_VERIFY.into(),
+            &cmd_args[PAYLOAD_OFFSET..],
+        ) {
+            return Err(CaliptraError::RUNTIME_INVALID_CHECKSUM);
+        }
+        let key = Array4x12::from(cmd.key);
+        let key = Hmac384Key::from(&key);
+        let mut out_tag = Array4x12::default();
+        let len = usize::try_from(cmd.len).unwrap();
+        if len > cmd.msg.len() {
+            return Err(CaliptraError::RUNTIME_HMAC_VERIFY_FAILED);
+        }
+        let data = Hmac384Data::from(&cmd.msg[0..len]);
+        let mut trng = unsafe {
+            Trng::new(
+                CsrngReg::new(),
+                EntropySrcReg::new(),
+                SocIfcTrngReg::new(),
+                &SocIfcReg::new(),
+            )
+        }?;
+
+        drivers
+            .hmac
+            .hmac(&key, &data, &mut trng, (&mut out_tag).into())?;
+
+        if out_tag != Array4x12::from(cmd.tag) {
+            return Err(CaliptraError::RUNTIME_HMAC_VERIFY_FAILED);
         }
     } else {
         return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);

--- a/runtime/tests/hmac.rs
+++ b/runtime/tests/hmac.rs
@@ -1,0 +1,88 @@
+// Licensed under the Apache-2.0 license.
+pub mod common;
+
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::{CommandId, HmacVerifyCmd};
+use common::run_rt_test;
+use zerocopy::AsBytes;
+
+#[test]
+fn hmac_cmd_run_wycheproof() {
+    let mut model = run_rt_test(None);
+
+    model
+        .step_until_output_contains("Caliptra RT listening for mailbox commands...")
+        .unwrap();
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct WycheproofResults {
+        id: usize,
+        comment: String,
+    }
+
+    // Collect all the errors and print at the end
+    let mut wyche_fail: Vec<WycheproofResults> = Vec::new();
+    let mut wyche_ran: Vec<WycheproofResults> = Vec::new();
+    let test_set = wycheproof::mac::TestSet::load(wycheproof::mac::TestName::HmacSha384).unwrap();
+
+    for test_groups in test_set.test_groups {
+        for test in &test_groups.tests {
+            // The mailbox is only implemented for keys and tags of 384 bits
+            if test.key.len() != 48 || test.tag.len() != 48 {
+                continue;
+            }
+            wyche_ran.push(WycheproofResults {
+                id: test.tc_id,
+                comment: test.comment.to_string(),
+            });
+            let mut cmd = HmacVerifyCmd {
+                chksum: 0,
+                key: test.key[..].try_into().unwrap(),
+                tag: test.tag[..].try_into().unwrap(),
+                len: u32::try_from(test.msg.len()).unwrap(),
+                msg: [0u8; 256],
+            };
+            cmd.msg[..test.msg.len()].clone_from_slice(test.msg.as_slice());
+            let checksum = caliptra_common::checksum::calc_checksum(
+                u32::from(CommandId::TEST_ONLY_HMAC384_VERIFY),
+                &cmd.as_bytes()[4..],
+            );
+            let cmd = HmacVerifyCmd {
+                chksum: checksum,
+                ..cmd
+            };
+            let resp = model.mailbox_execute(
+                u32::from(CommandId::TEST_ONLY_HMAC384_VERIFY),
+                cmd.as_bytes(),
+            );
+            match test.result {
+                wycheproof::TestResult::Valid | wycheproof::TestResult::Acceptable => match resp {
+                    Err(_) | Ok(Some(_)) => {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                    _ => {}
+                },
+                wycheproof::TestResult::Invalid => {
+                    if let Ok(None) = resp {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    println!("Executed wycheproof tests:\n{:#?}", wyche_ran);
+    if !wyche_fail.is_empty() {
+        panic!(
+            "Number of failed tests {}:\n{:#?}",
+            wyche_fail.len(),
+            wyche_fail
+        );
+    }
+}

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -110,7 +110,7 @@ fn test_fw_info() {
 }
 
 #[test]
-fn test_verify_cmd() {
+fn test_ecdsa_verify_cmd() {
     let mut model = run_rom_test("mbox");
 
     model.step_until(|m| {


### PR DESCRIPTION
This implements:
- The mailbox command to verify HMAC
- running hmac sha384 tests over the HMAC mailbox