### PR TITLE
caliptra-size-history: Use submodules.

### DIFF
--- a/ci-tools/size-history/src/cache_gha.rs
+++ b/ci-tools/size-history/src/cache_gha.rs
@@ -8,7 +8,7 @@ use crate::{
     Cache,
 };
 
-const VERSION: &str = "caliptra-size-history-cache0";
+const VERSION: &str = "caliptra-size-history-cache1";
 
 pub struct GithubActionCache {
     prefix: String,

--- a/ci-tools/size-history/src/git.rs
+++ b/ci-tools/size-history/src/git.rs
@@ -101,6 +101,16 @@ impl<'a> WorkTree<'a> {
         )?;
         Ok(())
     }
+    pub fn submodule_update(&self) -> io::Result<()> {
+        run_cmd_stdout(
+            Command::new("git")
+                .current_dir(self.path)
+                .arg("submodule")
+                .arg("update"),
+            None,
+        )?;
+        Ok(())
+    }
     pub fn head_commit_id(&self) -> io::Result<String> {
         Ok(to_utf8(run_cmd_stdout(
             Command::new("git")

--- a/ci-tools/size-history/src/main.rs
+++ b/ci-tools/size-history/src/main.rs
@@ -118,6 +118,7 @@ fn real_main() -> io::Result<()> {
             commit.id, commit.title
         );
         worktree.checkout(&commit.id)?;
+        worktree.submodule_update()?;
 
         let sizes = match compute_size(
             &worktree,


### PR DESCRIPTION
This is necessary because the main workspace with default features is now relying on code in the dpe/ submodule, and the build will fail if it's not populated.

Change the cache buster to regenerate all history.