### PR TITLE
libcaliptra: idev, ldev, dpe commands

### DIFF
--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -28,8 +28,15 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer);
 // Read Caliptra FIPS Version
 int caliptra_get_fips_version(struct caliptra_fips_version *version);
 
+
 // Stash Measurement command
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp);
+
+// Get IDEV CSR
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp);
+
+// Get LDEV Cert
+int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp);
 
 // Execute Mailbox Command
 int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);

--- a/libcaliptra/inc/caliptra_enums.h
+++ b/libcaliptra/inc/caliptra_enums.h
@@ -31,3 +31,44 @@ enum toc_entry_id {
     MAX     = 0xFFFFFFFF,
 };
 
+// The below enums are placeholders to set up the baseline
+// required for communication of DPE commands to Caliptra
+// firmware.
+
+enum dpe_commands {
+    DPE_GET_PROFILE        = 0x1,
+    DPE_INITIALIZE_CONTEXT = 0x7,
+    DPE_DERIVE_CHILD       = 0x8,
+    DPE_CERTIFY_KEY        = 0x9,
+    DPE_SIGN               = 0xA,
+    DPE_ROTATE_CTX_HANDLE  = 0xE,
+    DPE_DESTROY_CTX        = 0xF,
+    DPE_GET_CERT_CHAIN     = 0x80,
+    DPE_EXTEND_TCI         = 0x81,
+    DPE_TAG_TCI            = 0x82,
+    DPE_GET_TAGGED_TCI     = 0x83,
+};
+
+enum dpe_error_codes {
+    DPE_NO_ERROR               = 0,
+    DPE_INTERNAL_ERROR         = 1,
+    DPE_INVALID_COMMAND        = 2,
+    DPE_INVALID_ARGUMENT       = 3,
+    DPE_ARGUMENT_NOT_SUPPORTED = 4,
+    DPE_INVALID_HANDLE         = 0x1000,
+    DPE_INVALID_LOCALITY       = 0x1001,
+    DPE_BADTAG                 = 0x1002,
+    DPE_MAXTCIS                = 0x1003,
+    DPE_PLATFORM_ERROR         = 0x1004,
+    DPE_CRYPTO_ERROR           = 0x1005,
+    DPE_HASH_ERROR             = 0x1006,
+    DPE_RAND_ERROR             = 0x1007,
+};
+
+#define DPE_PROFILE_256 1
+#define DPE_PROFILE_384 2
+
+enum dpe_profile {
+    P256Sha256 = DPE_PROFILE_256,
+    P384Sha384 = DPE_PROFILE_384,
+};

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -64,6 +64,18 @@ struct caliptra_stash_measurement_resp {
     uint32_t                   dpe_result;
 };
 
+struct caliptra_get_idev_csr_resp {
+    struct caliptra_completion cpl;
+    uint32_t                   data_size;
+    uint8_t                    data[1024];
+};
+
+struct caliptra_get_ldev_cert_resp {
+    struct caliptra_completion cpl;
+    uint32_t                   data_size;
+    uint8_t                    data[1024];
+};
+
 // The below fields are placeholders to set up the baseline
 // required for communication of DPE commands to Caliptra
 // firmware.
