### PR TITLE
Replace runtime key digest calculation with build time

### DIFF
--- a/libcaliptra/examples/generic/main.mk
+++ b/libcaliptra/examples/generic/main.mk
@@ -10,8 +10,6 @@ LIBCALIPTRA_INC  = $(LIBCALIPTRA_ROOT)/inc
 
 OBJS := $(patsubst %.c,%.o, $(filter %.c,$(SOURCE)))
 
-CFLAGS += -lssl -lcrypto
-
 # SOC REFERENCE
 RTL_SOC_IFC_INCLUDE_PATH = ../../../hw-latest/caliptra-rtl/src/soc_ifc/rtl
 
@@ -20,9 +18,18 @@ INCLUDES += -I$(RTL_SOC_IFC_INCLUDE_PATH) -I$(LIBCALIPTRA_INC)
 
 .PHONY = run clean
 
+# The below lines are not optimal but required to fetch the keys from the image and calculate
+# their digest, and pack them into bespoke sections for later usage.
 $(TARGET): $(OBJS) $(DEPS)
 	@echo [LINK] $(TARGET)
 	$(Q)$(CC) -o $(TARGET) $(OBJS) $(CFLAGS)
+	@echo [ADD DIGESTS] VENDOR OWNER
+	$(Q)dd status=none if=$(FW_FILE) bs=4 count=480 skip=2   | sha384sum | xxd -r -p > vpk.bin
+	$(Q)dd status=none if=$(FW_FILE) bs=4 count=36  skip=913 | sha384sum | xxd -r -p > opk.bin
+	$(Q)objcopy $(TARGET) --update-section VPK_HASH=vpk.bin
+	$(Q)objcopy $(TARGET) --update-section OPK_HASH=opk.bin
+	$(Q)rm -f vpk.bin opk.bin
+
 
 $(CALIPTRA_API):
 	$(Q)make -C ../../


### PR DESCRIPTION
This replaces OpenSSL usage with a build-time step that extracts the keys and generates a digest that is then plugged into an ELF section.