### PR TITLE
In sha drivers, take digest during finalize instead of init

### DIFF
--- a/drivers/src/lms.rs
+++ b/drivers/src/lms.rs
@@ -290,13 +290,13 @@ impl Lms {
         nonce: &[U32<LittleEndian>; N],
     ) -> CaliptraResult<HashValue<N>> {
         let mut digest = Array4x8::default();
-        let mut hasher = sha256_driver.digest_init(&mut digest)?;
+        let mut hasher = sha256_driver.digest_init()?;
         hasher.update(lms_identifier)?;
         hasher.update(q)?;
         hasher.update(&D_MESG.to_be_bytes())?;
         hasher.update(nonce.as_bytes())?;
         hasher.update(message)?;
-        hasher.finalize()?;
+        hasher.finalize(&mut digest)?;
         Ok(HashValue::from(digest))
     }
 
@@ -348,7 +348,7 @@ impl Lms {
             hash_block[20..22].clone_from_slice(&(i as u16).to_be_bytes());
             for j in a..upper {
                 let mut digest = Array4x8::default();
-                let mut hasher = sha256_driver.digest_init(&mut digest)?;
+                let mut hasher = sha256_driver.digest_init()?;
                 hash_block[22] = j;
                 let mut i = 23;
                 for val in tmp.0.iter().take(N) {
@@ -356,13 +356,13 @@ impl Lms {
                     i += 4;
                 }
                 hasher.update(&hash_block[0..23 + N * 4])?;
-                hasher.finalize()?;
+                hasher.finalize(&mut digest)?;
                 tmp = HashValue::<N>::from(digest);
             }
             *val = tmp;
         }
         let mut digest = Array4x8::default();
-        let mut hasher = sha256_driver.digest_init(&mut digest)?;
+        let mut hasher = sha256_driver.digest_init()?;
         hasher.update(lms_identifier)?;
         hasher.update(q)?;
         hasher.update(&D_PBLC.to_be_bytes())?;
@@ -371,7 +371,7 @@ impl Lms {
                 hasher.update(&val.to_be_bytes())?;
             }
         }
-        hasher.finalize()?;
+        hasher.finalize(&mut digest)?;
         let result = HashValue::<N>::from(digest);
         digest.0.fill(0);
         Ok(result)
@@ -420,19 +420,19 @@ impl Lms {
         }
 
         let mut digest = Array4x8::default();
-        let mut hasher = sha256_driver.digest_init(&mut digest)?;
+        let mut hasher = sha256_driver.digest_init()?;
         hasher.update(&lms_public_key.id)?;
         hasher.update(&node_num.to_be_bytes())?;
         hasher.update(&D_LEAF.to_be_bytes())?;
         for val in candidate_key.0.iter() {
             hasher.update(&val.to_be_bytes())?;
         }
-        hasher.finalize()?;
+        hasher.finalize(&mut digest)?;
         let mut temp = HashValue::<N>::from(digest);
         let mut i = 0;
         while node_num > 1 {
             let mut digest = Array4x8::default();
-            let mut hasher = sha256_driver.digest_init(&mut digest)?;
+            let mut hasher = sha256_driver.digest_init()?;
             hasher.update(&lms_public_key.id)?;
             hasher.update(&(node_num / 2).to_be_bytes())?;
             hasher.update(&D_INTR.to_be_bytes())?;
@@ -457,7 +457,7 @@ impl Lms {
                         .as_bytes(),
                 )?;
             }
-            hasher.finalize()?;
+            hasher.finalize(&mut digest)?;
             temp = HashValue::<N>::from(digest);
             node_num /= 2;
             i += 1;

--- a/drivers/src/sha1.rs
+++ b/drivers/src/sha1.rs
@@ -31,17 +31,13 @@ impl Sha1 {
     /// # Returns
     ///
     /// * `Sha1Digest` - Object representing the digest operation
-    pub fn digest_init<'a>(
-        &'a mut self,
-        digest: Sha1Digest<'a>,
-    ) -> CaliptraResult<Sha1DigestOp<'a>> {
+    pub fn digest_init(&mut self) -> CaliptraResult<Sha1DigestOp<'_>> {
         let op = Sha1DigestOp {
             sha: self,
             state: Sha1DigestState::Init,
             buf: [0u8; SHA1_BLOCK_BYTE_SIZE],
             buf_idx: 0,
             data_size: 0,
-            digest,
         };
 
         Ok(op)
@@ -200,9 +196,6 @@ pub struct Sha1DigestOp<'a> {
 
     /// Data size
     data_size: usize,
