### PR TITLE
Make Xoshiro128 a normal rust type, and remove call to Trng::assume_init()

### DIFF
--- a/cfi/lib/src/lib.rs
+++ b/cfi/lib/src/lib.rs
@@ -17,4 +17,4 @@ mod xoshiro;
 
 pub use cfi::*;
 pub use cfi_ctr::{CfiCounter, CfiInt};
-pub use xoshiro::{Xoshiro128, Xoshiro128Reg};
+pub use xoshiro::Xoshiro128;

--- a/cfi/lib/src/xoshiro.rs
+++ b/cfi/lib/src/xoshiro.rs
@@ -15,187 +15,68 @@ References:
 
 --*/
 
+use core::cell::Cell;
+
 use crate::{cfi_panic, CfiPanicInfo};
-#[cfg(not(feature = "cfi-test"))]
-use caliptra_common::memory_layout::{CFI_XO_S0_ORG, CFI_XO_S1_ORG, CFI_XO_S2_ORG, CFI_XO_S3_ORG};
-
-#[cfg(feature = "cfi-test")]
-static mut S0: u32 = 0u32;
-#[cfg(feature = "cfi-test")]
-static mut S1: u32 = 0u32;
-#[cfg(feature = "cfi-test")]
-static mut S2: u32 = 0u32;
-#[cfg(feature = "cfi-test")]
-static mut S3: u32 = 0u32;
-
-pub struct Xoshiro128Reg;
-
-impl Xoshiro128Reg {
-    pub fn s0(&self) -> u32 {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::read_volatile(&S0 as *const u32)
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::read_volatile(CFI_XO_S0_ORG as *const u32)
-            }
-        }
-    }
-
-    pub fn set_s0(&self, val: u32) {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::write_volatile(&mut S0 as *mut u32, val);
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::write_volatile(CFI_XO_S0_ORG as *mut u32, val);
-            }
-        }
-    }
-
-    pub fn s1(&self) -> u32 {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::read_volatile(&S1 as *const u32)
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::read_volatile(CFI_XO_S1_ORG as *const u32)
-            }
-        }
-    }
-
-    pub fn set_s1(&self, val: u32) {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::write_volatile(&mut S1 as *mut u32, val);
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::write_volatile(CFI_XO_S1_ORG as *mut u32, val);
-            }
-        }
-    }
-
-    pub fn s2(&self) -> u32 {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::read_volatile(&S2 as *const u32)
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::read_volatile(CFI_XO_S2_ORG as *const u32)
-            }
-        }
-    }
-
-    pub fn set_s2(&self, val: u32) {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::write_volatile(&mut S2 as *mut u32, val);
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::write_volatile(CFI_XO_S2_ORG as *mut u32, val);
-            }
-        }
-    }
-
-    pub fn s3(&self) -> u32 {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::read_volatile(&S3 as *const u32)
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::read_volatile(CFI_XO_S3_ORG as *const u32)
-            }
-        }
-    }
-
-    pub fn set_s3(&self, val: u32) {
-        unsafe {
-            #[cfg(feature = "cfi-test")]
-            {
-                core::ptr::write_volatile(&mut S3 as *mut u32, val);
-            }
-
-            #[cfg(not(feature = "cfi-test"))]
-            {
-                core::ptr::write_volatile(CFI_XO_S3_ORG as *mut u32, val);
-            }
-        }
-    }
-}
 
 /// Provides an implementation of the xoshiro128** algorithm. This implementation is used
 /// on 32-bit when no seed is specified and an instance of the base Random class is constructed.
 /// As such, we are free to implement however we see fit, without back compat concerns around
 /// the sequence of numbers generated or what methods call what other methods.
