### PR TITLE
[fix] Validate LMS vendor public key index on update reset

### DIFF
--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -107,9 +107,14 @@ impl<'a> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a> {
         self.soc_ifc.lifecycle()
     }
 
-    /// Get the vendor key index saved in data vault on cold boot
-    fn vendor_pub_key_idx_dv(&self) -> u32 {
+    /// Get the vendor ECC key index saved in data vault on cold boot
+    fn vendor_ecc_pub_key_idx_dv(&self) -> u32 {
         self.data_vault.ecc_vendor_pk_index()
+    }
+
+    /// Get the vendor LMS key index saved in data vault on cold boot
+    fn vendor_lms_pub_key_idx_dv(&self) -> u32 {
+        self.data_vault.lms_vendor_pk_index()
     }
 
     /// Get the owner public key digest saved in the dv on cold boot

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -190,7 +190,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b001c);
     pub const IMAGE_VERIFIER_ERR_UPDATE_RESET_OWNER_DIGEST_FAILURE: CaliptraError =
         CaliptraError::new_const(0x000b001d);
-    pub const IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PUB_KEY_IDX_MISMATCH: CaliptraError =
+    pub const IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH: CaliptraError =
         CaliptraError::new_const(0x000b001e);
     pub const IMAGE_VERIFIER_ERR_UPDATE_RESET_FMC_DIGEST_MISMATCH: CaliptraError =
         CaliptraError::new_const(0x000b001f);
@@ -245,6 +245,8 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b003b);
     pub const IMAGE_VERIFIER_ERR_RUNTIME_SIZE_ZERO: CaliptraError =
         CaliptraError::new_const(0x000b003c);
+    pub const IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_LMS_PUB_KEY_IDX_MISMATCH: CaliptraError =
+        CaliptraError::new_const(0x000b003d);
 
     /// Driver Error: LMS
     pub const DRIVER_LMS_INVALID_LMS_ALGO_TYPE: CaliptraError =

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -139,8 +139,11 @@ pub trait ImageVerificationEnv {
     // Get Device Lifecycle state
     fn dev_lifecycle(&self) -> Lifecycle;
 
-    // Get the vendor key index saved on cold boot in data vault
-    fn vendor_pub_key_idx_dv(&self) -> u32;
+    // Get the vendor ECC key index saved on cold boot in data vault
+    fn vendor_ecc_pub_key_idx_dv(&self) -> u32;
+
+    // Get the vendor LMS key index saved on cold boot in data vault
+    fn vendor_lms_pub_key_idx_dv(&self) -> u32;
 
     // Get the owner key digest saved on cold boot in data vault
     fn owner_pub_key_digest_dv(&self) -> ImageDigest;

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -231,9 +231,11 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         }
 
         if reason == ResetReason::UpdateReset {
-            let expected = self.env.vendor_pub_key_idx_dv();
+            let expected = self.env.vendor_ecc_pub_key_idx_dv();
             if expected != key_idx {
-                Err(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PUB_KEY_IDX_MISMATCH)?;
+                Err(
+                    CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH,
+                )?;
             }
         }
 
@@ -244,7 +246,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     fn verify_vendor_lms_pk_idx(
         &mut self,
         preamble: &ImagePreamble,
-        _reason: ResetReason,
+        reason: ResetReason,
     ) -> CaliptraResult<(Option<u32>, Option<u32>)> {
         const SECOND_LAST_KEY_IDX: u32 = VENDOR_LMS_KEY_COUNT - 2;
         const LAST_KEY_IDX: u32 = SECOND_LAST_KEY_IDX + 1;
@@ -264,13 +266,14 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
             _ => Err(CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_LMS_PUB_KEY_INDEX_OUT_OF_BOUNDS)?,
         }
 
-        // [TODO] Need to put the Vendor pub key index in datavault
-        // if reason == ResetReason::UpdateReset {
-        //     let expected = self.env.vendor_pub_key_idx_dv();
-        //     if expected != key_idx {
-        //         Err(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PUB_KEY_IDX_MISMATCH)?;
-        //     }
-        // }
+        if reason == ResetReason::UpdateReset {
+            let expected = self.env.vendor_lms_pub_key_idx_dv();
+            if expected != key_idx {
+                Err(
+                    CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_LMS_PUB_KEY_IDX_MISMATCH,
+                )?;
+            }
+        }
 
         Ok((Some(key_idx), Some(revocation)))
     }
@@ -791,7 +794,7 @@ mod tests {
         let result = verifier.verify_vendor_ecc_pk_idx(&preamble, ResetReason::UpdateReset);
         assert_eq!(
             result.err(),
-            Some(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PUB_KEY_IDX_MISMATCH)
+            Some(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH)
         );
     }
 
@@ -1772,7 +1775,11 @@ mod tests {
             self.lifecycle
         }
 