-
-    /// Digest
-    digest: Sha1Digest<'a>,
 }
 
 impl<'a> Sha1DigestOp<'a> {
@@ -244,7 +237,7 @@ impl<'a> Sha1DigestOp<'a> {
     }
 
     /// Finalize the digest operations
-    pub fn finalize(&mut self) -> CaliptraResult<()> {
+    pub fn finalize(mut self, digest: &mut Array4x5) -> CaliptraResult<()> {
         if self.state == Sha1DigestState::Final {
             return Err(CaliptraError::DRIVER_SHA1_INVALID_STATE);
         }
@@ -262,7 +255,7 @@ impl<'a> Sha1DigestOp<'a> {
         self.state = Sha1DigestState::Final;
 
         // Copy digest
-        self.sha.copy_digest_to_buf(self.digest)?;
+        self.sha.copy_digest_to_buf(digest)?;
 
         Ok(())
     }

--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -41,17 +41,13 @@ impl Sha384 {
     /// # Returns
     ///
     /// * `Sha384Digest` - Object representing the digest operation
-    pub fn digest_init<'a>(
-        &'a mut self,
-        digest: Sha384Digest<'a>,
-    ) -> CaliptraResult<Sha384DigestOp<'a>> {
+    pub fn digest_init(&mut self) -> CaliptraResult<Sha384DigestOp<'_>> {
         let op = Sha384DigestOp {
             sha: self,
             state: Sha384DigestState::Init,
             buf: [0u8; SHA384_BLOCK_BYTE_SIZE],
             buf_idx: 0,
             data_size: 0,
-            digest,
         };
 
         Ok(op)
@@ -306,9 +302,6 @@ pub struct Sha384DigestOp<'a> {
 
     /// Data size
     data_size: usize,
-
-    /// Digest
-    digest: Sha384Digest<'a>,
 }
 
 impl<'a> Sha384DigestOp<'a> {
@@ -350,7 +343,7 @@ impl<'a> Sha384DigestOp<'a> {
     }
 
     /// Finalize the digest operations
-    pub fn finalize(&mut self) -> CaliptraResult<()> {
+    pub fn finalize(mut self, digest: &mut Array4x12) -> CaliptraResult<()> {
         if self.state == Sha384DigestState::Final {
             return Err(CaliptraError::DRIVER_SHA384_INVALID_STATE_ERR);
         }
@@ -368,7 +361,7 @@ impl<'a> Sha384DigestOp<'a> {
         self.state = Sha384DigestState::Final;
 
         // Copy digest
-        *self.digest = self.sha.read_digest();
+        *digest = self.sha.read_digest();
 
         Ok(())
     }

--- a/drivers/test-fw/src/bin/sha1_tests.rs
+++ b/drivers/test-fw/src/bin/sha1_tests.rs
@@ -54,11 +54,11 @@ fn test_op1() {
     const DATA: [u8; 1000] = [0x61; 1000];
     let mut digest = Array4x5::default();
     let mut sha = Sha1::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     for _ in 0..1_000 {
         assert!(digest_op.update(&DATA).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, expected);
 }

--- a/drivers/test-fw/src/bin/sha256_tests.rs
+++ b/drivers/test-fw/src/bin/sha256_tests.rs
@@ -77,8 +77,8 @@ fn test_op0() {
         0xB8, 0x55,
     ];
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
-    let actual = digest_op.finalize();
+    let digest_op = sha.digest_init().unwrap();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -92,9 +92,9 @@ fn test_op1() {
     ];
     let data = [];
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     assert!(digest_op.update(&data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -108,9 +108,9 @@ fn test_op2() {
     ];
     let data = "abc".as_bytes();
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -124,9 +124,9 @@ fn test_op3() {
     ];
     let data = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes();
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -140,9 +140,9 @@ fn test_op4() {
     ];
     let data = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_bytes();
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -156,11 +156,11 @@ fn test_op5() {
     ];
     const DATA: [u8; 1000] = [0x61; 1000];
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     for _ in 0..1_000 {
         assert!(digest_op.update(&DATA).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -174,11 +174,11 @@ fn test_op6() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".as_bytes();
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -192,11 +192,11 @@ fn test_op7() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl".as_bytes();
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }
@@ -210,11 +210,11 @@ fn test_op8() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcd".as_bytes(); // Exact single block
     let mut digest = Array4x8::default();
-    let mut digest_op = sha.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x8::from(expected));
 }

--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -83,8 +83,8 @@ fn test_op0() {
         0x98, 0xB9, 0x5B,
     ];
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
-    let actual = digest_op.finalize();
+    let digest_op = sha384.digest_init().unwrap();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -98,8 +98,8 @@ fn test_op1() {
         0x98, 0xB9, 0x5B,
     ];
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
-    let actual = digest_op.finalize();
+    let digest_op = sha384.digest_init().unwrap();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -115,9 +115,9 @@ fn test_op2() {
 
     let data = "abc".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -132,9 +132,9 @@ fn test_op3() {
     ];
     let data = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -149,9 +149,9 @@ fn test_op4() {
     ];
     let data = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     assert!(digest_op.update(data).is_ok());
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -166,11 +166,11 @@ fn test_op5() {
     ];
     const DATA: [u8; 1000] = [0x61; 1000];
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     for _ in 0..1_000 {
         assert!(digest_op.update(&DATA).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -185,11 +185,11 @@ fn test_op6() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -204,11 +204,11 @@ fn test_op7() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }
@@ -223,11 +223,11 @@ fn test_op8() {
     ];
     let data = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh".as_bytes();
     let mut digest = Array4x12::default();
-    let mut digest_op = sha384.digest_init(&mut digest).unwrap();
+    let mut digest_op = sha384.digest_init().unwrap();
     for idx in 0..data.len() {
         assert!(digest_op.update(&data[idx..idx + 1]).is_ok());
     }
-    let actual = digest_op.finalize();
+    let actual = digest_op.finalize(&mut digest);
     assert!(actual.is_ok());
     assert_eq!(digest, Array4x12::from(expected));
 }


### PR DESCRIPTION
Currently, the sha drivers take a digest reference during init, and then don't use it until finalize is called. This can be complicated for managing the lifetime of the digest structure. RT would like to be able to hold a sha context which contains a SHA op and a digest; but the lifetime management for doing this is very tricky.

Instead, take the digest as input to finalize and write the state to it then.

This does not change any functionality of the SHA drivers, only the interface.