### PR TITLE
FMC : Log PCR extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "caliptra-x509",
  "caliptra_common",
  "cfg-if 1.0.0",
+ "openssl",
  "ufmt",
  "zerocopy",
 ]
@@ -388,6 +389,7 @@ dependencies = [
  "caliptra_common",
  "cfg-if 1.0.0",
  "ufmt",
+ "ureg",
  "zerocopy",
 ]
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -30,7 +30,7 @@ pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 
 pub const FMC_ORG: u32 = 0x40000000;
-pub const FMC_SIZE: u32 = 16 * 1024;
+pub const FMC_SIZE: u32 = 18 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 96 * 1024;
 

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -272,6 +272,9 @@ pub struct FirmwareHandoffTable {
     /// PCR log Address
     pub pcr_log_addr: u32,
 
+    /// Last empty PCR log entry slot index
+    pub pcr_log_index: u32,
+
     /// Fuse log Address
     pub fuse_log_addr: u32,
 
@@ -286,7 +289,7 @@ pub struct FirmwareHandoffTable {
     pub rom_info_addr: RomAddr<RomInfo>,
 
     /// Reserved for future use.
-    pub reserved: [u8; 128],
+    pub reserved: [u8; 124],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -313,10 +316,11 @@ impl Default for FirmwareHandoffTable {
             rt_min_svn_dv_hdl: FHT_INVALID_HANDLE,
             ldevid_tbs_size: 0,
             fmcalias_tbs_size: 0,
-            reserved: [0u8; 128],
+            reserved: [0u8; 124],
             ldevid_tbs_addr: 0,
             fmcalias_tbs_addr: 0,
             pcr_log_addr: 0,
+            pcr_log_index: 0,
             fuse_log_addr: 0,
             rt_dice_sign: Ecc384Signature::default(),
             rt_dice_pub_key: Ecc384PubKey::default(),

--- a/drivers/src/pcr_log.rs
+++ b/drivers/src/pcr_log.rs
@@ -34,6 +34,8 @@ pub enum PcrLogEntryId {
     FmcFuseSvn = 9,            // data size = 1 byte
     LmsVendorPubKeyIndex = 10, // data size = 1 byte
     RomVerifyConfig = 11,      // data size = 1 byte
+    RtTci = 12,                // data size = 48 bytes
+    FwImageManifest = 13,      // data size = 48 bytes
 }
 
 impl From<u16> for PcrLogEntryId {
@@ -51,6 +53,8 @@ impl From<u16> for PcrLogEntryId {
             9 => PcrLogEntryId::FmcFuseSvn,
             10 => PcrLogEntryId::LmsVendorPubKeyIndex,
             11 => PcrLogEntryId::RomVerifyConfig,
+            12 => PcrLogEntryId::RtTci,
+            13 => PcrLogEntryId::FwImageManifest,
             _ => PcrLogEntryId::Invalid,
         }
     }
@@ -89,6 +93,8 @@ impl PcrLogEntry {
             PcrLogEntryId::FmcFuseSvn => 1,
             PcrLogEntryId::LmsVendorPubKeyIndex => 1,
             PcrLogEntryId::RomVerifyConfig => 1,
+            PcrLogEntryId::RtTci => 48,
+            PcrLogEntryId::FwImageManifest => 48,
         };
 
         &self.pcr_data.as_bytes()[..data_len]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -321,6 +321,10 @@ impl CaliptraError {
     pub const FMC_RT_ALIAS_TBS_SIZE_EXCEEDED: CaliptraError = CaliptraError::new_const(0x000F0007);
     pub const FMC_CDI_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0008);
     pub const FMC_ALIAS_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0009);
+    pub const FMC_PCR_LOG_INVALID_ENTRY_ID: CaliptraError = CaliptraError::new_const(0x000F000A);
+    pub const FMC_PCR_LOG_UNSUPPORTED_DATA_LENGTH: CaliptraError =
+        CaliptraError::new_const(0x000F000B);
+    pub const FMC_GLOBAL_PCR_LOG_EXHAUSTED: CaliptraError = CaliptraError::new_const(0x000F000C);
 
     /// TRNG_EXT Errors
     pub const DRIVER_TRNG_EXT_TIMEOUT: CaliptraError = CaliptraError::new_const(0x00100001);

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -16,6 +16,7 @@ caliptra-x509 = { workspace = true, default-features = false }
 ufmt.workspace = true
 zerocopy.workspace = true
 
+
 [build-dependencies]
 caliptra_common = { workspace = true, default-features = false }
 caliptra-gen-linker-scripts.workspace = true
@@ -25,6 +26,7 @@ cfg-if.workspace = true
 caliptra-builder.workspace = true
 caliptra-hw-model.workspace = true
 caliptra-image-types.workspace = true
+openssl.workspace = true
 
 [features]
 default = ["std"]

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -15,7 +15,7 @@ use crate::flow::dice::DiceOutput;
 use crate::fmc_env::FmcEnv;
 use caliptra_common::DataStore::*;
 use caliptra_common::{DataStore, FirmwareHandoffTable, HandOffDataHandle, Vault};
-use caliptra_drivers::{memory_layout, Array4x12, Ecc384Signature, KeyId, PersistentDataAccessor};
+use caliptra_drivers::{memory_layout, Array4x12, Ecc384Signature, KeyId};
 use caliptra_drivers::{Ecc384PubKey, Ecc384Scalar};
 use caliptra_error::CaliptraResult;
 
@@ -66,12 +66,13 @@ pub struct HandOff {
 
 impl HandOff {
     /// Create a new `HandOff` from the FHT table.
-    pub fn from_previous(persistent_data: &PersistentDataAccessor) -> Option<HandOff> {
-        let fht = &persistent_data.get().fht;
+    pub fn from_previous(env: &mut FmcEnv) -> Option<HandOff> {
+        let fht = &env.persistent_data.get().fht;
         // Perform basic sanity check of the FHT (check FHT marker, valid indices, etc.)
         if !fht.is_valid() {
             return None;
         }
+        env.pcr_bank.log_index = fht.pcr_log_index as usize;
         Some(Self { fht: fht.clone() })
     }
 

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
+
 use core::hint::black_box;
 
 use caliptra_common::cprintln;
@@ -45,7 +46,7 @@ pub extern "C" fn entry_point() -> ! {
         Err(e) => report_error(e.into()),
     };
 
-    if let Some(mut hand_off) = HandOff::from_previous(&env.persistent_data) {
+    if let Some(mut hand_off) = HandOff::from_previous(&mut env) {
         // Jump straight to RT for val-FMC for now
         if cfg!(feature = "val-fmc") {
             hand_off.to_rt(&mut env);
@@ -59,6 +60,7 @@ pub extern "C" fn entry_point() -> ! {
             Err(e) => report_error(e.into()),
         }
     }
+
     caliptra_drivers::ExitCtrl::exit(0xff)
 }
 

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -12,6 +12,7 @@ caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
+ureg.workspace = true
 
 [build-dependencies]
 cfg-if.workspace = true
@@ -19,8 +20,10 @@ cfg-if.workspace = true
 [dev-dependencies]
 caliptra-builder.workspace = true
 
+
 [features]
 default = ["std"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
+interactive_test = []

--- a/fmc/test-fw/test-rt/src/interactive_test.rs
+++ b/fmc/test-fw/test-rt/src/interactive_test.rs
@@ -1,0 +1,144 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_drivers::memory_layout::{FHT_ORG, PCR_LOG_ORG};
+use caliptra_drivers::pcr_log::{PcrLogEntry, PcrLogEntryId};
+use caliptra_drivers::{cprintln, FirmwareHandoffTable, PcrBank, PcrId};
+use caliptra_registers::pv::PvReg;
+use ureg::RealMmioMut;
+
+use core::convert::TryInto;
+use zerocopy::{AsBytes, FromBytes};
+
+pub const TEST_CMD_READ_PCR_LOG: u32 = 0x1000_0000;
+pub const TEST_CMD_READ_FHT: u32 = 0x1000_0001;
+pub const TEST_CMD_READ_PCRS: u32 = 0x1000_0002;
+
+fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let cmd = mbox.cmd().read();
+    cprintln!("[fmc-test-harness] Received command: 0x{:08X}", cmd);
+    match cmd {
+        TEST_CMD_READ_PCR_LOG => {
+            read_pcr_log(mbox);
+        }
+        TEST_CMD_READ_FHT => {
+            read_fht(mbox);
+        }
+        TEST_CMD_READ_PCRS => {
+            read_pcrs(mbox);
+        }
+        _ => {
+            assert!(false);
+        }
+    }
+}
+
+pub fn process_mailbox_commands() {
+    let mut mbox = unsafe { caliptra_registers::mbox::MboxCsr::new() };
+    let mbox = mbox.regs_mut();
+
+    cprintln!("Waiting for mailbox commands...");
+    loop {
+        if mbox.status().read().mbox_fsm_ps().mbox_execute_uc() {
+            process_mailbox_command(&mbox);
+        }
+    }
+}
+
+fn read_fht(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    // Copy the FHT from DCCM
+    let mut fht: [u8; core::mem::size_of::<FirmwareHandoffTable>()] =
+        [0u8; core::mem::size_of::<FirmwareHandoffTable>()];
+
+    let src = unsafe {
+        let ptr = FHT_ORG as *mut u8;
+        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FirmwareHandoffTable>())
+    };
+
+    fht.copy_from_slice(src);
+
+    send_to_mailbox(mbox, fht.as_bytes(), true);
+}
+
+fn send_to_mailbox(
+    mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>,
+    data: &[u8],
+    update_mb_state: bool,
+) {
+    let data_len = data.len();
+    let word_size = core::mem::size_of::<u32>();
+    let remainder = data_len % word_size;
+    let n = data_len - remainder;
+    for idx in (0..n).step_by(word_size) {
+        mbox.datain()
+            .write(|_| u32::from_le_bytes(data[idx..idx + word_size].try_into().unwrap()));
+    }
+
+    if remainder > 0 {
+        let mut last_word = data[n] as u32;
+        for idx in 1..remainder {
+            last_word |= (data[n + idx] as u32) << (idx << 3);
+        }
+        mbox.datain().write(|_| last_word);
+    }
+
+    if update_mb_state {
+        mbox.dlen().write(|_| data_len as u32);
+        mbox.status().write(|w| w.status(|w| w.data_ready()));
+    }
+}
+
+fn read_pcr_log(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let mut pcr_entry_count = 0;
+    loop {
+        let pcr_entry = get_pcr_entry(pcr_entry_count);
+        if PcrLogEntryId::from(pcr_entry.id) == PcrLogEntryId::Invalid {
+            break;
+        }
+
+        pcr_entry_count += 1;
+        send_to_mailbox(mbox, pcr_entry.as_bytes(), false);
+    }
+
+    mbox.dlen().write(|_| {
+        (core::mem::size_of::<PcrLogEntry>() * pcr_entry_count)
+            .try_into()
+            .unwrap()
+    });
+    mbox.status().write(|w| w.status(|w| w.data_ready()));
+}
+
+fn get_pcr_entry(entry_index: usize) -> PcrLogEntry {
+    // Copy the pcr log entry from DCCM
+    let mut pcr_entry: [u8; core::mem::size_of::<PcrLogEntry>()] =
+        [0u8; core::mem::size_of::<PcrLogEntry>()];
+
+    let src = unsafe {
+        let offset = core::mem::size_of::<PcrLogEntry>() * entry_index;
+        let ptr = (PCR_LOG_ORG as *mut u8).add(offset);
+        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<PcrLogEntry>())
+    };
+
+    pcr_entry.copy_from_slice(src);
+    PcrLogEntry::read_from_prefix(pcr_entry.as_bytes()).unwrap()
+}
+
+fn read_pcrs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let pcr_bank = unsafe { PcrBank::new(PvReg::new()) };
+    const PCR_COUNT: usize = 32;
+    for i in 0..PCR_COUNT {
+        let pcr = pcr_bank.read_pcr(PcrId::try_from(i as u8).unwrap());
+        let mut pcr_bytes: [u32; 12] = pcr.try_into().unwrap();
+
+        swap_word_bytes_inplace(&mut pcr_bytes);
+        send_to_mailbox(mbox, pcr.as_bytes(), false);
+    }
+
+    mbox.dlen().write(|_| (48 * PCR_COUNT).try_into().unwrap());
+    mbox.status().write(|w| w.status(|w| w.data_ready()));
+}
+
+fn swap_word_bytes_inplace(words: &mut [u32]) {
+    for word in words.iter_mut() {
+        *word = word.swap_bytes()
+    }
+}

--- a/fmc/test-fw/test-rt/src/main.rs
+++ b/fmc/test-fw/test-rt/src/main.rs
@@ -13,6 +13,8 @@ Abstract:
 --*/
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(feature = "interactive_test", allow(unused_imports))]
+mod interactive_test;
 
 use caliptra_common::cprintln;
 use caliptra_cpu::TrapRecord;
@@ -50,6 +52,10 @@ pub extern "C" fn entry_point() -> ! {
     assert!(pcr_bank
         .erase_pcr(caliptra_common::RT_FW_JOURNEY_PCR)
         .is_err());
+
+    if cfg!(feature = "interactive_test") {
+        interactive_test::process_mailbox_commands();
+    }
     caliptra_drivers::ExitCtrl::exit(0)
 }
 

--- a/fmc/tests/test_rtalias.rs
+++ b/fmc/tests/test_rtalias.rs
@@ -1,6 +1,17 @@
 // Licensed under the Apache-2.0 license
 use caliptra_builder::{FwId, ImageOptions, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_drivers::{
+    pcr_log::{PcrLogEntry, PcrLogEntryId},
+    FirmwareHandoffTable, PcrId,
+};
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
+
+use zerocopy::{AsBytes, FromBytes};
+
+use openssl::hash::{Hasher, MessageDigest};
+
+const TEST_CMD_READ_PCR_LOG: u32 = 0x1000_0000;
+const TEST_CMD_READ_FHT: u32 = 0x1000_0001;
 
 const RT_ALIAS_MEASUREMENT_COMPLETE: u32 = 0x400;
 const RT_ALIAS_DERIVED_CDI_COMPLETE: u32 = 0x401;
@@ -9,6 +20,9 @@ const RT_ALIAS_SUBJ_ID_SN_GENERATION_COMPLETE: u32 = 0x403;
 const RT_ALIAS_SUBJ_KEY_ID_GENERATION_COMPLETE: u32 = 0x404;
 const RT_ALIAS_CERT_SIG_GENERATION_COMPLETE: u32 = 0x405;
 const RT_ALIAS_DERIVATION_COMPLETE: u32 = 0x406;
+
+const PCR_COUNT: usize = 32;
+const PCR_ENTRY_SIZE: usize = core::mem::size_of::<PcrLogEntry>();
 
 #[test]
 fn test_boot_status_reporting() {
@@ -45,7 +59,231 @@ fn test_boot_status_reporting() {
     hw.step_until_boot_status(RT_ALIAS_SUBJ_KEY_ID_GENERATION_COMPLETE, true);
     hw.step_until_boot_status(RT_ALIAS_CERT_SIG_GENERATION_COMPLETE, true);
     hw.step_until_boot_status(RT_ALIAS_DERIVATION_COMPLETE, true);
+}
 
-    let mut output = vec![];
-    hw.copy_output_until_exit_success(&mut output).unwrap();
+#[test]
+fn test_fht_info() {
+    pub const MOCK_RT_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-fmc-mock-rt",
+        bin_name: "caliptra-fmc-mock-rt",
+        features: &["emu", "interactive_test"],
+        workspace_dir: None,
+    };
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let result = hw.mailbox_execute(TEST_CMD_READ_FHT, &[]);
+    assert!(result.is_ok());
+
+    let data = result.unwrap().unwrap();
+    let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+    assert_eq!(fht.ldevid_tbs_size, 533);
+    assert_eq!(fht.fmcalias_tbs_size, 745);
+    assert_eq!(fht.ldevid_tbs_addr, 0x50003800);
+    assert_eq!(fht.fmcalias_tbs_addr, 0x50003C00);
+    assert_eq!(fht.pcr_log_addr, 0x50004400);
+    assert_eq!(fht.fuse_log_addr, 0x50004800);
+}
+
+#[test]
+fn test_pcr_log() {
+    pub const MOCK_RT_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-fmc-mock-rt",
+        bin_name: "caliptra-fmc-mock-rt",
+        features: &["emu", "interactive_test"],
+        workspace_dir: None,
+    };
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let result = hw.mailbox_execute(TEST_CMD_READ_FHT, &[]);
+    assert!(result.is_ok());
+
+    let data = result.unwrap().unwrap();
+    let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+
+    let pcr_entry_arr = hw
+        .mailbox_execute(TEST_CMD_READ_PCR_LOG, &[])
+        .unwrap()
+        .unwrap();
+
+    // Check PCR entry for RtTci.
+    let mut pcr_log_entry_offset = (fht.pcr_log_index as usize) * PCR_ENTRY_SIZE;
+
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::RtTci as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_CURRENT_PCR as u8)
+    );
+
+    // Check PCR entry for Manifest digest.
+    pcr_log_entry_offset += core::mem::size_of::<PcrLogEntry>();
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::FwImageManifest as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_CURRENT_PCR as u8)
+    );
+
+    // Check PCR entry for RtTci.
+    pcr_log_entry_offset += core::mem::size_of::<PcrLogEntry>();
+
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::RtTci as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_JOURNEY_PCR as u8)
+    );
+
+    // Check PCR entry for Manifest digest.
+    pcr_log_entry_offset += PCR_ENTRY_SIZE;
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::FwImageManifest as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_JOURNEY_PCR as u8)
+    );
+
+    // Fetch and validate PCR values against the log.
+    let pcrs = hw.mailbox_execute(0x1000_0002, &[]).unwrap().unwrap();
+    assert_eq!(pcrs.len(), PCR_COUNT * 48);
+    let mut pcr2_from_hw: [u8; 48] = pcrs[(2 * 48)..(3 * 48)].try_into().unwrap();
+    let mut pcr3_from_hw: [u8; 48] = pcrs[(3 * 48)..(4 * 48)].try_into().unwrap();
+
+    change_dword_endianess(&mut pcr2_from_hw);
+    change_dword_endianess(&mut pcr3_from_hw);
+
+    let pcr2_from_log = hash_pcr_log_entries(&[0; 48], &pcr_entry_arr, PcrId::PcrId2);
+    let pcr3_from_log = hash_pcr_log_entries(&[0; 48], &pcr_entry_arr, PcrId::PcrId3);
+
+    assert_eq!(pcr2_from_log, pcr2_from_hw);
+    assert_eq!(pcr3_from_log, pcr3_from_hw);
+
+    hw.soc_ifc()
+        .internal_fw_update_reset()
+        .write(|w| w.core_rst(true));
+
+    assert!(hw.upload_firmware(&image.to_bytes().unwrap()).is_ok());
+
+    hw.step_until_boot_status(RT_ALIAS_DERIVATION_COMPLETE, true);
+
+    let pcr_entry_arr = hw
+        .mailbox_execute(TEST_CMD_READ_PCR_LOG, &[])
+        .unwrap()
+        .unwrap();
+
+    // Check PCR entry for RtTci.
+    let mut pcr_log_entry_offset =
+        (fht.pcr_log_index as usize) * core::mem::size_of::<PcrLogEntry>();
+
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::RtTci as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_CURRENT_PCR as u8)
+    );
+
+    // Check PCR entry for Manifest digest.
+    pcr_log_entry_offset += PCR_ENTRY_SIZE;
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::FwImageManifest as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_CURRENT_PCR as u8)
+    );
+
+    // Check PCR entry for RtTci.
+    pcr_log_entry_offset += core::mem::size_of::<PcrLogEntry>();
+
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::RtTci as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_JOURNEY_PCR as u8)
+    );
+
+    // Check PCR entry for Manifest digest.
+    pcr_log_entry_offset += PCR_ENTRY_SIZE;
+    let pcr_log_entry =
+        PcrLogEntry::read_from_prefix(pcr_entry_arr[pcr_log_entry_offset..].as_bytes()).unwrap();
+    assert_eq!(pcr_log_entry.id, PcrLogEntryId::FwImageManifest as u16);
+    assert_eq!(
+        pcr_log_entry.pcr_ids,
+        1 << (caliptra_common::RT_FW_JOURNEY_PCR as u8)
+    );
+}
+
+// Computes the PCR from the log.
+fn hash_pcr_log_entries(initial_pcr: &[u8; 48], pcr_entry_arr: &[u8], pcr_id: PcrId) -> [u8; 48] {
+    let mut offset: usize = 0;
+    let mut pcr: [u8; 48] = *initial_pcr;
+
+    assert_eq!(pcr_entry_arr.len() % PCR_ENTRY_SIZE, 0);
+
+    loop {
+        if offset == pcr_entry_arr.len() {
+            break;
+        }
+
+        let entry = PcrLogEntry::read_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
+        offset += PCR_ENTRY_SIZE;
+
+        if (entry.pcr_ids & (1 << pcr_id as u8)) == 0 {
+            continue;
+        }
+
+        let mut hasher = Hasher::new(MessageDigest::sha384()).unwrap();
+        hasher.update(&pcr).unwrap();
+        hasher.update(entry.measured_data()).unwrap();
+        let digest: &[u8] = &hasher.finish().unwrap();
+
+        pcr.copy_from_slice(digest);
+    }
+
+    pcr
+}
+
+pub fn change_dword_endianess(data: &mut [u8]) {
+    for idx in (0..data.len()).step_by(4) {
+        data.swap(idx, idx + 3);
+        data.swap(idx + 1, idx + 2);
+    }
 }

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -170,6 +170,7 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         ldevid_tbs_addr,
         fmcalias_tbs_addr,
         pcr_log_addr,
+        pcr_log_index: env.pcr_bank.log_index as u32,
         fuse_log_addr,
         idev_dice_pub_key: env.fht_data_store.idev_pub,
         ..Default::default()


### PR DESCRIPTION
This change logs a PCR entry to DCCM when a PCR is extended.

- Adds a 4-byte `pcr_log_index ` to the FHT to handoff.  
-  Adds tests to validate the log against the PCR values in hardware.