-        fn vendor_pub_key_idx_dv(&self) -> u32 {
+        fn vendor_ecc_pub_key_idx_dv(&self) -> u32 {
+            0
+        }
+
+        fn vendor_lms_pub_key_idx_dv(&self) -> u32 {
             0
         }
 

--- a/rom/dev/doc/test-coverage/test-coverage.md
+++ b/rom/dev/doc/test-coverage/test-coverage.md
@@ -99,6 +99,8 @@ Test Name |  Description | ROM Error Code
 **test_update_reset_no_mailbox_cmd** | Tests update reset flow by not providing firmware image  | ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE
 **test_update_reset_non_fw_load_cmd** | Tests update reset flow by providing a non-fw load Mailbox command  | ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND
 **test_update_reset_verify_image_failure** | Tests update reset flow by providing non-compliant fw image  | IMAGE_VERIFIER_ERR_MANIFEST_MARKER_MISMATCH
+**test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch** | Tests update reset flow by providing a different vendor ECC public key index in the image | IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH
+**test_update_reset_vendor_lms_pub_key_idx_dv_mismatch** | Tests update reset flow by providing a different vendor LMS public key index in the image | IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_LMS_PUB_KEY_IDX_MISMATCH
 <br><br>
 # **Mailbox Tests**
 Test Name | ROM Stage | Description | ROM Error Code

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -318,9 +318,14 @@ impl<'a> ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'a> {
         self.soc_ifc.lifecycle()
     }
 
-    /// Get the vendor key index saved in data vault on cold boot
-    fn vendor_pub_key_idx_dv(&self) -> u32 {
+    /// Get the vendor ECC key index saved in data vault on cold boot
+    fn vendor_ecc_pub_key_idx_dv(&self) -> u32 {
         self.data_vault.ecc_vendor_pk_index()
+    }
+
+    /// Get the vendor LMS key index saved in data vault on cold boot
+    fn vendor_lms_pub_key_idx_dv(&self) -> u32 {
+        self.data_vault.lms_vendor_pk_index()
     }
 
     /// Get the owner public key digest saved in the dv on cold boot

--- a/rom/dev/tests/test_update_reset.rs
+++ b/rom/dev/tests/test_update_reset.rs
@@ -5,6 +5,8 @@ use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::RomBootStatus::*;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
+use caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0;
+use caliptra_image_gen::ImageGeneratorVendorConfig;
 pub mod helpers;
 
 const TEST_FMC_CMD_RESET_FOR_UPDATE: u32 = 0x1000_0004;
@@ -304,4 +306,145 @@ fn test_update_reset_boot_status() {
     hw.step_until_boot_status(UpdateResetComplete.into(), false);
 
     hw.step_until_exit_success().unwrap();
+}
+
+#[test]
+fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
+    pub const TEST_FMC_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-rom-test-fmc",
+        bin_name: "caliptra-rom-test-fmc",
+        features: &["emu"],
+        workspace_dir: None,
+    };
+
+    let fuses = Fuses::default();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            security_state: SecurityState::from(fuses.life_cycle as u32),
+            ..Default::default()
+        },
+        fuses,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let vendor_config_cold_boot = ImageGeneratorVendorConfig {
+        ecc_key_idx: 3,
+        ..VENDOR_CONFIG_KEY_0
+    };
+    let image_options = ImageOptions {
+        vendor_config: vendor_config_cold_boot,
+        ..Default::default()
+    };
+
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, image_options)
+            .unwrap();
+
+    hw.upload_firmware(&image_bundle.to_bytes().unwrap())
+        .unwrap();
+
+    hw.step_until_boot_status(ColdResetComplete.into(), true);
+
+    hw.mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE, &[])
+        .unwrap();
+    hw.step_until_boot_status(UpdateResetStarted.into(), true);
+
+    // Upload firmware with a different vendor ECC key index.
+    let vendor_config_update_reset = ImageGeneratorVendorConfig {
+        ecc_key_idx: 2,
+        ..VENDOR_CONFIG_KEY_0
+    };
+    let image_options = ImageOptions {
+        vendor_config: vendor_config_update_reset,
+        ..Default::default()
+    };
+
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, image_options)
+            .unwrap();
+
+    let _ = hw.upload_firmware(&image_bundle.to_bytes().unwrap());
+
+    hw.step_until_exit_success().unwrap();
+
+    assert_eq!(
+        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+        CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH.into()
+    );
+}
+
+#[test]
+fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
+    pub const TEST_FMC_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-rom-test-fmc",
+        bin_name: "caliptra-rom-test-fmc",
+        features: &["emu"],
+        workspace_dir: None,
+    };
+
+    let fuses = caliptra_hw_model::Fuses {
+        lms_verify: true,
+        ..Default::default()
+    };
+
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            security_state: SecurityState::from(fuses.life_cycle as u32),
+            ..Default::default()
+        },
+        fuses,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let vendor_config_cold_boot = ImageGeneratorVendorConfig {
+        lms_key_idx: 3,
+        ..VENDOR_CONFIG_KEY_0
+    };
+    let image_options = ImageOptions {
+        vendor_config: vendor_config_cold_boot,
+        ..Default::default()
+    };
+
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, image_options)
+            .unwrap();
+
+    hw.upload_firmware(&image_bundle.to_bytes().unwrap())
+        .unwrap();
+
+    hw.step_until_boot_status(ColdResetComplete.into(), true);
+
+    hw.mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE, &[])
+        .unwrap();
+
+    hw.step_until_boot_status(UpdateResetStarted.into(), true);
+
+    // Upload firmware with a different vendor LMS key index.
+    let vendor_config_update_reset = ImageGeneratorVendorConfig {
+        lms_key_idx: 2,
+        ..VENDOR_CONFIG_KEY_0
+    };
+    let image_options = ImageOptions {
+        vendor_config: vendor_config_update_reset,
+        ..Default::default()
+    };
+
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, image_options)
+            .unwrap();
+
+    let _ = hw.upload_firmware(&image_bundle.to_bytes().unwrap());
+
+    hw.step_until_exit_success().unwrap();
+
+    assert_eq!(
+        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+        CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_LMS_PUB_KEY_IDX_MISMATCH.into()
+    );
 }


### PR DESCRIPTION
This change ensures that the LMS vendor public key index stored in the data vault on cold boot matches the one in the update reset firmware image.