### PR TITLE
Export caliptra_rom_run_fips_test() from the ROM to FMC/RT.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,12 +519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-rom-exports"
+version = "0.1.0"
+dependencies = [
+ "caliptra-error",
+]
+
+[[package]]
 name = "caliptra-rom-test-fmc"
 version = "0.1.0"
 dependencies = [
  "caliptra-cpu",
  "caliptra-drivers",
+ "caliptra-error",
  "caliptra-registers",
+ "caliptra-rom-exports",
  "caliptra-x509",
  "caliptra_common",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
   "image/fake-keys",
   "lms-types",
   "rom/dev",
+  "rom/dev/exports",
   "rom/dev/tools/test-fmc",
   "rom/dev/tools/test-rt",
   "test",
@@ -94,6 +95,7 @@ caliptra-image-verify = { path = "image/verify", default-features = false }
 caliptra-kat = { path = "kat" }
 caliptra-lms-types = { path = "lms-types" }
 caliptra-registers = { path = "registers" }
+caliptra-rom-exports = { path = "rom/dev/exports" }
 caliptra-runtime = { path = "runtime", default-features = false }
 caliptra-systemrdl = { path = "systemrdl" }
 caliptra-test = { path = "test" }

--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -55,6 +55,17 @@ impl Csrng {
         Self::with_seed(csrng, entropy_src, Seed::EntropySrc)
     }
 
+    /// # Safety
+    ///
+    /// The caller MUST ensure that the CSRNG peripheral is in a state where new
+    /// entropy is accessible via the generate command.
+    pub unsafe fn assume_initialized(
+        csrng: caliptra_registers::csrng::CsrngReg,
+        entropy_src: caliptra_registers::entropy_src::EntropySrcReg,
+    ) -> Self {
+        Self { csrng, entropy_src }
+    }
+
     /// Returns a handle to the CSRNG configured to use the provided [`Seed`].
     ///
     /// # Safety

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -367,6 +367,8 @@ impl CaliptraError {
     pub const ROM_GLOBAL_UNSUPPORTED_FMCALIAS_TBS_SIZE: CaliptraError =
         CaliptraError::new_const(0x01050009);
 
+    pub const ROM_GLOBAL_UNIMPLEMENTED_EXPORT: CaliptraError = CaliptraError::new_const(0x0105000a);
+
     /// ROM KAT Errors
     pub const ROM_KAT_SHA256_DIGEST_FAILURE: CaliptraError = CaliptraError::new_const(0x90010001);
     pub const ROM_KAT_SHA256_DIGEST_MISMATCH: CaliptraError = CaliptraError::new_const(0x90010002);

--- a/rom/dev/exports/Cargo.toml
+++ b/rom/dev/exports/Cargo.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-rom-exports"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+caliptra-error.workspace = true

--- a/rom/dev/exports/src/exports.ld
+++ b/rom/dev/exports/src/exports.ld
@@ -1,6 +1,6 @@
 /* Licensed under the Apache-2.0 license */
 
-caliptra_rom_unimplemented_export_2 = 0x08;
+caliptra_rom_run_fips_tests = 0x08;
 caliptra_rom_unimplemented_export_3 = 0x0c;
 caliptra_rom_unimplemented_export_4 = 0x10;
 caliptra_rom_unimplemented_export_5 = 0x14;

--- a/rom/dev/exports/src/exports.ld
+++ b/rom/dev/exports/src/exports.ld
@@ -1,0 +1,8 @@
+/* Licensed under the Apache-2.0 license */
+
+caliptra_rom_unimplemented_export_2 = 0x08;
+caliptra_rom_unimplemented_export_3 = 0x0c;
+caliptra_rom_unimplemented_export_4 = 0x10;
+caliptra_rom_unimplemented_export_5 = 0x14;
+caliptra_rom_unimplemented_export_6 = 0x18;
+caliptra_rom_unimplemented_export_7 = 0x1c;

--- a/rom/dev/exports/src/lib.rs
+++ b/rom/dev/exports/src/lib.rs
@@ -1,0 +1,46 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]
+
+use caliptra_error::{CaliptraResult, FromU32};
+
+mod c_abi {
+    // All these functions MUST have a u32 return value, as that is where the
+    // CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT error will be returned if
+    // the ROM hasn't implemented that method.
+    extern "C" {
+        pub fn caliptra_rom_unimplemented_export_2() -> u32;
+        pub fn caliptra_rom_unimplemented_export_3() -> u32;
+        pub fn caliptra_rom_unimplemented_export_4() -> u32;
+        pub fn caliptra_rom_unimplemented_export_5() -> u32;
+        pub fn caliptra_rom_unimplemented_export_6() -> u32;
+        pub fn caliptra_rom_unimplemented_export_7() -> u32;
+    }
+}
+
+// Safe wrappers
+
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_2() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_2() })
+}
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_3() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_3() })
+}
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_4() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_4() })
+}
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_5() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_5() })
+}
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_6() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_6() })
+}
+#[inline(always)]
+pub fn caliptra_rom_unimplemented_export_7() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_7() })
+}

