### PR TITLE
API expansion and type cleanup

### DIFF
--- a/libcaliptra/examples/Makefile
+++ b/libcaliptra/examples/Makefile
@@ -1,0 +1,15 @@
+Q=@
+
+PLAT ?= hwmodel
+
+.PHONY: all clean run 
+
+all:
+	$(Q)make -C $(PLAT)
+
+clean:
+	@echo [CLEAN] $(PLAT)
+	$(Q)make -C $(PLAT) clean
+
+run:
+	$(Q)make -C $(PLAT) run

--- a/libcaliptra/examples/README.md
+++ b/libcaliptra/examples/README.md
@@ -3,15 +3,35 @@
 In this directory you will find a basic example on how to interact with the
 Caliptra C API and adapt it to your target platform.
 
+## Build
+
+Build can be done either in this directory by naming a target, or in the individual interface example directories.
+
+In the examples root, the following is valid:
+
+`$ make`
+
+`$ make run`
+
+`$ make clean`
+
+By default, the *hwmodel* example will be built and run. By supplying:
+
+`PLAT=<target>`
+
+on the Make command line, where <target> is a directory in *examples* other than *generic*, that example will be acted upon:
+
+`$ make PLAT=hwmodel`
+
+`$ make PLAT=hwmodel run`
+
 ## Generic
 
 `generic/`
 
-The generic example contains the main() function, basic Caliptra startup, and firmware interaction.
+The generic example contains the main() function, basic Caliptra startup, and firmware interaction. This file is built by and linked in by other examples.
 
-> NOTE: The current test executes a command that is ignored by ROM and not yet implemented by firmware.
-
-## hwmodel
+## Example: hwmodel
 
 `hwmodel/`
 

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -3,7 +3,7 @@ TARGET = hwmodel
 .DEFAULT_GOAL = $(TARGET)
 
 LIBCALIPTRA_ROOT = ../../
-LIBCALIPTRA_INC  = 
+LIBCALIPTRA_INC  =
 
 OUTPUT_DIR = ../../../target/debug
 
@@ -60,6 +60,8 @@ $(HWMODEL_HEADER):
 	@echo "[CARGO] hw-model"
 	$(Q)cd ../../../hw-model
 	$(Q)cargo --config="$(EXTRA_CARGO_CONFIG)" build
+
+all: $(TARGET)
 
 run: $(TARGET)
 	@echo [RUN] $(TARGET)

--- a/libcaliptra/examples/hwmodel/interface.c
+++ b/libcaliptra/examples/hwmodel/interface.c
@@ -96,7 +96,7 @@ int caliptra_write_u32(uint32_t address, uint32_t data)
 
     caliptra_model_step(m);
 
-    return result; 
+    return result;
 }
 
 /**

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -5,18 +5,7 @@
 #include <stdbool.h>
 
 #include "caliptra_if.h"
-
-/**
- * caliptra_buffer
- *
- * Transfer buffer for Caliptra mailbox commands
- */
-#if !defined(HWMODEL)
-typedef struct caliptra_buffer {
-  const uint8_t *data; //< Pointer to a buffer with data to send/space to receive
-  uintptr_t len;       //< Size of the buffer
-} caliptra_buffer;
-#endif
+#include "caliptra_types.h"
 
 /**
  * DeviceLifecycle
@@ -50,11 +39,7 @@ struct caliptra_fuses {
     enum DeviceLifecycle life_cycle;
 };
 
-struct caliptra_fips_version {
-    uint32_t mode;
-    uint32_t fips_rev[3];
-    uint8_t name[12];
-};
+
 
 // Query if ROM is ready for fuses
 bool caliptra_ready_for_fuses(void);
@@ -65,14 +50,53 @@ int caliptra_init_fuses(struct caliptra_fuses *fuses);
 // Write into Caliptra BootFSM Go Register
 int caliptra_bootfsm_go();
 
-// Query if ROM is ready for firmware
+/**
+ * caliptra_ready_for_firmware
+ *
+ * Reports if the Caliptra hardware is ready for firmware upload
+ *
+ * @return bool True if ready, false otherwise
+ */
 bool caliptra_ready_for_firmware(void);
 
-// Upload Caliptra Firmware
+/**
+ * caliptra_upload_fw
+ *
+ * Upload firmware to the Caliptra device
+ *
+ * @param[in] fw_buffer Buffer containing Caliptra firmware
+ *
+ * @return See caliptra_mailbox, mb_resultx_execute for possible results.
+ */
 int caliptra_upload_fw(struct caliptra_buffer *fw_buffer);
 
-// Read Caliptra FIPS Version
+/**
+ * caliptra_get_fips_version
+ *
+ * Read Caliptra FIPS Version
+ *
+ * @param[out] version pointer to fips_version unsigned integer
+ *
+ * @return See caliptra_mailbox_execute for possible results.
+ */
 int caliptra_get_fips_version(struct caliptra_fips_version *version);
 
