### PR TITLE
Move DPE submodule to root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 	path = hw-latest/caliptra-rtl
 	url = https://github.com/chipsalliance/caliptra-rtl
 	branch = main
-[submodule "runtime/dpe"]
-	path = runtime/dpe
+[submodule "dpe"]
+	path = dpe
 	url = https://github.com/chipsalliance/caliptra-dpe.git
 	branch = main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 exclude = [
   # Uses a custom .cargo/config
   "sw-emulator/example",
+  "dpe/*",
 ]
 
 members = [


### PR DESCRIPTION
If (1) Crate A is in a workspace and (2) Crate B is in a subdirectory of a crate A, then Crate B cannot be excluded from the workspace. This causes some problems when trying to build DPE from within the workspace.

Move the DPE submodule out from under runtime so that it can be excluded.