### PR TITLE
Update caliptra-file-header-fix instructions.

### DIFF
--- a/ci-tools/file-header-fix.sh
+++ b/ci-tools/file-header-fix.sh
@@ -1,0 +1,7 @@
+# Licensed under the Apache-2.0 license
+
+#!/bin/bash
+set -e
+cd $(dirname "$0")
+cd ..
+cargo run -p caliptra-file-header-fix -- "$@"

--- a/ci-tools/file-header-fix/README.md
+++ b/ci-tools/file-header-fix/README.md
@@ -13,7 +13,7 @@ $ touch foo.rs bar.rs
 $ cargo run -p caliptra-file-header-fix -- --check
 File "./bar.rs" doesn't contain "Licensed under the Apache-2.0 license" in the first 3 lines
 File "./foo.rs" doesn't contain "Licensed under the Apache-2.0 license" in the first 3 lines
-To fix, run "cargo run --bin caliptra-file-header-fix" in the workspace directory.
+To fix, run \"ci-tools/file-header-fix.sh\" from the repo root.
 $ echo $?
 2
 ```

--- a/ci-tools/file-header-fix/src/main.rs
+++ b/ci-tools/file-header-fix/src/main.rs
@@ -7,11 +7,12 @@ use std::{
 };
 
 const REQUIRED_TEXT: &str = "Licensed under the Apache-2.0 license";
-const EXTENSIONS: &[&str] = &["rs", "h", "c", "cpp", "cc", "toml", "sh", "py", "ld"];
+const EXTENSIONS: &[&str] = &["rs", "h", "c", "cpp", "cc", "toml", "sh", "py", "ld", "go"];
 
 const IGNORED_PATHS: &[&str] = &[
     // BSD-licensed
     "./sw-emulator/compliance-test/target-files/link.ld",
+    "./runtime/dpe",
 ];
 
 const IGNORED_DIRS: &[&str] = &[".git", "caliptra-rtl", "out", "target"];
@@ -119,7 +120,7 @@ fn main() {
         }
     }
     if failed {
-        println!("To fix, run \"cargo run --bin file-header-fix\" in the workspace directory.");
+        println!("To fix, run \"ci-tools/file-header-fix.sh\" from the repo root.");
         std::process::exit(2);
     }
 }

--- a/ci-tools/file-header-fix/tests/integration_test.rs
+++ b/ci-tools/file-header-fix/tests/integration_test.rs
@@ -41,7 +41,7 @@ fn test_check_only_failure() {
     assert_eq!(std::str::from_utf8(&out.stdout), Ok(
         "File \"./foo.rs\" doesn't contain \"Licensed under the Apache-2.0 license\" in the first 3 lines\n\
          File \"./scripts/foo.sh\" doesn't contain \"Licensed under the Apache-2.0 license\" in the first 3 lines\n\
-         To fix, run \"cargo run --bin file-header-fix\" in the workspace directory.\n"));
+         To fix, run \"ci-tools/file-header-fix.sh\" from the repo root.\n"));
 
     // Make sure it didn't rewrite
     assert_eq!(tmp_dir.read("foo.rs"), "#![no_std]\n");
@@ -71,7 +71,7 @@ fn test_check_only_success() {
 
 #[test]
 fn test_fix() {
-    let tmp_dir = TmpDir::new("caliptra-file-header-fix").unwrap();
+    let tmp_dir = TmpDir::new("caliptra-file-header-fix-test").unwrap();
     tmp_dir.write("ignore.txt", "Hi!");
     tmp_dir.write("target/bar/foo.rs", "Ignore Me!");
     tmp_dir.write("hello.rs", "/* Licensed under the Apache-2.0 license. */\n");


### PR DESCRIPTION
As part of this, create a shell script so that the same "fix instructions" are valid from other caliptra repos.

Also, don't descend into the caliptra/dpe submodule if it exists, as that makes a mess.

Also, add .go to the list of checked file extensions (needed for caliptra-dpe).
