### PR TITLE
Update FMC Alias cert to contain everything in PCR_ID_FMC_CURRENT

### DIFF
--- a/hw-model/types/src/lib.rs
+++ b/hw-model/types/src/lib.rs
@@ -155,6 +155,7 @@ impl TryFrom<u32> for U4 {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct Fuses {
     pub uds_seed: [u32; 12],
     pub field_entropy: [u32; 8],

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -155,6 +155,20 @@ impl FmcAliasLayer {
         let svn = env.data_vault.fmc_svn() as u8;
         let fuse_svn = fw_proc_info.fmc_effective_fuse_svn as u8;
 
+        let mut fuse_info_digest = Array4x12::default();
+        let mut hasher = env.sha384.digest_init()?;
+        hasher.update(&[env.soc_ifc.lifecycle() as u8])?;
+        hasher.update(&[env.soc_ifc.debug_locked() as u8])?;
+        hasher.update(&[env.soc_ifc.fuse_bank().anti_rollback_disable() as u8])?;
+        hasher.update(&<[u8; 48]>::from(
+            env.soc_ifc.fuse_bank().vendor_pub_key_hash(),
+        ))?;
+        hasher.update(&<[u8; 48]>::from(env.data_vault.owner_pk_hash()))?;
+        hasher.update(&[env.data_vault.ecc_vendor_pk_index() as u8])?;
+        hasher.update(&[env.data_vault.lms_vendor_pk_index() as u8])?;
+        hasher.update(&[env.soc_ifc.fuse_bank().lms_verify() as u8])?;
+        hasher.finalize(&mut fuse_info_digest)?;
+
         // Certificate `To Be Signed` Parameters
         let params = FmcAliasCertTbsParams {
             ueid: &X509::ueid(env)?,
@@ -165,7 +179,7 @@ impl FmcAliasLayer {
             serial_number: &X509::cert_sn(env, pub_key)?,
             public_key: &pub_key.to_der(),
             tcb_info_fmc_tci: &(&env.data_vault.fmc_tci()).into(),
-            tcb_info_owner_pk_hash: &(&env.data_vault.owner_pk_hash()).into(),
+            tcb_info_device_info_hash: &fuse_info_digest.into(),
             tcb_info_flags: &flags,
             tcb_info_fmc_svn: &svn.to_be_bytes(),
             tcb_info_fmc_svn_fuses: &fuse_svn.to_be_bytes(),

--- a/rom/dev/tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/test_fmcalias_derivation.rs
@@ -683,7 +683,7 @@ fn test_fht_info() {
     let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
     let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
     assert_eq!(fht.ldevid_tbs_size, 533);
-    assert_eq!(fht.fmcalias_tbs_size, 745);
+    assert_eq!(fht.fmcalias_tbs_size, 769);
     assert_eq!(fht.ldevid_tbs_addr, LDEVID_TBS_ORG);
     assert_eq!(fht.fmcalias_tbs_addr, FMCALIAS_TBS_ORG);
     assert_eq!(fht.pcr_log_addr, PCR_LOG_ORG);

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -66,22 +66,24 @@ fn gen_fmc_alias_cert(out_dir: &str) {
         .add_basic_constraints_ext(true, 0)
         .add_key_usage_ext(usage)
         .add_ueid_ext(&[0xFF; 8])
-        .add_fmc_dice_tcb_info_ext(&[
-            FwidParam {
+        .add_fmc_dice_tcb_info_ext(
+            /*device_fwids=*/
+            &[FwidParam {
+                name: "TCB_INFO_DEVICE_INFO_HASH",
+                fwid: Fwid {
+                    hash_alg: asn1::oid!(/*sha384*/ 2, 16, 840, 1, 101, 3, 4, 2, 2),
+                    digest: &[0xEF; 48],
+                },
+            }],
+            /*fmc_fwids=*/
+            &[FwidParam {
                 name: "TCB_INFO_FMC_TCI",
                 fwid: Fwid {
                     hash_alg: asn1::oid!(/*sha384*/ 2, 16, 840, 1, 101, 3, 4, 2, 2),
                     digest: &[0xCD; 48],
                 },
-            },
-            FwidParam {
-                name: "TCB_INFO_OWNER_PK_HASH",
-                fwid: Fwid {
-                    hash_alg: asn1::oid!(/*sha384*/ 2, 16, 840, 1, 101, 3, 4, 2, 2),
-                    digest: &[0xEF; 48],
-                },
-            },
-        ]);
+            }],
+        );
     let template = bldr.tbs_template("Caliptra FMC Alias", "Caliptra LDevID");
     CodeGen::gen_code("FmcAliasCertTbs", template, out_dir);
 }

--- a/x509/build/cert.rs
+++ b/x509/build/cert.rs
@@ -85,14 +85,22 @@ impl<Algo: SigningAlgorithm> CertTemplateBuilder<Algo> {
         self
     }
 
-    pub fn add_fmc_dice_tcb_info_ext(mut self, fwids: &[FwidParam]) -> Self {
+    pub fn add_fmc_dice_tcb_info_ext(
+        mut self,
+        device_fwids: &[FwidParam],
+        fmc_fwids: &[FwidParam],
+    ) -> Self {
         let flags: u32 = 0xC0C1C2C3;
         let svn: u8 = 0xC4;
         let svn_fuses: u8 = 0xC5;
 
         self.exts
             .push(x509::make_fmc_dice_tcb_info_ext(
-                flags, svn, svn_fuses, fwids,
+                flags,
+                svn,
+                svn_fuses,
+                device_fwids,
+                fmc_fwids,
             ))
             .unwrap();
 
@@ -115,7 +123,7 @@ impl<Algo: SigningAlgorithm> CertTemplateBuilder<Algo> {
             needle: svn_fuses.to_be_bytes().to_vec(),
         });
 
-        for fwid in fwids.iter() {
+        for fwid in device_fwids.iter().chain(fmc_fwids.iter()) {
             self.params.push(CertTemplateParam {
                 tbs_param: TbsParam::new(fwid.name, 0, fwid.fwid.digest.len()),
                 needle: fwid.fwid.digest.to_vec(),

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -308,7 +308,8 @@ pub fn make_fmc_dice_tcb_info_ext(
     flags: u32,
     svn: u8,
     svn_fuses: u8,
-    fwids: &[FwidParam],
+    device_fwids: &[FwidParam],
+    fmc_fwids: &[FwidParam],
 ) -> X509Extension {
     let wide_svn = fixed_width_svn(svn);
     let wide_svn_fuses = fixed_width_svn(svn_fuses);
@@ -316,6 +317,7 @@ pub fn make_fmc_dice_tcb_info_ext(
     let be_flags = flags.to_be_bytes();
     let be_flags_mask = FLAG_MASK.to_be_bytes();
 
+    let device_asn1_fwids: Vec<&Fwid> = device_fwids.iter().map(|f| &f.fwid).collect();
     let device_info = TcbInfo {
         vendor: Some(asn1::Utf8String::new("Caliptra")),
         model: Some(asn1::Utf8String::new("Device")),
@@ -323,15 +325,14 @@ pub fn make_fmc_dice_tcb_info_ext(
         svn: Some(wide_svn_fuses.into()),
         layer: None,
         index: None,
-        fwids: None,
+        fwids: Some(asn1::SequenceOfWriter::new(&device_asn1_fwids)),
         flags: asn1::BitString::new(be_flags.as_ref(), 0),
         vendor_info: None,
-        tcb_type: None,
+        tcb_type: Some(b"DEVICE_INFO"),
         flags_mask: asn1::BitString::new(be_flags_mask.as_ref(), 0),
     };
 
-    let asn1_fwids: Vec<&Fwid> = fwids.iter().map(|f| &f.fwid).collect();
-
+    let fmc_asn1_fwids: Vec<&Fwid> = fmc_fwids.iter().map(|f| &f.fwid).collect();
     let fmc_info = TcbInfo {
         vendor: Some(asn1::Utf8String::new("Caliptra")),
         model: Some(asn1::Utf8String::new("FMC")),
@@ -339,10 +340,10 @@ pub fn make_fmc_dice_tcb_info_ext(
         svn: Some(wide_svn.into()),
         layer: None,
         index: None,
-        fwids: Some(asn1::SequenceOfWriter::new(&asn1_fwids)),
+        fwids: Some(asn1::SequenceOfWriter::new(&fmc_asn1_fwids)),
         flags: None,
         vendor_info: None,
-        tcb_type: None,
+        tcb_type: Some(b"FMC_INFO"),
         flags_mask: None,
     };
 

--- a/x509/src/fmc_alias_cert.rs
+++ b/x509/src/fmc_alias_cert.rs
@@ -31,7 +31,8 @@ mod tests {
     use x509_parser::prelude::X509CertificateParser;
     use x509_parser::x509::X509Version;
 
-    const TEST_OWNER_PK_HASH: &[u8] = &[0xCDu8; FmcAliasCertTbsParams::TCB_INFO_OWNER_PK_HASH_LEN];
+    const TEST_DEVICE_INFO_HASH: &[u8] =
+        &[0xCDu8; FmcAliasCertTbsParams::TCB_INFO_DEVICE_INFO_HASH_LEN];
     const TEST_FMC_HASH: &[u8] = &[0xEFu8; FmcAliasCertTbsParams::TCB_INFO_FMC_TCI_LEN];
     const TEST_UEID: &[u8] = &[0xABu8; FmcAliasCertTbsParams::UEID_LEN];
     const TEST_TCB_INFO_FLAGS: &[u8] = &[0xB0, 0xB1, 0xB2, 0xB3];
@@ -58,7 +59,7 @@ mod tests {
             subject_key_id: &subject_key.sha1(),
             authority_key_id: &issuer_key.sha1(),
             tcb_info_flags: TEST_TCB_INFO_FLAGS.try_into().unwrap(),
-            tcb_info_owner_pk_hash: &TEST_OWNER_PK_HASH.try_into().unwrap(),
+            tcb_info_device_info_hash: &TEST_DEVICE_INFO_HASH.try_into().unwrap(),
             tcb_info_fmc_tci: &TEST_FMC_HASH.try_into().unwrap(),
             tcb_info_fmc_svn: &TEST_TCB_INFO_FMC_SVN.try_into().unwrap(),
             tcb_info_fmc_svn_fuses: &TEST_TCB_INFO_FMC_SVN_FUSES.try_into().unwrap(),
@@ -121,10 +122,10 @@ mod tests {
             TEST_TCB_INFO_FLAGS,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_OWNER_PK_HASH_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_OWNER_PK_HASH_OFFSET
-                    + FmcAliasCertTbs::TCB_INFO_OWNER_PK_HASH_LEN],
-            TEST_OWNER_PK_HASH,
+            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                ..FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                    + FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_LEN],
+            TEST_DEVICE_INFO_HASH,
         );
         assert_eq!(
             &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_TCI_OFFSET


### PR DESCRIPTION
ROM measures several things into PCR_ID_FMC_CURRENT which are not present in the FMC Alias Cert. Update cert generation to hash together all this device info (fuse and data vault into) into one TcbInfo. The other TcbInfo just contains the FMC code hash.

Additionally, give the TCB infos types so they are easier to distinguish.