--- a/rom/dev/exports/src/lib.rs
+++ b/rom/dev/exports/src/lib.rs
@@ -9,7 +9,7 @@ mod c_abi {
     // CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT error will be returned if
     // the ROM hasn't implemented that method.
     extern "C" {
-        pub fn caliptra_rom_unimplemented_export_2() -> u32;
+        pub fn caliptra_rom_run_fips_tests() -> u32;
         pub fn caliptra_rom_unimplemented_export_3() -> u32;
         pub fn caliptra_rom_unimplemented_export_4() -> u32;
         pub fn caliptra_rom_unimplemented_export_5() -> u32;
@@ -18,12 +18,20 @@ mod c_abi {
     }
 }
 
+/// Run all the FIPS tests implemented in the ROM. Caller is responsible for
+/// handling any errors
+///
+/// # Safety
+///
+/// Caller must confirm that all cryptographic peripherals are in an idle state
+/// and are ready to be used by the ROM.
+#[inline(always)]
+pub unsafe fn caliptra_rom_run_fips_tests() -> CaliptraResult<()> {
+    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_run_fips_tests() })
+}
+
 // Safe wrappers
 
-#[inline(always)]
-pub fn caliptra_rom_unimplemented_export_2() -> CaliptraResult<()> {
-    CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_2() })
-}
 #[inline(always)]
 pub fn caliptra_rom_unimplemented_export_3() -> CaliptraResult<()> {
     CaliptraResult::from_u32(unsafe { c_abi::caliptra_rom_unimplemented_export_3() })

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -22,6 +22,7 @@ use caliptra_drivers::{
     report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError, Ecc384, Hmac384, KeyVault,
     Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, SocIfc,
 };
+use caliptra_error::ToU32;
 use rom_env::RomEnv;
 
 #[cfg(not(feature = "std"))]
@@ -222,4 +223,10 @@ fn panic_is_possible() {
     black_box(());
     // The existence of this symbol is used to inform test_panic_missing
     // that panics are possible. Do not remove or rename this symbol.
+}
+
+#[no_mangle]
+pub extern "C" fn caliptra_rom_run_fips_tests() -> u32 {
+    let mut env = unsafe { RomEnv::assume_initialized() };
+    kat::execute_kat(&mut env).to_u32()
 }

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -83,6 +83,16 @@ impl RomEnv {
         end: ICCM_ORG + ICCM_SIZE,
     };
 
+    pub unsafe fn assume_initialized() -> Self {
+        let trng = Trng::assume_initialized(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+        );
+        Self::new_from_registers_common(trng)
+    }
+
     pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
         let trng = Trng::new(
             CsrngReg::new(),
@@ -90,8 +100,12 @@ impl RomEnv {
             SocIfcTrngReg::new(),
             &SocIfcReg::new(),
         )?;
+        Ok(Self::new_from_registers_common(trng))
+    }
 
-        Ok(Self {
+    unsafe fn new_from_registers_common(trng: Trng) -> Self {
+        // These peripherals do no initialization in their constructor
+        Self {
             doe: DeobfuscationEngine::new(DoeReg::new()),
             sha1: Sha1::default(),
             sha256: Sha256::new(Sha256Reg::new()),
@@ -107,6 +121,6 @@ impl RomEnv {
             pcr_bank: PcrBank::new(PvReg::new()),
             fht_data_store: FhtDataStore::default(),
             trng,
-        })
+        }
     }
 }

--- a/rom/dev/src/start.S
+++ b/rom/dev/src/start.S
@@ -17,6 +17,20 @@ Environment:
 --*/
 
 .section .init, "ax"
+.global _jump_table
+.option push
+.option norvc
+_jump_table:
+  j _start
+  j _start
+  j unimplemented_export
+  j unimplemented_export
+  j unimplemented_export
+  j unimplemented_export
+  j unimplemented_export
+  j unimplemented_export
+.option pop
+  
 .global _start
 _start:
    .cfi_startproc
@@ -370,3 +384,9 @@ exit_rom:
     j 1b
     .cfi_endproc
 
+.align 2
+.global unimplemented_export
+unimplemented_export:
+    // Error code: ROM_GLOBAL_unimplemented_export
+    li a0, 0x0105000a
+    ret

--- a/rom/dev/src/start.S
+++ b/rom/dev/src/start.S
@@ -23,7 +23,7 @@ Environment:
 _jump_table:
   j _start
   j _start
-  j unimplemented_export
+  j caliptra_rom_run_fips_tests
   j unimplemented_export
   j unimplemented_export
   j unimplemented_export

--- a/rom/dev/test-fw/asm_tests.rs
+++ b/rom/dev/test-fw/asm_tests.rs
@@ -16,6 +16,7 @@ mod exception;
 mod print;
 
 use caliptra_drivers::ExitCtrl;
+use caliptra_error::CaliptraError;
 
 #[no_mangle]
 #[inline(never)]
@@ -116,4 +117,9 @@ pub extern "C" fn rom_entry() -> ! {
     }
 
     ExitCtrl::exit(0)
+}
+
+#[no_mangle]
+pub extern "C" fn caliptra_rom_run_fips_tests() -> u32 {
+    CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT.into()
 }