+#[repr(C)]
 pub struct Xoshiro128 {
-    reg: Xoshiro128Reg,
+    // It is critical for safety that every bit-pattern of this struct
+    // is valid (no padding, no enums, no references), similar to the requirements for
+    // zerocopy::FromBytes.
+    s0: Cell<u32>,
+    s1: Cell<u32>,
+    s2: Cell<u32>,
+    s3: Cell<u32>,
 }
 
 impl Xoshiro128 {
-    /// Create a new instance of the xoshiro128** algorithm.
-    ///
-    /// # Arguments
-    ///
-    /// * `reg` - Register to use
-    ///
-    /// # Returns
-    ///
-    /// * Instance of the xoshiro128** algorithm
-    pub(crate) fn new(reg: Xoshiro128Reg) -> Self {
-        if !cfg!(feature = "cfi-test") {
-            let mut trng = unsafe {
-                caliptra_drivers::Trng::assume_initialized(
-                    caliptra_registers::csrng::CsrngReg::new(),
-                    caliptra_registers::entropy_src::EntropySrcReg::new(),
-                    caliptra_registers::soc_ifc_trng::SocIfcTrngReg::new(),
-                    &caliptra_registers::soc_ifc::SocIfcReg::new(),
-                )
-            };
-
-            loop {
-                if let Ok(entropy) = trng.generate() {
-                    reg.set_s0(entropy.0[0]);
-                    reg.set_s1(entropy.0[1]);
-                    reg.set_s2(entropy.0[2]);
-                    reg.set_s3(entropy.0[3]);
-                } else {
-                    cfi_panic(CfiPanicInfo::TrngError)
-                }
-
-                // Atlease one value must be non-zero
-                if reg.s0() | reg.s1() | reg.s2() | reg.s3() != 0 {
-                    break;
-                }
-            }
-        }
-
-        Self { reg }
+    /// Create a new instance of the xoshiro128** algorithm seeded with zeroes.
+    pub(crate) const fn new_unseeded() -> Self {
+        Self::new_with_seed(0, 0, 0, 0)
     }
 
-    /// Create a new instance of the xoshiro128** algorithm from a register
-    pub fn assume_init(reg: Xoshiro128Reg) -> Self {
-        Self { reg }
+    /// Create a new instance of the xoshiro128** algorithm with a seed.
+    pub const fn new_with_seed(s0: u32, s1: u32, s2: u32, s3: u32) -> Self {
+        Self {
+            s0: Cell::new(s0),
+            s1: Cell::new(s1),
+            s2: Cell::new(s2),
+            s3: Cell::new(s3),
+        }
+    }
+
+    /// Get a reference to a xoshiro instance backed by static memory
+    ///
+    /// # Safety
+    ///
+    /// Caller must verify that the memory locations between `addr` and
+    /// `addr + size_of::<Xoshiro128>()` are valid and meet the alignment
+    /// requirements of Xoshiro128, and are not used for anything else.
+    pub unsafe fn from_address(addr: u32) -> &'static Self {
+        &*(addr as *const Xoshiro128)
+    }
+
+    pub fn seed_from_trng(&self, trng: &mut caliptra_drivers::Trng) {
+        loop {
+            if let Ok(entropy) = trng.generate() {
+                self.s0.set(entropy.0[0]);
+                self.s1.set(entropy.0[1]);
+                self.s2.set(entropy.0[2]);
+                self.s3.set(entropy.0[3]);
+            } else {
+                cfi_panic(CfiPanicInfo::TrngError)
+            }
+
+            // Atlease one value must be non-zero
+            if self.s0.get() | self.s1.get() | self.s2.get() | self.s3.get() != 0 {
+                break;
+            }
+        }
     }
 
     /// Get the next random number
@@ -209,10 +90,10 @@ impl Xoshiro128 {
         //     worldwide. This software is distributed without any warranty.
         //
         //     See <http://creativecommons.org/publicdomain/zero/1.0/>.
-        let mut s0 = self.reg.s0();
-        let mut s1 = self.reg.s1();
-        let mut s2 = self.reg.s2();
-        let mut s3 = self.reg.s3();
+        let mut s0 = self.s0.get();
+        let mut s1 = self.s1.get();
+        let mut s2 = self.s2.get();
+        let mut s3 = self.s3.get();
 
         let result = u32::wrapping_mul(u32::wrapping_mul(s1, 5).rotate_left(7), 9);
         let t = s1 << 9;
@@ -225,10 +106,10 @@ impl Xoshiro128 {
         s2 ^= t;
         s3 = s3.rotate_left(11);
 
-        self.reg.set_s0(s0);
-        self.reg.set_s1(s1);
-        self.reg.set_s2(s2);
-        self.reg.set_s3(s3);
+        self.s0.set(s0);
+        self.s1.set(s1);
+        self.s2.set(s2);
+        self.s3.set(s3);
 
         result
     }

--- a/cfi/lib/tests/test_derive.rs
+++ b/cfi/lib/tests/test_derive.rs
@@ -9,7 +9,7 @@ File Name:
 --*/
 
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
-use caliptra_cfi_lib::{CfiCounter, Xoshiro128, Xoshiro128Reg};
+use caliptra_cfi_lib::{CfiCounter, Xoshiro128};
 
 #[cfi_mod_fn]
 fn test1<T>(val: T) -> T {
@@ -57,7 +57,7 @@ fn test_with_not_initialized_counter() {
 
 #[test]
 fn test_with_initialized_counter() {
-    CfiCounter::reset();
+    CfiCounter::reset_for_test();
     assert_eq!(test1(10), 10);
 
     assert_eq!(Test::test1(10), 10);
@@ -67,25 +67,7 @@ fn test_with_initialized_counter() {
 }
 
 #[test]
-fn test_rand_seed_read_write() {
-    let reg = Xoshiro128Reg;
-    reg.set_s0(1);
-    assert_eq!(reg.s0(), 1);
-
-    reg.set_s1(2);
-    assert_eq!(reg.s1(), 2);
-
-    reg.set_s2(3);
-    assert_eq!(reg.s2(), 3);
-
-    reg.set_s3(4);
-    assert_eq!(reg.s3(), 4);
-}
-
-#[test]
 fn test_rand() {
-    let reg = Xoshiro128Reg;
-
     // Expected random numbers generated from a modified implementation of:
     // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Random.Xoshiro128StarStarImpl.cs
     let expected_rand_num: [u32; 20] = [
@@ -93,26 +75,16 @@ fn test_rand() {
         4258142804, 337829053, 2142557243, 3576906021, 2006103318, 3870238204, 1001584594,
         3804789018, 2299676403, 3571406116, 2962224741,
     ];
-    reg.set_s0(1);
-    reg.set_s1(2);
-    reg.set_s2(3);
-    reg.set_s3(4);
+    let prng = Xoshiro128::new_with_seed(1, 2, 3, 4);
     for expected_rand_num in expected_rand_num.iter() {
-        assert_eq!(
-            Xoshiro128::assume_init(Xoshiro128Reg).next(),
-            *expected_rand_num
-        );
+        assert_eq!(prng.next(), *expected_rand_num);
     }
 }
 
 #[test]
 fn test_rand_stress() {
-    let reg = Xoshiro128Reg;
-    reg.set_s0(1);
-    reg.set_s1(2);
-    reg.set_s2(3);
-    reg.set_s3(4);
+    let prng = Xoshiro128::new_with_seed(1, 2, 3, 4);
     for _idx in 0..1000 {
-        let _ = Xoshiro128::assume_init(Xoshiro128Reg).next();
+        prng.next();
     }
 }

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -55,17 +55,17 @@ Running Caliptra ROM ...
 pub extern "C" fn rom_entry() -> ! {
     cprintln!("{}", BANNER);
 
-    if !cfg!(feature = "no-cfi") {
-        cprintln!("[state] CFI Enabled");
-        CfiCounter::reset();
-    } else {
-        cprintln!("[state] CFI Disabled");
-    }
-
     let mut env = match unsafe { rom_env::RomEnv::new_from_registers() } {
         Ok(env) => env,
         Err(e) => handle_fatal_error(e.into()),
     };
+
+    if !cfg!(feature = "no-cfi") {
+        cprintln!("[state] CFI Enabled");
+        CfiCounter::reset(&mut env.trng);
+    } else {
+        cprintln!("[state] CFI Disabled");
+    }
 
     let _lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",


### PR DESCRIPTION
The latter fixes a serious bug with the csrng not being initialized before we seed the xorshiro prng.