### PR TITLE
Add more code owners for libcaliptra

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,4 @@
 /fmc/ @FerralCoder @rusty1968 @bluegate010
 /runtime/ @jhand2 @fdamato @rusty1968 @bluegate010
 /hw-model/ @korran @fdamato @jlmahowa-amd
-/libcaliptra/ @fdamato @wmaroneAMD
+/libcaliptra/ @fdamato @wmaroneAMD @JohnTraverAmd @jlmahowa-amd @korran @mhatrevi


### PR DESCRIPTION
Two owners is insufficient for situations where the primary developers do not have full coverage. This adds additional owners that can sign off on changes to libcaliptra.