### PR TITLE
libcaliptra: Stash Management plus cleanup

### DIFF
--- a/libcaliptra/examples/generic/main.c
+++ b/libcaliptra/examples/generic/main.c
@@ -69,15 +69,41 @@ int main(int argc, char *argv[])
         status = caliptra_get_fips_version(&version);
         if (status)
         {
-            printf("Caliptra C API Integration Test Failed: %x\n", status);
-            return status;
+            printf("Get FIPS Version failed!\n");
+            break;
+        }
+        else
+        {
+            printf("FIPS_VERSION = mode: 0x%x, fips_rev (0x%x, 0x%x, 0x%x), name %s \n", version.mode,
+                version.fips_rev[0], version.fips_rev[1], version.fips_rev[2], version.name);
+        }
+
+        // Need some representative values for these, see below.
+        struct caliptra_stash_measurement_req r = {0};
+        struct caliptra_stash_measurement_resp c = {0};
+
+        status = caliptra_stash_measurement(&r, &c);
+
+        if (status)
+        {
+            printf("Stash measurement failed!\n");
+        }
+        else
+        {
+            printf("Stash measurement: OK\n");
         }
 
         break;
     }
-    printf("Caliptra C API Integration Test Passed: \n\tFIPS_VERSION = mode: 0x%x, fips_rev (0x%x, 0x%x, 0x%x), name %s \n", version.mode,
-                version.fips_rev[0], version.fips_rev[1], version.fips_rev[2], version.name);
+
+    if (status)
+    {
+        printf("Caliptra C API Integration Test Failed: %x\n", status);
+    }
+    else
+    {
+        printf("Caliptr a C API Integration Test Passed!\n");
+    }
+
     return 0;
 }
-
-

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -28,5 +28,8 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer);
 // Read Caliptra FIPS Version
 int caliptra_get_fips_version(struct caliptra_fips_version *version);
 
+// Stash Measurement command
+int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp);
+
 // Execute Mailbox Command
 int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);

--- a/libcaliptra/inc/caliptra_if.h
+++ b/libcaliptra/inc/caliptra_if.h
@@ -39,11 +39,3 @@ int caliptra_read_u32(uint32_t address, uint32_t *data);
  */
 void caliptra_wait(void);
 
-/**
- * caliptra_if_init
- *
- * Initialization step for the Caliptra interface implementation, if required.
- *
- * @return bool True if the interface initialized itself successfully.
- */
-bool caliptra_if_init(void);

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -52,3 +52,14 @@ struct caliptra_fips_version {
     uint8_t name[12];
 };
 
+struct caliptra_stash_measurement_req {
+    caliptra_checksum checksum;
+    uint8_t           metadata[4];
+    uint8_t           measurement[48];
+    uint32_t          svn;
+};
+
+struct caliptra_stash_measurement_resp {
+    struct caliptra_completion cpl;
+    uint32_t                   dpe_result;
+};

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -45,11 +45,6 @@ static uint32_t calculate_caliptra_checksum(uint32_t cmd, uint8_t *buffer, uint3
     return (0 - sum);
 }
 
-static inline bool validate_caliptra_checksum(caliptra_checksum checksum, enum mailbox_command command, uint8_t *buffer, uint32_t length)
-{
-    return (checksum - calculate_caliptra_checksum(command, buffer, length) == 0);
-}
-
 static inline uint32_t caliptra_read_status(void)
 {
     uint32_t status;
@@ -346,6 +341,21 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
     return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL);
 }
 
+static int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
+{
+    uint32_t calc_checksum = calculate_caliptra_checksum(0, buffer + sizeof(uint32_t), buffer_size - sizeof(uint32_t));
+
+    bool checksum_valid = !(cpl->checksum - calc_checksum);
+    bool fips_approved  = (cpl->fips == FIPS_STATUS_APPROVED);
+
+    if ((checksum_valid == false) || (fips_approved == false))
+    {
+        return -EBADMSG;
+    }
+
+    return 0;
+}
+
 /**
  * caliptra_get_fips_version
  *
@@ -374,16 +384,39 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
 
     int status = caliptra_mailbox_execute(OP_FIPS_VERSION, &in_buf, &out_buf);
 
-    if (!status)
+    if (status)
     {
         return status;
     }
 
-    bool checksum_valid = validate_caliptra_checksum(version->cpl.checksum, OP_FIPS_VERSION, (uint8_t*)version, sizeof(struct caliptra_fips_version));
-    bool fips_approved  = version->cpl.fips != FIPS_STATUS_APPROVED;
+    return check_command_response(&version->cpl, (uint8_t*)version, sizeof(struct caliptra_fips_version));
+}
 
-    if (!checksum_valid || !fips_approved)
+int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp)
+{
+    if (!req || !resp)
     {
-        return -EBADMSG;
+        return -EINVAL;
     }
+
+    struct caliptra_buffer in_buf = {
+        .data = (uint8_t*)req,
+        .len  = sizeof(struct caliptra_stash_measurement_req),
+    };
+
+    struct caliptra_buffer out_buf = {
+        .data = (uint8_t*)resp,
+        .len  = sizeof(struct caliptra_stash_measurement_resp),
+    };
+
+    req->checksum = calculate_caliptra_checksum(OP_STASH_MEASUREMENT, (uint8_t*)req, sizeof(struct caliptra_stash_measurement_req));
+
+    int status = caliptra_mailbox_execute(OP_STASH_MEASUREMENT, &in_buf, &out_buf);
+
+    if (status)
+    {
+        return status;
+    }
+
+    return check_command_response(&resp->cpl, (uint8_t*)resp, sizeof(struct caliptra_stash_measurement_resp));
 }


### PR DESCRIPTION
This adds support for the Stash Management RT FW command.

* Added structs for stash management request and completions.
  * Including svn field on Sree's branch
* Resolved an issue with mailbox request status handling.
* Resolved an issue with checksum calculation on completion.
* Unified generic command response handling.
* Added test in generic flow that asserts STASH_MEASUREMENT command will fail, must be updated once merged.