### PR TITLE
Use PersistentDataAccessor in ROM Firmware

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -79,7 +79,7 @@ pub use mailbox::{Mailbox, MailboxRecvTxn, MailboxSendTxn};
 pub use okref::okmutref;
 pub use okref::okref;
 pub use pcr_bank::{PcrBank, PcrId};
-pub use persistent::{PersistentData, PersistentDataAccessor};
+pub use persistent::{FuseLogArray, PcrLogArray, PersistentData, PersistentDataAccessor};
 pub use sha1::{Sha1, Sha1Digest, Sha1DigestOp};
 pub use sha256::{Sha256, Sha256DigestOp};
 pub use sha384::{Sha384, Sha384Digest, Sha384DigestOp};

--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -287,6 +287,32 @@ impl<'a> MailboxRecvPeek<'a> {
 mod fifo {
     use super::*;
 
+    fn dequeue_words(mbox: &mut MboxCsr, buf: &mut [Unalign<u32>]) {
+        let mbox = mbox.regs_mut();
+        for word in buf.iter_mut() {
+            *word = Unalign::new(mbox.dataout().read());
+        }
+    }
+    pub fn dequeue(mbox: &mut MboxCsr, mut buf: &mut [u8]) {
+        let dlen_bytes = mbox.regs().dlen().read() as usize;
+        if dlen_bytes < buf.len() {
+            buf = &mut buf[..dlen_bytes];
+        }
+
+        let len_words = buf.len() / size_of::<u32>();
+        let (mut buf_words, suffix) =
+            LayoutVerified::new_slice_unaligned_from_prefix(buf, len_words).unwrap();
+
+        dequeue_words(mbox, &mut buf_words);
+        if !suffix.is_empty() {
+            let last_word = mbox.regs().dataout().read();
+            let suffix_len = suffix.len();
+            suffix
+                .as_bytes_mut()
+                .copy_from_slice(&last_word.as_bytes()[..suffix_len]);
+        }
+    }
+
     fn enqueue_words(mbox: &mut MboxCsr, buf: &[Unalign<u32>]) {
         let mbox = mbox.regs_mut();
         for word in buf {
@@ -336,17 +362,6 @@ impl MailboxRecvTxn<'_> {
         mbox.dlen().read()
     }
 
-    fn dequeue(&mut self, buf: &mut [u32]) -> CaliptraResult<()> {
-        let mbox = self.mbox.regs_mut();
-        let dlen_bytes = mbox.dlen().read() as usize;
-        let dlen_words = (dlen_bytes + 3) / 4;
-        let words_to_read = min(buf.len(), dlen_words);
-        for dest_word in buf[0..words_to_read].iter_mut() {
-            *dest_word = mbox.dataout().read();
-        }
-        Ok(())
-    }
-
     /// Pulls at most `count` words from the mailbox and throws them away
     pub fn drop_words(&mut self, count: usize) -> CaliptraResult<()> {
         let mbox = self.mbox.regs_mut();
@@ -376,7 +391,8 @@ impl MailboxRecvTxn<'_> {
         Ok(())
     }
 
-    /// Pulls at most `data.len()` words from the mailbox FIFO without performing state transition.
+    /// Pulls at most `(data.len() + 3) / 4` words from the mailbox FIFO without
+    /// performing state transition.
     ///
     /// # Arguments
     ///
@@ -386,14 +402,15 @@ impl MailboxRecvTxn<'_> {
     ///
     /// Status of Operation
     ///
-    pub fn copy_request(&mut self, data: &mut [u32]) -> CaliptraResult<()> {
+    pub fn copy_request(&mut self, data: &mut [u8]) -> CaliptraResult<()> {
         if self.state != MailboxOpState::Execute {
             return Err(CaliptraError::DRIVER_MAILBOX_INVALID_STATE);
         }
-        self.dequeue(data)
+        fifo::dequeue(self.mbox, data);
+        Ok(())
     }
 
-    /// Pulls at most `data.len()` words from the mailbox FIFO.
+    /// Pulls at most `(data.len() + 3) / 4` words from the mailbox FIFO.
     /// Transitions from Execute --> Idle (releases the lock)
     ///
     /// # Arguments
@@ -404,7 +421,7 @@ impl MailboxRecvTxn<'_> {
     ///
     /// Status of Operation
     ///
-    pub fn recv_request(&mut self, data: &mut [u32]) -> CaliptraResult<()> {
+    pub fn recv_request(&mut self, data: &mut [u8]) -> CaliptraResult<()> {
         self.copy_request(data)?;
         self.complete(true)
     }

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -7,6 +7,9 @@ use zerocopy::{AsBytes, FromBytes};
 
 use crate::{fuse_log::FuseLogEntry, memory_layout, pcr_log::PcrLogEntry, FirmwareHandoffTable};
 
+pub type PcrLogArray = [PcrLogEntry; 17];
+pub type FuseLogArray = [FuseLogEntry; 62];
+
 #[derive(FromBytes, AsBytes)]
 #[repr(C)]
 pub struct PersistentData {
@@ -25,10 +28,10 @@ pub struct PersistentData {
     pub fmcalias_tbs: [u8; memory_layout::FMCALIAS_TBS_SIZE as usize],
     pub rtalias_tbs: [u8; memory_layout::RTALIAS_TBS_SIZE as usize],
 
-    pub pcr_log: [PcrLogEntry; 17],
+    pub pcr_log: PcrLogArray,
     reserved3: [u8; 4],
 
-    pub fuse_log: [FuseLogEntry; 62],
+    pub fuse_log: FuseLogArray,
     reserved4: [u8; 4],
 }
 impl PersistentData {

--- a/drivers/test-fw/src/bin/mailbox_driver_responder.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_responder.rs
@@ -11,6 +11,7 @@ use caliptra_test_harness::{self, println};
 
 use caliptra_drivers::{self, Mailbox};
 use caliptra_registers::mbox::MboxCsr;
+use zerocopy::AsBytes;
 
 #[panic_handler]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {
@@ -31,8 +32,16 @@ extern "C" fn main() {
                 let mut buf = [0u32; 4];
                 let dlen = txn.dlen();
                 println!("dlen: {dlen}");
-                txn.recv_request(&mut buf).unwrap();
+                txn.recv_request(buf.as_bytes_mut()).unwrap();
                 println!("buf: {:08x?}", buf);
+            }
+            // Test recv_request with non-multiple-of-4 result buffer
+            0x5000_0001 => {
+                let mut buf = [0u8; 5];
+                let dlen = txn.dlen();
+                println!("dlen: {dlen}");
+                txn.recv_request(&mut buf).unwrap();
+                println!("buf: {:02x?}", buf);
             }
             // Test copy_request function
             0x6000_0000 => {
@@ -41,7 +50,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(&mut buf).unwrap();
+                    txn.copy_request(buf.as_bytes_mut()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -63,7 +72,7 @@ extern "C" fn main() {
                 let rem_words = dlen_words / 2;
                 let mut buf = [0u32; 1];
                 for _ in 0..rem_words {
-                    txn.copy_request(&mut buf).unwrap();
+                    txn.copy_request(buf.as_bytes_mut()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -79,7 +88,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(&mut buf).unwrap();
+                    txn.copy_request(buf.as_bytes_mut()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.send_response(&[0x98, 0x76]).unwrap();

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -188,7 +188,7 @@ impl FirmwareProcessor {
             core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
         };
 
-        txn.copy_request(slice)?;
+        txn.copy_request(slice.as_bytes_mut())?;
 
         let opt = ImageManifest::read_from(slice.as_bytes());
         let result = opt.is_some();
@@ -334,7 +334,7 @@ impl FirmwareProcessor {
             core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
         };
 
-        txn.copy_request(fmc_dest)?;
+        txn.copy_request(fmc_dest.as_bytes_mut())?;
 
         cprintln!(
             "[afmc] Loading Runtime at address 0x{:08x} len {}",
@@ -347,7 +347,7 @@ impl FirmwareProcessor {
             core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
         };
 
-        txn.copy_request(runtime_dest)?;
+        txn.copy_request(runtime_dest.as_bytes_mut())?;
 
         report_boot_status(FwProcessorLoadImageComplete.into());
         Ok(())

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -18,16 +18,15 @@ use crate::rom_env::RomEnv;
 use crate::{cprintln, verifier::RomImageVerificationEnv};
 use crate::{pcr, wdt};
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_cfi_lib::{cfi_assert, cfi_assert_eq, cfi_launder};
 use caliptra_common::capabilities::Capabilities;
 use caliptra_common::mailbox_api::CommandId;
-use caliptra_common::{cprint, memory_layout::MAN1_ORG, FuseLogEntryId, RomBootStatus::*};
+use caliptra_common::{cprint, FuseLogEntryId, RomBootStatus::*};
 use caliptra_drivers::*;
 use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
 use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier};
 use caliptra_x509::{NotAfter, NotBefore};
 use core::mem::ManuallyDrop;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::AsBytes;
 
 #[derive(Debug, Default)]
 pub struct FwProcInfo {
@@ -60,7 +59,7 @@ impl FirmwareProcessor {
         wdt::start_wdt(&mut env.soc_ifc);
 
         // Load the manifest
-        let manifest = Self::load_manifest(&mut txn);
+        let manifest = Self::load_manifest(&mut env.persistent_data, &mut txn);
         let manifest = okref(&manifest)?;
 
         let mut venv = RomImageVerificationEnv {
@@ -71,16 +70,17 @@ impl FirmwareProcessor {
             ecc384: &mut env.ecc384,
             data_vault: &mut env.data_vault,
             pcr_bank: &mut env.pcr_bank,
+            persistent_data: &mut env.persistent_data,
         };
 
         // Verify the image
         let info = Self::verify_image(&mut venv, manifest, txn.dlen());
         let info = okref(&info)?;
 
-        Self::update_fuse_log(&info.log_info)?;
+        Self::update_fuse_log(&mut venv.persistent_data.get_mut().fuse_log, &info.log_info)?;
 
         // Populate data vault
-        Self::populate_data_vault(venv.data_vault, info);
+        Self::populate_data_vault(venv.data_vault, info, venv.persistent_data);
 
         // Extend PCR0 and PCR1
         pcr::extend_pcrs(&mut venv, info)?;
@@ -182,24 +182,14 @@ impl FirmwareProcessor {
     ///
     /// * `Manifest` - Caliptra Image Bundle Manifest
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
-        let slice = unsafe {
-            let ptr = MAN1_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        txn.copy_request(slice.as_bytes_mut())?;
-
-        let opt = ImageManifest::read_from(slice.as_bytes());
-        let result = opt.is_some();
-        if cfi_launder(result) {
-            cfi_assert!(opt.is_some());
-            report_boot_status(FwProcessorManifestLoadComplete.into());
-            Ok(opt.unwrap())
-        } else {
-            cfi_assert!(opt.is_none());
-            Err(CaliptraError::FW_PROC_MANIFEST_READ_FAILURE)
-        }
+    fn load_manifest(
+        persistent_data: &mut PersistentDataAccessor,
+        txn: &mut MailboxRecvTxn,
+    ) -> CaliptraResult<ImageManifest> {
+        let manifest = &mut persistent_data.get_mut().manifest1;
+        txn.copy_request(manifest.as_bytes_mut())?;
+        report_boot_status(FwProcessorManifestLoadComplete.into());
+        Ok(*manifest)
     }
 
     /// Verify the image
@@ -239,15 +229,20 @@ impl FirmwareProcessor {
     /// # Returns
     /// * CaliptraResult
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn update_fuse_log(log_info: &ImageVerificationLogInfo) -> CaliptraResult<()> {
+    fn update_fuse_log(
+        log: &mut FuseLogArray,
+        log_info: &ImageVerificationLogInfo,
+    ) -> CaliptraResult<()> {
         // Log VendorPubKeyIndex
         log_fuse_data(
+            log,
             FuseLogEntryId::VendorEccPubKeyIndex,
             log_info.vendor_ecc_pub_key_idx.as_bytes(),
         )?;
 
         // Log VendorPubKeyRevocation
         log_fuse_data(
+            log,
             FuseLogEntryId::VendorEccPubKeyRevocation,
             log_info
                 .fuse_vendor_ecc_pub_key_revocation
@@ -257,36 +252,42 @@ impl FirmwareProcessor {
 
         // Log ManifestFmcSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::ManifestFmcSvn,
             log_info.fmc_log_info.manifest_svn.as_bytes(),
         )?;
 
         // Log ManifestFmcMinSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::ManifestFmcMinSvn,
             log_info.fmc_log_info.manifest_min_svn.as_bytes(),
         )?;
 
         // Log FuseFmcSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::FuseFmcSvn,
             log_info.fmc_log_info.fuse_svn.as_bytes(),
         )?;
 
         // Log ManifestRtSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::ManifestRtSvn,
             log_info.rt_log_info.manifest_svn.as_bytes(),
         )?;
 
         // Log ManifestRtMinSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::ManifestRtMinSvn,
             log_info.rt_log_info.manifest_min_svn.as_bytes(),
         )?;
 
         // Log FuseRtSvn
         log_fuse_data(
+            log,
             FuseLogEntryId::FuseRtSvn,
             log_info.rt_log_info.fuse_svn.as_bytes(),
         )?;
@@ -294,6 +295,7 @@ impl FirmwareProcessor {
         // Log VendorLmsPubKeyIndex
         if let Some(vendor_lms_pub_key_idx) = log_info.vendor_lms_pub_key_idx {
             log_fuse_data(
+                log,
                 FuseLogEntryId::VendorLmsPubKeyIndex,
                 vendor_lms_pub_key_idx.as_bytes(),
             )?;
@@ -304,6 +306,7 @@ impl FirmwareProcessor {
             log_info.fuse_vendor_lms_pub_key_revocation
         {
             log_fuse_data(
+                log,
                 FuseLogEntryId::VendorLmsPubKeyRevocation,
                 fuse_vendor_lms_pub_key_revocation.as_bytes(),
             )?;
@@ -360,7 +363,11 @@ impl FirmwareProcessor {
     /// * `env`  - ROM Environment
     /// * `info` - Image Verification Info
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn populate_data_vault(data_vault: &mut DataVault, info: &ImageVerificationInfo) {
+    fn populate_data_vault(
+        data_vault: &mut DataVault,
+        info: &ImageVerificationInfo,
+        persistent_data: &PersistentDataAccessor,
+    ) {
         data_vault.write_cold_reset_entry48(ColdResetEntry48::FmcTci, &info.fmc.digest.into());
 
         data_vault.write_cold_reset_entry4(ColdResetEntry4::FmcSvn, info.fmc.svn);
@@ -390,7 +397,10 @@ impl FirmwareProcessor {
 
         data_vault.write_warm_reset_entry4(WarmResetEntry4::RtEntryPoint, info.runtime.entry_point);
 
-        data_vault.write_warm_reset_entry4(WarmResetEntry4::ManifestAddr, MAN1_ORG);
+        data_vault.write_warm_reset_entry4(
+            WarmResetEntry4::ManifestAddr,
+            &persistent_data.get().manifest1 as *const _ as u32,
+        );
         report_boot_status(FwProcessorPopulateDataVaultComplete.into());
     }
 

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -223,15 +223,10 @@ pub fn copy_canned_ldev_cert(env: &mut RomEnv) -> CaliptraResult<()> {
     // Copy TBS to DCCM
     let tbs = &FAKE_LDEV_TBS;
     env.fht_data_store.ldevid_tbs_size = u16::try_from(tbs.len()).unwrap();
-    let dst = unsafe {
-        let tbs_max_size = LDEVID_TBS_SIZE as usize;
-        if tbs.len() > tbs_max_size {
-            return Err(CaliptraError::ROM_GLOBAL_UNSUPPORTED_LDEVID_TBS_SIZE);
-        }
-        let ptr = LDEVID_TBS_ORG as *mut u8;
-        core::slice::from_raw_parts_mut(ptr, tbs.len())
+    let Some(dst) = env.persistent_data.get_mut().ldevid_tbs.get_mut(..tbs.len()) else {
+        return Err(CaliptraError::ROM_GLOBAL_UNSUPPORTED_LDEVID_TBS_SIZE);
     };
-    dst[..tbs.len()].copy_from_slice(tbs);
+    dst.copy_from_slice(tbs);
 
     Ok(())
 }
@@ -246,17 +241,10 @@ pub fn copy_canned_fmc_alias_cert(env: &mut RomEnv) -> CaliptraResult<()> {
     // Copy TBS to DCCM
     let tbs = &FAKE_FMC_ALIAS_TBS;
     env.fht_data_store.fmcalias_tbs_size = u16::try_from(tbs.len()).unwrap();
-    let dst = unsafe {
-        let tbs_max_size = FMCALIAS_TBS_SIZE as usize;
-        if tbs.len() > tbs_max_size {
-            return Err(CaliptraError::ROM_GLOBAL_UNSUPPORTED_FMCALIAS_TBS_SIZE);
-        }
-
-        let ptr = FMCALIAS_TBS_ORG as *mut u8;
-        core::slice::from_raw_parts_mut(ptr, tbs.len())
+    let Some(dst) = env.persistent_data.get_mut().fmcalias_tbs.get_mut(..tbs.len()) else {
+        return Err(CaliptraError::ROM_GLOBAL_UNSUPPORTED_FMCALIAS_TBS_SIZE);
     };
-    dst[..tbs.len()].copy_from_slice(tbs);
-
+    dst.copy_from_slice(tbs);
     Ok(())
 }
 

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -175,7 +175,7 @@ impl UpdateResetFlow {
             core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
         };
 
-        txn.copy_request(runtime_dest)?;
+        txn.copy_request(runtime_dest.as_bytes_mut())?;
 
         //Call the complete here to reset the execute bit
         txn.complete(true)?;
@@ -195,7 +195,7 @@ impl UpdateResetFlow {
             core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
         };
 
-        txn.copy_request(slice)?;
+        txn.copy_request(slice.as_bytes_mut())?;
 
         ImageManifest::read_from(slice.as_bytes())
             .ok_or(CaliptraError::ROM_UPDATE_RESET_FLOW_MANIFEST_READ_FAILURE)

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -17,17 +17,16 @@ use crate::{cprintln, pcr, rom_env::RomEnv, verifier::RomImageVerificationEnv};
 
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::CommandId;
-use caliptra_common::memory_layout::{MAN1_ORG, MAN2_ORG};
 use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::RomBootStatus::*;
-use caliptra_drivers::DataVault;
 use caliptra_drivers::{
     okref, report_boot_status, MailboxRecvTxn, ResetReason, WarmResetEntry4, WarmResetEntry48,
 };
+use caliptra_drivers::{DataVault, PersistentData};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
 use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::AsBytes;
 
 #[derive(Default)]
 pub struct UpdateResetFlow {}
@@ -53,7 +52,7 @@ impl UpdateResetFlow {
             return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND);
         }
 
-        let manifest = Self::load_manifest(&mut recv_txn)?;
+        let manifest = Self::load_manifest(env.persistent_data.get_mut(), &mut recv_txn)?;
         report_boot_status(UpdateResetLoadManifestComplete.into());
 
         let mut venv = RomImageVerificationEnv {
@@ -64,6 +63,7 @@ impl UpdateResetFlow {
             ecc384: &mut env.ecc384,
             data_vault: &mut env.data_vault,
             pcr_bank: &mut env.pcr_bank,
+            persistent_data: &mut env.persistent_data,
         };
 
         let info = Self::verify_image(&mut venv, &manifest, recv_txn.dlen());
@@ -89,7 +89,9 @@ impl UpdateResetFlow {
         drop(recv_txn);
         report_boot_status(UpdateResetLoadImageComplete.into());
 
-        Self::copy_regions();
+        let persistent_data = env.persistent_data.get_mut();
+        cprintln!("[update-reset] Copying MAN_2 To MAN_1");
+        persistent_data.manifest1 = persistent_data.manifest2;
         report_boot_status(UpdateResetOverwriteManifestComplete.into());
 
         // Set RT version. FMC does not change.
@@ -126,30 +128,6 @@ impl UpdateResetFlow {
         let info = verifier.verify(manifest, img_bundle_sz, ResetReason::UpdateReset)?;
 
         Ok(info)
-    }
-
-    ///
-    /// Copy the verified MAN_2 region to MAN_1
-    ///
-    /// # Arguments
-    ///
-    /// * `manifest` - Manifest
-    ///
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn copy_regions() {
-        cprintln!("[update-reset] Copying MAN_2 To MAN_1");
-
-        let dst = unsafe {
-            let ptr = MAN1_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        let src = unsafe {
-            let ptr = MAN2_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        dst.clone_from_slice(src);
     }
 
     /// Load the image to ICCM & DCCM
@@ -189,16 +167,12 @@ impl UpdateResetFlow {
     ///
     /// * `Manifest` - Caliptra Image Bundle Manifest
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn load_manifest(txn: &mut MailboxRecvTxn) -> CaliptraResult<ImageManifest> {
-        let slice = unsafe {
-            let ptr = MAN2_ORG as *mut u32;
-            core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<ImageManifest>() / 4)
-        };
-
-        txn.copy_request(slice.as_bytes_mut())?;
-
-        ImageManifest::read_from(slice.as_bytes())
-            .ok_or(CaliptraError::ROM_UPDATE_RESET_FLOW_MANIFEST_READ_FAILURE)
+    fn load_manifest(
+        persistent_data: &mut PersistentData,
+        txn: &mut MailboxRecvTxn,
+    ) -> CaliptraResult<ImageManifest> {
+        txn.copy_request(persistent_data.manifest2.as_bytes_mut())?;
+        Ok(persistent_data.manifest2)
     }
 
     /// Populate data vault

--- a/rom/dev/src/fuse.rs
+++ b/rom/dev/src/fuse.rs
@@ -11,11 +11,8 @@ Abstract:
 
 --*/
 use caliptra_cfi_derive::cfi_mod_fn;
-use caliptra_common::{
-    memory_layout::{FUSE_LOG_ORG, FUSE_LOG_SIZE},
-    FuseLogEntry, FuseLogEntryId,
-};
-use caliptra_drivers::{CaliptraError, CaliptraResult};
+use caliptra_common::{FuseLogEntry, FuseLogEntryId};
+use caliptra_drivers::{CaliptraError, CaliptraResult, FuseLogArray};
 use zerocopy::AsBytes;
 
 /// Log Fuse data
@@ -30,13 +27,13 @@ use zerocopy::AsBytes;
 /// * `Err(GlobalErr::FuseLogUpsupportedDataLength)` - Unsupported data length
 ///
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
-pub fn log_fuse_data(entry_id: FuseLogEntryId, data: &[u8]) -> CaliptraResult<()> {
+pub fn log_fuse_data(
+    log: &mut FuseLogArray,
+    entry_id: FuseLogEntryId,
+    data: &[u8],
+) -> CaliptraResult<()> {
     if entry_id == FuseLogEntryId::Invalid {
         return Err(CaliptraError::ROM_GLOBAL_FUSE_LOG_INVALID_ENTRY_ID);
-    }
-
-    if data.len() > 4 {
-        return Err(CaliptraError::ROM_GLOBAL_FUSE_LOG_UNSUPPORTED_DATA_LENGTH);
     }
 
     // Create a FUSE log entry
@@ -44,15 +41,15 @@ pub fn log_fuse_data(entry_id: FuseLogEntryId, data: &[u8]) -> CaliptraResult<()
         entry_id: entry_id as u32,
         ..Default::default()
     };
-    log_entry.log_data.as_bytes_mut()[..data.len()].copy_from_slice(data);
-
-    let dst: &mut [FuseLogEntry] = unsafe {
-        let ptr = FUSE_LOG_ORG as *mut FuseLogEntry;
-        core::slice::from_raw_parts_mut(ptr, FUSE_LOG_SIZE / core::mem::size_of::<FuseLogEntry>())
+    let Some(data_dest) = log_entry.log_data.as_bytes_mut().get_mut(..data.len()) else {
+        return Err(CaliptraError::ROM_GLOBAL_FUSE_LOG_UNSUPPORTED_DATA_LENGTH);
     };
+    data_dest.copy_from_slice(data);
 
-    // Store the log entry.
-    dst[entry_id as usize - 1] = log_entry;
+    // Compiler will optimize out the bounds check because the largest
+    // FuseLogEntryId is well within the bounds of the array. (double-checked
+    // via panic_is_possible)
+    log[entry_id as usize - 1] = log_entry;
 
     Ok(())
 }

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -115,7 +115,7 @@ pub extern "C" fn rom_entry() -> ! {
     match result {
         Ok(Some(mut fht)) => {
             fht.rom_info_addr = RomAddr::from(rom_info);
-            fht::store(fht);
+            fht::store(&mut env, fht);
         }
         Ok(None) => {}
         Err(err) => {

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -18,8 +18,8 @@ Abstract:
 use crate::fht::FhtDataStore;
 use caliptra_common::memory_layout::*;
 use caliptra_drivers::{
-    DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank, Sha1, Sha256,
-    Sha384, Sha384Acc, SocIfc, Trng,
+    DataVault, DeobfuscationEngine, Ecc384, Hmac384, KeyVault, Lms, Mailbox, PcrBank,
+    PersistentDataAccessor, Sha1, Sha256, Sha384, Sha384Acc, SocIfc, Trng,
 };
 use caliptra_error::CaliptraResult;
 use caliptra_registers::{
@@ -75,6 +75,9 @@ pub struct RomEnv {
 
     /// Cryptographically Secure Random Number Generator
     pub trng: Trng,
+
+    // Mechanism to access the persistent data safely
+    pub persistent_data: PersistentDataAccessor,
 }
 
 impl RomEnv {
@@ -107,6 +110,7 @@ impl RomEnv {
             pcr_bank: PcrBank::new(PvReg::new()),
             fht_data_store: FhtDataStore::default(),
             trng,
+            persistent_data: PersistentDataAccessor::new(),
         })
     }
 }

--- a/rom/dev/src/verifier.rs
+++ b/rom/dev/src/verifier.rs
@@ -28,6 +28,7 @@ pub(crate) struct RomImageVerificationEnv<'a> {
     pub(crate) ecc384: &'a mut Ecc384,
     pub(crate) data_vault: &'a mut DataVault,
     pub(crate) pcr_bank: &'a mut PcrBank,
+    pub(crate) persistent_data: &'a mut PersistentDataAccessor,
 }
 
 impl<'a> ImageVerificationEnv for &mut RomImageVerificationEnv<'a> {

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -14,13 +14,9 @@ Abstract:
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
 
-use caliptra_common::memory_layout::{
-    FHT_ORG, FMCALIAS_TBS_ORG, FUSE_LOG_ORG, LDEVID_TBS_ORG, PCR_LOG_ORG,
-};
-use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::{FuseLogEntry, FuseLogEntryId};
 use caliptra_common::{PcrLogEntry, PcrLogEntryId};
-use caliptra_drivers::ColdResetEntry4::*;
+use caliptra_drivers::{ColdResetEntry4::*, PersistentDataAccessor};
 use caliptra_drivers::{DataVault, Mailbox, PcrBank, PcrId};
 use caliptra_registers::dv::DvReg;
 use caliptra_registers::pv::PvReg;
@@ -28,7 +24,6 @@ use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, Loc
 use core::ptr;
 use ureg::RealMmioMut;
 use zerocopy::AsBytes;
-use zerocopy::FromBytes;
 
 #[cfg(not(feature = "std"))]
 core::arch::global_asm!(include_str!("start.S"));
@@ -47,15 +42,9 @@ Running Caliptra FMC ...
 pub extern "C" fn fmc_entry() -> ! {
     cprintln!("{}", BANNER);
 
-    let slice = unsafe {
-        let ptr = FHT_ORG as *mut u8;
-        cprintln!("[fmc] Loading FHT from 0x{:08X}", ptr as u32);
-        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FirmwareHandoffTable>())
-    };
-
     if cfg!(not(feature = "fake-fmc")) {
-        let fht = FirmwareHandoffTable::read_from(slice).unwrap();
-        assert!(fht.is_valid());
+        let persistent_data = unsafe { PersistentDataAccessor::new() };
+        assert!(persistent_data.get().fht.is_valid());
     }
 
     process_mailbox_commands();
@@ -164,34 +153,19 @@ fn create_certs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
 }
 
 fn copy_tbs(tbs: &mut [u8], ldevid_tbs: bool) {
+    let persistent_data = unsafe { PersistentDataAccessor::new() };
     // Copy the tbs from DCCM
     let src = if ldevid_tbs {
-        unsafe {
-            let ptr = LDEVID_TBS_ORG as *mut u8;
-            core::slice::from_raw_parts_mut(ptr, tbs.len())
-        }
+        &persistent_data.get().ldevid_tbs
     } else {
-        unsafe {
-            let ptr = FMCALIAS_TBS_ORG as *mut u8;
-            core::slice::from_raw_parts_mut(ptr, tbs.len())
-        }
+        &persistent_data.get().fmcalias_tbs
     };
-    tbs.copy_from_slice(src);
+    tbs.copy_from_slice(&src[..tbs.len()]);
 }
 
 fn get_pcr_entry(entry_index: usize) -> PcrLogEntry {
-    // Copy the pcr log entry from DCCM
-    let mut pcr_entry: [u8; core::mem::size_of::<PcrLogEntry>()] =
-        [0u8; core::mem::size_of::<PcrLogEntry>()];
-
-    let src = unsafe {
-        let offset = core::mem::size_of::<PcrLogEntry>() * entry_index;
-        let ptr = (PCR_LOG_ORG as *mut u8).add(offset);
-        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<PcrLogEntry>())
-    };
-
-    pcr_entry.copy_from_slice(src);
-    PcrLogEntry::read_from_prefix(pcr_entry.as_bytes()).unwrap()
+    let persistent_data = unsafe { PersistentDataAccessor::new() };
+    persistent_data.get().pcr_log[entry_index]
 }
 
 fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
@@ -341,8 +315,18 @@ fn try_to_reset_pcrs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>
 }
 
 fn read_rom_info(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
-    let fht = unsafe { &*(FHT_ORG as *const FirmwareHandoffTable) };
-    send_to_mailbox(mbox, fht.rom_info_addr.get().unwrap().as_bytes(), true);
+    let persistent_data = unsafe { PersistentDataAccessor::new() };
+    send_to_mailbox(
+        mbox,
+        persistent_data
+            .get()
+            .fht
+            .rom_info_addr
+            .get()
+            .unwrap()
+            .as_bytes(),
+        true,
+    );
 }
 
 fn read_fuse_log(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
@@ -366,33 +350,13 @@ fn read_fuse_log(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
 }
 
 fn get_fuse_entry(entry_index: usize) -> FuseLogEntry {
-    // Copy the Fuse log entry from DCCM
-    let mut fuse_entry: [u8; core::mem::size_of::<FuseLogEntry>()] =
-        [0u8; core::mem::size_of::<FuseLogEntry>()];
-
-    let src = unsafe {
-        let offset = core::mem::size_of::<FuseLogEntry>() * entry_index;
-        let ptr = (FUSE_LOG_ORG as *mut u8).add(offset);
-        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FuseLogEntry>())
-    };
-
-    fuse_entry.copy_from_slice(src);
-    FuseLogEntry::read_from_prefix(fuse_entry.as_bytes()).unwrap()
+    let persistent_data = unsafe { PersistentDataAccessor::new() };
+    persistent_data.get().fuse_log[entry_index]
 }
 
 fn read_fht(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
-    // Copy the FHT from DCCM
-    let mut fht: [u8; core::mem::size_of::<FirmwareHandoffTable>()] =
-        [0u8; core::mem::size_of::<FirmwareHandoffTable>()];
-
-    let src = unsafe {
-        let ptr = FHT_ORG as *mut u8;
-        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FirmwareHandoffTable>())
-    };
-
-    fht.copy_from_slice(src);
-
-    send_to_mailbox(mbox, fht.as_bytes(), true);
+    let persistent_data = unsafe { PersistentDataAccessor::new() };
+    send_to_mailbox(mbox, persistent_data.get().fht.as_bytes(), true);
 }
 
 fn send_to_mailbox(


### PR DESCRIPTION
I recommend reviewing each commit independently.

This allows us to remove quite a bit of unsafe code. The PersistentDataAccessor is introduced in https://github.com/chipsalliance/caliptra-sw/pull/690 (Add safe abstraction for accessing persistent data).

Also, support byte-length requests in mailbox driver. This allows for less awkward interaction with zerocopy as_bytes_mut(), which is useful when dealing with the persistent data directly rather than through word slices.