### PR TITLE
Shrink ROM data section

### DIFF
--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -40,6 +40,10 @@ pub const CFI_XO_S0_ORG: u32 = 0x50004BF0;
 pub const CFI_XO_S1_ORG: u32 = 0x50004BF4;
 pub const CFI_XO_S2_ORG: u32 = 0x50004BF8;
 pub const CFI_XO_S3_ORG: u32 = 0x50004BFC;
+
+// Note: ROM DATA_ORG begins at 0x50018000. So FMC/RT are free to claim
+// any space between here and that address without fear of it being overwritten
+// by ROM on warm/update reset.
 pub const DATA_ORG: u32 = 0x50004C00;
 pub const STACK_ORG: u32 = 0x5001A000;
 pub const ESTACK_ORG: u32 = 0x5001F800;
@@ -61,7 +65,7 @@ pub const FMCALIAS_TBS_SIZE: u32 = 1024;
 pub const RTALIAS_TBS_SIZE: u32 = 1024;
 pub const PCR_LOG_SIZE: usize = 1024;
 pub const FUSE_LOG_SIZE: usize = 996;
-pub const DATA_SIZE: u32 = 85 * 1024;
+pub const DATA_SIZE: u32 = 81 * 1024;
 pub const STACK_SIZE: u32 = 22 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const NSTACK_SIZE: u32 = 1024;

--- a/rom/dev/src/rom.ld
+++ b/rom/dev/src/rom.ld
@@ -19,7 +19,10 @@ ENTRY(_start)
 ROM_ORG          = 0x00000000;
 ICCM_ORG         = 0x40000000;
 DCCM_ORG         = 0x50000000;
-DATA_ORG         = 0x50004C00;
+/* The space between DCCM_ORG and DATA_ORG is reserved for persistent data
+ * which is expected to persist across warm/update resets.
+ */
+DATA_ORG         = 0x50018000;
 STACK_ORG        = 0x5001C000;
 ESTACK_ORG       = 0x5001F800;
 NSTACK_ORG       = 0x5001FC00;
@@ -33,7 +36,7 @@ ROM_RELAXATION_PADDING = 4k;
 ROM_SIZE          = 48K;
 ICCM_SIZE         = 128K;
 DCCM_SIZE         = 128K;
-DATA_SIZE         = 93K;
+DATA_SIZE         = 4K;
 STACK_SIZE        = 14K;
 ESTACK_SIZE       = 1K;
 NSTACK_SIZE       = 1K;


### PR DESCRIPTION
Shrink the ROM data section to 4KiB. This prevents the compiler from using large portions of DCCM to store ROM's .data and .bss regions. This shouldn't impact ROM; as of this writing, those sections are all empty in the caliptra-rom binary. This reorganization is just a precaution to ensure changes aren't made to ROM which change this situation.

This is to ensure FMC and RT have full control over a large portion of DCCM (89KiB) which will be untouched by ROM. This is important because it allows mutable firmware to store data in DCCM which will persist across warm/update resets. Some of this region will be used to hold runtime's DPE state (about 3.5 KiB).