### PR TITLE
Populate FHT at the beginning of the cold reset flow.

### DIFF
--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::rom_env::RomEnv;
+use crate::{rom_env::RomEnv, CALIPTRA_ROM_INFO};
 use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_common::{
     keyids::{KEY_ID_FMC_PRIV_KEY, KEY_ID_ROM_FMC_CDI},
@@ -20,23 +20,14 @@ use caliptra_common::{
     FHT_MARKER,
 };
 use caliptra_drivers::{
-    cprintln, ColdResetEntry4, ColdResetEntry48, Ecc384PubKey, WarmResetEntry4, WarmResetEntry48,
+    cprintln, ColdResetEntry4, ColdResetEntry48, RomAddr, WarmResetEntry4, WarmResetEntry48,
 };
 
 const FHT_MAJOR_VERSION: u16 = 1;
 const FHT_MINOR_VERSION: u16 = 0;
 
 #[derive(Debug, Default)]
-pub struct FhtDataStore {
-    /// LdevId TBS size
-    pub ldevid_tbs_size: u16,
-
-    /// FmcAlias TBS size
-    pub fmcalias_tbs_size: u16,
-
-    /// IDevID public key
-    pub idev_pub: Ecc384PubKey,
-}
+pub struct FhtDataStore {}
 
 impl FhtDataStore {
     /// The FMC CDI is stored in a 32-bit DataVault sticky register.
@@ -156,18 +147,19 @@ impl FhtDataStore {
     }
 }
 
-pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
+#[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
+pub fn initialize_fht(env: &mut RomEnv) {
     let pdata = &env.persistent_data.get();
-    let ldevid_tbs_addr: u32 = &pdata.ldevid_tbs as *const _ as u32;
-    let fmcalias_tbs_addr: u32 = &pdata.fmcalias_tbs as *const _ as u32;
-    let pcr_log_addr: u32 = &pdata.pcr_log as *const _ as u32;
-    let fuse_log_addr: u32 = &pdata.fuse_log as *const _ as u32;
 
-    FirmwareHandoffTable {
+    cprintln!(
+        "[fht] Storing FHT @ 0x{:08X}",
+        &pdata.fht as *const _ as usize
+    );
+
+    env.persistent_data.get_mut().fht = FirmwareHandoffTable {
         fht_marker: FHT_MARKER,
         fht_major_ver: FHT_MAJOR_VERSION,
         fht_minor_ver: FHT_MINOR_VERSION,
-        manifest_load_addr: env.data_vault.manifest_addr(),
         fips_fw_load_addr_hdl: FHT_INVALID_HANDLE,
         rt_fw_entry_point_hdl: FhtDataStore::rt_fw_entry_point(),
         fmc_cdi_kv_hdl: FhtDataStore::fmc_cdi_store(),
@@ -183,26 +175,14 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         rt_tci_dv_hdl: FhtDataStore::rt_tci_data_store(),
         rt_svn_dv_hdl: FhtDataStore::rt_svn_data_store(),
         rt_min_svn_dv_hdl: FhtDataStore::rt_min_svn_data_store(),
-        ldevid_tbs_size: env.fht_data_store.ldevid_tbs_size,
-        fmcalias_tbs_size: env.fht_data_store.fmcalias_tbs_size,
-        ldevid_tbs_addr,
-        fmcalias_tbs_addr,
-        pcr_log_addr,
-        // TODO: remove `pcr_bank.log_index` and just increment `fht.pcr_log_index`
-        pcr_log_index: env.pcr_bank.log_index as u32,
-        fuse_log_addr,
-        idev_dice_pub_key: env.fht_data_store.idev_pub,
         ldevid_cert_sig_r_dv_hdl: FhtDataStore::ldevid_cert_sig_r_store(),
         ldevid_cert_sig_s_dv_hdl: FhtDataStore::ldevid_cert_sig_s_store(),
+        rom_info_addr: RomAddr::from(unsafe { &CALIPTRA_ROM_INFO }),
+        manifest_load_addr: &pdata.manifest1 as *const _ as u32,
+        ldevid_tbs_addr: &pdata.ldevid_tbs as *const _ as u32,
+        fmcalias_tbs_addr: &pdata.fmcalias_tbs as *const _ as u32,
+        pcr_log_addr: &pdata.pcr_log as *const _ as u32,
+        fuse_log_addr: &pdata.fuse_log as *const _ as u32,
         ..Default::default()
-    }
-}
-
-#[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
-pub fn store(env: &mut RomEnv, fht: FirmwareHandoffTable) {
-    cprintln!(
-        "[fht] Storing FHT @ 0x{:08X}",
-        &env.persistent_data.get().fht as *const _ as usize
-    );
-    env.persistent_data.get_mut().fht = fht;
+    };
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -17,7 +17,6 @@ use crate::fuse::log_fuse_data;
 use crate::pcr;
 use crate::rom_env::RomEnv;
 use crate::run_fips_tests;
-use crate::CALIPTRA_ROM_INFO;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::capabilities::Capabilities;
@@ -228,8 +227,7 @@ impl FirmwareProcessor {
                             // TODO: set non-fatal error register?
                             txn.complete(false)?;
                         } else {
-                            let rom_info = unsafe { &CALIPTRA_ROM_INFO };
-                            run_fips_tests(env, rom_info)?;
+                            run_fips_tests(env)?;
                             let mut resp = MailboxResp::default();
                             resp.populate_chksum()?;
                             txn.send_response(resp.as_bytes())?;

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -89,7 +89,7 @@ impl InitDevIdLayer {
         Self::generate_csr(env, &output)?;
 
         // Write IDevID pub to FHT
-        env.fht_data_store.idev_pub = output.subj_key_pair.pub_key;
+        env.persistent_data.get_mut().fht.idev_dice_pub_key = output.subj_key_pair.pub_key;
 
         cprintln!("[idev] --");
         report_boot_status(IDevIdDerivationComplete.into());

--- a/rom/dev/src/flow/mod.rs
+++ b/rom/dev/src/flow/mod.rs
@@ -22,7 +22,6 @@ use crate::cprintln;
 use crate::{handle_fatal_error, rom_env::RomEnv};
 use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_cfi_lib::cfi_assert_eq;
-use caliptra_common::FirmwareHandoffTable;
 use caliptra_drivers::{CaliptraResult, ResetReason};
 use caliptra_error::CaliptraError;
 
@@ -32,7 +31,7 @@ use caliptra_error::CaliptraError;
 ///
 /// * `env` - ROM Environment
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
-pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
+pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
     let reset_reason = env.soc_ifc.reset_reason();
 
     if cfg!(not(feature = "fake-rom")) {
@@ -62,8 +61,7 @@ pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
             }
         }
     } else {
-        let _result: CaliptraResult<Option<FirmwareHandoffTable>> =
-            Err(CaliptraError::ROM_GLOBAL_PANIC);
+        let _result: CaliptraResult<()> = Err(CaliptraError::ROM_GLOBAL_PANIC);
 
         if env.soc_ifc.lifecycle() == caliptra_drivers::Lifecycle::Production {
             cprintln!("Fake ROM in Production lifecycle prohibited");

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -18,7 +18,6 @@ use caliptra_common::verifier::FirmwareImageVerificationEnv;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::CommandId;
-use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::report_fw_error_non_fatal;
 use caliptra_drivers::{
@@ -40,7 +39,7 @@ impl UpdateResetFlow {
     ///
     /// * `env` - ROM Environment
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
+    pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[update-reset] ++");
         report_boot_status(UpdateResetStarted.into());
 
@@ -112,7 +111,7 @@ impl UpdateResetFlow {
         cprintln!("[update-reset Success] --");
         report_boot_status(UpdateResetComplete.into());
 
-        Ok(None)
+        Ok(())
     }
 
     /// Verify the image

--- a/rom/dev/src/flow/warm_reset.rs
+++ b/rom/dev/src/flow/warm_reset.rs
@@ -14,7 +14,6 @@ Abstract:
 use crate::{cprintln, rom_env::RomEnv};
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_eq, cfi_launder};
-use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::RomBootStatus::ColdResetComplete;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
@@ -29,7 +28,7 @@ impl WarmResetFlow {
     /// * `env` - ROM Environment
     #[inline(never)]
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn run(env: &mut RomEnv) -> CaliptraResult<Option<FirmwareHandoffTable>> {
+    pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[warm-reset] ++");
 
         // Check if previous Cold-Reset was successful.
@@ -42,6 +41,6 @@ impl WarmResetFlow {
 
         cprintln!("[warm-reset] --");
 
-        Ok(None)
+        Ok(())
     }
 }

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -28,14 +28,14 @@ use caliptra_common::{
     PcrLogEntry, PcrLogEntryId,
 };
 use caliptra_drivers::{
-    CaliptraError, CaliptraResult, PcrBank, PcrLogArray, PersistentDataAccessor, Sha384,
+    CaliptraError, CaliptraResult, PcrBank, PersistentData, PersistentDataAccessor, Sha384,
 };
 use caliptra_image_verify::ImageVerificationInfo;
 
 use zerocopy::AsBytes;
 
 struct PcrExtender<'a> {
-    pcr_log: &'a mut PcrLogArray,
+    persistent_data: &'a mut PersistentData,
     pcr_bank: &'a mut PcrBank,
     sha384: &'a mut Sha384,
 }
@@ -48,7 +48,7 @@ impl PcrExtender<'_> {
             .extend_pcr(PCR_ID_FMC_JOURNEY, self.sha384, data)?;
 
         let pcr_ids: u32 = (1 << PCR_ID_FMC_CURRENT as u8) | (1 << PCR_ID_FMC_JOURNEY as u8);
-        log_pcr(self.pcr_log, self.pcr_bank, pcr_entry_id, pcr_ids, data)
+        log_pcr(self.persistent_data, pcr_entry_id, pcr_ids, data)
     }
 }
 
@@ -63,11 +63,14 @@ pub(crate) fn extend_pcrs(
     info: &ImageVerificationInfo,
     persistent_data: &mut PersistentDataAccessor,
 ) -> CaliptraResult<()> {
+    // Reset the PCR log size to zero.
+    persistent_data.get_mut().fht.pcr_log_index = 0;
+
     // Clear the Current PCR, but do not clear the Journey PCR
     env.pcr_bank.erase_pcr(PCR_ID_FMC_CURRENT)?;
 
     let mut pcr = PcrExtender {
-        pcr_log: &mut persistent_data.get_mut().pcr_log,
+        persistent_data: persistent_data.get_mut(),
         pcr_bank: env.pcr_bank,
         sha384: env.sha384,
     };
@@ -117,8 +120,7 @@ pub(crate) fn extend_pcrs(
 ///
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 pub fn log_pcr(
-    pcr_log: &mut PcrLogArray,
-    pcr_bank: &mut PcrBank,
+    persistent_data: &mut PersistentData,
     pcr_entry_id: PcrLogEntryId,
     pcr_ids: u32,
     data: &[u8],
@@ -127,7 +129,10 @@ pub fn log_pcr(
         return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_INVALID_ENTRY_ID);
     }
 
-    let Some(dst) = pcr_log.get_mut(pcr_bank.log_index) else {
+    let pcr_log = &mut persistent_data.pcr_log;
+    let fht = &mut persistent_data.fht;
+
+    let Some(dst) = pcr_log.get_mut(fht.pcr_log_index as usize) else {
         return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_EXHAUSTED);
     };
 
@@ -142,7 +147,7 @@ pub fn log_pcr(
     };
     dest_data.copy_from_slice(data);
 
-    pcr_bank.log_index += 1;
+    fht.pcr_log_index += 1;
     *dst = pcr_log_entry;
 
     Ok(())


### PR DESCRIPTION
This allows the PCR logging routine in ROM to directly update the PCR log index in FHT, from both the cold and warm reset flows.