### PR TITLE
Move DPE Instance to persistent data in DCCM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "caliptra-registers",
  "caliptra-test",
  "cfg-if 1.0.0",
+ "dpe",
  "openssl",
  "ufmt",
  "ureg",

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -16,12 +16,14 @@ caliptra-image-types.workspace = true
 caliptra-lms-types.workspace = true
 caliptra-registers.workspace = true
 cfg-if.workspace = true
+dpe = { workspace = true, optional = true }
 ufmt.workspace = true
 ureg.workspace = true
 zerocopy.workspace = true
 
 [features]
 emu = []
+runtime = ["dep:dpe"]
 fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]

--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -42,7 +42,8 @@ pub const RTALIAS_TBS_ORG: u32 = 0x50004400;
 pub const PCR_LOG_ORG: u32 = 0x50004800;
 pub const MEASUREMENT_LOG_ORG: u32 = 0x50004C00;
 pub const FUSE_LOG_ORG: u32 = 0x50005000;
-pub const DATA_ORG: u32 = 0x50005400;
+pub const DPE_ORG: u32 = 0x50005400;
+pub const DATA_ORG: u32 = 0x50006400;
 pub const STACK_ORG: u32 = 0x5001A000;
 pub const ESTACK_ORG: u32 = 0x5001F800;
 pub const NSTACK_ORG: u32 = 0x5001FC00;
@@ -64,7 +65,8 @@ pub const RTALIAS_TBS_SIZE: u32 = 1024;
 pub const PCR_LOG_SIZE: u32 = 1024;
 pub const MEASUREMENT_LOG_SIZE: u32 = 1024;
 pub const FUSE_LOG_SIZE: u32 = 1024;
-pub const DATA_SIZE: u32 = 83 * 1024;
+pub const DPE_SIZE: u32 = 4 * 1024;
+pub const DATA_SIZE: u32 = 79 * 1024;
 pub const STACK_SIZE: u32 = 22 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const NSTACK_SIZE: u32 = 1024;
@@ -124,7 +126,13 @@ fn mem_layout_test_measurement_log() {
 #[test]
 #[allow(clippy::assertions_on_constants)]
 fn mem_layout_test_fuselog() {
-    assert_eq!((DATA_ORG - FUSE_LOG_ORG), FUSE_LOG_SIZE);
+    assert_eq!((DPE_ORG - FUSE_LOG_ORG), FUSE_LOG_SIZE);
+}
+
+#[test]
+#[allow(clippy::assertions_on_constants)]
+fn mem_layout_test_dpe() {
+    assert_eq!((DATA_ORG - DPE_ORG), DPE_SIZE);
 }
 
 #[test]

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -3,6 +3,8 @@
 use core::{marker::PhantomData, mem::size_of, ptr::addr_of};
 
 use caliptra_image_types::ImageManifest;
+#[cfg(feature = "runtime")]
+use dpe::DpeInstance;
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::{
@@ -47,6 +49,13 @@ pub struct PersistentData {
 
     pub fuse_log: FuseLogArray,
     reserved5: [u8; memory_layout::FUSE_LOG_SIZE as usize - size_of::<FuseLogArray>()],
+
+    #[cfg(feature = "runtime")]
+    pub dpe: DpeInstance,
+    #[cfg(feature = "runtime")]
+    reserved6: [u8; memory_layout::DPE_SIZE as usize - size_of::<DpeInstance>()],
+    #[cfg(not(feature = "runtime"))]
+    dpe: [u8; memory_layout::DPE_SIZE as usize],
 }
 impl PersistentData {
     pub fn assert_matches_layout() {
@@ -65,9 +74,10 @@ impl PersistentData {
                 memory_layout::MEASUREMENT_LOG_ORG
             );
             assert_eq!(addr_of!((*P).fuse_log) as u32, memory_layout::FUSE_LOG_ORG);
+            assert_eq!(addr_of!((*P).dpe) as u32, memory_layout::DPE_ORG);
             assert_eq!(
                 P.add(1) as u32,
-                memory_layout::FUSE_LOG_ORG + memory_layout::FUSE_LOG_SIZE
+                memory_layout::DPE_ORG + memory_layout::DPE_SIZE
             );
         }
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 caliptra_common = { workspace = true, default-features = false }
 caliptra-cpu.workspace = true
-caliptra-drivers.workspace = true
+caliptra-drivers = { workspace = true, features = ["runtime"] }
 caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false }
 caliptra-kat.workspace = true

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -33,6 +33,8 @@ impl InvokeDpeCmd {
             };
 
             match drivers
+                .persistent_data
+                .get_mut()
                 .dpe
                 .execute_serialized_command(&mut env, drivers.mbox.user(), &cmd.data)
             {

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -51,7 +51,11 @@ impl StashMeasurementCmd {
                 tci_type: u32::from_be_bytes(cmd.metadata),
                 target_locality: locality,
             }
-            .execute(&mut drivers.dpe, &mut env, locality);
+            .execute(
+                &mut drivers.persistent_data.get_mut().dpe,
+                &mut env,
+                locality,
+            );
 
             let dpe_result = match derive_child_resp {
                 Ok(_) => DpeErrorCode::NoError,


### PR DESCRIPTION
This is necessary so that DPE measurements don't get cleared upon warm resets.
We will still need to add logic to RT to only initialize dpe upon
cold reset and validate the DpeInstance in DCCM, but these will
take longer and don't touch ROM so they can be done later.

Note: DpeInstance only uses ~ 3400 bytes currently, but I am reserving 4k bytes in DCCM for it.
This is in case we add new fields to the DpeInstance struct. 