--- a/rom/dev/tests/test_exports.rs
+++ b/rom/dev/tests/test_exports.rs
@@ -1,0 +1,77 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{FwId, APP_WITH_UART, ROM_WITH_UART};
+use caliptra_common::RomBootStatus;
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams};
+use zerocopy::FromBytes;
+
+fn run_exported_func(hw: &mut DefaultHwModel, command_id: u32) -> u32 {
+    u32::read_from(
+        hw.mailbox_execute(command_id, &[])
+            .unwrap()
+            .unwrap()
+            .as_slice(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_exports() {
+    const TEST_FMC: FwId = FwId {
+        crate_name: "caliptra-rom-test-fmc",
+        bin_name: "caliptra-rom-test-fmc",
+        features: &["emu", "interactive_test_fmc"],
+        workspace_dir: None,
+    };
+
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .unwrap();
+
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&TEST_FMC, &APP_WITH_UART, Default::default())
+            .unwrap();
+
+    hw.upload_firmware(&image_bundle.to_bytes().unwrap())
+        .unwrap();
+
+    hw.step_until_boot_status(RomBootStatus::ColdResetComplete.into(), true);
+
+    //caliptra_rom_unimplemented_export_2
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0002),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+    //caliptra_rom_unimplemented_export_3
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0003),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+    //caliptra_rom_unimplemented_export_4
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0004),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+    //caliptra_rom_unimplemented_export_5
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0005),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+    //caliptra_rom_unimplemented_export_6
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0006),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+    //caliptra_rom_unimplemented_export_7
+    assert_eq!(
+        run_exported_func(&mut hw, 0x1001_0007),
+        u32::from(CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_EXPORT)
+    );
+}

