### PR TITLE
Execute FIPS Self Test in Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "caliptra-image-openssl",
  "caliptra-image-serde",
  "caliptra-image-types",
+ "caliptra-image-verify",
  "caliptra-kat",
  "caliptra-registers",
  "caliptra-x509",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
+ "ufmt",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "bitflags 2.4.0",
  "caliptra-drivers",
  "caliptra-image-types",
+ "caliptra-image-verify",
  "caliptra-registers",
  "ufmt",
  "zerocopy",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -64,7 +64,7 @@ pub const FMC_FAKE_WITH_UART: FwId = FwId {
 pub const APP_WITH_UART: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "test_only_commands"],
+    features: &["emu", "test_only_commands", "fips_self_test"],
     workspace_dir: None,
 };
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,6 +11,7 @@ bitfield.workspace = true
 bitflags.workspace = true
 caliptra-drivers.workspace = true
 caliptra-image-types = { workspace = true, default-features = false }
+caliptra-image-verify.workspace = true
 caliptra-registers.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod crypto;
 pub mod dice;
 pub mod keyids;
 pub mod mailbox_api;
+pub mod verifier;
 pub mod wdt;
 
 ///merge imports

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -27,7 +27,7 @@ impl CommandId {
     /// The status command.
     pub const VERSION: Self = Self(0x4650_5652); // "FPVR"
     /// The self-test command.
-    pub const SELF_TEST: Self = Self(0x4650_4C54); // "FPST"
+    pub const SELF_TEST_START: Self = Self(0x4650_4C54); // "FPST"
     /// The shutdown command.
     pub const SHUTDOWN: Self = Self(0x4650_5344); // "FPSD"
 

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -28,6 +28,8 @@ impl CommandId {
     pub const VERSION: Self = Self(0x4650_5652); // "FPVR"
     /// The self-test command.
     pub const SELF_TEST_START: Self = Self(0x4650_4C54); // "FPST"
+    /// The self-test get results.
+    pub const SELF_TEST_GET_RESULTS: Self = Self(0x4650_4C67); // "FPGR"
     /// The shutdown command.
     pub const SHUTDOWN: Self = Self(0x4650_5344); // "FPSD"
 

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -17,20 +17,20 @@ use caliptra_image_types::*;
 use caliptra_image_verify::ImageVerificationEnv;
 use core::ops::Range;
 
-use crate::rom_env::RomEnv;
+use caliptra_drivers::memory_layout::ICCM_RANGE;
 
 /// ROM Verification Environemnt
-pub(crate) struct RomImageVerificationEnv<'a> {
-    pub(crate) sha256: &'a mut Sha256,
-    pub(crate) sha384: &'a mut Sha384,
-    pub(crate) sha384_acc: &'a mut Sha384Acc,
-    pub(crate) soc_ifc: &'a mut SocIfc,
-    pub(crate) ecc384: &'a mut Ecc384,
-    pub(crate) data_vault: &'a mut DataVault,
-    pub(crate) pcr_bank: &'a mut PcrBank,
+pub struct FirmwareImageVerificationEnv<'a> {
+    pub sha256: &'a mut Sha256,
+    pub sha384: &'a mut Sha384,
+    pub sha384_acc: &'a mut Sha384Acc,
+    pub soc_ifc: &'a mut SocIfc,
+    pub ecc384: &'a mut Ecc384,
+    pub data_vault: &'a mut DataVault,
+    pub pcr_bank: &'a mut PcrBank,
 }
 
-impl<'a> ImageVerificationEnv for &mut RomImageVerificationEnv<'a> {
+impl<'a> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a> {
     /// Calculate Digest using SHA-384 Accelerator
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest> {
         loop {
@@ -133,7 +133,7 @@ impl<'a> ImageVerificationEnv for &mut RomImageVerificationEnv<'a> {
     }
 
     fn iccm_range(&self) -> Range<u32> {
-        RomEnv::ICCM_RANGE
+        ICCM_RANGE
     }
 
     fn lms_verify_enabled(&self) -> bool {

--- a/drivers/src/lms.rs
+++ b/drivers/src/lms.rs
@@ -379,12 +379,12 @@ impl Lms {
 
     ///  Note: Use this function only if glitch protection is not needed.
     ///        If glitch protection is needed, use `verify_lms_signature_cfi` instead.
-    pub fn verify_lms_signature<const N: usize, const P: usize, const H: usize>(
+    pub fn verify_lms_signature(
         &self,
         sha256_driver: &mut Sha256,
         input_string: &[u8],
-        lms_public_key: &LmsPublicKey<N>,
-        lms_sig: &LmsSignature<N, P, H>,
+        lms_public_key: &LmsPublicKey<6>,
+        lms_sig: &LmsSignature<6, 51, 15>,
     ) -> CaliptraResult<LmsResult> {
         let mut candidate_key =
             self.verify_lms_signature_cfi(sha256_driver, input_string, lms_public_key, lms_sig)?;
@@ -397,7 +397,50 @@ impl Lms {
         result
     }
 
-    pub fn verify_lms_signature_cfi<const N: usize, const P: usize, const H: usize>(
+    ///  Note: Use this function only if glitch protection is not needed.
+    ///        If glitch protection is needed, use `verify_lms_signature_cfi_generic` instead.
+    pub fn verify_lms_signature_generic<const N: usize, const P: usize, const H: usize>(
+        &self,
+        sha256_driver: &mut Sha256,
+        input_string: &[u8],
+        lms_public_key: &LmsPublicKey<N>,
+        lms_sig: &LmsSignature<N, P, H>,
+    ) -> CaliptraResult<LmsResult> {
+        let mut candidate_key = self.verify_lms_signature_cfi_generic(
+            sha256_driver,
+            input_string,
+            lms_public_key,
+            lms_sig,
+        )?;
+        let result = if candidate_key != HashValue::from(lms_public_key.digest) {
+            Ok(LmsResult::SigVerifyFailed)
+        } else {
+            Ok(LmsResult::Success)
+        };
+        candidate_key.0.fill(0);
+        result
+    }
+
+    // When callers from separate crates call a function like
+    // verify_lms_signature_cfi_generic(), Rustc 1.70
+    // may build multiple versions (depending on optimizer heuristics), even when all the
+    // generic parameters are identical. This is bad, as it can bloat the binary and the
+    // second copy violates the FIPS requirements that the same machine code be used for the
+    // KAT as the actual implementation. To defend against it, we provide this non-generic
+    // function that production firmware should call instead.
+    #[inline(never)]
+    pub fn verify_lms_signature_cfi(
+        &self,
+        sha256_driver: &mut Sha256,
+        input_string: &[u8],
+        lms_public_key: &LmsPublicKey<6>,
+        lms_sig: &LmsSignature<6, 51, 15>,
+    ) -> CaliptraResult<HashValue<6>> {
+        self.verify_lms_signature_cfi_generic(sha256_driver, input_string, lms_public_key, lms_sig)
+    }
+
+    #[inline(always)]
+    pub fn verify_lms_signature_cfi_generic<const N: usize, const P: usize, const H: usize>(
         &self,
         sha256_driver: &mut Sha256,
         input_string: &[u8],

--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -66,6 +66,11 @@ pub const STACK_SIZE: u32 = 22 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const NSTACK_SIZE: u32 = 1024;
 
+pub const ICCM_RANGE: core::ops::Range<u32> = core::ops::Range {
+    start: ICCM_ORG,
+    end: ICCM_ORG + ICCM_SIZE,
+};
+
 #[test]
 #[allow(clippy::assertions_on_constants)]
 fn mem_layout_test_manifest() {

--- a/drivers/test-fw/src/bin/lms_32_tests.rs
+++ b/drivers/test-fw/src/bin/lms_32_tests.rs
@@ -551,12 +551,12 @@ fn test_lms_lower_32() {
     };
 
     let final_result = Lms::default()
-        .verify_lms_signature(&mut sha256, &MESSAGE, &LMS_PUBLIC_KEY, &FINAL_LMS_SIG)
+        .verify_lms_signature_generic(&mut sha256, &MESSAGE, &LMS_PUBLIC_KEY, &FINAL_LMS_SIG)
         .unwrap();
     assert_eq!(final_result, LmsResult::Success);
 
     let candidate_key = Lms::default()
-        .verify_lms_signature_cfi(&mut sha256, &MESSAGE, &LMS_PUBLIC_KEY, &FINAL_LMS_SIG)
+        .verify_lms_signature_cfi_generic(&mut sha256, &MESSAGE, &LMS_PUBLIC_KEY, &FINAL_LMS_SIG)
         .unwrap();
     assert_eq!(candidate_key, HashValue::from(LMS_PUBLIC_KEY.digest));
 }
@@ -815,7 +815,7 @@ fn test_hss_upper_32() {
     };
 
     let result = Lms::default()
-        .verify_lms_signature(
+        .verify_lms_signature_generic(
             &mut sha256,
             &PUBLIC_BUFFER,
             &HSS_PUBLIC_KEY,

--- a/drivers/test-fw/src/bin/negative_tests_lms.rs
+++ b/drivers/test-fw/src/bin/negative_tests_lms.rs
@@ -436,7 +436,7 @@ fn test_failures_lms_24() {
     );
 
     assert_eq!(
-        Lms::default().verify_lms_signature(
+        Lms::default().verify_lms_signature_generic(
             &mut sha256,
             &MESSAGE,
             &LmsPublicKey {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -312,6 +312,7 @@ impl CaliptraError {
     pub const RUNTIME_GET_DEVID_CERT_FAILED: CaliptraError = CaliptraError::new_const(0x000E0013);
     pub const RUNTIME_CERT_CHAIN_CREATION_FAILED: CaliptraError =
         CaliptraError::new_const(0x000E0014);
+    pub const RUNTIME_SELF_TEST_IN_PROGREESS: CaliptraError = CaliptraError::new_const(0x000E0015);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -312,7 +312,7 @@ impl CaliptraError {
     pub const RUNTIME_GET_DEVID_CERT_FAILED: CaliptraError = CaliptraError::new_const(0x000E0013);
     pub const RUNTIME_CERT_CHAIN_CREATION_FAILED: CaliptraError =
         CaliptraError::new_const(0x000E0014);
-    pub const RUNTIME_SELF_TEST_IN_PROGREESS: CaliptraError = CaliptraError::new_const(0x000E0015);
+    pub const RUNTIME_SELF_TEST_IN_PROGRESS: CaliptraError = CaliptraError::new_const(0x000E0015);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/kat/Cargo.toml
+++ b/kat/Cargo.toml
@@ -13,3 +13,4 @@ doctest = false
 caliptra-drivers.workspace = true
 caliptra-lms-types.workspace = true
 zerocopy.workspace = true
+ufmt.workspace = true

--- a/kat/src/kats_env.rs
+++ b/kat/src/kats_env.rs
@@ -1,0 +1,27 @@
+use caliptra_drivers::Ecc384;
+use caliptra_drivers::{Hmac384, Lms, Sha1, Sha256, Sha384, Sha384Acc, Trng};
+
+pub struct KatsEnv<'a> {
+    // SHA1 Engine
+    pub sha1: &'a mut Sha1,
+
+    pub sha256: &'a mut Sha256,
+
+    // SHA2-384 Engine
+    pub sha384: &'a mut Sha384,
+
+    // SHA2-384 Accelerator
+    pub sha384_acc: &'a mut Sha384Acc,
+
+    /// Hmac384 Engine
+    pub hmac384: &'a mut Hmac384,
+
+    /// Cryptographically Secure Random Number Generator
+    pub trng: &'a mut Trng,
+
+    /// LMS Engine
+    pub lms: &'a mut Lms,
+
+    /// Ecc384 Engine
+    pub ecc384: &'a mut Ecc384,
+}

--- a/kat/src/kats_env.rs
+++ b/kat/src/kats_env.rs
@@ -1,3 +1,5 @@
+// Licensed under the Apache-2.0 license
+
 use caliptra_drivers::Ecc384;
 use caliptra_drivers::{Hmac384, Lms, Sha1, Sha256, Sha384, Sha384Acc, Trng};
 

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -16,6 +16,7 @@ Abstract:
 
 mod ecc384_kat;
 mod hmac384_kat;
+mod kats_env;
 mod lms_kat;
 mod sha1_kat;
 mod sha256_kat;
@@ -25,8 +26,45 @@ mod sha384acc_kat;
 pub use caliptra_drivers::{CaliptraError, CaliptraResult};
 pub use ecc384_kat::Ecc384Kat;
 pub use hmac384_kat::Hmac384Kat;
+pub use kats_env::KatsEnv;
 pub use lms_kat::LmsKat;
 pub use sha1_kat::Sha1Kat;
 pub use sha256_kat::Sha256Kat;
 pub use sha384_kat::Sha384Kat;
 pub use sha384acc_kat::Sha384AccKat;
+
+use caliptra_drivers::cprintln;
+
+/// Execute Known Answer Tests
+///
+/// # Arguments
+///
+/// * `env` - ROM Environment
+pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
+    cprintln!("[kat] ++");
+
+    cprintln!("[kat] sha1");
+    Sha1Kat::default().execute(env.sha1)?;
+
+    cprintln!("[kat] SHA2-256");
+    Sha256Kat::default().execute(env.sha256)?;
+
+    cprintln!("[kat] SHA2-384");
+    Sha384Kat::default().execute(env.sha384)?;
+
+    cprintln!("[kat] SHA2-384-ACC");
+    Sha384AccKat::default().execute(env.sha384_acc)?;
+
+    cprintln!("[kat] ECC-384");
+    Ecc384Kat::default().execute(env.ecc384, env.trng)?;
+
+    cprintln!("[kat] HMAC-384");
+    Hmac384Kat::default().execute(env.hmac384, env.trng)?;
+
+    cprintln!("[kat] LMS");
+    LmsKat::default().execute(env.sha256, env.lms)?;
+
+    cprintln!("[kat] --");
+
+    Ok(())
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -15,12 +15,12 @@ Abstract:
 use crate::flow::fake::FakeRomImageVerificationEnv;
 use crate::fuse::log_fuse_data;
 use crate::rom_env::RomEnv;
-use crate::{cprintln, verifier::RomImageVerificationEnv};
 use crate::{pcr, wdt};
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_eq, cfi_launder};
 use caliptra_common::capabilities::Capabilities;
 use caliptra_common::mailbox_api::CommandId;
+use caliptra_common::verifier::FirmwareImageVerificationEnv;
 use caliptra_common::{cprint, memory_layout::MAN1_ORG, FuseLogEntryId, RomBootStatus::*};
 use caliptra_drivers::*;
 use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
@@ -63,7 +63,7 @@ impl FirmwareProcessor {
         let manifest = Self::load_manifest(&mut txn);
         let manifest = okref(&manifest)?;
 
-        let mut venv = RomImageVerificationEnv {
+        let mut venv = FirmwareImageVerificationEnv {
             sha256: &mut env.sha256,
             sha384: &mut env.sha384,
             sha384_acc: &mut env.sha384_acc,
@@ -209,7 +209,7 @@ impl FirmwareProcessor {
     /// * `env` - ROM Environment
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn verify_image(
-        venv: &mut RomImageVerificationEnv,
+        venv: &mut FirmwareImageVerificationEnv,
         manifest: &ImageManifest,
         img_bundle_sz: u32,
     ) -> CaliptraResult<ImageVerificationInfo> {

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -134,7 +134,7 @@ impl FirmwareProcessor {
             if let Some(txn) = mbox.peek_recv() {
                 report_fw_error_non_fatal(0);
                 match CommandId::from(txn.cmd()) {
-                    CommandId::SELF_TEST | CommandId::VERSION | CommandId::SHUTDOWN => {
+                    CommandId::SELF_TEST_START | CommandId::VERSION | CommandId::SHUTDOWN => {
                         // [TODO] Placeholder for FIPS ROM commands.
                         txn.start_txn().complete(false)?;
                         continue;

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -356,7 +356,7 @@ impl<'a> ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'a> {
     }
 
     fn iccm_range(&self) -> Range<u32> {
-        RomEnv::ICCM_RANGE
+        caliptra_common::memory_layout::ICCM_RANGE
     }
 
     fn lms_verify_enabled(&self) -> bool {

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -13,7 +13,8 @@ Abstract:
 --*/
 #[cfg(feature = "fake-rom")]
 use crate::flow::fake::FakeRomImageVerificationEnv;
-use crate::{cprintln, pcr, rom_env::RomEnv, verifier::RomImageVerificationEnv};
+use crate::{cprintln, pcr, rom_env::RomEnv};
+use caliptra_common::verifier::FirmwareImageVerificationEnv;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::CommandId;
@@ -56,7 +57,7 @@ impl UpdateResetFlow {
         let manifest = Self::load_manifest(&mut recv_txn)?;
         report_boot_status(UpdateResetLoadManifestComplete.into());
 
-        let mut venv = RomImageVerificationEnv {
+        let mut venv = FirmwareImageVerificationEnv {
             sha256: &mut env.sha256,
             sha384: &mut env.sha384,
             sha384_acc: &mut env.sha384_acc,
@@ -110,7 +111,7 @@ impl UpdateResetFlow {
     ///
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn verify_image(
-        env: &mut RomImageVerificationEnv,
+        env: &mut FirmwareImageVerificationEnv,
         manifest: &ImageManifest,
         img_bundle_sz: u32,
     ) -> CaliptraResult<ImageVerificationInfo> {

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -41,7 +41,6 @@ mod kat;
 mod lock;
 mod pcr;
 mod rom_env;
-mod verifier;
 mod wdt;
 
 use caliptra_drivers::printer as print;

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -21,8 +21,8 @@ Note:
 
 --*/
 
-use crate::verifier::RomImageVerificationEnv;
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_common::verifier::FirmwareImageVerificationEnv;
 use caliptra_common::{
     memory_layout::{PCR_LOG_ORG, PCR_LOG_SIZE},
     pcr::{PCR_ID_FMC_CURRENT, PCR_ID_FMC_JOURNEY},
@@ -67,7 +67,7 @@ impl PcrExtender<'_> {
 /// * `env` - ROM Environment
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 pub(crate) fn extend_pcrs(
-    env: &mut RomImageVerificationEnv,
+    env: &mut FirmwareImageVerificationEnv,
     info: &ImageVerificationInfo,
 ) -> CaliptraResult<()> {
     // Clear the Current PCR, but do not clear the Journey PCR

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,7 +16,6 @@ Abstract:
 --*/
 
 use crate::fht::FhtDataStore;
-use caliptra_common::memory_layout::*;
 use caliptra_drivers::{
     DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
     Sha384, Sha384Acc, SocIfc, Trng,
@@ -27,7 +26,6 @@ use caliptra_registers::{
     hmac::HmacReg, kv::KvReg, mbox::MboxCsr, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
     sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
-use core::ops::Range;
 
 /// Rom Context
 pub struct RomEnv {
@@ -78,11 +76,6 @@ pub struct RomEnv {
 }
 
 impl RomEnv {
-    pub const ICCM_RANGE: Range<u32> = Range {
-        start: ICCM_ORG,
-        end: ICCM_ORG + ICCM_SIZE,
-    };
-
     pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
         let trng = Trng::new(
             CsrngReg::new(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,6 +20,7 @@ platform.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
 arrayvec.workspace = true
+caliptra-image-verify.workspace = true
 
 [build-dependencies]
 caliptra_common = { workspace = true, default-features = false }
@@ -45,3 +46,4 @@ riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 test_only_commands = []
 verilator = ["caliptra-hw-model/verilator"]
+fips_self_test=[]

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -135,8 +135,8 @@ pub mod fips_self_test_cmd {
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<()> {
         caliptra_drivers::report_boot_status(RtFipSelfTestStarted.into());
         cprintln!("[rt] FIPS self test");
-        copy_and_verify_image(env)?;
         execute_kats(env)?;
+        copy_and_verify_image(env)?;
         caliptra_drivers::report_boot_status(RtFipSelfTestComplete.into());
         Ok(())
     }

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -10,7 +10,6 @@ use caliptra_drivers::KeyVault;
 use caliptra_drivers::Sha256;
 use caliptra_drivers::Sha384;
 use caliptra_drivers::Sha384Acc;
-use caliptra_kat::{Ecc384Kat, Hmac384Kat, Sha256Kat, Sha384AccKat, Sha384Kat};
 use caliptra_registers::mbox::enums::MboxStatusE;
 
 use crate::Drivers;
@@ -37,26 +36,6 @@ impl FipsModule {
         }
         env.persistent_data.get_mut().zeroize();
     }
-
-    /// Execute KAT for cryptographic algorithms implemented in H/W.
-    fn execute_kats(env: &mut Drivers) -> CaliptraResult<()> {
-        cprintln!("[kat] Executing SHA2-256 Engine KAT");
-        Sha256Kat::default().execute(&mut env.sha256)?;
-
-        cprintln!("[kat] Executing SHA2-384 Engine KAT");
-        Sha384Kat::default().execute(&mut env.sha384)?;
-
-        cprintln!("[kat] Executing SHA2-384 Accelerator KAT");
-        Sha384AccKat::default().execute(&mut env.sha384_acc)?;
-
-        cprintln!("[kat] Executing ECC-384 Engine KAT");
-        Ecc384Kat::default().execute(&mut env.ecc384, &mut env.trng)?;
-
-        cprintln!("[kat] Executing HMAC-384 Engine KAT");
-        Hmac384Kat::default().execute(&mut env.hmac384, &mut env.trng)?;
-
-        Ok(())
-    }
 }
 
 pub struct FipsVersionCmd;
@@ -78,14 +57,47 @@ impl FipsVersionCmd {
         Ok(MailboxResp::FipsVersion(resp))
     }
 }
+#[cfg(feature = "fips_self_test")]
+pub mod fips_self_test_cmd {
+    use super::*;
 
-pub struct FipsSelfTestCmd;
-impl FipsSelfTestCmd {
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<MailboxResp> {
         cprintln!("[rt] FIPS self test");
-        FipsModule::execute_kats(env)?;
+        execute_kats(env)?;
 
         Ok(MailboxResp::default())
+    }
+
+    /// Execute KAT for cryptographic algorithms implemented in H/W.
+    fn execute_kats(env: &mut Drivers) -> CaliptraResult<()> {
+        let mut kats_env = caliptra_kat::KatsEnv {
+            // SHA1 Engine
+            sha1: &mut env.sha1,
+
+            // sha256
+            sha256: &mut env.sha256,
+
+            // SHA2-384 Engine
+            sha384: &mut env.sha384,
+
+            // SHA2-384 Accelerator
+            sha384_acc: &mut env.sha384_acc,
+
+            // Hmac384 Engine
+            hmac384: &mut env.hmac384,
+
+            /// Cryptographically Secure Random Number Generator
+            trng: &mut env.trng,
+
+            // LMS Engine
+            lms: &mut env.lms,
+
+            /// Ecc384 Engine
+            ecc384: &mut env.ecc384,
+        };
+
+        caliptra_kat::execute_kat(&mut kats_env)?;
+        Ok(())
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -266,7 +266,7 @@ impl Drivers {
 }
 
 /// Run pending jobs and enter low power mode.
-fn goto_idle(drivers: &mut Drivers) {
+fn enter_idle(drivers: &mut Drivers) {
     // Run pending jobs before entering low power mode.
     #[cfg(feature = "fips_self_test")]
     if let SelfTestStatus::InProgress(execute) = drivers.self_test_status {
@@ -354,7 +354,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> ! {
     drivers.soc_ifc.assert_ready_for_runtime();
     caliptra_drivers::report_boot_status(RtBootStatus::RtReadyForCommands.into());
     loop {
-        goto_idle(drivers);
+        enter_idle(drivers);
         if drivers.mbox.is_cmd_ready() {
             // TODO : Move start/stop WDT to wait_for_cmd when NMI is implemented.
             caliptra_common::wdt::start_wdt(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -337,7 +337,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 drivers.self_test_status = SelfTestStatus::Idle;
                 Ok(MailboxResp::default())
             }
-            _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGREESS),
+            _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGRESS),
         },
         CommandId::SHUTDOWN => FipsShutdownCmd::execute(drivers),
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -328,11 +328,15 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::TEST_ONLY_HMAC384_VERIFY => HmacVerifyCmd::execute(drivers, cmd_bytes),
         CommandId::VERSION => FipsVersionCmd::execute(drivers),
         #[cfg(feature = "fips_self_test")]
-        CommandId::SELF_TEST => match drivers.self_test_status {
+        CommandId::SELF_TEST_START => match drivers.self_test_status {
             SelfTestStatus::Idle => {
                 drivers.self_test_status = SelfTestStatus::InProgress(fips_self_test_cmd::execute);
                 Ok(MailboxResp::default())
             }
+            _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGRESS),
+        },
+        #[cfg(feature = "fips_self_test")]
+        CommandId::SELF_TEST_GET_RESULTS => match drivers.self_test_status {
             SelfTestStatus::Done => {
                 drivers.self_test_status = SelfTestStatus::Idle;
                 Ok(MailboxResp::default())

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -665,25 +665,6 @@ fn test_fips_cmd_api() {
     let name = &fips_version.name[..];
     assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
 
-    // SELF_TEST
-    let payload = MailboxReqHeader {
-        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::SELF_TEST), &[]),
-    };
-
-    let resp = model
-        .mailbox_execute(u32::from(CommandId::SELF_TEST), payload.as_bytes())
-        .unwrap()
-        .unwrap();
-
-    let resp = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
-    // Verify checksum and FIPS status
-    assert!(caliptra_common::checksum::verify_checksum(
-        resp.chksum,
-        0x0,
-        &resp.as_bytes()[core::mem::size_of_val(&resp.chksum)..],
-    ));
-    assert_eq!(resp.fips_status, MailboxRespHeader::FIPS_STATUS_APPROVED);
-
     // SHUTDOWN
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::SHUTDOWN), &[]),

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -24,3 +24,4 @@ openssl.workspace = true
 fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
+fips_self_test = ["caliptra-runtime/fips_self_test"]

--- a/test/tests/smoke_test.rs
+++ b/test/tests/smoke_test.rs
@@ -396,11 +396,14 @@ fn fips_self_test() {
     );
 
     let payload = MailboxReqHeader {
-        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::SELF_TEST), &[]),
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::SELF_TEST_START),
+            &[],
+        ),
     };
 
     let resp = hw
-        .mailbox_execute(u32::from(CommandId::SELF_TEST), payload.as_bytes())
+        .mailbox_execute(u32::from(CommandId::SELF_TEST_START), payload.as_bytes())
         .unwrap()
         .unwrap();
 
@@ -419,7 +422,7 @@ fn fips_self_test() {
         true,
     );
     let _resp = hw
-        .mailbox_execute(u32::from(CommandId::SELF_TEST), payload.as_bytes())
+        .mailbox_execute(u32::from(CommandId::SELF_TEST_START), payload.as_bytes())
         .unwrap_err();
 
     hw.step_until_boot_status(
@@ -428,7 +431,7 @@ fn fips_self_test() {
     );
 
     let resp = hw
-        .mailbox_execute(u32::from(CommandId::SELF_TEST), payload.as_bytes())
+        .mailbox_execute(u32::from(CommandId::SELF_TEST_START), payload.as_bytes())
         .unwrap()
         .unwrap();
 

--- a/test/tests/smoke_test.rs
+++ b/test/tests/smoke_test.rs
@@ -430,8 +430,18 @@ fn fips_self_test() {
         true,
     );
 
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::SELF_TEST_GET_RESULTS),
+            &[],
+        ),
+    };
+
     let resp = hw
-        .mailbox_execute(u32::from(CommandId::SELF_TEST_START), payload.as_bytes())
+        .mailbox_execute(
+            u32::from(CommandId::SELF_TEST_GET_RESULTS),
+            payload.as_bytes(),
+        )
         .unwrap()
         .unwrap();
 

--- a/test/tests/smoke_test.rs
+++ b/test/tests/smoke_test.rs
@@ -364,7 +364,7 @@ fn smoke_test() {
 }
 
 #[test]
-fn test_fips_verify() {
+fn fips_self_test() {
     let fuses = Fuses::default();
     let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
     let mut hw = caliptra_hw_model::new(BootParams {


### PR DESCRIPTION
This commit enables Runtime to run FIPS Self Tests as follows : KATs, verification of firmware image in ICCM, and ROM integrity test. 

- Light refactor to decouple KAT crate from Rom dependency.
- Light refactor to decouple Image verification crate from ROM dependency.
- Ability for RT to defer execution of self test (basic job control). 

Runtime copies image from ICCM to mailbox SRAM , so it needs to fake a send a transaction and hold the mailbox lock while the image is being validated,. It defers the actual self test execution until the mailbox lock can be acquired. SoC must "poll" for self test completion.

- SoC must send a FIPS self test command one time to schedule the execution.
- Caliptra holds the mailbox lock while the self test is in progress.  
- Failure of FIPS self test is handled as fatal error.
- Upon successful self-test completion the mailbox lock is released and SoC will receive a positive acknowledgement when FIPS Self test command is re-issued.