### PR TITLE
[feat] ROM mailbox infra for FIPS commands

### DIFF
--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -16,9 +16,9 @@ use crate::flow::val::ValRomImageVerificationEnv;
 use crate::{cprintln, pcr, rom_env::RomEnv, verifier::RomImageVerificationEnv};
 
 use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::memory_layout::{MAN1_ORG, MAN2_ORG};
 use caliptra_common::FirmwareHandoffTable;
-
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::DataVault;
 use caliptra_drivers::{
@@ -33,8 +33,6 @@ use zerocopy::{AsBytes, FromBytes};
 pub struct UpdateResetFlow {}
 
 impl UpdateResetFlow {
-    const MBOX_DOWNLOAD_FIRMWARE_CMD_ID: u32 = 0x46574C44;
-
     /// Execute update reset flow
     ///
     /// # Arguments
@@ -50,7 +48,7 @@ impl UpdateResetFlow {
             return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE);
         };
 
-        if recv_txn.cmd() != Self::MBOX_DOWNLOAD_FIRMWARE_CMD_ID {
+        if recv_txn.cmd() != CommandId::FIRMWARE_LOAD.into() {
             cprintln!("Invalid command 0x{:08x} received", recv_txn.cmd());
             return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND);
         }

--- a/rom/dev/tests/helpers.rs
+++ b/rom/dev/tests/helpers.rs
@@ -7,8 +7,6 @@ use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_hw_model::{DefaultHwModel, ModelError};
 use caliptra_image_types::ImageBundle;
 
-pub const FW_LOAD_CMD_OPCODE: u32 = 0x4657_4C44;
-
 pub fn build_hw_model_and_image_bundle(
     fuses: Fuses,
     image_options: ImageOptions,

--- a/rom/dev/tests/test_dice_derivations.rs
+++ b/rom/dev/tests/test_dice_derivations.rs
@@ -1,11 +1,10 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_builder::ImageOptions;
+use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::RomBootStatus::*;
 use caliptra_hw_model::Fuses;
 use caliptra_hw_model::HwModel;
-
-use crate::helpers::FW_LOAD_CMD_OPCODE;
 
 pub mod helpers;
 
@@ -42,7 +41,9 @@ fn test_cold_reset_status_reporting() {
     // This is too late for this test.
     let buf: &[u8] = &image_bundle.to_bytes().unwrap();
     assert!(!hw.soc_mbox().lock().read().lock());
-    hw.soc_mbox().cmd().write(|_| FW_LOAD_CMD_OPCODE);
+    hw.soc_mbox()
+        .cmd()
+        .write(|_| CommandId::FIRMWARE_LOAD.into());
     hw.soc_mbox().dlen().write(|_| buf.len() as u32);
     let mut remaining = buf;
     while remaining.len() >= 4 {

--- a/rom/dev/tests/test_update_reset.rs
+++ b/rom/dev/tests/test_update_reset.rs
@@ -1,11 +1,10 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_builder::{FwId, ImageOptions, APP_WITH_UART, ROM_WITH_UART};
+use caliptra_common::mailbox_api::CommandId;
+use caliptra_common::RomBootStatus::*;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
-
-use crate::helpers::FW_LOAD_CMD_OPCODE;
-use caliptra_common::RomBootStatus::*;
 pub mod helpers;
 
 const TEST_FMC_CMD_RESET_FOR_UPDATE: u32 = 0x1000_0004;
@@ -277,7 +276,9 @@ fn test_update_reset_boot_status() {
     // This is too late for this test.
     let buf: &[u8] = &image_bundle.to_bytes().unwrap();
     assert!(!hw.soc_mbox().lock().read().lock());
-    hw.soc_mbox().cmd().write(|_| FW_LOAD_CMD_OPCODE);
+    hw.soc_mbox()
+        .cmd()
+        .write(|_| CommandId::FIRMWARE_LOAD.into());
     hw.soc_mbox().dlen().write(|_| buf.len() as u32);
     let mut remaining = buf;
     while remaining.len() >= 4 {

--- a/test/tests/warm_reset.rs
+++ b/test/tests/warm_reset.rs
@@ -3,6 +3,7 @@
 #![cfg(any(feature = "verilator", feature = "fpga_realtime"))]
 
 use caliptra_builder::{ImageOptions, APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_common::mailbox_api::CommandId;
 use caliptra_hw_model::{mbox_write_fifo, BootParams, HwModel, InitParams, SecurityState};
 use caliptra_hw_model_types::{DeviceLifecycle, Fuses};
 use caliptra_test::swap_word_bytes_inplace;
@@ -120,7 +121,9 @@ fn warm_reset_during_fw_load() {
     // Lock the mailbox
     assert!(!hw.soc_mbox().lock().read().lock());
     // Write load firmware command and data
-    hw.soc_mbox().cmd().write(|_| 0x4657_4C44);
+    hw.soc_mbox()
+        .cmd()
+        .write(|_| CommandId::FIRMWARE_LOAD.into());
     let buf = &image.to_bytes().unwrap();
     assert!(!mbox_write_fifo(&hw.soc_mbox(), buf).is_err());
     // Ask the microcontroller to execute this command


### PR DESCRIPTION
This PR updates the ROM logic for accepting the following FIPS commands:
	1. SHUTDOWN
	2. VERSION
	3. SELF_TEST