-// Execute Mailbox Command
-int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);
+// Retrieve the self-signed IDevID CSR
+// This command is available in ROM ONLY.
+int caliptra_get_idev_csr_rom(struct caliptra_buffer *buffer);
+
+// Retrieve the self-signed LDevID certificate.
+// This command is available in ROM ONLY.
+int caliptra_get_ldev_csr_rom(struct caliptra_buffer *buffer);
+
+/**
+ * caliptra_stash_measurement
+ *
+ * Perform a measurement in to the DPE context.
+ *
+ * @param[in] req Data to be measured and stored.
+ * @param[out] response DPE measurement result
+ *
+ * @return -EINVAL if the return checksum fails
+ */
+int caliptra_stash_measurement(struct stash_measurement_req *req, struct dpe_result *resp);

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -1,0 +1,52 @@
+// Licensed under the Apache-2.0 license
+#pragma once
+
+#include <stdint.h>
+
+typedef uint32_t caliptra_checksum;
+
+struct ecdsa384_sigverify {
+    caliptra_checksum checksum;
+    uint8_t           pub_key_x[48];
+    uint8_t           pub_key_y[48];
+    uint8_t           signature_r[48];
+    uint8_t           signature_s[48];
+};
+
+struct stash_measurement_req {
+    caliptra_checksum checksum;
+    uint8_t           metadata[4];
+    uint8_t           measurement[48];
+};
+
+struct stash_mesurement_resp {
+    caliptra_checksum checksum;
+    uint32_t          dpe_result;
+};
+
+struct dpe {
+    caliptra_checksum checksum;
+    uint8_t           data_start;
+};
+
+struct dpe_result {
+    caliptra_checksum checksum;
+    uint32_t           result;
+};
+
+struct caliptra_fips_version {
+    uint32_t mode;
+    uint32_t fips_rev[3];
+    uint8_t name[12];
+};
+/**
+ * caliptra_buffer
+ *
+ * Transfer buffer for Caliptra mailbox commands
+ */
+#if !defined(HWMODEL)
+struct caliptra_buffer {
+  const uint8_t *data; //< Pointer to a buffer with data to send/space to receive
+  uintptr_t len;       //< Size of the buffer
+};
+#endif

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -10,17 +10,43 @@
  *       command completion.
  */
 
-#define CALIPTRA_MBOX_STATUS_BUSY               0
-#define CALIPTRA_MBOX_STATUS_DATA_READY         1
-#define CALIPTRA_MBOX_STATUS_CMD_COMPLETE       2
-#define CALIPTRA_MBOX_STATUS_CMD_FAILURE        3
+#define CALIPTRA_MAILBOX_MAX_SIZE (128u * 1024u)
 
-#define CALIPTRA_MBOX_STATUS_FSM_IDLE           0
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_CMD  1
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DATA 2
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DLEN 3
-#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_SOC    4
-#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_UC     6
+enum caliptra_mailbox_status {
+    CALIPTRA_MBOX_STATUS_BUSY         = 0,
+    CALIPTRA_MBOX_STATUS_DATA_READY   = 1,
+    CALIPTRA_MBOX_STATUS_CMD_COMPLETE = 2,
+    CALIPTRA_MBOX_STATUS_CMD_FAILURE  = 3,
+};
+
+enum caliptra_mailbox_fsm_states {
+    CALIPTRA_MBOX_STATUS_FSM_IDLE           = 0,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_CMD  = 1,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DATA = 2,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DLEN = 3,
+    CALIPTRA_MBOX_STATUS_FSM_EXECUTE_SOC    = 4,
+    CALIPTRA_MBOX_STATUS_FSM_EXECUTE_UC     = 6,
+};
+
+enum mailbox_commands {
+    OP_CALIPTRA_FW_LOAD          = 0x46574C44, // "FWLD"
+    OP_GET_IDEV_CSR              = 0x49444556, // "IDEV"
+    OP_GET_LDEV_CERT             = 0x4C444556, // "LDEV"
+    OP_ECDSA384_SIGNATURE_VERIFY = 0x53494756, // "SIGV"
+    OP_STASH_MEASUREMENT         = 0x4D454153, // "MEAS"
+    OP_DISABLE_ATTESTATION       = 0x4453424C, // "DSBL"
+    OP_INVOKE_DPE_COMMAND        = 0x44504543, // "DPEC"
+    OP_FIPS_VERSION              = 0x46505652, // "FPVR"
+};
+
+enum mailbox_results {
+    SUCCESS        = 0x00000000,
+    BAD_VENDOR_SIG = 0x56534947, // "VSIG"
+    BAD_OWNER_SIG  = 0x4F534947, // "OSIG"
+    BAD_SIG        = 0x42534947, // "BSIG"
+    BAD_IMAGE      = 0x42494D47, // "BIMG"
+    BAD_CHKSUM     = 0x4243484B, // "BCHK"
+};
 
 static inline void caliptra_mbox_write(uint32_t offset, uint32_t data)
 {


### PR DESCRIPTION
Continuing to add APIs for Caliptra commands.

* Added makefile in examples root to provide a more abstracted build.
* Convert some defines to enum values.
* Added buffer types for commands with input/output of fixed size.
* Added buffer types for commands with input/output of variable size.
* Minimize use of typdefs for structs since they aren't being used anyway.
* Added checksum calculation routine so the user does not need to.
* Removed magic numbers, replaced with defined values.
* Mailbox Execute
  > Now transparently handles placeholder buffers for null
    arguments - this allows callers to leave fields as NULL if they aren't
    using them, rather than every caller creating an unused buffer.
  > Reorganized response handling logic to make intent clear.
* Deployed enum values for commands.
* New APIs
  > caliptra_get_idev_csr_rom
  > caliptra_get_ldev_csr_rom
  > caliptra_stash_measurement
  > caliptra_ecdsa384_signature_verify