--- a/rom/dev/tools/test-fmc/Cargo.toml
+++ b/rom/dev/tools/test-fmc/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2021"
 caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
+caliptra-error.workspace = true
 caliptra-registers.workspace = true
+caliptra-rom-exports.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
 ufmt.workspace = true
 ureg.workspace = true

--- a/rom/dev/tools/test-fmc/src/fmc.ld
+++ b/rom/dev/tools/test-fmc/src/fmc.ld
@@ -16,6 +16,7 @@ OUTPUT_ARCH(riscv)
 OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv", "elf32-littleriscv")
 ENTRY(_start)
 
+INCLUDE "../../../../../../rom/dev/exports/src/exports.ld"
 
 ICCM_ORG         = 0x40000000;
 DCCM_ORG         = 0x50000000;

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -22,7 +22,13 @@ use caliptra_common::{FuseLogEntry, FuseLogEntryId};
 use caliptra_common::{PcrLogEntry, PcrLogEntryId};
 use caliptra_drivers::ColdResetEntry4::*;
 use caliptra_drivers::{DataVault, Mailbox};
+use caliptra_error::ToU32;
 use caliptra_registers::dv::DvReg;
+use caliptra_rom_exports::{
+    caliptra_rom_unimplemented_export_2, caliptra_rom_unimplemented_export_3,
+    caliptra_rom_unimplemented_export_4, caliptra_rom_unimplemented_export_5,
+    caliptra_rom_unimplemented_export_6, caliptra_rom_unimplemented_export_7,
+};
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, LocalDevIdCertTbs};
 use core::ptr;
 use ureg::RealMmioMut;
@@ -217,6 +223,48 @@ fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMm
         }
         0x1000_0005 => {
             read_datavault_coldresetentry4(mbox);
+        }
+        0x1001_0002 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_2().to_u32().as_bytes(),
+                true,
+            );
+        }
+        0x1001_0003 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_3().to_u32().as_bytes(),
+                true,
+            );
+        }
+        0x1001_0004 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_4().to_u32().as_bytes(),
+                true,
+            );
+        }
+        0x1001_0005 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_5().to_u32().as_bytes(),
+                true,
+            );
+        }
+        0x1001_0006 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_6().to_u32().as_bytes(),
+                true,
+            );
+        }
+        0x1001_0007 => {
+            send_to_mailbox(
+                mbox,
+                caliptra_rom_unimplemented_export_7().to_u32().as_bytes(),
+                true,
+            );
         }
         _ => {}
     }

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -25,7 +25,7 @@ use caliptra_drivers::{DataVault, Mailbox};
 use caliptra_error::ToU32;
 use caliptra_registers::dv::DvReg;
 use caliptra_rom_exports::{
-    caliptra_rom_unimplemented_export_2, caliptra_rom_unimplemented_export_3,
+    caliptra_rom_run_fips_tests, caliptra_rom_unimplemented_export_3,
     caliptra_rom_unimplemented_export_4, caliptra_rom_unimplemented_export_5,
     caliptra_rom_unimplemented_export_6, caliptra_rom_unimplemented_export_7,
 };
@@ -227,7 +227,7 @@ fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMm
         0x1001_0002 => {
             send_to_mailbox(
                 mbox,
-                caliptra_rom_unimplemented_export_2().to_u32().as_bytes(),
+                unsafe { caliptra_rom_run_fips_tests().to_u32().as_bytes() },
                 true,
             );
         }


### PR DESCRIPTION
This PR creates a 6-entry jump table in the ROM. When mutable firmware tries to call a unimplemented exported function, it will return the CaliptraError::ROM_GLOBAL_UNIMPLEMENTED_ENTRY_POINT error.

Only the first entry is implemented, with this symbol: 

```
pub fn caliptra_rom_run_fips_tests() -> u32
```