### PR TITLE
FMC : Log PCR extensions to the PCR_Log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "caliptra_common",
  "cfg-if 1.0.0",
  "ufmt",
+ "ureg",
  "zerocopy",
 ]
 

--- a/common/src/pcr.rs
+++ b/common/src/pcr.rs
@@ -34,6 +34,8 @@ pub enum PcrLogEntryId {
     FmcFuseSvn = 9,            // data size = 1 byte
     LmsVendorPubKeyIndex = 10, // data size = 1 byte
     RomVerifyConfig = 11,      // data size = 1 byte
+    RtTci = 12,                // data size = 48 bytes
+    ManifestDigest = 13,       // data size = 48 bytes
 }
 
 impl From<u16> for PcrLogEntryId {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -299,6 +299,9 @@ impl CaliptraError {
     pub const FMC_RT_ALIAS_TBS_SIZE_EXCEEDED: CaliptraError = CaliptraError::new_const(0x000F0007);
     pub const FMC_CDI_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0008);
     pub const FMC_ALIAS_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0009);
+    pub const FMC_PCR_LOG_INVALID_ENTRY_ID: CaliptraError = CaliptraError::new_const(0x000F000A);
+    pub const FMC_PCR_LOG_UNSUPPORTED_DATA_LENGTH: CaliptraError =
+        CaliptraError::new_const(0x000F000B);
 
     /// TRNG_EXT Errors
     pub const DRIVER_TRNG_EXT_TIMEOUT: CaliptraError = CaliptraError::new_const(0x00100001);

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -23,9 +23,30 @@ Note:
 use crate::flow::tci::Tci;
 use crate::fmc_env::FmcEnv;
 use crate::HandOff;
-use caliptra_drivers::{okref, CaliptraResult, PcrId};
+use caliptra_drivers::{okref, CaliptraError, CaliptraResult, PcrBank, PcrId, Sha384};
 
-use caliptra_common::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
+use caliptra_common::{
+    memory_layout::{PCR_LOG_ORG, PCR_LOG_SIZE},
+    PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR,
+};
+use zerocopy::AsBytes;
+
+struct PcrExtender<'a> {
+    pcr_bank: &'a mut PcrBank,
+    sha384: &'a mut Sha384,
+}
+impl PcrExtender<'_> {
+    fn extend(
+        &mut self,
+        pcr_id: PcrId,
+        bytes: &[u8],
+        pcr_entry_id: PcrLogEntryId,
+    ) -> CaliptraResult<()> {
+        self.pcr_bank
+            .extend_pcr(PcrId::PcrId0, self.sha384, bytes)?;
+        log_pcr(pcr_entry_id, pcr_id, bytes)
+    }
+}
 
 /// Extend current PCR
 ///
@@ -56,16 +77,62 @@ pub fn extend_journey_pcr(env: &mut FmcEnv, hand_off: &HandOff) -> CaliptraResul
 /// * `env` - FMC Environment
 /// * `pcr_id` - PCR slot to extend the data into
 fn extend_pcr_common(env: &mut FmcEnv, hand_off: &HandOff, pcr_id: PcrId) -> CaliptraResult<()> {
-    // Extend RT TCI (Hash over runtime code)
-    let rt_tci = Tci::rt_tci(env, hand_off);
-    let rt_tci: [u8; 48] = okref(&rt_tci)?.into();
-    env.pcr_bank.extend_pcr(pcr_id, &mut env.sha384, &rt_tci)?;
-
-    // Extend FW Image Manifest
     let manifest_digest = Tci::image_manifest_digest(env, hand_off);
     let manifest_digest: [u8; 48] = okref(&manifest_digest)?.into();
-    env.pcr_bank
-        .extend_pcr(pcr_id, &mut env.sha384, &manifest_digest)?;
+
+    // Extend RT TCI (Hash over runtime code)
+    let rt_tci = Tci::rt_tci(env, hand_off);
+    let rt_tci_bytes: [u8; 48] = okref(&rt_tci)?.into();
+
+    let mut extender = PcrExtender {
+        pcr_bank: &mut env.pcr_bank,
+        sha384: &mut env.sha384,
+    };
+
+    extender.extend(pcr_id, &rt_tci_bytes, PcrLogEntryId::RtTci)?;
+
+    // Extend FW Image Manifest
+    extender.extend(pcr_id, &manifest_digest, PcrLogEntryId::ManifestDigest)?;
+
+    Ok(())
+}
+
+/// Log PCR data
+///
+/// # Arguments
+/// * `pcr_entry_id` - PCR log entry ID
+/// * `pcr_id` - PCR ID
+/// * `data` - PCR data
+///
+/// # Return Value
+/// * `Ok(())` - Success
+/// * `Err(GlobalErr::PcrLogInvalidEntryId)` - Invalid PCR log entry ID
+/// * `Err(GlobalErr::PcrLogUpsupportedDataLength)` - Unsupported data length
+///
+pub fn log_pcr(pcr_entry_id: PcrLogEntryId, pcr_id: PcrId, data: &[u8]) -> CaliptraResult<()> {
+    if pcr_entry_id == PcrLogEntryId::Invalid {
+        return Err(CaliptraError::FMC_PCR_LOG_INVALID_ENTRY_ID);
+    }
+
+    if data.len() > 48 {
+        return Err(CaliptraError::FMC_PCR_LOG_UNSUPPORTED_DATA_LENGTH);
+    }
+
+    // Create a PCR log entry
+    let mut pcr_log_entry = PcrLogEntry {
+        id: pcr_entry_id as u16,
+        pcr_id: pcr_id as u16,
+        ..Default::default()
+    };
+    pcr_log_entry.pcr_data.as_bytes_mut()[..data.len()].copy_from_slice(data);
+
+    let dst: &mut [PcrLogEntry] = unsafe {
+        let ptr = PCR_LOG_ORG as *mut PcrLogEntry;
+        core::slice::from_raw_parts_mut(ptr, PCR_LOG_SIZE / core::mem::size_of::<PcrLogEntry>())
+    };
+
+    // Store the log entry.
+    dst[pcr_entry_id as usize - 1] = pcr_log_entry;
 
     Ok(())
 }

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -11,6 +11,7 @@ caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
 ufmt.workspace = true
