### PR TITLE
[fix] CFI fixes

### DIFF
--- a/cfi/derive/src/lib.rs
+++ b/cfi/derive/src/lib.rs
@@ -61,13 +61,21 @@ fn cfi_fn(mod_fn: bool, input: TokenStream) -> TokenStream {
 
     wrapper_fn.block.stmts.clear();
     wrapper_fn.block.stmts = parse_quote!(
-        let saved_ctr = caliptra_cfi_lib::CfiCounter::increment();
+        let saved_ctr = caliptra_cfi_lib::CfiCounter::read();
         caliptra_cfi_lib::CfiCounter::delay();
         let ret = #fn_call;
         caliptra_cfi_lib::CfiCounter::delay();
         let new_ctr = caliptra_cfi_lib::CfiCounter::decrement();
         caliptra_cfi_lib::CfiCounter::assert_eq(saved_ctr, new_ctr);
         ret
+    );
+
+    // Add CFI counter increment statement to the beginning of the original function.
+    orig_fn.block.stmts.insert(
+        0,
+        parse_quote!(
+            caliptra_cfi_lib::CfiCounter::increment();
+        ),
     );
 
     let code = quote! {

--- a/cfi/lib/src/cfi.rs
+++ b/cfi/lib/src/cfi.rs
@@ -15,6 +15,7 @@ References:
 
 --*/
 
+use crate::CfiCounter;
 use caliptra_drivers::CaliptraError;
 use core::cfg;
 use core::cmp::{Eq, Ord, PartialEq, PartialOrd};
@@ -154,6 +155,7 @@ macro_rules! cfi_assert_macro {
             T: $trait1 + $trait2,
         {
             if cfg!(feature = "cfi") {
+                CfiCounter::delay();
                 if !(lhs $op rhs) {
                     cfi_panic(CfiPanicInfo::$panic_info);
                 }

--- a/cfi/lib/src/cfi_counter.rs
+++ b/cfi/lib/src/cfi_counter.rs
@@ -169,22 +169,22 @@ impl CfiCounter {
 
     #[inline(never)]
     pub fn delay() {
+        let cycles = prng().next() % 256;
+        let _real_cyc = 1 + cycles / 2;
         #[cfg(all(target_arch = "riscv32", feature = "cfi", feature = "cfi-counter"))]
         unsafe {
-            let cycles = prng().next() % 256;
-            let real_cyc = 1 + cycles / 2;
             core::arch::asm!(
                 "1:",
                 "addi {0}, {0}, -1",
                 "bne {0}, zero, 1b",
-                inout(reg) real_cyc => _,
+                inout(reg) _real_cyc => _,
                 options(nomem, nostack),
             );
         }
     }
 
     /// Read counter value
-    fn read() -> CfiInt {
+    pub fn read() -> CfiInt {
         unsafe {
             #[cfg(feature = "cfi-test")]
             {

--- a/cfi/lib/src/lib.rs
+++ b/cfi/lib/src/lib.rs
@@ -12,9 +12,9 @@ File Name:
 extern crate core;
 
 mod cfi;
-mod cfi_ctr;
+mod cfi_counter;
 mod xoshiro;
 
 pub use cfi::*;
-pub use cfi_ctr::{CfiCounter, CfiInt};
+pub use cfi_counter::{CfiCounter, CfiInt};
 pub use xoshiro::Xoshiro128;

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -176,11 +176,11 @@ impl FirmwareProcessor {
         let opt = ImageManifest::read_from(slice.as_bytes());
         let result = opt.is_some();
         if cfi_launder(result) {
-            cfi_assert!(result);
+            cfi_assert!(opt.is_some());
             report_boot_status(FwProcessorManifestLoadComplete.into());
             Ok(opt.unwrap())
         } else {
-            cfi_assert!(!result);
+            cfi_assert!(opt.is_none());
             Err(CaliptraError::FW_PROC_MANIFEST_READ_FAILURE)
         }
     }


### PR DESCRIPTION
This change contains the following fixes:

	1. CFI Counter increment is moved to the start of the original function from the wrapper function to make the increment/decrement calls asymmetrical.

	2. Adds a delay to the launder assert checks.

	3. Addresses feedback from original CFI PR: 
	        a. Renamed cfi_ctr.rs to cfi_counter.rs 
                b. Effective launder function use.