### PR TITLE
RT FIPS Shutdown : zeroize crypto blocks and lock accelerator.

### DIFF
--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -3,6 +3,12 @@
 use caliptra_common::cprintln;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
+use caliptra_drivers::Ecc384;
+use caliptra_drivers::Hmac384;
+use caliptra_drivers::KeyVault;
+use caliptra_drivers::Sha256;
+use caliptra_drivers::Sha384;
+use caliptra_drivers::Sha384Acc;
 use caliptra_kat::{Ecc384Kat, Hmac384Kat, Sha256Kat, Sha384AccKat, Sha384Kat};
 use caliptra_registers::mbox::enums::MboxStatusE;
 use zerocopy::{AsBytes, FromBytes};
@@ -62,6 +68,21 @@ impl FipsModule {
 
     /// Clear data structures in DCCM.  
     fn zeroize(env: &mut Drivers) {
+        unsafe {
+            // Zeroize the crypto blocks.
+            Ecc384::zeroize();
+            Hmac384::zeroize();
+            Sha256::zeroize();
+            Sha384::zeroize();
+            Sha384Acc::zeroize();
+
+            // Zeroize the key vault.
+            KeyVault::zeroize();
+
+            // Lock the SHA Accelerator.
+            Sha384Acc::lock();
+        }
+
         env.regions.zeroize();
     }
 


### PR DESCRIPTION
This commit performs more extensive zeroization upon receipt of the FIPS shutdown command.