### PR TITLE
Expose RomInfo address via FHT

### DIFF
--- a/drivers/src/bounded_address.rs
+++ b/drivers/src/bounded_address.rs
@@ -1,6 +1,5 @@
 // Licensed under the Apache-2.0 license
 
-#![allow(dead_code)]
 use core::fmt::Debug;
 use core::marker::PhantomData;
 

--- a/drivers/src/bounded_address.rs
+++ b/drivers/src/bounded_address.rs
@@ -1,0 +1,125 @@
+// Licensed under the Apache-2.0 license
+
+#![allow(dead_code)]
+use core::fmt::Debug;
+use core::marker::PhantomData;
+
+use caliptra_error::CaliptraError;
+use zerocopy::{AsBytes, FromBytes};
+
+use crate::memory_layout;
+
+pub trait MemBounds {
+    const ORG: usize;
+    const SIZE: usize;
+    const ERROR: CaliptraError;
+}
+pub struct RomBounds {}
+impl MemBounds for RomBounds {
+    const ORG: usize = memory_layout::ROM_ORG as usize;
+    const SIZE: usize = memory_layout::ROM_SIZE as usize;
+    const ERROR: CaliptraError = CaliptraError::ADDRESS_NOT_IN_ROM;
+}
+
+pub type RomAddr<T> = BoundedAddr<T, RomBounds>;
+
+#[repr(C)]
+pub struct BoundedAddr<T: AsBytes + FromBytes, B: MemBounds> {
+    addr: u32,
+    _phantom: PhantomData<(T, B)>,
+}
+unsafe impl<T: AsBytes + FromBytes, B: MemBounds> FromBytes for BoundedAddr<T, B> {
+    fn only_derive_is_allowed_to_implement_this_trait() {}
+}
+unsafe impl<T: AsBytes + FromBytes, B: MemBounds> AsBytes for BoundedAddr<T, B> {
+    fn only_derive_is_allowed_to_implement_this_trait() {}
+}
+impl<T: AsBytes + FromBytes, B: MemBounds> BoundedAddr<T, B> {
+    pub fn new(addr: u32) -> Self {
+        Self {
+            addr,
+            _phantom: Default::default(),
+        }
+    }
+    pub fn get(&self) -> Result<&T, CaliptraError> {
+        assert!(core::mem::size_of::<Self>() == core::mem::size_of::<u32>());
+        Self::validate_addr(self.addr)?;
+        Ok(unsafe { &*(self.addr as *const T) })
+    }
+    pub fn is_valid(&self) -> bool {
+        Self::validate_addr(self.addr).is_ok()
+    }
+    pub fn validate_addr(addr: u32) -> Result<(), CaliptraError> {
+        let addr = addr as usize;
+
+        if addr % core::mem::align_of::<T>() != 0 {
+            return Err(CaliptraError::ADDRESS_MISALIGNED);
+        }
+        let size = core::mem::size_of::<T>();
+        if addr < B::ORG || size > B::SIZE || addr > B::ORG + (B::SIZE - size) {
+            return Err(B::ERROR);
+        }
+        Ok(())
+    }
+}
+impl<T: AsBytes + FromBytes, B: MemBounds> Clone for BoundedAddr<T, B> {
+    fn clone(&self) -> Self {
+        Self::new(self.addr)
+    }
+}
+impl<T: AsBytes + FromBytes, B: MemBounds> Debug for BoundedAddr<T, B> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RomAddr").field("addr", &self.addr).finish()
+    }
+}
+impl<T: AsBytes + FromBytes, B: MemBounds> From<&'static T> for BoundedAddr<T, B> {
+    fn from(value: &'static T) -> Self {
+        Self::new(value as *const T as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_layout::{ROM_ORG, ROM_SIZE};
+
+    #[derive(AsBytes, FromBytes)]
+    #[repr(C)]
+    struct MyStruct {
+        a: u32,
+        b: u32,
+    }
+
+    #[test]
+    fn test_rom_address_validate() {
+        RomAddr::<MyStruct>::validate_addr(ROM_ORG).unwrap();
+        RomAddr::<MyStruct>::validate_addr(ROM_ORG + 4).unwrap();
+        RomAddr::<MyStruct>::validate_addr(ROM_ORG + ROM_SIZE - 8).unwrap();
+        RomAddr::<u8>::validate_addr(ROM_ORG + ROM_SIZE - 1).unwrap();
+
+        assert_eq!(
+            RomAddr::<MyStruct>::validate_addr(ROM_ORG + 1),
+            Err(CaliptraError::ADDRESS_MISALIGNED)
+        );
+        assert_eq!(
+            RomAddr::<MyStruct>::validate_addr(ROM_ORG + 2),
+            Err(CaliptraError::ADDRESS_MISALIGNED)
+        );
+        assert_eq!(
+            RomAddr::<MyStruct>::validate_addr(ROM_ORG + ROM_SIZE - 4),
+            Err(CaliptraError::ADDRESS_NOT_IN_ROM)
+        );
+        assert_eq!(
+            RomAddr::<u8>::validate_addr(ROM_ORG + ROM_SIZE),
+            Err(CaliptraError::ADDRESS_NOT_IN_ROM)
+        );
+        assert_eq!(
+            RomAddr::<u8>::validate_addr(ROM_ORG + ROM_SIZE + 24381),
+            Err(CaliptraError::ADDRESS_NOT_IN_ROM)
+        );
+        assert_eq!(
+            RomAddr::<[u8; 128 * 1024]>::validate_addr(ROM_ORG),
+            Err(CaliptraError::ADDRESS_NOT_IN_ROM)
+        );
+    }
+}

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -1,11 +1,13 @@
 // Licensed under the Apache-2.0 license.
-use crate::{memory_layout::FHT_ORG, soc_ifc};
+
 use crate::{
-    report_fw_error_non_fatal, ColdResetEntry4, ColdResetEntry48, Ecc384PubKey, Ecc384Signature,
-    KeyId, ResetReason, WarmResetEntry4, WarmResetEntry48,
+    memory_layout, report_fw_error_non_fatal, ColdResetEntry4, ColdResetEntry48, Ecc384PubKey,
+    Ecc384Signature, KeyId, ResetReason, WarmResetEntry4, WarmResetEntry48,
 };
+use crate::{memory_layout::FHT_ORG, soc_ifc};
 use bitfield::{bitfield_bitrange, bitfield_fields};
 use caliptra_error::CaliptraError;
+use core::mem::size_of;
 use zerocopy::{AsBytes, FromBytes};
 
 pub const FHT_MARKER: u32 = 0x54484643;
@@ -188,6 +190,8 @@ impl From<DataStore> for HandOffDataHandle {
 /// The Firmware Handoff Table is a data structure that is resident at a well-known
 /// location in DCCM. It is initially populated by ROM and modified by FMC as a way
 /// to pass parameters and configuration information from one firmware layer to the next.
+const _: () = assert!(size_of::<FirmwareHandoffTable>() == 512);
+const _: () = assert!(size_of::<FirmwareHandoffTable>() <= memory_layout::FHT_SIZE as usize);
 #[repr(C)]
 #[derive(Clone, Debug, AsBytes, FromBytes)]
 pub struct FirmwareHandoffTable {

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -50,6 +50,7 @@ mod trng_ext;
 
 pub use array::{Array4x12, Array4x4, Array4x5, Array4x8, Array4xN};
 pub use array_concat::array_concat3;
+pub use bounded_address::RomAddr;
 pub use caliptra_error::{CaliptraError, CaliptraResult};
 pub use csrng::{Csrng, HealthFailCounts as CsrngHealthFailCounts, Seed as CsrngSeed};
 pub use data_vault::{

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -18,6 +18,7 @@ mod array;
 mod array_concat;
 mod wait;
 
+mod bounded_address;
 mod csrng;
 mod data_vault;
 mod doe;

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -329,6 +329,10 @@ impl CaliptraError {
     pub const DRIVER_SOC_IFC_INVALID_TIMER_CONFIG: CaliptraError =
         CaliptraError::new_const(0x00100001);
 
+    /// Bounded address Errors
+    pub const ADDRESS_MISALIGNED: CaliptraError = CaliptraError::new_const(0x00110000);
+    pub const ADDRESS_NOT_IN_ROM: CaliptraError = CaliptraError::new_const(0x00110001);
+
     /// Initial Device ID Errors
     pub const ROM_IDEVID_CSR_BUILDER_INIT_FAILURE: CaliptraError =
         CaliptraError::new_const(0x01000001);

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -140,7 +140,8 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | rt_dice_pub_key       | 96           | FMC        | RT Alias DICE Public Key.                                                                                |
 | rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.                                                                                 |
 | idev_dice_pub_key     | 96           | ROM        | Initial Device ID Public Key.                                                                            |
-| reserved              | 132          |            | Reserved for future use.                                                                                 |
+| rom_info_addr         | 4            | ROM        | Address of ROMInfo struct describing the ROM digest and git commit.                                      |
+| reserved              | 128          |            | Reserved for future use.                                                                                 |
 
 *FHT is currently defined to be 512 bytes in length.*
 

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -21,7 +21,7 @@ use core::hint::black_box;
 
 use caliptra_drivers::{
     cprintln, report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError, Ecc384, Hmac384,
-    KeyVault, Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, SocIfc,
+    KeyVault, Mailbox, ResetReason, RomAddr, Sha256, Sha384, Sha384Acc, SocIfc,
 };
 use caliptra_error::CaliptraResult;
 use caliptra_image_types::RomInfo;
@@ -113,7 +113,8 @@ pub extern "C" fn rom_entry() -> ! {
 
     let result = flow::run(&mut env);
     match result {
-        Ok(Some(fht)) => {
+        Ok(Some(mut fht)) => {
+            fht.rom_info_addr = RomAddr::from(rom_info);
             fht::store(fht);
         }
         Ok(None) => {}

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -222,6 +222,9 @@ fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMm
         0x1000_0007 => {
             try_to_reset_pcrs(mbox);
         }
+        0x1000_0008 => {
+            read_rom_info(mbox);
+        }
         _ => {}
     }
 }
@@ -335,6 +338,11 @@ fn try_to_reset_pcrs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>
     send_to_mailbox(mbox, &ret_vals, false);
     mbox.dlen().write(|_| ret_vals.len().try_into().unwrap());
     mbox.status().write(|w| w.status(|w| w.data_ready()));
+}
+
+fn read_rom_info(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let fht = unsafe { &*(FHT_ORG as *const FirmwareHandoffTable) };
+    send_to_mailbox(mbox, fht.rom_info_addr.get().unwrap().as_bytes(), true);
 }
 
 fn read_fuse_log(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {


### PR DESCRIPTION
This can be used by the runtime firmware to perform an integrity check of the ROM, or inform the user which git commit was used to build the ROM.