### PR TITLE
Remove Csrng::drop().

### DIFF
--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -160,10 +160,8 @@ impl Csrng {
             specific: e.alert_fail_counts().read(),
         }
     }
-}
 
-impl Drop for Csrng {
-    fn drop(&mut self) {
+    pub fn uninstantiate(mut self) {
         let _ = send_command(&mut self.csrng, Command::Uninstantiate);
     }
 }

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -127,6 +127,11 @@ path = "src/bin/csrng_tests.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "csrng2"
+path = "src/bin/csrng_tests2.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "trng_driver_responder"
 path = "src/bin/trng_driver_responder.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/csrng_tests2.rs
+++ b/drivers/test-fw/src/bin/csrng_tests2.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]
+#![no_main]
+
+use core::num::NonZeroUsize;
+
+use caliptra_drivers::Csrng;
+use caliptra_registers::{csrng::CsrngReg, entropy_src::EntropySrcReg};
+use caliptra_test_harness::test_suite;
+
+fn test_assume_initialized() {
+    let csrng_reg = unsafe { CsrngReg::new() };
+    let entropy_src_reg = unsafe { EntropySrcReg::new() };
+
+    let mut csrng0 = Csrng::new(csrng_reg, entropy_src_reg).expect("construct CSRNG");
+
+    let one = NonZeroUsize::new(1).unwrap();
+
+    assert_eq!(csrng0.generate(one).unwrap().next().unwrap(), 0x15eb2a44);
+
+    {
+        let mut csrng1 =
+            unsafe { Csrng::assume_initialized(CsrngReg::new(), EntropySrcReg::new()) };
+
+        assert_eq!(csrng1.generate(one).unwrap().next().unwrap(), 0xb5848d3a);
+    }
+
+    assert_eq!(csrng0.generate(one).unwrap().next().unwrap(), 0x22a79509);
+}
+
+test_suite! {
+    test_assume_initialized,
+}


### PR DESCRIPTION
Csrng::assume_initialized() isn't very useful when the Csrng is uninstantiated when it is dropped. Replace drop with an explicit method.