### PR TITLE
Makefile updates for libcaliptra

### DIFF
--- a/libcaliptra/Makefile
+++ b/libcaliptra/Makefile
@@ -1,5 +1,8 @@
 Q=@
 
+CC=$(CROSS_COMPILE)gcc
+AR=$(CROSS_COMPILE)ar
+
 ifneq ($(MAKECMDGOALS),clean)
 ifndef RTL_SOC_IFC_INCLUDE_PATH
 $(error RTL_SOC_IFC_INCLUDE_PATH must be defined and point to a location where caliptra_top_reg.h can be found)
@@ -16,7 +19,7 @@ INCLUDES += -Iinc
 
 $(LIBCALIPTRA): $(OBJS)
 	@echo [AR] $@
-	$(Q)ar -cq $@ $(OBJS)
+	$(Q)$(AR) -cq $@ $(OBJS)
 
 %.o: %.c
 	@echo [CC] $< \-\> $@

--- a/libcaliptra/README.md
+++ b/libcaliptra/README.md
@@ -29,6 +29,8 @@ To compile the API, the following must be provided:
 
 Run `make RTL_SOC_IFC_INCLUDE_PATH=<path>` to generate libcaliptra.a
 
+Run `make CROSS_COMPILE=<prefix> RTL_SOC_IFC_INCLUDE_PATH=<path>` to cross compile libcaliptra.a for a different target.
+
 ## Link
 
 To link the API, the following must be provided:

--- a/libcaliptra/examples/Makefile
+++ b/libcaliptra/examples/Makefile
@@ -1,0 +1,17 @@
+Q=@
+
+CROSS_COMPILE ?=
+
+PLAT ?= hwmodel
+
+.PHONY: all clean run 
+
+all:
+	$(Q)make CROSS_COMPILE=$(CROSS_COMPILE) -C $(PLAT)
+
+clean:
+	@echo [CLEAN] $(PLAT)
+	$(Q)make -C $(PLAT) clean
+
+run:
+	$(Q)make -C $(PLAT) run

--- a/libcaliptra/examples/README.md
+++ b/libcaliptra/examples/README.md
@@ -3,15 +3,37 @@
 In this directory you will find a basic example on how to interact with the
 Caliptra C API and adapt it to your target platform.
 
+## Build
+
+Build can be done either in this directory by naming a target, or in the individual interface example directories.
+
+In the examples root, the following is valid:
+
+`$ make`
+
+`$ make run`
+
+`$ make clean`
+
+By default, the *hwmodel* example will be built and run. By supplying:
+
+`PLAT=<target>`
+
+on the Make command line, where <target> is a directory in *examples* other than *generic*, that example will be acted upon:
+
+`$ make PLAT=hwmodel`
+
+`$ make PLAT=hwmodel run`
+
 ## Generic
 
 `generic/`
 
-The generic example contains the main() function, basic Caliptra startup, and firmware interaction.
+The generic example contains the main() function, basic Caliptra startup, and firmware interaction. This file is built by and linked in by other examples.
 
 > NOTE: The current test executes a command that is ignored by ROM and not yet implemented by firmware.
 
-## hwmodel
+## Example: hwmodel
 
 `hwmodel/`
 

--- a/libcaliptra/examples/generic/main.mk
+++ b/libcaliptra/examples/generic/main.mk
@@ -1,5 +1,8 @@
 Q=@
 
+CC=$(CROSS_COMPILE)gcc
+AR=$(CROSS_COMPILE)ar
+
 SOURCE += ../generic/main.c ../../src/caliptra_api.c
 
 LIBCALIPTRA_ROOT = ../..

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -1,5 +1,7 @@
 TARGET = hwmodel
 
+CROSS_COMPILE ?=
+
 .DEFAULT_GOAL = $(TARGET)
 
 LIBCALIPTRA_ROOT = ../../


### PR DESCRIPTION
* Added a variable-derived source for the AR step
* Added high level build step for the examples, the platform can be selected via the PLAT= variable on the make command line
* Documentation updates

Part of a breakup of #570