### PR TITLE
Implement Platform::get_certificate_chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
 name = "caliptra-runtime"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "caliptra-builder",
  "caliptra-cpu",
  "caliptra-drivers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ aes = "0.8.2"
 anyhow = "1.0.70"
 arbitrary = { version = "1.3.0", features = ["derive"] }
 arrayref = "0.3.6"
+arrayvec = { version = "0.7.4", default-features = false }
 asn1 = "0.13.0"
 bitfield = "0.14.0"
 bitflags = "2.0.1"

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -285,8 +285,11 @@ pub struct FirmwareHandoffTable {
     // Address of RomInfo struct
     pub rom_info_addr: RomAddr<RomInfo>,
 
+    /// RtAlias TBS Size.
+    pub rtalias_tbs_size: u16,
+
     /// Reserved for future use.
-    pub reserved: [u8; 128],
+    pub reserved: [u8; 126],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -313,7 +316,8 @@ impl Default for FirmwareHandoffTable {
             rt_min_svn_dv_hdl: FHT_INVALID_HANDLE,
             ldevid_tbs_size: 0,
             fmcalias_tbs_size: 0,
-            reserved: [0u8; 128],
+            rtalias_tbs_size: 0,
+            reserved: [0u8; 126],
             ldevid_tbs_addr: 0,
             fmcalias_tbs_addr: 0,
             pcr_log_addr: 0,
@@ -378,6 +382,7 @@ pub fn print_fht(fht: &FirmwareHandoffTable) {
     crate::cprintln!("LdevId TBS Size: {} bytes", fht.ldevid_tbs_size);
     crate::cprintln!("FmcAlias TBS Address: 0x{:08x}", fht.fmcalias_tbs_addr);
     crate::cprintln!("FmcAlias TBS Size: {} bytes", fht.fmcalias_tbs_size);
+    crate::cprintln!("RtAlias TBS Size: {} bytes", fht.rtalias_tbs_size);
     crate::cprintln!("PCR log Address: 0x{:08x}", fht.pcr_log_addr);
     crate::cprintln!("Fuse log Address: 0x{:08x}", fht.fuse_log_addr);
 }
@@ -507,6 +512,7 @@ mod tests {
             && fht.fips_fw_load_addr_hdl == FHT_INVALID_HANDLE
             && fht.ldevid_tbs_size == 0
             && fht.fmcalias_tbs_size == 0
+            && fht.rtalias_tbs_size == 0
             && fht.ldevid_tbs_addr != 0
             && fht.fmcalias_tbs_addr != 0
             && fht.pcr_log_addr != 0

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -310,6 +310,8 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E0011);
     pub const RUNTIME_HANDOFF_INVALID_PARM: CaliptraError = CaliptraError::new_const(0x000E0012);
     pub const RUNTIME_GET_DEVID_CERT_FAILED: CaliptraError = CaliptraError::new_const(0x000E0013);
+    pub const RUNTIME_CERT_CHAIN_CREATION_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0014);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -141,6 +141,7 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.                                                                                 |
 | idev_dice_pub_key     | 96           | ROM        | Initial Device ID Public Key.                                                                            |
 | rom_info_addr         | 4            | ROM        | Address of ROMInfo struct describing the ROM digest and git commit.                                      |
+| rtalias_tbs_size      | 2            | FMC        | RT Alias TBS Size.                                                                                      |
 | reserved              | 128          |            | Reserved for future use.                                                                                 |
 
 *FHT is currently defined to be 512 bytes in length.*

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -318,8 +318,9 @@ impl RtAliasLayer {
 
         hand_off.set_rt_dice_signature(sig);
 
-        //  Copy TBS to DCCM.
+        //  Copy TBS to DCCM and set size in FHT.
         Self::copy_tbs(tbs.tbs(), env.persistent_data.get_mut())?;
+        hand_off.set_rtalias_tbs_size(tbs.tbs().len());
 
         report_boot_status(FmcBootStatus::RtAliasCertSigGenerationComplete as u32);
 

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -289,6 +289,10 @@ impl HandOff {
         self.fht.rt_dice_sign = *sig;
     }
 
+    pub fn set_rtalias_tbs_size(&mut self, rtalias_tbs_size: usize) {
+        self.fht.rtalias_tbs_size = rtalias_tbs_size as u16;
+    }
+
     /// Retrieve image manifest load address in DCCM
     pub fn image_manifest_address(&self, _env: &FmcEnv) -> u32 {
         if !DccmAddress(self.fht.manifest_load_addr).is_valid() {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,6 +19,7 @@ crypto.workspace = true
 platform.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
+arrayvec.workspace = true
 
 [build-dependencies]
 caliptra_common = { workspace = true, default-features = false }

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -14,6 +14,7 @@ use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
 enum CertType {
     LDevId,
     FmcAlias,
+    RtAlias,
 }
 
 pub struct GetLdevCertCmd;
@@ -80,6 +81,18 @@ pub fn copy_fmc_alias_cert(
     cert_from_dccm(dv, persistent_data, cert, CertType::FmcAlias)
 }
 
+/// Copy RT Alias certificate produced by ROM to `cert` buffer
+///
+/// Returns the number of bytes written to `cert`
+#[inline(never)]
+pub fn copy_rt_alias_cert(
+    dv: &DataVault,
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    cert_from_dccm(dv, persistent_data, cert, CertType::RtAlias)
+}
+
 /// Copy a certificate from `dccm_offset`, append signature, and write the
 /// output to `cert`.
 fn cert_from_dccm(
@@ -100,6 +113,12 @@ fn cert_from_dccm(
                 .fmcalias_tbs
                 .get(..persistent_data.fht.fmcalias_tbs_size.into()),
             dv.fmc_dice_signature(),
+        ),
+        CertType::RtAlias => (
+            persistent_data
+                .rtalias_tbs
+                .get(..persistent_data.fht.rtalias_tbs_size.into()),
+            persistent_data.fht.rt_dice_sign,
         ),
     };
     let Some(tbs) = tbs else {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -25,7 +25,11 @@ impl InvokeDpeCmd {
                 .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
             let mut env = DpeEnv::<CptraDpeTypes> {
                 crypto,
-                platform: DpePlatform::new(pdata.manifest1.header.pl0_pauser, hashed_rt_pub_key),
+                platform: DpePlatform::new(
+                    pdata.manifest1.header.pl0_pauser,
+                    hashed_rt_pub_key,
+                    &mut drivers.cert_chain,
+                ),
             };
 
             match drivers

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -33,7 +33,11 @@ impl StashMeasurementCmd {
                 .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
             let mut env = DpeEnv::<CptraDpeTypes> {
                 crypto,
-                platform: DpePlatform::new(pdata.manifest1.header.pl0_pauser, hashed_rt_pub_key),
+                platform: DpePlatform::new(
+                    pdata.manifest1.header.pl0_pauser,
+                    hashed_rt_pub_key,
+                    &mut drivers.cert_chain,
+                ),
             };
 
             let locality = drivers.mbox.user();


### PR DESCRIPTION
The Platform implementation is complete with this commit.

We also add rtalias_tbs_size to the Firmware handoff table for use in the dice module, so we can piece the cert chain together.