### PR TITLE
Allocate reserved command codes.

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod crypto;
 pub mod dice;
 pub mod fuse;
 pub mod keyids;
+pub mod mailbox;
 pub mod pcr;
 pub mod wdt;
 

--- a/common/src/mailbox.rs
+++ b/common/src/mailbox.rs
@@ -1,0 +1,17 @@
+/*++
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    mailbox.rs
+
+Abstract:
+
+    Mailbox command codes
+
+--*/
+
+pub const MBOX_CMD_ID_DOWNLOAD_FIRMWARE: u32 = 0x46574C44;
+pub const MBOX_CMD_ID_RESERVED_O: u32 = 0x60187A4D;
+pub const MBOX_CMD_ID_RESERVED_1: u32 = 0xC307C53C;
+pub const MBOX_CMD_ID_RESERVED_2: u32 = 0xBB518809;


### PR DESCRIPTION
Unlike unknown commands, these do not trigger a fatal error. Instead, they simply return failures. In the future, these codes can be repurposed if needed. The code values were chosen at random.