### PR TITLE
Add must_use attribute to Ecc384Result

### DIFF
--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -23,6 +23,7 @@ use zerocopy::{AsBytes, FromBytes};
 /// ECC-384 Coordinate
 pub type Ecc384Scalar = Array4x12;
 
+#[must_use]
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ecc384Result {


### PR DESCRIPTION
This ensures that a compiler warning is generated if somebody forgets to look at the Ecc384Result in a `CaliptraResult<Ecc384Result>`. For example:

```
warning: unused `Ecc384Result` that must be used
    |
    |     ecc.verify(&pub_key, &Ecc384Scalar::from(msg), &signature).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
```

Our CI promotes warnings to errors, so buggy code will be caught before submission.