### PR TITLE
Create enums for statuses and opcodes

### DIFF
--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -109,16 +109,13 @@ int caliptra_bootfsm_go()
  */
 static int caliptra_mailbox_write_fifo(struct caliptra_buffer *buffer)
 {
-    // Check against max size
-    const uint32_t MBOX_SIZE = (128u * 1024u);
-
     // Check if buffer is not null.
     if (buffer == NULL)
     {
         return -EINVAL;
     }
 
-    if (buffer->len > MBOX_SIZE)
+    if (buffer->len > CALIPTRA_MAILBOX_MAX_SIZE)
     {
         return -EINVAL;
     }
@@ -303,8 +300,7 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
     if (fw_buffer == NULL)
         return -EINVAL;
 
-    const uint32_t FW_LOAD_CMD_OPCODE = 0x46574C44u;
-    return caliptra_mailbox_execute(FW_LOAD_CMD_OPCODE, fw_buffer, NULL);
+    return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL);
 }
 
 /**
@@ -322,7 +318,6 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
     if (version == NULL)
         return -EINVAL;
 
-    uint32_t FIPS_VERSION_OPCODE = 0x46505652;
     // TODO: Remove this with the new caliptra API changes that add checksum support
     int32_t checksum = 318;
 
@@ -335,5 +330,5 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
         .len = sizeof(struct caliptra_fips_version),
     };
 
-    return caliptra_mailbox_execute(FIPS_VERSION_OPCODE, &in_buf, &out_buf);
+    return caliptra_mailbox_execute(OP_FIPS_VERSION, &in_buf, &out_buf);
 }

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -1,6 +1,44 @@
 // Licensed under the Apache-2.0 license
 #pragma once
 
+#define CALIPTRA_MAILBOX_MAX_SIZE (128u * 1024u)
+
+enum caliptra_mailbox_status {
+    CALIPTRA_MBOX_STATUS_BUSY         = 0,
+    CALIPTRA_MBOX_STATUS_DATA_READY   = 1,
+    CALIPTRA_MBOX_STATUS_CMD_COMPLETE = 2,
+    CALIPTRA_MBOX_STATUS_CMD_FAILURE  = 3,
+};
+
+enum caliptra_mailbox_fsm_states {
+    CALIPTRA_MBOX_STATUS_FSM_IDLE           = 0,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_CMD  = 1,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DATA = 2,
+    CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DLEN = 3,
+    CALIPTRA_MBOX_STATUS_FSM_EXECUTE_SOC    = 4,
+    CALIPTRA_MBOX_STATUS_FSM_EXECUTE_UC     = 6,
+};
+
+enum mailbox_commands {
+    OP_CALIPTRA_FW_LOAD          = 0x46574C44, // "FWLD"
+    OP_GET_IDEV_CSR              = 0x49444556, // "IDEV"
+    OP_GET_LDEV_CERT             = 0x4C444556, // "LDEV"
+    OP_ECDSA384_SIGNATURE_VERIFY = 0x53494756, // "SIGV"
+    OP_STASH_MEASUREMENT         = 0x4D454153, // "MEAS"
+    OP_DISABLE_ATTESTATION       = 0x4453424C, // "DSBL"
+    OP_INVOKE_DPE_COMMAND        = 0x44504543, // "DPEC"
+    OP_FIPS_VERSION              = 0x46505652, // "FPVR"
+};
+
+enum mailbox_results {
+    SUCCESS        = 0x00000000,
+    BAD_VENDOR_SIG = 0x56534947, // "VSIG"
+    BAD_OWNER_SIG  = 0x4F534947, // "OSIG"
+    BAD_SIG        = 0x42534947, // "BSIG"
+    BAD_IMAGE      = 0x42494D47, // "BIMG"
+    BAD_CHKSUM     = 0x4243484B, // "BCHK"
+};
+
 /**
  * Mailbox helper functions
  *
@@ -9,19 +47,6 @@
  * TODO: Investigate interrupts for notification on mailbox
  *       command completion.
  */
-
-#define CALIPTRA_MBOX_STATUS_BUSY               0
-#define CALIPTRA_MBOX_STATUS_DATA_READY         1
-#define CALIPTRA_MBOX_STATUS_CMD_COMPLETE       2
-#define CALIPTRA_MBOX_STATUS_CMD_FAILURE        3
-
-#define CALIPTRA_MBOX_STATUS_FSM_IDLE           0
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_CMD  1
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DATA 2
-#define CALIPTRA_MBOX_STATUS_FSM_READY_FOR_DLEN 3
-#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_SOC    4
-#define CALIPTRA_MBOX_STATUS_FSM_EXECUTE_UC     6
-
 static inline void caliptra_mbox_write(uint32_t offset, uint32_t data)
 {
     caliptra_write_u32((offset + CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR), data);


### PR DESCRIPTION
This consolidates statuses, constants, and opcodes into the mailbox header and packs related values, including opcodes, into enums.

Part of a breakup of #570 