### PR TITLE
runtime/test: Implement wycheproof vectors test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +564,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "openssl",
  "ufmt",
+ "wycheproof",
  "zerocopy",
 ]
 
@@ -2062,6 +2069,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wycheproof"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e639f57253b80c6584b378011aec0fed61c4c21d7a4b97c4d9d7eaf35ca77d12"
+dependencies = [
+ "base64",
+ "hex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ ureg = { path = "ureg" }
 ureg-codegen = { path = "ureg/lib/codegen" }
 ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
+wycheproof = "0.5.1"
 zerocopy = "0.6.1"
 
 [profile.firmware]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ caliptra-image-gen.workspace = true
 caliptra-image-openssl.workspace = true
 caliptra-image-serde.workspace = true
 openssl.workspace = true
+wycheproof.workspace = true
 
 [features]
 default = ["std", "test_only_commands"]


### PR DESCRIPTION
Use wycheproof crate to run test vectors. The design of the mailbox (fixed length input for key and signature) limit the amount of tests that can meaningfully be ran on in the mailbox so those tests are skipped.

The openssl crate has some troubles with parsing DER. Those tests are skipped for now with a whitelist.