### PR TITLE
Moving mailbox_api to common from runtime

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod crypto;
 pub mod dice;
 pub mod fuse;
 pub mod keyids;
+pub mod mailbox_api;
 pub mod pcr;
 pub mod wdt;
 

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -87,8 +87,7 @@ impl MailboxResp {
     /// Takes into account the size override for variable-lenth payloads
     pub fn populate_chksum(&mut self) -> CaliptraResult<()> {
         // Calc checksum, use the size override if provided
-        let checksum =
-            caliptra_common::checksum::calc_checksum(0, &self.as_bytes()[size_of::<i32>()..]);
+        let checksum = crate::checksum::calc_checksum(0, &self.as_bytes()[size_of::<i32>()..]);
 
         // cast as header struct
         let hdr: &mut MailboxRespHeader = LayoutVerified::<&mut [u8], MailboxRespHeader>::new(

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 #[cfg(feature = "test_only_commands")]
-use crate::{GetLdevCertResp, MailboxResp, MailboxRespHeader, TestGetFmcAliasCertResp};
+use caliptra_common::mailbox_api::{
+    GetLdevCertResp, MailboxResp, MailboxRespHeader, TestGetFmcAliasCertResp,
+};
 use caliptra_drivers::{CaliptraError, CaliptraResult, DataVault};
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, LocalDevIdCertTbs};
 

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -1,7 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{Drivers, MailboxResp};
+use crate::Drivers;
 use caliptra_common::keyids::{KEY_ID_RT_CDI, KEY_ID_RT_PRIV_KEY};
+use caliptra_common::mailbox_api::MailboxResp;
 use caliptra_drivers::{
     hmac384_kdf, CaliptraError, CaliptraResult, KeyReadArgs, KeyUsage, KeyWriteArgs,
 };

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_common::cprintln;
+use caliptra_common::mailbox_api::{FipsVersionResp, MailboxResp, MailboxRespHeader};
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Ecc384;
@@ -12,7 +13,7 @@ use caliptra_drivers::Sha384Acc;
 use caliptra_kat::{Ecc384Kat, Hmac384Kat, Sha256Kat, Sha384AccKat, Sha384Kat};
 use caliptra_registers::mbox::enums::MboxStatusE;
 
-use crate::{Drivers, FipsVersionResp, MailboxResp, MailboxRespHeader};
+use crate::Drivers;
 
 pub struct FipsModule;
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{Drivers, FwInfoResp, MailboxResp, MailboxRespHeader};
+use crate::Drivers;
+use caliptra_common::mailbox_api::{FwInfoResp, MailboxResp, MailboxRespHeader};
 use caliptra_drivers::CaliptraResult;
 
 pub struct FwInfoCmd;

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -1,9 +1,7 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{
-    CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, InvokeDpeReq, InvokeDpeResp,
-    MailboxResp, MailboxRespHeader,
-};
+use crate::{CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers};
+use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxResp, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use zerocopy::FromBytes;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,19 +16,11 @@ mod verify;
 pub mod mailbox;
 use mailbox::Mailbox;
 
-pub mod mailbox_api;
-pub use mailbox_api::{
-    CommandId, EcdsaVerifyReq, FipsVersionResp, FwInfoResp, GetIdevCsrResp, GetLdevCertResp,
-    HmacVerifyReq, InvokeDpeReq, InvokeDpeResp, MailboxReqHeader, MailboxResp, MailboxRespHeader,
-    StashMeasurementReq, StashMeasurementResp, TestGetFmcAliasCertResp,
-};
-
-use dpe_crypto::DpeCrypto;
-pub use dpe_platform::{DpePlatform, VENDOR_ID, VENDOR_SKU};
-
 #[cfg(feature = "test_only_commands")]
 pub use dice::{GetLdevCertCmd, TestGetFmcAliasCertCmd};
 pub use disable::DisableAttestationCmd;
+use dpe_crypto::DpeCrypto;
+pub use dpe_platform::{DpePlatform, VENDOR_ID, VENDOR_SKU};
 pub use fips::{FipsSelfTestCmd, FipsShutdownCmd, FipsVersionCmd};
 pub use info::FwInfoCmd;
 pub use invoke_dpe::InvokeDpeCmd;
@@ -36,6 +28,7 @@ pub use verify::EcdsaVerifyCmd;
 pub mod packet;
 use packet::Packet;
 
+use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::memory_layout::{
     FHT_ORG, FHT_SIZE, FMCALIAS_TBS_ORG, FMCALIAS_TBS_SIZE, FUSE_LOG_ORG, FUSE_LOG_SIZE,
     LDEVID_TBS_ORG, LDEVID_TBS_SIZE, MAN1_ORG, MAN1_SIZE, MAN2_ORG, MAN2_SIZE, PCR_LOG_ORG,

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -3,7 +3,7 @@
 // License by Apache-2.0
 use caliptra_drivers::CaliptraResult;
 
-use crate::mailbox_api::{MailboxReqHeader, MailboxResp};
+use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxResp};
 use caliptra_drivers::CaliptraError;
 use zerocopy::{AsBytes, LayoutVerified};
 

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -1,8 +1,9 @@
 // Licensed under the Apache-2.0 license
 
+use crate::Drivers;
 #[cfg(feature = "test_only_commands")]
-use crate::HmacVerifyReq;
-use crate::{Drivers, EcdsaVerifyReq, MailboxResp};
+use caliptra_common::mailbox_api::HmacVerifyReq;
+use caliptra_common::mailbox_api::{EcdsaVerifyReq, MailboxResp};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Signature,

--- a/runtime/test-fw/src/cert_tests.rs
+++ b/runtime/test-fw/src/cert_tests.rs
@@ -5,8 +5,9 @@
 #![no_main]
 #![no_std]
 
+use caliptra_common::mailbox_api::CommandId;
 use caliptra_registers::mbox::enums::MboxStatusE;
-use caliptra_runtime::{dice, CommandId, Drivers};
+use caliptra_runtime::{dice, Drivers};
 use caliptra_test_harness::{runtime_handlers, test_suite};
 use zerocopy::AsBytes;
 

--- a/runtime/tests/ecdsa.rs
+++ b/runtime/tests/ecdsa.rs
@@ -1,8 +1,10 @@
 // Licensed under the Apache-2.0 license.
 pub mod common;
 
+use caliptra_common::mailbox_api::{
+    CommandId, EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader,
+};
 use caliptra_hw_model::{HwModel, ShaAccMode};
-use caliptra_runtime::{CommandId, EcdsaVerifyReq, MailboxReqHeader, MailboxRespHeader};
 use common::run_rom_test;
 use zerocopy::{AsBytes, FromBytes};
 

--- a/runtime/tests/hmac.rs
+++ b/runtime/tests/hmac.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license.
 pub mod common;
 
+use caliptra_common::mailbox_api::{CommandId, HmacVerifyReq, MailboxReqHeader, MailboxRespHeader};
 use caliptra_hw_model::HwModel;
-use caliptra_runtime::{CommandId, HmacVerifyReq, MailboxReqHeader, MailboxRespHeader};
 use common::run_rt_test;
 use zerocopy::{AsBytes, FromBytes};
 

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -3,13 +3,13 @@
 pub mod common;
 
 use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART};
+use caliptra_common::mailbox_api::{
+    CommandId, EcdsaVerifyReq, FipsVersionResp, FwInfoResp, InvokeDpeReq, InvokeDpeResp,
+    MailboxReqHeader, MailboxRespHeader,
+};
 use caliptra_drivers::Ecc384PubKey;
 use caliptra_hw_model::{HwModel, ModelError, ShaAccMode};
-use caliptra_runtime::{
-    CommandId, EcdsaVerifyReq, FipsVersionCmd, FipsVersionResp, FwInfoResp, InvokeDpeReq,
-    InvokeDpeResp, MailboxReqHeader, MailboxRespHeader, RtBootStatus, DPE_SUPPORT, VENDOR_ID,
-    VENDOR_SKU,
-};
+use caliptra_runtime::{FipsVersionCmd, RtBootStatus, DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
 use common::{run_rom_test, run_rt_test};
 use dpe::{
     commands::{Command, CommandHdr},

--- a/test/tests/smoke_test.rs
+++ b/test/tests/smoke_test.rs
@@ -1,11 +1,11 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
-use caliptra_hw_model::{BootParams, HwModel, InitParams, SecurityState};
-use caliptra_hw_model_types::{DeviceLifecycle, Fuses};
-use caliptra_runtime::{
+use caliptra_common::mailbox_api::{
     CommandId, GetLdevCertResp, MailboxReqHeader, MailboxRespHeader, TestGetFmcAliasCertResp,
 };
+use caliptra_hw_model::{BootParams, HwModel, InitParams, SecurityState};
+use caliptra_hw_model_types::{DeviceLifecycle, Fuses};
 use caliptra_test::{
     derive::{DoeInput, DoeOutput, FmcAliasKey, IDevId, LDevId, Pcr0, Pcr0Input},
     swap_word_bytes, swap_word_bytes_inplace,


### PR DESCRIPTION
Moves the mailbox api (command IDs, format structs, and some helper collateral) from runtime to common so it can be leveraged by ROM code.