### PR TITLE
Remove rerun-if-changed lines from cpu/build.rs

### DIFF
--- a/cpu/build.rs
+++ b/cpu/build.rs
@@ -123,7 +123,4 @@ fn main() {
     )
     .unwrap();
     println!("cargo:rustc-link-search={}", out_dir.display());
-
-    println!("cargo:rerun-if-changed=link.x");
-    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
These aren't necessary, and are causing this package and depedents to be re-built every time cargo is invoked (since build.rs writes link.x).