### PR TITLE
Move ROM's DATA_ORG to the start of DCCM

### DIFF
--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -25,22 +25,23 @@ pub const ROM_ORG: u32 = 0x00000000;
 pub const MBOX_ORG: u32 = 0x30000000;
 pub const ICCM_ORG: u32 = 0x40000000;
 pub const DCCM_ORG: u32 = 0x50000000;
-pub const MAN1_ORG: u32 = 0x50000000;
-pub const MAN2_ORG: u32 = 0x50001800;
-pub const FHT_ORG: u32 = 0x50003000;
-pub const LDEVID_TBS_ORG: u32 = 0x50003800;
-pub const FMCALIAS_TBS_ORG: u32 = 0x50003C00;
-pub const RTALIAS_TBS_ORG: u32 = 0x50004000;
-pub const PCR_LOG_ORG: u32 = 0x50004400;
-pub const MEASUREMENT_LOG_ORG: u32 = 0x50004800;
-pub const FUSE_LOG_ORG: u32 = 0x50004C00;
-pub const BOOT_STATUS_ORG: u32 = 0x50005000;
-pub const CFI_VAL_ORG: u32 = 0x50005004;
-pub const CFI_MASK_ORG: u32 = 0x50005008;
-pub const CFI_XO_S0_ORG: u32 = 0x5000500C;
-pub const CFI_XO_S1_ORG: u32 = 0x50005010;
-pub const CFI_XO_S2_ORG: u32 = 0x50005014;
-pub const CFI_XO_S3_ORG: u32 = 0x50005018;
+// Region of ~ 1k bytes between DCCM_ORG and CFI_VAL_ORG is reserved for ROM's DATA_ORG
+pub const CFI_VAL_ORG: u32 = 0x500003E4;
+pub const CFI_MASK_ORG: u32 = 0x500003E8;
+pub const CFI_XO_S0_ORG: u32 = 0x500003EC;
+pub const CFI_XO_S1_ORG: u32 = 0x500003F0;
+pub const CFI_XO_S2_ORG: u32 = 0x500003F4;
+pub const CFI_XO_S3_ORG: u32 = 0x500003F8;
+pub const BOOT_STATUS_ORG: u32 = 0x500003FC;
+pub const MAN1_ORG: u32 = 0x50000400;
+pub const MAN2_ORG: u32 = 0x50001C00;
+pub const FHT_ORG: u32 = 0x50003400;
+pub const LDEVID_TBS_ORG: u32 = 0x50003C00;
+pub const FMCALIAS_TBS_ORG: u32 = 0x50004000;
+pub const RTALIAS_TBS_ORG: u32 = 0x50004400;
+pub const PCR_LOG_ORG: u32 = 0x50004800;
+pub const MEASUREMENT_LOG_ORG: u32 = 0x50004C00;
+pub const FUSE_LOG_ORG: u32 = 0x50005000;
 pub const DATA_ORG: u32 = 0x50005400;
 pub const STACK_ORG: u32 = 0x5001A000;
 pub const ESTACK_ORG: u32 = 0x5001F800;
@@ -123,7 +124,7 @@ fn mem_layout_test_measurement_log() {
 #[test]
 #[allow(clippy::assertions_on_constants)]
 fn mem_layout_test_fuselog() {
-    assert_eq!((BOOT_STATUS_ORG - FUSE_LOG_ORG), FUSE_LOG_SIZE);
+    assert_eq!((DATA_ORG - FUSE_LOG_ORG), FUSE_LOG_SIZE);
 }
 
 #[test]

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -50,7 +50,7 @@ pub struct PersistentData {
 }
 impl PersistentData {
     pub fn assert_matches_layout() {
-        const P: *const PersistentData = memory_layout::DCCM_ORG as *const PersistentData;
+        const P: *const PersistentData = memory_layout::MAN1_ORG as *const PersistentData;
         use memory_layout as layout;
         unsafe {
             assert_eq!(addr_of!((*P).manifest1) as u32, layout::MAN1_ORG);
@@ -65,7 +65,10 @@ impl PersistentData {
                 memory_layout::MEASUREMENT_LOG_ORG
             );
             assert_eq!(addr_of!((*P).fuse_log) as u32, memory_layout::FUSE_LOG_ORG);
-            assert_eq!(P.add(1) as u32, memory_layout::BOOT_STATUS_ORG);
+            assert_eq!(
+                P.add(1) as u32,
+                memory_layout::FUSE_LOG_ORG + memory_layout::FUSE_LOG_SIZE
+            );
         }
     }
 
@@ -98,7 +101,7 @@ impl PersistentDataAccessor {
     pub fn get(&self) -> &PersistentData {
         // WARNING: The returned lifetime elided from `self` is critical for
         // safety. Do not change this API without review by a Rust expert.
-        unsafe { ref_from_addr(memory_layout::DCCM_ORG) }
+        unsafe { ref_from_addr(memory_layout::MAN1_ORG) }
     }
 
     /// # Safety
@@ -109,7 +112,7 @@ impl PersistentDataAccessor {
     pub fn get_mut(&mut self) -> &mut PersistentData {
         // WARNING: The returned lifetime elided from `self` is critical for
         // safety. Do not change this API without review by a Rust expert.
-        unsafe { ref_mut_from_addr(memory_layout::DCCM_ORG) }
+        unsafe { ref_mut_from_addr(memory_layout::MAN1_ORG) }
     }
 }
 

--- a/rom/dev/src/rom.ld
+++ b/rom/dev/src/rom.ld
@@ -19,7 +19,7 @@ ENTRY(_start)
 ROM_ORG          = 0x00000000;
 ICCM_ORG         = 0x40000000;
 DCCM_ORG         = 0x50000000;
-DATA_ORG         = 0x50004C00;
+DATA_ORG         = 0x50000000;
 STACK_ORG        = 0x5001C000;
 ESTACK_ORG       = 0x5001F800;
 NSTACK_ORG       = 0x5001FC00;
@@ -33,7 +33,7 @@ ROM_RELAXATION_PADDING = 4k;
 ROM_SIZE          = 48K;
 ICCM_SIZE         = 128K;
 DCCM_SIZE         = 128K;
-DATA_SIZE         = 93K;
+DATA_SIZE         = 996;
 STACK_SIZE        = 14K;
 ESTACK_SIZE       = 1K;
 NSTACK_SIZE       = 1K;

--- a/rom/dev/tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/test_fmcalias_derivation.rs
@@ -685,8 +685,6 @@ fn test_fht_info() {
     assert_eq!(fht.fmcalias_tbs_addr, FMCALIAS_TBS_ORG);
     assert_eq!(fht.pcr_log_addr, PCR_LOG_ORG);
     assert_eq!(fht.fuse_log_addr, FUSE_LOG_ORG);
-
-    // [TODO] Expand test to validate additional FHT fields.
 }
 
 #[test]


### PR DESCRIPTION
This change reorganizes ROM's usage of DCCM by moving ROM's DATA_ORG to the start of DCCM and shrinking it, thereby making space for FMC and RT to use a large portion of DCCM that is guaranteed to be untouched by ROM.

We make the following changes:
- Reserve 1k bytes at the the beginning of DCCM
- Move ROM's DATA_ORG to the start of DCCM and make it occupy exactly 996 bytes
- Move the CFI_* regions and BOOT_STATUS_ORG to the remaining 28 bytes of the reserved region
- Move all following sections 1k bytes forward (except for STACK_ORG, ESTACK_ORG, and NSTACK_ORG)
- Reduce DATA_SIZE by 1k bytes to make space for the reserved 1k bytes at start of DCCM