### PR TITLE
Wycheproof: hmac

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -288,6 +288,7 @@ impl CaliptraError {
     pub const RUNTIME_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000E000B);
     pub const RUNTIME_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x000E000C);
     pub const RUNTIME_GLOBAL_PANIC: CaliptraError = CaliptraError::new_const(0x000E000D);
+    pub const RUNTIME_HMAC_VERIFY_FAILED: CaliptraError = CaliptraError::new_const(0x000E000E);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/src/mailbox_api.rs
+++ b/runtime/src/mailbox_api.rs
@@ -14,6 +14,7 @@ impl CommandId {
     pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
     pub const FW_INFO: Self = Self(0x494E464F); // "INFO"
+    pub const TEST_ONLY_HMAC384_VERIFY: Self = Self(0x484D4143); // "HMAC"
 
     // TODO: Remove this and merge with GET_LDEV_CERT once that is implemented
     pub const TEST_ONLY_GET_LDEV_CERT: Self = Self(0x4345524c); // "CERL"
@@ -167,6 +168,18 @@ pub struct EcdsaVerifyReq {
     pub pub_key_y: [u8; 48],
     pub signature_r: [u8; 48],
     pub signature_s: [u8; 48],
+}
+// No command-specific output args
+
+// TEST_ONLY_HMAC384_SIGNATURE_VERIFY
+#[repr(C)]
+#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+pub struct HmacVerifyReq {
+    pub hdr: MailboxReqHeader,
+    pub key: [u8; 48],
+    pub tag: [u8; 48],
+    pub len: u32,
+    pub msg: [u8; 256],
 }
 // No command-specific output args
 

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -1,9 +1,18 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(feature = "test_only_commands")]
+use crate::HmacVerifyReq;
 use crate::{Drivers, EcdsaVerifyReq, MailboxResp};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Signature,
+};
+
+#[cfg(feature = "test_only_commands")]
+use caliptra_drivers::{Hmac384Data, Hmac384Key, Trng};
+#[cfg(feature = "test_only_commands")]
+use caliptra_registers::{
+    csrng::CsrngReg, entropy_src::EntropySrcReg, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 use zerocopy::FromBytes;
 
@@ -31,6 +40,48 @@ impl EcdsaVerifyCmd {
             let success = drivers.ecdsa.verify(&pubkey, &digest, &sig)?;
             if success != Ecc384Result::Success {
                 return Err(CaliptraError::RUNTIME_ECDSA_VERIFY_FAILED);
+            }
+        } else {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        };
+
+        Ok(MailboxResp::default())
+    }
+}
+
+/// Handle the `TEST_ONLY_HMAC_SHA384_VERIFY` mailbox command
+#[cfg(feature = "test_only_commands")]
+pub struct HmacVerifyCmd;
+#[cfg(feature = "test_only_commands")]
+impl HmacVerifyCmd {
+    #[cfg(feature = "test_only_commands")]
+    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        if let Some(cmd) = HmacVerifyReq::read_from(cmd_args) {
+            let key = Array4x12::from(cmd.key);
+            let key = Hmac384Key::from(&key);
+            let mut out_tag = Array4x12::default();
+            let Ok(len) = usize::try_from(cmd.len) else {
+                return Err(CaliptraError::RUNTIME_HMAC_VERIFY_FAILED);
+            };
+            if len > cmd.msg.len() {
+                return Err(CaliptraError::RUNTIME_HMAC_VERIFY_FAILED);
+            }
+            let data = Hmac384Data::from(&cmd.msg[0..len]);
+            let mut trng = unsafe {
+                Trng::new(
+                    CsrngReg::new(),
+                    EntropySrcReg::new(),
+                    SocIfcTrngReg::new(),
+                    &SocIfcReg::new(),
+                )
+            }?;
+
+            drivers
+                .hmac
+                .hmac(&key, &data, &mut trng, (&mut out_tag).into())?;
+
+            if out_tag != Array4x12::from(cmd.tag) {
+                return Err(CaliptraError::RUNTIME_HMAC_VERIFY_FAILED);
             }
         } else {
             return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);

--- a/runtime/tests/hmac.rs
+++ b/runtime/tests/hmac.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache-2.0 license.
+pub mod common;
+
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::{CommandId, HmacVerifyReq, MailboxReqHeader, MailboxRespHeader};
+use common::run_rt_test;
+use zerocopy::{AsBytes, FromBytes};
+
+#[test]
+fn hmac_cmd_run_wycheproof() {
+    let mut model = run_rt_test(None);
+
+    model
+        .step_until_output_contains("Caliptra RT listening for mailbox commands...")
+        .unwrap();
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct WycheproofResults {
+        id: usize,
+        comment: String,
+    }
+
+    // Collect all the errors and print at the end
+    let mut wyche_fail: Vec<WycheproofResults> = Vec::new();
+    let mut wyche_ran: Vec<WycheproofResults> = Vec::new();
+    let test_set = wycheproof::mac::TestSet::load(wycheproof::mac::TestName::HmacSha384).unwrap();
+
+    for test_groups in test_set.test_groups {
+        for test in &test_groups.tests {
+            // The mailbox is only implemented for keys and tags of 384 bits
+            if test.key.len() != 48 || test.tag.len() != 48 {
+                continue;
+            }
+            wyche_ran.push(WycheproofResults {
+                id: test.tc_id,
+                comment: test.comment.to_string(),
+            });
+            let mut msg = [0; 256];
+            msg[..test.msg.len()].copy_from_slice(test.msg.as_slice());
+            let cmd = HmacVerifyReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                key: test.key[..].try_into().unwrap(),
+                tag: test.tag[..].try_into().unwrap(),
+                len: test.msg.len().try_into().unwrap(),
+                msg,
+            };
+            let checksum = caliptra_common::checksum::calc_checksum(
+                u32::from(CommandId::TEST_ONLY_HMAC384_VERIFY),
+                &cmd.as_bytes()[4..],
+            );
+            let cmd = HmacVerifyReq {
+                hdr: MailboxReqHeader { chksum: checksum },
+                ..cmd
+            };
+            let resp = model.mailbox_execute(
+                u32::from(CommandId::TEST_ONLY_HMAC384_VERIFY),
+                cmd.as_bytes(),
+            );
+            match test.result {
+                wycheproof::TestResult::Valid | wycheproof::TestResult::Acceptable => match resp {
+                    Err(_) | Ok(None) => {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                    Ok(Some(resp)) => {
+                        // Verify the checksum and FIPS status
+                        let resp_hdr = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
+                        assert_eq!(
+                            resp_hdr.fips_status,
+                            MailboxRespHeader::FIPS_STATUS_APPROVED
+                        );
+                        // Checksum is just going to be 0 because FIPS_STATUS_APPROVED is 0
+                        assert_eq!(resp_hdr.chksum, 0);
+                    }
+                },
+                wycheproof::TestResult::Invalid => {
+                    if resp.is_ok() {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    println!("Executed wycheproof tests:\n{:#?}", wyche_ran);
+    if !wyche_fail.is_empty() {
+        panic!(
+            "Number of failed tests {}:\n{:#?}",
+            wyche_fail.len(),
+            wyche_fail
+        );
+    }
+}

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -128,7 +128,7 @@ fn test_fw_info() {
 }
 
 #[test]
-fn test_verify_cmd() {
+fn test_ecdsa_verify_cmd() {
     let mut model = run_rom_test("mbox");
 
     model.step_until(|m| {


### PR DESCRIPTION
This implements:
- A test mailbox command to verify HMAC
- Running hmac sha384 tests over the test HMAC mailbox