@@ -148,9 +160,9 @@ struct dpe_get_certificate_chain_response {
 };
 
 struct caliptra_dpe_req {
-    caliptra_checksum  checksum;
-    uint32_t           data_size;
-    uint8_t            data[DPE_DATA_MAX];
+    caliptra_checksum checksum;
+    uint32_t          data_size;
+    uint8_t           data[DPE_DATA_MAX];
 };
 
 struct caliptra_dpe_resp {

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -63,3 +63,108 @@ struct caliptra_stash_measurement_resp {
     struct caliptra_completion cpl;
     uint32_t                   dpe_result;
 };
+
+// The below fields are placeholders to set up the baseline
+// required for communication of DPE commands to Caliptra
+// firmware.
+
+#define DPE_DATA_MAX 512
+#define DPE_MAGIC    0x44504543 // "DPEC"
+
+struct dpe_cmd_hdr {
+    uint32_t magic;
+    uint32_t cmd_id;
+    uint32_t profile;
+};
+
+struct dpe_resp_hdr {
+    uint32_t magic;
+    uint32_t status;
+    uint32_t profile;
+};
+
+
+#define DPE_HANDLE_SIZE 16
+#define DPE_CERT_SIZE   2048
+
+#ifndef DPE_PROFILE
+#define DPE_PROFILE DPE_PROFILE_384
+#endif
+
+#if (DPE_PROFILE == DPE_PROFILE_256)
+#define DPE_ECC_SIZE 32
+#endif
+
+#if (DPE_PROFILE == DPE_PROFILE_384)
+#define DPE_ECC_SIZE 48
+#endif
+
+struct dpe_get_profile_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint16_t major_version;
+    uint16_t minor_version;
+    uint32_t vendor_id;
+    uint32_t vendor_sku;
+    uint32_t max_tci_nodes;
+    uint32_t flags;
+};
+
+struct dpe_new_handle_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t             handle[DPE_HANDLE_SIZE];
+};
+
+struct dpe_derive_child_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t             handle[DPE_HANDLE_SIZE];
+    uint8_t             parent_handle[DPE_HANDLE_SIZE];
+};
+
+struct dpe_certify_key_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t             new_context_handle[DPE_HANDLE_SIZE];
+    uint8_t             derived_pubkey_x[DPE_ECC_SIZE];
+    uint32_t            cert_size;
+    uint8_t             cert[DPE_CERT_SIZE];
+};
+
+struct dpe_sign_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t             new_context_handle[DPE_HANDLE_SIZE];
+    uint8_t             sig_r_or_hmac[DPE_ECC_SIZE];
+    uint8_t             sig_s;
+};
+
+struct dpe_get_tagged_tci_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t             tci_cumulative[DPE_ECC_SIZE];
+    uint8_t             tci_current[DPE_ECC_SIZE];
+};
+
+struct dpe_get_certificate_chain_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint32_t            certificate_size;
+    uint8_t             certificate_chain[DPE_CERT_SIZE];
+};
+
+struct caliptra_dpe_req {
+    caliptra_checksum  checksum;
+    uint32_t           data_size;
+    uint8_t            data[DPE_DATA_MAX];
+};
+
+struct caliptra_dpe_resp {
+    struct caliptra_completion cpl;
+    uint32_t                   data_size;
+    union {
+        struct dpe_get_profile_response           get_profile;
+        struct dpe_new_handle_response            new_handle;
+        struct dpe_derive_child_response          derive_child;
+        struct dpe_certify_key_response           certify_key;
+        struct dpe_sign_response                  sign;
+        struct dpe_get_tagged_tci_response        get_tagged_tci;
+        struct dpe_get_certificate_chain_response get_certified_chain;
+        uint8_t                                   data[sizeof(struct dpe_certify_key_response)];
+    };
+};
+

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -341,11 +341,7 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
     return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL);
 }
 
-<<<<<<< HEAD
-static int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
-=======
 static inline int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
