### PR TITLE
[fuzzing] Fix x509 fuzzing target to match its seed corpus

### DIFF
--- a/x509/fuzz/src/fuzz_target_1.rs
+++ b/x509/fuzz/src/fuzz_target_1.rs
@@ -25,9 +25,11 @@ fn harness(data: &[u8]) {
     }
 
     // TODO: Alternatively, use structure-aware fuzzing, input comprising arguments
+    // The corpus is seeded with TBS blobs, so parse the input as TBS first
+    let tbs_len = data.len() - size_of::<Ecdsa384Signature>();
     unsafe {
-        tbs = &data[size_of::<Ecdsa384Signature>()..];
-        sig = &*(data.as_ptr() as *const Ecdsa384Signature);
+        tbs = &data[..tbs_len];
+        sig = &*(data[tbs_len..].as_ptr() as *const Ecdsa384Signature);
     }
 
     let builder = Ecdsa384CertBuilder::new(tbs, sig).unwrap();


### PR DESCRIPTION
The corpus is seeded with TBS blobs, so parse the input as TBS first. We assume the fuzzer will generally follow the seed corpus for available bytes, then generate other data, which will be parsed as the 'signature.'

Note that this has no effect on the current findings, the target panics before and after. It is only intended to help the fuzzer make better use of the seed corpus.