+ureg.workspace = true
 zerocopy.workspace = true
 
 [build-dependencies]

--- a/fmc/tests/test_rtalias.rs
+++ b/fmc/tests/test_rtalias.rs
@@ -1,6 +1,11 @@
 // Licensed under the Apache-2.0 license
 use caliptra_builder::{FwId, ImageOptions, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_common::keyids::{KEY_ID_RT_CDI, KEY_ID_RT_PRIV_KEY};
+use caliptra_common::FirmwareHandoffTable;
+use caliptra_common::HandOffDataHandle;
+use caliptra_common::Vault;
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
+use zerocopy::{AsBytes, FromBytes};
 
 const RT_ALIAS_DERIVED_CDI_COMPLETE: u32 = 0x400;
 const RT_ALIAS_KEY_PAIR_DERIVATION_COMPLETE: u32 = 0x401;
@@ -8,6 +13,15 @@ const RT_ALIAS_SUBJ_ID_SN_GENERATION_COMPLETE: u32 = 0x402;
 const RT_ALIAS_SUBJ_KEY_ID_GENERATION_COMPLETE: u32 = 0x403;
 const RT_ALIAS_CERT_SIG_GENERATION_COMPLETE: u32 = 0x404;
 const RT_ALIAS_DERIVATION_COMPLETE: u32 = 0x405;
+
+/// The FMC CDI is stored in a 32-bit DataVault sticky register.
+const fn rt_cdi_store() -> HandOffDataHandle {
+    HandOffDataHandle(((Vault::KeyVault as u32) << 12) | KEY_ID_RT_CDI as u32)
+}
+
+const fn rt_priv_key_store() -> HandOffDataHandle {
+    HandOffDataHandle(((Vault::KeyVault as u32) << 12) | KEY_ID_RT_PRIV_KEY as u32)
+}
 
 #[test]
 fn test_boot_status_reporting() {
@@ -46,4 +60,44 @@ fn test_boot_status_reporting() {
 
     let mut output = vec![];
     hw.copy_output_until_exit_success(&mut output).unwrap();
+}
+
+#[test]
+fn test_fht_update() {
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+
+    pub const MOCK_RT_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-fmc-mock-rt",
+        bin_name: "caliptra-fmc-mock-rt",
+        features: &["emu"],
+        workspace_dir: None,
+    };
+
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let result = hw.mailbox_execute(0x1000_0003, &[]);
+    assert!(result.is_ok());
+
+    let data = result.unwrap().unwrap();
+    let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+
+    assert_eq!(fht.rt_cdi_kv_hdl, rt_cdi_store());
+    assert_eq!(fht.rt_priv_key_kv_hdl, rt_priv_key_store());
+
+    // [TODO] Expand test to validate additional FHT fields.
 }


### PR DESCRIPTION
FMC appends to the PCR log in DCCM, to enhance testability. 