### PR TITLE
Fixes and ROM Integrity test trigger from runtime as part of FIPS self-test

### DIFF
--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -89,18 +89,29 @@ pub enum DataVaultRegister {
 impl TryInto<DataStore> for HandOffDataHandle {
     type Error = CaliptraError;
     fn try_into(self) -> Result<DataStore, Self::Error> {
-        let vault = Vault::try_from(self.vault())
-            .unwrap_or_else(|_| report_handoff_error_and_halt("Invalid Vault", 0xbadbad));
+        let vault = Vault::try_from(self.vault()).unwrap_or_else(|_| {
+            report_handoff_error_and_halt(
+                "Invalid Vault",
+                CaliptraError::DRIVER_HANDOFF_INVALID_VAULT.into(),
+            )
+        });
         match vault {
             Vault::KeyVault => Ok(DataStore::KeyVaultSlot(
-                KeyId::try_from(self.reg_num() as u8)
-                    .unwrap_or_else(|_| report_handoff_error_and_halt("Invalid KeyId", 0xbadbad)),
+                KeyId::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
+                    report_handoff_error_and_halt(
+                        "Invalid KeyId",
+                        CaliptraError::DRIVER_HANDOFF_INVALID_KEY_ID.into(),
+                    )
+                }),
             )),
             Vault::DataVault => match self.reg_type() {
                 1 => {
                     let entry = DataStore::DataVaultSticky4(
                         ColdResetEntry4::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
-                            report_handoff_error_and_halt("Invalid ColdResetEntry4", 0xbadbad)
+                            report_handoff_error_and_halt(
+                                "Invalid ColdResetEntry4",
+                                CaliptraError::DRIVER_HANDOFF_INVALID_COLD_RESET_ENTRY4.into(),
+                            )
                         }),
                     );
                     Ok(entry)
@@ -109,7 +120,10 @@ impl TryInto<DataStore> for HandOffDataHandle {
                 2 => {
                     let entry = DataStore::DataVaultSticky48(
                         ColdResetEntry48::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
-                            report_handoff_error_and_halt("Invalid ColdResetEntry48", 0xbadbad)
+                            report_handoff_error_and_halt(
+                                "Invalid ColdResetEntry48",
+                                CaliptraError::DRIVER_HANDOFF_INVALID_COLD_RESET_ENTRY48.into(),
+                            )
                         }),
                     );
                     Ok(entry)
@@ -118,7 +132,10 @@ impl TryInto<DataStore> for HandOffDataHandle {
                 3 => {
                     let entry =
                         WarmResetEntry4::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
-                            report_handoff_error_and_halt("Invalid WarmResetEntry4", 0xbadbad)
+                            report_handoff_error_and_halt(
+                                "Invalid WarmResetEntry4",
+                                CaliptraError::DRIVER_HANDOFF_INVALID_WARM_RESET_ENTRY4.into(),
+                            )
                         });
 
                     let ds = DataStore::DataVaultNonSticky4(entry);
@@ -128,7 +145,10 @@ impl TryInto<DataStore> for HandOffDataHandle {
                 4 => {
                     let entry = DataStore::DataVaultNonSticky48(
                         WarmResetEntry48::try_from(self.reg_num() as u8).unwrap_or_else(|_| {
-                            report_handoff_error_and_halt("Invalid WarmResetEntry48", 0xbadbad)
+                            report_handoff_error_and_halt(
+                                "Invalid WarmResetEntry48",
+                                CaliptraError::DRIVER_HANDOFF_INVALID_WARM_RESET_ENTRY48.into(),
+                            )
                         }),
                     );
                     Ok(entry)

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -288,6 +288,17 @@ impl CaliptraError {
     pub const DRIVER_CSRNG_ADAPTP_HEALTH_CHECK_FAILED: CaliptraError =
         CaliptraError::new_const(0x000d0008);
 
+    pub const DRIVER_HANDOFF_INVALID_VAULT: CaliptraError = CaliptraError::new_const(0x000D100);
+    pub const DRIVER_HANDOFF_INVALID_KEY_ID: CaliptraError = CaliptraError::new_const(0x000D101);
+    pub const DRIVER_HANDOFF_INVALID_COLD_RESET_ENTRY4: CaliptraError =
+        CaliptraError::new_const(0x000D102);
+    pub const DRIVER_HANDOFF_INVALID_COLD_RESET_ENTRY48: CaliptraError =
+        CaliptraError::new_const(0x000D103);
+    pub const DRIVER_HANDOFF_INVALID_WARM_RESET_ENTRY4: CaliptraError =
+        CaliptraError::new_const(0x000D104);
+    pub const DRIVER_HANDOFF_INVALID_WARM_RESET_ENTRY48: CaliptraError =
+        CaliptraError::new_const(0x000D104);
+
     /// Runtime Errors
     pub const RUNTIME_INTERNAL: CaliptraError = CaliptraError::new_const(0x000E0001);
     pub const RUNTIME_UNIMPLEMENTED_COMMAND: CaliptraError = CaliptraError::new_const(0x000E0002);

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -42,8 +42,10 @@ impl FipsModule {
 pub mod fips_self_test_cmd {
     use super::*;
     use crate::RtBootStatus::{RtFipSelfTestComplete, RtFipSelfTestStarted};
+    use caliptra_common::HexBytes;
     use caliptra_common::{verifier::FirmwareImageVerificationEnv, FMC_ORG, RUNTIME_ORG};
     use caliptra_drivers::ResetReason;
+    use caliptra_image_types::RomInfo;
     use caliptra_image_verify::ImageVerifier;
     use zerocopy::AsBytes;
 
@@ -116,6 +118,7 @@ pub mod fips_self_test_cmd {
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<()> {
         caliptra_drivers::report_boot_status(RtFipSelfTestStarted.into());
         cprintln!("[rt] FIPS self test");
+        rom_integrity_test(env)?;
         execute_kats(env)?;
         copy_and_verify_image(env)?;
         caliptra_drivers::report_boot_status(RtFipSelfTestComplete.into());
@@ -153,8 +156,32 @@ pub mod fips_self_test_cmd {
         caliptra_kat::execute_kat(&mut kats_env)?;
         Ok(())
     }
-}
 
+    fn rom_integrity_test(env: &mut Drivers) -> CaliptraResult<()> {
+        // Extract the expected has from the fht.
+        let rom_info = env.persistent_data.get().fht.rom_info_addr.get()?;
+
+        // WARNING: It is undefined behavior to dereference a zero (null) pointer in
+        // rust code. This is only safe because the dereference is being done by an
+        // an assembly routine ([`ureg::opt_riscv::copy_16_words`]) rather
+        // than dereferencing directly in Rust.
+        #[allow(clippy::zero_ptr)]
+        let rom_start = 0 as *const [u32; 16];
+
+        let n_blocks =
+            env.persistent_data.get().fht.rom_info_addr.get()? as *const RomInfo as usize / 64;
+
+        let digest = unsafe { env.sha256.digest_blocks_raw(rom_start, n_blocks)? };
+        cprintln!("ROM Digest: {}", HexBytes(&<[u8; 32]>::from(digest)));
+        if digest.0 != rom_info.sha256_digest {
+            cprintln!("ROM integrity test failed");
+            return Err(CaliptraError::ROM_INTEGRITY_FAILURE);
+        }
+
+        // Run digest function and compare with expected hash.
+        Ok(())
+    }
+}
 pub struct FipsShutdownCmd;
 impl FipsShutdownCmd {
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<MailboxResp> {


### PR DESCRIPTION
This commit adds the ROM integrity check call to runtime. Please merge into the combined FIPS ROM/RUNTIME support PR.