### PR TITLE
Add Trng::assume_init() function.

### DIFF
--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -55,6 +55,17 @@ impl Csrng {
         Self::with_seed(csrng, entropy_src, Seed::EntropySrc)
     }
 
+    /// # Safety
+    ///
+    /// The caller MUST ensure that the CSRNG peripheral is in a state where new
+    /// entropy is accessible via the generate command.
+    pub unsafe fn assume_initialized(
+        csrng: caliptra_registers::csrng::CsrngReg,
+        entropy_src: caliptra_registers::entropy_src::EntropySrcReg,
+    ) -> Self {
+        Self { csrng, entropy_src }
+    }
+
     /// Returns a handle to the CSRNG configured to use the provided [`Seed`].
     ///
     /// # Safety


### PR DESCRIPTION
This unsafe function can be used to create a Trng if the caller is certain Trng::new() has previously been called.