### PR TITLE
Use PersistentDataAccessor in Runtime firmware.

### DIFF
--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -1,15 +1,15 @@
 // Licensed under the Apache-2.0 license
+
 #[cfg(feature = "test_only_commands")]
 use caliptra_common::mailbox_api::{
     GetLdevCertResp, MailboxResp, MailboxRespHeader, TestGetFmcAliasCertResp,
 };
-use caliptra_drivers::{CaliptraError, CaliptraResult, DataVault};
-use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, LocalDevIdCertTbs};
 
-extern "C" {
-    static mut LDEVID_TBS_ORG: [u8; LocalDevIdCertTbs::TBS_TEMPLATE_LEN];
-    static mut FMCALIAS_TBS_ORG: [u8; FmcAliasCertTbs::TBS_TEMPLATE_LEN];
-}
+#[cfg(feature = "test_only_commands")]
+use crate::Drivers;
+
+use caliptra_drivers::{CaliptraError, CaliptraResult, DataVault, PersistentData};
+use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
 
 enum CertType {
     LDevId,
@@ -19,14 +19,18 @@ enum CertType {
 pub struct GetLdevCertCmd;
 impl GetLdevCertCmd {
     #[cfg(feature = "test_only_commands")]
-    pub(crate) fn execute(dv: &DataVault) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut resp = GetLdevCertResp {
             hdr: MailboxRespHeader::default(),
             data_size: 0,
             data: [0u8; GetLdevCertResp::DATA_MAX_SIZE],
         };
 
-        resp.data_size = copy_ldevid_cert(dv, &mut resp.data)? as u32;
+        resp.data_size = copy_ldevid_cert(
+            &drivers.data_vault,
+            drivers.persistent_data.get(),
+            &mut resp.data,
+        )? as u32;
 
         Ok(MailboxResp::GetLdevCert(resp))
     }
@@ -35,14 +39,18 @@ impl GetLdevCertCmd {
 pub struct TestGetFmcAliasCertCmd;
 impl TestGetFmcAliasCertCmd {
     #[cfg(feature = "test_only_commands")]
-    pub(crate) fn execute(dv: &DataVault) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut resp = TestGetFmcAliasCertResp {
             hdr: MailboxRespHeader::default(),
             data_size: 0,
             data: [0u8; TestGetFmcAliasCertResp::DATA_MAX_SIZE],
         };
 
-        resp.data_size = copy_fmc_alias_cert(dv, &mut resp.data)? as u32;
+        resp.data_size = copy_fmc_alias_cert(
+            &drivers.data_vault,
+            drivers.persistent_data.get(),
+            &mut resp.data,
+        )? as u32;
 
         Ok(MailboxResp::TestGetFmcAliasCert(resp))
     }
@@ -52,24 +60,50 @@ impl TestGetFmcAliasCertCmd {
 ///
 /// Returns the number of bytes written to `cert`
 #[inline(never)]
-pub fn copy_ldevid_cert(dv: &DataVault, cert: &mut [u8]) -> CaliptraResult<usize> {
-    cert_from_dccm(dv, cert, CertType::LDevId)
+pub fn copy_ldevid_cert(
+    dv: &DataVault,
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    cert_from_dccm(dv, persistent_data, cert, CertType::LDevId)
 }
 
 /// Copy FMC Alias certificate produced by ROM to `cert` buffer
 ///
 /// Returns the number of bytes written to `cert`
 #[inline(never)]
-pub fn copy_fmc_alias_cert(dv: &DataVault, cert: &mut [u8]) -> CaliptraResult<usize> {
-    cert_from_dccm(dv, cert, CertType::FmcAlias)
+pub fn copy_fmc_alias_cert(
+    dv: &DataVault,
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    cert_from_dccm(dv, persistent_data, cert, CertType::FmcAlias)
 }
 
 /// Copy a certificate from `dccm_offset`, append signature, and write the
 /// output to `cert`.
-fn cert_from_dccm(dv: &DataVault, cert: &mut [u8], cert_type: CertType) -> CaliptraResult<usize> {
+fn cert_from_dccm(
+    dv: &DataVault,
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+    cert_type: CertType,
+) -> CaliptraResult<usize> {
     let (tbs, sig) = match cert_type {
-        CertType::LDevId => (unsafe { &LDEVID_TBS_ORG[..] }, dv.ldev_dice_signature()),
-        CertType::FmcAlias => (unsafe { &FMCALIAS_TBS_ORG[..] }, dv.fmc_dice_signature()),
+        CertType::LDevId => (
+            persistent_data
+                .ldevid_tbs
+                .get(..persistent_data.fht.ldevid_tbs_size.into()),
+            dv.ldev_dice_signature(),
+        ),
+        CertType::FmcAlias => (
+            persistent_data
+                .fmcalias_tbs
+                .get(..persistent_data.fht.fmcalias_tbs_size.into()),
+            dv.fmc_dice_signature(),
+        ),
+    };
+    let Some(tbs) = tbs else {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
     };
 
     // DataVault returns a different type than CertBuilder accepts

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -35,8 +35,7 @@ impl FipsModule {
             // Lock the SHA Accelerator.
             Sha384Acc::lock();
         }
-
-        env.regions.zeroize();
+        env.persistent_data.get_mut().zeroize();
     }
 
     /// Execute KAT for cryptographic algorithms implemented in H/W.

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -7,9 +7,11 @@ use caliptra_drivers::CaliptraResult;
 pub struct FwInfoCmd;
 impl FwInfoCmd {
     pub(crate) fn execute(drivers: &Drivers) -> CaliptraResult<MailboxResp> {
+        let pdata = drivers.persistent_data.get();
+
         let handoff = RtHandoff {
             data_vault: &drivers.data_vault,
-            fht: drivers.fht,
+            fht: &pdata.fht,
         };
 
         let runtime_svn = handoff.rt_svn()?;
@@ -18,7 +20,7 @@ impl FwInfoCmd {
 
         Ok(MailboxResp::FwInfo(FwInfoResp {
             hdr: MailboxRespHeader::default(),
-            pl0_pauser: drivers.manifest.header.pl0_pauser,
+            pl0_pauser: pdata.manifest1.header.pl0_pauser,
             runtime_svn,
             min_runtime_svn,
             fmc_manifest_svn,

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -10,7 +10,8 @@ pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if let Some(cmd) = InvokeDpeReq::read_from(cmd_args) {
-            let rt_pub_key = drivers.fht.rt_dice_pub_key;
+            let pdata = drivers.persistent_data.get();
+            let rt_pub_key = pdata.fht.rt_dice_pub_key;
             let mut crypto = DpeCrypto::new(
                 &mut drivers.sha384,
                 &mut drivers.trng,
@@ -24,7 +25,7 @@ impl InvokeDpeCmd {
                 .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
             let mut env = DpeEnv::<CptraDpeTypes> {
                 crypto,
-                platform: DpePlatform::new(drivers.manifest.header.pl0_pauser, hashed_rt_pub_key),
+                platform: DpePlatform::new(pdata.manifest1.header.pl0_pauser, hashed_rt_pub_key),
             };
 
             match drivers

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -18,7 +18,8 @@ pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if let Some(cmd) = StashMeasurementReq::read_from(cmd_args) {
-            let rt_pub_key = drivers.fht.rt_dice_pub_key;
+            let pdata = drivers.persistent_data.get();
+            let rt_pub_key = pdata.fht.rt_dice_pub_key;
             let mut crypto = DpeCrypto::new(
                 &mut drivers.sha384,
                 &mut drivers.trng,
@@ -32,7 +33,7 @@ impl StashMeasurementCmd {
                 .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
             let mut env = DpeEnv::<CptraDpeTypes> {
                 crypto,
-                platform: DpePlatform::new(drivers.manifest.header.pl0_pauser, hashed_rt_pub_key),
+                platform: DpePlatform::new(pdata.manifest1.header.pl0_pauser, hashed_rt_pub_key),
             };
 
             let locality = drivers.mbox.user();

--- a/runtime/test-fw/src/locked_dv_test.rs
+++ b/runtime/test-fw/src/locked_dv_test.rs
@@ -19,8 +19,8 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::{runtime_handlers, test_suite};
 
 fn test_locked_dv_slot() {
-    let mut fht = unsafe { caliptra_common::FirmwareHandoffTable::try_load().unwrap() };
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let mut drivers = unsafe { Drivers::new_from_registers().unwrap() };
+    assert!(drivers.persistent_data.get().fht.is_valid());
     let min_svn: u32 = drivers.data_vault.rt_min_svn();
     drivers.data_vault.set_rt_min_svn(min_svn + 1);
 }

--- a/runtime/test-fw/src/mbox_tests.rs
+++ b/runtime/test-fw/src/mbox_tests.rs
@@ -20,8 +20,7 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::test_suite;
 
 fn test_mbox_cmd() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::default();
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let mut drivers = unsafe { Drivers::new_from_registers().unwrap() };
     let mut soc_ifc = unsafe { SocIfcReg::new() };
 
     // Unlock the sha_acc peripheral for use by the SoC

--- a/runtime/test-fw/src/wdt_timeout_tests.rs
+++ b/runtime/test-fw/src/wdt_timeout_tests.rs
@@ -21,8 +21,7 @@ use caliptra_runtime::Drivers;
 use caliptra_test_harness::{runtime_handlers, test_suite};
 
 fn test_wdt_timeout() {
-    let mut fht = caliptra_common::FirmwareHandoffTable::default();
-    let mut drivers = unsafe { Drivers::new_from_registers(&mut fht).unwrap() };
+    let mut drivers = unsafe { Drivers::new_from_registers().unwrap() };
 
     start_wdt(&mut drivers.soc_ifc, WdtTimeout::default());
 


### PR DESCRIPTION
The PersistentDataAccessor is introduced in #690 (Add safe abstraction for accessing persistent data).