### PR TITLE
Use a reference to persistent FHT in runtime firmware

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -114,7 +114,7 @@ pub struct Drivers<'a> {
     /// Ecc384 Engine
     pub ecc384: Ecc384,
 
-    pub fht: &'a mut FirmwareHandoffTable,
+    pub fht: &'a FirmwareHandoffTable,
 
     /// A copy of the ImageHeader for the currently running image
     pub manifest: ImageManifest,
@@ -137,7 +137,7 @@ impl<'a> Drivers<'a> {
     /// Callers must ensure that this function is called only once, and that
     /// any concurrent access to these register blocks does not conflict with
     /// these drivers.
-    pub unsafe fn new_from_registers(fht: &'a mut FirmwareHandoffTable) -> CaliptraResult<Self> {
+    pub unsafe fn new_from_registers(fht: &'a FirmwareHandoffTable) -> CaliptraResult<Self> {
         let manifest_slice = unsafe {
             let ptr = MAN1_ORG as *mut u32;
             core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -36,8 +36,8 @@ const BANNER: &str = r#"
 #[no_mangle]
 pub extern "C" fn entry_point() -> ! {
     cprintln!("{}", BANNER);
-    if let Some(mut fht) = caliptra_common::FirmwareHandoffTable::try_load() {
-        let mut drivers = unsafe { Drivers::new_from_registers(&mut fht) }.unwrap_or_else(|e| {
+    if let Some(fht) = caliptra_common::FirmwareHandoffTable::try_into_ref() {
+        let mut drivers = unsafe { Drivers::new_from_registers(fht) }.unwrap_or_else(|e| {
             caliptra_common::report_handoff_error_and_halt("Runtime can't load drivers", e.into())
         });
 

--- a/runtime/test-fw/src/cert_tests.rs
+++ b/runtime/test-fw/src/cert_tests.rs
@@ -12,8 +12,8 @@ use caliptra_test_harness::{runtime_handlers, test_suite};
 use zerocopy::AsBytes;
 
 fn mbox_responder() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::try_load().unwrap();
-    let drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let fht = caliptra_common::FirmwareHandoffTable::try_into_ref().unwrap();
+    let drivers = unsafe { Drivers::new_from_registers(fht).unwrap() };
     let mut mbox = drivers.mbox;
 
     loop {

--- a/runtime/test-fw/src/locked_dv_test.rs
+++ b/runtime/test-fw/src/locked_dv_test.rs
@@ -19,8 +19,8 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::{runtime_handlers, test_suite};
 
 fn test_locked_dv_slot() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::try_load().unwrap();
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let fht = caliptra_common::FirmwareHandoffTable::default();
+    let mut drivers = unsafe { Drivers::new_from_registers(&fht).unwrap() };
     let min_svn: u32 = drivers.data_vault.rt_min_svn();
     drivers.data_vault.set_rt_min_svn(min_svn + 1);
 }

--- a/runtime/test-fw/src/mbox_tests.rs
+++ b/runtime/test-fw/src/mbox_tests.rs
@@ -20,8 +20,8 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::test_suite;
 
 fn test_mbox_cmd() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::default();
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let fht = caliptra_common::FirmwareHandoffTable::default();
+    let mut drivers = unsafe { Drivers::new_from_registers(&fht).unwrap() };
     let mut soc_ifc = unsafe { SocIfcReg::new() };
 
     // Unlock the sha_acc peripheral for use by the SoC

--- a/runtime/test-fw/src/wdt_timeout_tests.rs
+++ b/runtime/test-fw/src/wdt_timeout_tests.rs
@@ -21,8 +21,8 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::{runtime_handlers, test_suite};
 
 fn test_wdt_timeout() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::default();
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let fht = caliptra_common::FirmwareHandoffTable::default();
+    let mut drivers = unsafe { Drivers::new_from_registers(&fht).unwrap() };
 
     start_wdt(&mut drivers.soc_ifc, WdtTimeout::default());
 


### PR DESCRIPTION
Add the ability to get a reference to the FHT in persistent DCCM. This allows RT firmware to avoid copying the FHT onto the stack.