->>>>>>> aff9fb5 (DPE Command Support)
 {
     uint32_t calc_checksum = calculate_caliptra_checksum(0, buffer + sizeof(uint32_t), buffer_size - sizeof(uint32_t));
 
@@ -360,11 +356,17 @@ static inline int check_command_response(struct caliptra_completion *cpl, uint8_
     return 0;
 }
 
-<<<<<<< HEAD
-=======
 static int pack_and_send_command(struct parcel *parcel)
 {
     if (parcel == NULL)
+    {
+        return -EINVAL;
+    }
+
+    // Parcels will always have, at a minimum:
+    //  > 4 byte tx buffer, for the checksum
+    //  > 8 byte rx buffer, for the checksum and FIPS status
+    if (!parcel->tx_buffer || !parcel->rx_buffer)
     {
         return -EINVAL;
     }
@@ -393,7 +395,6 @@ static int pack_and_send_command(struct parcel *parcel)
     return check_command_response(cpl, parcel->rx_buffer, parcel->rx_bytes);
 }
 
->>>>>>> aff9fb5 (DPE Command Support)
 /**
  * caliptra_get_fips_version
  *
@@ -407,7 +408,9 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
 {
     // Parameter check
     if (version == NULL)
+    {
         return -EINVAL;
+    }
 
     caliptra_checksum checksum = 0;
 
@@ -430,7 +433,7 @@ int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struc
     }
 
     struct parcel p = {
-        .command   = OP_FIPS_VERSION,
+        .command   = OP_STASH_MEASUREMENT,
         .tx_buffer = (uint8_t*)req,
         .tx_bytes  = sizeof(struct caliptra_stash_measurement_req),
         .rx_buffer = (uint8_t*)resp,
@@ -440,9 +443,9 @@ int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struc
     return pack_and_send_command(&p);
 }
 
-int caliptra_get_idev_csr(struct caliptra_get_idev_csr_cpl *cpl)
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp)
 {
-    if (!cpl)
+    if (!resp)
     {
         return -EINVAL;
     }
@@ -453,16 +456,16 @@ int caliptra_get_idev_csr(struct caliptra_get_idev_csr_cpl *cpl)
         .command   = OP_GET_IDEV_CSR,
         .tx_buffer = (uint8_t*)&checksum,
         .tx_bytes  = sizeof(caliptra_checksum),
-        .rx_buffer = (uint8_t*)cpl,
-        .rx_bytes  = sizeof(struct caliptra_get_idev_csr_cpl),
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(struct caliptra_get_idev_csr_resp),
     };
 
     return pack_and_send_command(&p);
 }
 
-int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_cpl *cpl)
+int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp)
 {
-    if (!cpl)
+    if (!resp)
     {
         return -EINVAL;
     }
@@ -473,8 +476,8 @@ int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_cpl *cpl)
         .command   = OP_GET_LDEV_CERT,
         .tx_buffer = (uint8_t*)&checksum,
         .tx_bytes  = sizeof(caliptra_checksum),
-        .rx_buffer = (uint8_t*)cpl,
-        .rx_bytes  = sizeof(struct caliptra_get_ldev_cert_cpl),
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(struct caliptra_get_ldev_cert_resp),
     };
 
     return pack_and_send_command(&p);

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -341,7 +341,11 @@ int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
     return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL);
 }
 
+<<<<<<< HEAD
 static int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
+=======
+static inline int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
+>>>>>>> aff9fb5 (DPE Command Support)
 {
     uint32_t calc_checksum = calculate_caliptra_checksum(0, buffer + sizeof(uint32_t), buffer_size - sizeof(uint32_t));
 
@@ -356,6 +360,40 @@ static int check_command_response(struct caliptra_completion *cpl, uint8_t *buff
     return 0;
 }
 
+<<<<<<< HEAD
+=======
+static int pack_and_send_command(struct parcel *parcel)
+{
+    if (parcel == NULL)
+    {
+        return -EINVAL;
+    }
+
+    struct caliptra_buffer in_buf = {
+        .data = parcel->tx_buffer,
+        .len  = parcel->tx_bytes,
+    };
+
+    struct caliptra_buffer out_buf = {
+        .data = parcel->rx_buffer,
+        .len  = parcel->rx_bytes,
+    };
+
+    *((caliptra_checksum*)parcel->tx_buffer) = calculate_caliptra_checksum(parcel->command, parcel->tx_buffer, parcel->tx_bytes);
+
+    int status = caliptra_mailbox_execute(parcel->command, &in_buf, &out_buf);
+
+    if (status)
+    {
+        return status;
+    }
+
+    struct caliptra_completion *cpl = (struct caliptra_completion*)parcel->rx_buffer;
+
+    return check_command_response(cpl, parcel->rx_buffer, parcel->rx_bytes);
+}
+
+>>>>>>> aff9fb5 (DPE Command Support)
 /**
  * caliptra_get_fips_version
  *
@@ -371,25 +409,17 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
     if (version == NULL)
         return -EINVAL;
 
-    caliptra_checksum checksum = calculate_caliptra_checksum(OP_FIPS_VERSION, NULL, 0);
+    caliptra_checksum checksum = 0;
 
-    struct caliptra_buffer in_buf = {
-        .data = (uint8_t *)&checksum,
-        .len = sizeof(checksum),
+    struct parcel p = {
+        .command   = OP_FIPS_VERSION,
+        .tx_buffer = (uint8_t*)&checksum,
+        .tx_bytes  = sizeof(caliptra_checksum),
+        .rx_buffer = (uint8_t*)version,
+        .rx_bytes  = sizeof(struct caliptra_fips_version),
     };
-    struct caliptra_buffer out_buf = {
-        .data = (uint8_t *)version,
-        .len = sizeof(struct caliptra_fips_version),
-    };
 
-    int status = caliptra_mailbox_execute(OP_FIPS_VERSION, &in_buf, &out_buf);
-
-    if (status)
-    {
-        return status;
-    }
-
-    return check_command_response(&version->cpl, (uint8_t*)version, sizeof(struct caliptra_fips_version));
+    return pack_and_send_command(&p);
 }
 
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp)
@@ -399,24 +429,77 @@ int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struc
         return -EINVAL;
     }
 
-    struct caliptra_buffer in_buf = {
-        .data = (uint8_t*)req,
-        .len  = sizeof(struct caliptra_stash_measurement_req),
+    struct parcel p = {
+        .command   = OP_FIPS_VERSION,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = sizeof(struct caliptra_stash_measurement_req),
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(struct caliptra_stash_measurement_resp),
     };
 
-    struct caliptra_buffer out_buf = {
-        .data = (uint8_t*)resp,
-        .len  = sizeof(struct caliptra_stash_measurement_resp),
-    };
+    return pack_and_send_command(&p);
+}
 
-    req->checksum = calculate_caliptra_checksum(OP_STASH_MEASUREMENT, (uint8_t*)req, sizeof(struct caliptra_stash_measurement_req));
-
-    int status = caliptra_mailbox_execute(OP_STASH_MEASUREMENT, &in_buf, &out_buf);
-
-    if (status)
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_cpl *cpl)
+{
+    if (!cpl)
     {
-        return status;
+        return -EINVAL;
     }
 
-    return check_command_response(&resp->cpl, (uint8_t*)resp, sizeof(struct caliptra_stash_measurement_resp));
+    caliptra_checksum checksum = 0;
+
+    struct parcel p = {
+        .command   = OP_GET_IDEV_CSR,
+        .tx_buffer = (uint8_t*)&checksum,
+        .tx_bytes  = sizeof(caliptra_checksum),
+        .rx_buffer = (uint8_t*)cpl,
+        .rx_bytes  = sizeof(struct caliptra_get_idev_csr_cpl),
+    };
+
+    return pack_and_send_command(&p);
 }
+
+int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_cpl *cpl)
+{
+    if (!cpl)
+    {
+        return -EINVAL;
+    }
+
+    caliptra_checksum checksum = 0;
+
+    struct parcel p = {
+        .command   = OP_GET_LDEV_CERT,
+        .tx_buffer = (uint8_t*)&checksum,
+        .tx_bytes  = sizeof(caliptra_checksum),
+        .rx_buffer = (uint8_t*)cpl,
+        .rx_bytes  = sizeof(struct caliptra_get_ldev_cert_cpl),
+    };
+
+    return pack_and_send_command(&p);
+}
+
+int caliptra_dpe_command(struct caliptra_dpe_req *req, struct caliptra_dpe_resp *resp)
+{
+    if (!req || !resp)
+    {
+        return -EINVAL;
+    }
+
+    // While it will likely cause no harm, there's no sense in writing more
+    // to the FIFO than is absolutely required. This command can have a variable
+    // data buffer.
+    uint32_t actual_bytes = sizeof(caliptra_checksum) + sizeof(uint32_t) + req->data_size;
+
+    struct parcel p = {
+        .command   = OP_INVOKE_DPE_COMMAND,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = actual_bytes,
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(struct caliptra_dpe_resp),
+    };
+
+    return pack_and_send_command(&p);
+}
+

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -23,7 +23,7 @@ enum mailbox_command {
     OP_CALIPTRA_FW_LOAD          = 0x46574C44, // "FWLD"
     OP_GET_IDEV_CSR              = 0x49444556, // "IDEV"
     OP_GET_LDEV_CERT             = 0x4C444556, // "LDEV"
-    OP_ECDSA384_SIGNATURE_VERIFY = 0x53494756, // "SIGV"
+    OP_ECDSA384_VERIFY           = 0x53494756, // "SIGV"
     OP_STASH_MEASUREMENT         = 0x4D454153, // "MEAS"
     OP_DISABLE_ATTESTATION       = 0x4453424C, // "DSBL"
     OP_INVOKE_DPE_COMMAND        = 0x44504543, // "DPEC"

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -30,6 +30,14 @@ enum mailbox_command {
     OP_FIPS_VERSION              = 0x46505652, // "FPVR"
 };
 
+struct parcel {
+    enum mailbox_command  command;
+    uint8_t              *tx_buffer;
+    size_t                tx_bytes;
+    uint8_t              *rx_buffer;
+    size_t                rx_bytes;
+};
+
 enum mailbox_results {
     SUCCESS        = 0x00000000,
     BAD_VENDOR_SIG = 0x56534947, // "VSIG"


### PR DESCRIPTION
This adds support for the following mailbox commands:

OP_GET_IDEV_CSR
OP_GET_LDEV_CERT
OP_INVOKE_DPE_COMMAND

It also normalizes the new command API pattern, which will be necessary in the future to support asynchronous mailbox operations.