### PR TITLE
Implement PCR logging in FMC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,9 +380,11 @@ dependencies = [
  "caliptra-hw-model",
  "caliptra-image-types",
  "caliptra-registers",
+ "caliptra-test",
  "caliptra-x509",
  "caliptra_common",
  "cfg-if 1.0.0",
+ "openssl",
  "ufmt",
  "zerocopy",
 ]
@@ -398,6 +400,7 @@ dependencies = [
  "caliptra_common",
  "cfg-if 1.0.0",
  "ufmt",
+ "ureg",
  "zerocopy",
 ]
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -32,7 +32,7 @@ pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 
 pub const FMC_ORG: u32 = 0x40000000;
-pub const FMC_SIZE: u32 = 16 * 1024;
+pub const FMC_SIZE: u32 = 18 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 96 * 1024;
 

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -292,6 +292,9 @@ pub struct FirmwareHandoffTable {
     /// PCR log Address
     pub pcr_log_addr: u32,
 
+    /// Last empty PCR log entry slot index
+    pub pcr_log_index: u32,
+
     /// Fuse log Address
     pub fuse_log_addr: u32,
 
@@ -309,7 +312,7 @@ pub struct FirmwareHandoffTable {
     pub rtalias_tbs_size: u16,
 
     /// Reserved for future use.
-    pub reserved: [u8; 126],
+    pub reserved: [u8; 122],
 }
 
 impl Default for FirmwareHandoffTable {
@@ -337,10 +340,11 @@ impl Default for FirmwareHandoffTable {
             ldevid_tbs_size: 0,
             fmcalias_tbs_size: 0,
             rtalias_tbs_size: 0,
-            reserved: [0u8; 126],
+            reserved: [0u8; 122],
             ldevid_tbs_addr: 0,
             fmcalias_tbs_addr: 0,
             pcr_log_addr: 0,
+            pcr_log_index: 0,
             fuse_log_addr: 0,
             rt_dice_sign: Ecc384Signature::default(),
             rt_dice_pub_key: Ecc384PubKey::default(),

--- a/drivers/src/pcr_log.rs
+++ b/drivers/src/pcr_log.rs
@@ -36,6 +36,8 @@ pub enum PcrLogEntryId {
     LmsVendorPubKeyIndex = 10, // data size = 1 byte
     RomVerifyConfig = 11,      // data size = 1 byte
     StashMeasurement = 12,     // data size = 48 bytes
+    RtTci = 13,                // data size = 48 bytes
+    FwImageManifest = 14,      // data size = 48 bytes
 }
 
 impl From<u16> for PcrLogEntryId {
@@ -54,6 +56,8 @@ impl From<u16> for PcrLogEntryId {
             10 => PcrLogEntryId::LmsVendorPubKeyIndex,
             11 => PcrLogEntryId::RomVerifyConfig,
             12 => PcrLogEntryId::StashMeasurement,
+            13 => PcrLogEntryId::RtTci,
+            14 => PcrLogEntryId::FwImageManifest,
             _ => PcrLogEntryId::Invalid,
         }
     }
@@ -91,6 +95,8 @@ impl PcrLogEntry {
             PcrLogEntryId::LmsVendorPubKeyIndex => 1,
             PcrLogEntryId::RomVerifyConfig => 1,
             PcrLogEntryId::StashMeasurement => 48,
+            PcrLogEntryId::RtTci => 48,
+            PcrLogEntryId::FwImageManifest => 48,
         };
 
         &self.pcr_data.as_bytes()[..data_len]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -340,6 +340,7 @@ impl CaliptraError {
     pub const FMC_RT_ALIAS_TBS_SIZE_EXCEEDED: CaliptraError = CaliptraError::new_const(0x000F0007);
     pub const FMC_CDI_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0008);
     pub const FMC_ALIAS_KV_COLLISION: CaliptraError = CaliptraError::new_const(0x000F0009);
+    pub const FMC_GLOBAL_PCR_LOG_EXHAUSTED: CaliptraError = CaliptraError::new_const(0x000F000A);
 
     /// TRNG_EXT Errors
     pub const DRIVER_TRNG_EXT_TIMEOUT: CaliptraError = CaliptraError::new_const(0x00100001);

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -24,7 +24,9 @@ cfg-if.workspace = true
 [dev-dependencies]
 caliptra-builder.workspace = true
 caliptra-hw-model.workspace = true
+caliptra-test.workspace = true
 caliptra-image-types.workspace = true
+openssl.workspace = true
 
 [features]
 default = ["std"]

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -221,6 +221,54 @@ This field provides the Handle into the Data Vault where the SVN<sub>RT</sub> is
 
 This field provides the Handle into the Data Vault where the Min-SVN<sub>RT</sub> is stored. Upon cold-boot this is set to SVN<sub>RT</sub>. On subsequent boots this is set to MIN(SVN<sub>RT</sub>, Min-SVN<sub>RT</sub>).
 
+### ldevid_tbs_addr
+
+TODO
+
+### fmcalias_tbs_addr
+
+TODO
+
+### ldevid_tbs_size
+
+TODO
+
+### fmcalias_tbs_size
+
+TODO
+
+### pcr_log_addr
+
+Address in DCCM of the PCR log
+
+### pcr_log_index
+
+Index within the PCR log of the next available log entry
+
+### fuse_log_addr
+
+TODO
+
+### rt_dice_pub_key
+
+TODO
+
+### rt_dice_sign
+
+TODO
+
+### idev_dice_pub_key
+
+TODO
+
+### rom_info_addr
+
+TODO
+
+### rtalias_tbs_size
+
+TODO
+
 ### reserved
 
 This area is reserved for definition of additional fields that may be added during Minor version updates of the FHT.

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -136,6 +136,7 @@ fields may not be changed or removed). Table revisions with different Major Vers
 | ldevid_tbs_size       | 2            | ROM        | Local Device ID TBS Size.                                                                                |
 | fmcalias_tbs_size     | 2            | ROM        | FMC Alias TBS Size.                                                                                      |
 | pcr_log_addr          | 4            | ROM        | PCR Log Address.                                                                                         |
+| pcr_log_index         | 4            | ROM        | Last empty PCR log entry slot index.                                                                     |
 | fuse_log_addr         | 4            | ROM        | Fuse Log Address.                                                                                        |
 | rt_dice_pub_key       | 96           | FMC        | RT Alias DICE Public Key.                                                                                |
 | rt_dice_sign          | 96           | FMC        | RT Alias DICE signature.                                                                                 |

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -23,49 +23,105 @@ Note:
 use crate::flow::tci::Tci;
 use crate::fmc_env::FmcEnv;
 use crate::HandOff;
-use caliptra_drivers::{okref, CaliptraResult, PcrId};
+use caliptra_drivers::{
+    cprintln, okref,
+    pcr_log::{PcrLogEntry, PcrLogEntryId},
+    CaliptraResult, PcrBank, PcrLogArray,
+};
 
 use caliptra_common::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
+use caliptra_error::CaliptraError;
+use zerocopy::AsBytes;
 
-/// Extend current PCR
-///
-/// # Arguments
-///
-/// * `env` - FMC Environment
-pub fn extend_current_pcr(env: &mut FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    // Clear current PCR before extending it.
-    if env.soc_ifc.reset_reason() == caliptra_drivers::ResetReason::UpdateReset {
-        env.pcr_bank.erase_pcr(RT_FW_CURRENT_PCR)?;
-    }
-    extend_pcr_common(env, hand_off, RT_FW_CURRENT_PCR)
-}
-
-/// Extend journey PCR
-///
-/// # Arguments
-///
-/// * `env` - FMC Environment
-pub fn extend_journey_pcr(env: &mut FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-    extend_pcr_common(env, hand_off, RT_FW_JOURNEY_PCR)
-}
-
-/// Extend common data into PCR
+/// Extend common data into the current and journey PCRs
 ///
 /// # Arguments
 ///
 /// * `env` - FMC Environment
 /// * `pcr_id` - PCR slot to extend the data into
-fn extend_pcr_common(env: &mut FmcEnv, hand_off: &HandOff, pcr_id: PcrId) -> CaliptraResult<()> {
-    // Extend RT TCI (Hash over runtime code)
+/// * `extend_journey` - Whether to extend into the journey PCR
+///
+/// TODO: Add CFI instrumentation
+pub fn extend_pcr_common(
+    env: &mut FmcEnv,
+    hand_off: &mut HandOff,
+    extend_journey: bool,
+) -> CaliptraResult<()> {
+    // Clear current PCR before extending it.
+    if env.soc_ifc.reset_reason() == caliptra_drivers::ResetReason::UpdateReset {
+        env.pcr_bank.erase_pcr(RT_FW_CURRENT_PCR)?;
+    }
+
+    // Calculate RT TCI (Hash over runtime code)
     let rt_tci = Tci::rt_tci(env, hand_off);
     let rt_tci: [u8; 48] = okref(&rt_tci)?.into();
-    env.pcr_bank.extend_pcr(pcr_id, &mut env.sha384, &rt_tci)?;
 
-    // Extend FW Image Manifest
+    // Calculate FW Image Manifest digest
     let manifest_digest = Tci::image_manifest_digest(env, hand_off);
     let manifest_digest: [u8; 48] = okref(&manifest_digest)?.into();
+
+    let mut pcr_ids: u32 = 1 << RT_FW_CURRENT_PCR as u8;
+
     env.pcr_bank
-        .extend_pcr(pcr_id, &mut env.sha384, &manifest_digest)?;
+        .extend_pcr(RT_FW_CURRENT_PCR, &mut env.sha384, &rt_tci)?;
+    env.pcr_bank
+        .extend_pcr(RT_FW_CURRENT_PCR, &mut env.sha384, &manifest_digest)?;
+
+    if extend_journey {
+        pcr_ids |= 1 << RT_FW_JOURNEY_PCR as u8;
+        env.pcr_bank
+            .extend_pcr(RT_FW_JOURNEY_PCR, &mut env.sha384, &rt_tci)?;
+        env.pcr_bank
+            .extend_pcr(RT_FW_JOURNEY_PCR, &mut env.sha384, &manifest_digest)?;
+    }
+
+    log_pcr(
+        &mut env.persistent_data.get_mut().pcr_log,
+        &mut env.pcr_bank,
+        PcrLogEntryId::RtTci,
+        pcr_ids,
+        &rt_tci,
+    )?;
+
+    log_pcr(
+        &mut env.persistent_data.get_mut().pcr_log,
+        &mut env.pcr_bank,
+        PcrLogEntryId::FwImageManifest,
+        pcr_ids,
+        &manifest_digest,
+    )?;
+
+    Ok(())
+}
+
+// TODO: Add CFI instrumentation
+fn log_pcr(
+    pcr_log: &mut PcrLogArray,
+    pcr_bank: &mut PcrBank,
+    pcr_entry_id: PcrLogEntryId,
+    pcr_ids: u32,
+    data: &[u8],
+) -> CaliptraResult<()> {
+    let Some(dst) = pcr_log.get_mut(pcr_bank.log_index) else {
+        return Err(CaliptraError::FMC_GLOBAL_PCR_LOG_EXHAUSTED);
+    };
+
+    // Create a PCR log entry
+    cprintln!("pcr_entry_id: {:?}", pcr_entry_id as u16);
+    cprintln!("FMC log_index: {:?}", pcr_bank.log_index as u16);
+    let mut pcr_log_entry = PcrLogEntry {
+        id: pcr_entry_id as u16,
+        pcr_ids,
+        ..Default::default()
+    };
+    pcr_log_entry.pcr_data.as_bytes_mut()[..data.len()].copy_from_slice(data);
+
+    // TODO: Increment FHT log index on each call. Can't do that yet because
+    // ROM does not touch the FHT's log index on update reset, which throws
+    // off the count.
+    pcr_bank.log_index += 1;
+
+    *dst = pcr_log_entry;
 
     Ok(())
 }

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -24,7 +24,7 @@ use crate::flow::tci::Tci;
 use crate::fmc_env::FmcEnv;
 use crate::HandOff;
 use caliptra_drivers::{
-    cprintln, okref,
+    okref,
     pcr_log::{PcrLogEntry, PcrLogEntryId},
     CaliptraResult, PcrBank, PcrLogArray,
 };
@@ -33,7 +33,7 @@ use caliptra_common::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 use caliptra_error::CaliptraError;
 use zerocopy::AsBytes;
 
-/// Extend common data into the current and journey PCRs
+/// Extend common data into the RT current and journey PCRs
 ///
 /// # Arguments
 ///
@@ -89,8 +89,6 @@ fn log_pcr(
     };
 
     // Create a PCR log entry
-    cprintln!("pcr_entry_id: {:?}", pcr_entry_id as u16);
-    cprintln!("FMC log_index: {:?}", pcr_bank.log_index as u16);
     let mut pcr_log_entry = PcrLogEntry {
         id: pcr_entry_id as u16,
         pcr_ids,

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 use crate::flow::crypto::Crypto;
 use crate::flow::dice::{DiceInput, DiceOutput};
-use crate::flow::pcr::{extend_current_pcr, extend_journey_pcr};
+use crate::flow::pcr::extend_pcr_common;
 use crate::flow::tci::Tci;
 use crate::flow::x509::X509;
 use crate::fmc_env::FmcEnv;
@@ -155,13 +155,15 @@ impl RtAliasLayer {
     ///
     /// * `env` - FMC Environment
     /// * `hand_off` - HandOff
-    pub fn extend_pcrs(env: &mut FmcEnv, hand_off: &HandOff) -> CaliptraResult<()> {
-        extend_current_pcr(env, hand_off)?;
-        match env.soc_ifc.reset_reason() {
-            ResetReason::ColdReset | ResetReason::UpdateReset => extend_journey_pcr(env, hand_off)?,
-            _ => cprintln!("[alias rt : skip journey pcr extension"),
-        }
-        Ok(())
+    pub fn extend_pcrs(env: &mut FmcEnv, hand_off: &mut HandOff) -> CaliptraResult<()> {
+        let extend_journey_pcr: bool = match env.soc_ifc.reset_reason() {
+            ResetReason::ColdReset | ResetReason::UpdateReset => true,
+            _ => {
+                cprintln!("[alias rt : skip journey pcr extension");
+                false
+            }
+        };
+        extend_pcr_common(env, hand_off, extend_journey_pcr)
     }
 
     /// Populate Data Vault

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -156,14 +156,13 @@ impl RtAliasLayer {
     /// * `env` - FMC Environment
     /// * `hand_off` - HandOff
     pub fn extend_pcrs(env: &mut FmcEnv, hand_off: &mut HandOff) -> CaliptraResult<()> {
-        let extend_journey_pcr: bool = match env.soc_ifc.reset_reason() {
-            ResetReason::ColdReset | ResetReason::UpdateReset => true,
+        match env.soc_ifc.reset_reason() {
+            ResetReason::ColdReset | ResetReason::UpdateReset => extend_pcr_common(env, hand_off),
             _ => {
-                cprintln!("[alias rt : skip journey pcr extension");
-                false
+                cprintln!("[alias rt : skip pcr extension");
+                Ok(())
             }
-        };
-        extend_pcr_common(env, hand_off, extend_journey_pcr)
+        }
     }
 
     /// Populate Data Vault

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -15,7 +15,7 @@ use crate::flow::dice::DiceOutput;
 use crate::fmc_env::FmcEnv;
 use caliptra_common::DataStore::*;
 use caliptra_common::{DataStore, FirmwareHandoffTable, HandOffDataHandle, Vault};
-use caliptra_drivers::{memory_layout, Array4x12, Ecc384Signature, KeyId, PersistentDataAccessor};
+use caliptra_drivers::{memory_layout, Array4x12, Ecc384Signature, KeyId};
 use caliptra_drivers::{Ecc384PubKey, Ecc384Scalar};
 use caliptra_error::CaliptraResult;
 
@@ -66,12 +66,13 @@ pub struct HandOff {
 
 impl HandOff {
     /// Create a new `HandOff` from the FHT table.
-    pub fn from_previous(persistent_data: &PersistentDataAccessor) -> Option<HandOff> {
-        let fht = &persistent_data.get().fht;
+    pub fn from_previous(env: &mut FmcEnv) -> Option<HandOff> {
+        let fht = &env.persistent_data.get().fht;
         // Perform basic sanity check of the FHT (check FHT marker, valid indices, etc.)
         if !fht.is_valid() {
             return None;
         }
+        env.pcr_bank.log_index = fht.pcr_log_index as usize;
         Some(Self { fht: fht.clone() })
     }
 
@@ -342,6 +343,7 @@ impl HandOff {
         self.fht.rt_dice_pub_key = out.subj_key_pair.pub_key;
         Ok(())
     }
+
     /// Check if the HandOff Table is valid by ensuring RTAlias CDI and private key handles
     /// are valid.
     pub fn is_valid(&self) -> bool {

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -44,7 +44,7 @@ pub extern "C" fn entry_point() -> ! {
         Err(e) => report_error(e.into()),
     };
 
-    if let Some(mut hand_off) = HandOff::from_previous(&env.persistent_data) {
+    if let Some(mut hand_off) = HandOff::from_previous(&mut env) {
         // Jump straight to RT for val-FMC for now
         if cfg!(feature = "fake-fmc") {
             hand_off.to_rt(&mut env);
@@ -58,6 +58,7 @@ pub extern "C" fn entry_point() -> ! {
             Err(e) => report_error(e.into()),
         }
     }
+
     caliptra_drivers::ExitCtrl::exit(0xff)
 }
 

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -12,6 +12,7 @@ caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
+ureg.workspace = true
 
 [build-dependencies]
 cfg-if.workspace = true
@@ -24,3 +25,4 @@ default = ["std"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
+interactive_test = []

--- a/fmc/test-fw/test-rt/src/interactive_test.rs
+++ b/fmc/test-fw/test-rt/src/interactive_test.rs
@@ -1,0 +1,144 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_drivers::memory_layout::{FHT_ORG, PCR_LOG_ORG};
+use caliptra_drivers::pcr_log::{PcrLogEntry, PcrLogEntryId};
+use caliptra_drivers::{cprintln, FirmwareHandoffTable, PcrBank, PcrId};
+use caliptra_registers::pv::PvReg;
+use ureg::RealMmioMut;
+
+use core::convert::TryInto;
+use zerocopy::{AsBytes, FromBytes};
+
+pub const TEST_CMD_READ_PCR_LOG: u32 = 0x1000_0000;
+pub const TEST_CMD_READ_FHT: u32 = 0x1000_0001;
+pub const TEST_CMD_READ_PCRS: u32 = 0x1000_0002;
+
+fn process_mailbox_command(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let cmd = mbox.cmd().read();
+    cprintln!("[fmc-test-harness] Received command: 0x{:08X}", cmd);
+    match cmd {
+        TEST_CMD_READ_PCR_LOG => {
+            read_pcr_log(mbox);
+        }
+        TEST_CMD_READ_FHT => {
+            read_fht(mbox);
+        }
+        TEST_CMD_READ_PCRS => {
+            read_pcrs(mbox);
+        }
+        _ => {
+            panic!();
+        }
+    }
+}
+
+pub fn process_mailbox_commands() {
+    let mut mbox = unsafe { caliptra_registers::mbox::MboxCsr::new() };
+    let mbox = mbox.regs_mut();
+
+    cprintln!("Waiting for mailbox commands...");
+    loop {
+        if mbox.status().read().mbox_fsm_ps().mbox_execute_uc() {
+            process_mailbox_command(&mbox);
+        }
+    }
+}
+
+fn read_fht(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    // Copy the FHT from DCCM
+    let mut fht: [u8; core::mem::size_of::<FirmwareHandoffTable>()] =
+        [0u8; core::mem::size_of::<FirmwareHandoffTable>()];
+
+    let src = unsafe {
+        let ptr = FHT_ORG as *mut u8;
+        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<FirmwareHandoffTable>())
+    };
+
+    fht.copy_from_slice(src);
+
+    send_to_mailbox(mbox, fht.as_bytes(), true);
+}
+
+fn send_to_mailbox(
+    mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>,
+    data: &[u8],
+    update_mb_state: bool,
+) {
+    let data_len = data.len();
+    let word_size = core::mem::size_of::<u32>();
+    let remainder = data_len % word_size;
+    let n = data_len - remainder;
+    for idx in (0..n).step_by(word_size) {
+        mbox.datain()
+            .write(|_| u32::from_le_bytes(data[idx..idx + word_size].try_into().unwrap()));
+    }
+
+    if remainder > 0 {
+        let mut last_word = data[n] as u32;
+        for idx in 1..remainder {
+            last_word |= (data[n + idx] as u32) << (idx << 3);
+        }
+        mbox.datain().write(|_| last_word);
+    }
+
+    if update_mb_state {
+        mbox.dlen().write(|_| data_len as u32);
+        mbox.status().write(|w| w.status(|w| w.data_ready()));
+    }
+}
+
+fn read_pcr_log(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let mut pcr_entry_count = 0;
+    loop {
+        let pcr_entry = get_pcr_entry(pcr_entry_count);
+        if PcrLogEntryId::from(pcr_entry.id) == PcrLogEntryId::Invalid {
+            break;
+        }
+
+        pcr_entry_count += 1;
+        send_to_mailbox(mbox, pcr_entry.as_bytes(), false);
+    }
+
+    mbox.dlen().write(|_| {
+        (core::mem::size_of::<PcrLogEntry>() * pcr_entry_count)
+            .try_into()
+            .unwrap()
+    });
+    mbox.status().write(|w| w.status(|w| w.data_ready()));
+}
+
+fn get_pcr_entry(entry_index: usize) -> PcrLogEntry {
+    // Copy the pcr log entry from DCCM
+    let mut pcr_entry: [u8; core::mem::size_of::<PcrLogEntry>()] =
+        [0u8; core::mem::size_of::<PcrLogEntry>()];
+
+    let src = unsafe {
+        let offset = core::mem::size_of::<PcrLogEntry>() * entry_index;
+        let ptr = (PCR_LOG_ORG as *mut u8).add(offset);
+        core::slice::from_raw_parts_mut(ptr, core::mem::size_of::<PcrLogEntry>())
+    };
+
+    pcr_entry.copy_from_slice(src);
+    PcrLogEntry::read_from_prefix(pcr_entry.as_bytes()).unwrap()
+}
+
+fn read_pcrs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
+    let pcr_bank = unsafe { PcrBank::new(PvReg::new()) };
+    const PCR_COUNT: usize = 32;
+    for i in 0..PCR_COUNT {
+        let pcr = pcr_bank.read_pcr(PcrId::try_from(i as u8).unwrap());
+        let mut pcr_bytes: [u32; 12] = pcr.try_into().unwrap();
+
+        swap_word_bytes_inplace(&mut pcr_bytes);
+        send_to_mailbox(mbox, pcr.as_bytes(), false);
+    }
+
+    mbox.dlen().write(|_| (48 * PCR_COUNT).try_into().unwrap());
+    mbox.status().write(|w| w.status(|w| w.data_ready()));
+}
+
+fn swap_word_bytes_inplace(words: &mut [u32]) {
+    for word in words.iter_mut() {
+        *word = word.swap_bytes()
+    }
+}

--- a/fmc/test-fw/test-rt/src/main.rs
+++ b/fmc/test-fw/test-rt/src/main.rs
@@ -13,6 +13,8 @@ Abstract:
 --*/
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
+#![cfg_attr(feature = "interactive_test", allow(unused_imports))]
+mod interactive_test;
 
 use caliptra_common::cprintln;
 use caliptra_cpu::TrapRecord;
@@ -50,6 +52,10 @@ pub extern "C" fn entry_point() -> ! {
     assert!(pcr_bank
         .erase_pcr(caliptra_common::RT_FW_JOURNEY_PCR)
         .is_err());
+
+    if cfg!(feature = "interactive_test") {
+        interactive_test::process_mailbox_commands();
+    }
     caliptra_drivers::ExitCtrl::exit(0)
 }
 

--- a/fmc/tests/test_rtalias.rs
+++ b/fmc/tests/test_rtalias.rs
@@ -94,10 +94,10 @@ fn test_fht_info() {
     let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
     assert_eq!(fht.ldevid_tbs_size, 533);
     assert_eq!(fht.fmcalias_tbs_size, 769);
-    assert_eq!(fht.ldevid_tbs_addr, 0x50003800);
-    assert_eq!(fht.fmcalias_tbs_addr, 0x50003C00);
-    assert_eq!(fht.pcr_log_addr, 0x50004400);
-    assert_eq!(fht.fuse_log_addr, 0x50004C00);
+    assert_eq!(fht.ldevid_tbs_addr, 0x50003C00);
+    assert_eq!(fht.fmcalias_tbs_addr, 0x50004000);
+    assert_eq!(fht.pcr_log_addr, 0x50004800);
+    assert_eq!(fht.fuse_log_addr, 0x50005000);
 }
 
 #[test]

--- a/fmc/tests/test_rtalias.rs
+++ b/fmc/tests/test_rtalias.rs
@@ -1,6 +1,18 @@
 // Licensed under the Apache-2.0 license
 use caliptra_builder::{FwId, ImageOptions, FMC_WITH_UART, ROM_WITH_UART};
+use caliptra_drivers::{
+    pcr_log::{PcrLogEntry, PcrLogEntryId},
+    FirmwareHandoffTable, PcrId,
+};
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
+
+use caliptra_test::swap_word_bytes;
+use zerocopy::{AsBytes, FromBytes};
+
+use openssl::hash::{Hasher, MessageDigest};
+
+const TEST_CMD_READ_PCR_LOG: u32 = 0x1000_0000;
+const TEST_CMD_READ_FHT: u32 = 0x1000_0001;
 
 const RT_ALIAS_MEASUREMENT_COMPLETE: u32 = 0x400;
 const RT_ALIAS_DERIVED_CDI_COMPLETE: u32 = 0x401;
@@ -9,6 +21,11 @@ const RT_ALIAS_SUBJ_ID_SN_GENERATION_COMPLETE: u32 = 0x403;
 const RT_ALIAS_SUBJ_KEY_ID_GENERATION_COMPLETE: u32 = 0x404;
 const RT_ALIAS_CERT_SIG_GENERATION_COMPLETE: u32 = 0x405;
 const RT_ALIAS_DERIVATION_COMPLETE: u32 = 0x406;
+
+const PCR_COUNT: usize = 32;
+const PCR_ENTRY_SIZE: usize = core::mem::size_of::<PcrLogEntry>();
+
+const PCR2_AND_PCR3_EXTENDED_ID: u32 = (1 << PcrId::PcrId2 as u8) | (1 << PcrId::PcrId3 as u8);
 
 #[test]
 fn test_boot_status_reporting() {
@@ -45,7 +62,231 @@ fn test_boot_status_reporting() {
     hw.step_until_boot_status(RT_ALIAS_SUBJ_KEY_ID_GENERATION_COMPLETE, true);
     hw.step_until_boot_status(RT_ALIAS_CERT_SIG_GENERATION_COMPLETE, true);
     hw.step_until_boot_status(RT_ALIAS_DERIVATION_COMPLETE, true);
+}
 
-    let mut output = vec![];
-    hw.copy_output_until_exit_success(&mut output).unwrap();
+#[test]
+fn test_fht_info() {
+    pub const MOCK_RT_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-fmc-mock-rt",
+        bin_name: "caliptra-fmc-mock-rt",
+        features: &["emu", "interactive_test"],
+        workspace_dir: None,
+    };
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let data = hw.mailbox_execute(TEST_CMD_READ_FHT, &[]).unwrap().unwrap();
+    let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+    assert_eq!(fht.ldevid_tbs_size, 533);
+    assert_eq!(fht.fmcalias_tbs_size, 769);
+    assert_eq!(fht.ldevid_tbs_addr, 0x50003800);
+    assert_eq!(fht.fmcalias_tbs_addr, 0x50003C00);
+    assert_eq!(fht.pcr_log_addr, 0x50004400);
+    assert_eq!(fht.fuse_log_addr, 0x50004C00);
+}
+
+#[test]
+fn test_pcr_log() {
+    pub const MOCK_RT_WITH_UART: FwId = FwId {
+        crate_name: "caliptra-fmc-mock-rt",
+        bin_name: "caliptra-fmc-mock-rt",
+        features: &["emu", "interactive_test"],
+        workspace_dir: None,
+    };
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image1 = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions {
+            app_version: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let mut hw = caliptra_hw_model::new(BootParams {
+        init_params: InitParams {
+            rom: &rom,
+            ..Default::default()
+        },
+        fw_image: Some(&image1.to_bytes().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let data = hw.mailbox_execute(TEST_CMD_READ_FHT, &[]).unwrap().unwrap();
+    let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+
+    let pcr_entry_arr = hw
+        .mailbox_execute(TEST_CMD_READ_PCR_LOG, &[])
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        pcr_entry_arr.len(),
+        (fht.pcr_log_index as usize + 2) * PCR_ENTRY_SIZE
+    );
+
+    let rt_tci1 = swap_word_bytes(&image1.manifest.runtime.digest);
+    let manifest_digest1 = openssl::sha::sha384(image1.manifest.as_bytes());
+
+    check_pcr_log_entry(
+        &pcr_entry_arr,
+        fht.pcr_log_index,
+        PcrLogEntryId::RtTci,
+        PCR2_AND_PCR3_EXTENDED_ID,
+        rt_tci1.as_bytes(),
+    );
+
+    check_pcr_log_entry(
+        &pcr_entry_arr,
+        fht.pcr_log_index + 1,
+        PcrLogEntryId::FwImageManifest,
+        PCR2_AND_PCR3_EXTENDED_ID,
+        &manifest_digest1,
+    );
+
+    // Fetch and validate PCR values against the log.
+    let pcrs = hw.mailbox_execute(0x1000_0002, &[]).unwrap().unwrap();
+    assert_eq!(pcrs.len(), PCR_COUNT * 48);
+    let mut pcr2_from_hw: [u8; 48] = pcrs[(2 * 48)..(3 * 48)].try_into().unwrap();
+    let mut pcr3_from_hw: [u8; 48] = pcrs[(3 * 48)..(4 * 48)].try_into().unwrap();
+
+    change_dword_endianess(&mut pcr2_from_hw);
+    change_dword_endianess(&mut pcr3_from_hw);
+
+    let pcr2_from_log = hash_pcr_log_entries(&[0; 48], &pcr_entry_arr, PcrId::PcrId2);
+    let pcr3_from_log = hash_pcr_log_entries(&[0; 48], &pcr_entry_arr, PcrId::PcrId3);
+
+    assert_eq!(pcr2_from_log, pcr2_from_hw);
+    assert_eq!(pcr3_from_log, pcr3_from_hw);
+
+    hw.soc_ifc()
+        .internal_fw_update_reset()
+        .write(|w| w.core_rst(true));
+
+    let image2 = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &MOCK_RT_WITH_UART,
+        ImageOptions {
+            app_version: 2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(hw.upload_firmware(&image2.to_bytes().unwrap()).is_ok());
+
+    hw.step_until_boot_status(RT_ALIAS_DERIVATION_COMPLETE, true);
+
+    let pcr_entry_arr = hw
+        .mailbox_execute(TEST_CMD_READ_PCR_LOG, &[])
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        pcr_entry_arr.len(),
+        (fht.pcr_log_index as usize + 2) * PCR_ENTRY_SIZE
+    );
+
+    let rt_tci2 = swap_word_bytes(&image2.manifest.runtime.digest);
+    let manifest_digest2 = openssl::sha::sha384(image2.manifest.as_bytes());
+
+    check_pcr_log_entry(
+        &pcr_entry_arr,
+        fht.pcr_log_index,
+        PcrLogEntryId::RtTci,
+        PCR2_AND_PCR3_EXTENDED_ID,
+        rt_tci2.as_bytes(),
+    );
+
+    check_pcr_log_entry(
+        &pcr_entry_arr,
+        fht.pcr_log_index + 1,
+        PcrLogEntryId::FwImageManifest,
+        PCR2_AND_PCR3_EXTENDED_ID,
+        &manifest_digest2,
+    );
+
+    let pcr2_from_log = hash_pcr_log_entries(&[0; 48], &pcr_entry_arr, PcrId::PcrId2);
+    let pcr3_from_log = hash_pcr_log_entries(&pcr3_from_log, &pcr_entry_arr, PcrId::PcrId3);
+
+    // Fetch and validate PCR values against the log.
+    let pcrs = hw.mailbox_execute(0x1000_0002, &[]).unwrap().unwrap();
+    assert_eq!(pcrs.len(), PCR_COUNT * 48);
+    let mut pcr2_from_hw: [u8; 48] = pcrs[(2 * 48)..(3 * 48)].try_into().unwrap();
+    let mut pcr3_from_hw: [u8; 48] = pcrs[(3 * 48)..(4 * 48)].try_into().unwrap();
+
+    change_dword_endianess(&mut pcr2_from_hw);
+    change_dword_endianess(&mut pcr3_from_hw);
+
+    assert_eq!(pcr2_from_log, pcr2_from_hw);
+    assert_eq!(pcr3_from_log, pcr3_from_hw);
+}
+
+fn check_pcr_log_entry(
+    pcr_entry_arr: &[u8],
+    pcr_entry_index: u32,
+    entry_id: PcrLogEntryId,
+    pcr_ids: u32,
+    pcr_data: &[u8],
+) {
+    let offset = pcr_entry_index as usize * PCR_ENTRY_SIZE;
+    let entry = PcrLogEntry::read_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
+
+    assert_eq!(entry.id, entry_id as u16);
+    assert_eq!(entry.pcr_ids, pcr_ids);
+    assert_eq!(entry.measured_data(), pcr_data);
+}
+
+// Computes the PCR from the log.
+fn hash_pcr_log_entries(initial_pcr: &[u8; 48], pcr_entry_arr: &[u8], pcr_id: PcrId) -> [u8; 48] {
+    let mut offset: usize = 0;
+    let mut pcr: [u8; 48] = *initial_pcr;
+
+    assert_eq!(pcr_entry_arr.len() % PCR_ENTRY_SIZE, 0);
+
+    loop {
+        if offset == pcr_entry_arr.len() {
+            break;
+        }
+
+        let entry = PcrLogEntry::read_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
+        offset += PCR_ENTRY_SIZE;
+
+        if (entry.pcr_ids & (1 << pcr_id as u8)) == 0 {
+            continue;
+        }
+
+        let mut hasher = Hasher::new(MessageDigest::sha384()).unwrap();
+        hasher.update(&pcr).unwrap();
+        hasher.update(entry.measured_data()).unwrap();
+        let digest: &[u8] = &hasher.finish().unwrap();
+
+        pcr.copy_from_slice(digest);
+    }
+
+    pcr
+}
+
+fn change_dword_endianess(data: &mut [u8]) {
+    for idx in (0..data.len()).step_by(4) {
+        data.swap(idx, idx + 3);
+        data.swap(idx + 1, idx + 2);
+    }
 }

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -168,6 +168,8 @@ pub fn make_fht(env: &RomEnv) -> FirmwareHandoffTable {
         ldevid_tbs_addr,
         fmcalias_tbs_addr,
         pcr_log_addr,
+        // TODO: remove `pcr_bank.log_index` and just increment `fht.pcr_log_index`
+        pcr_log_index: env.pcr_bank.log_index as u32,
         fuse_log_addr,
         idev_dice_pub_key: env.fht_data_store.idev_pub,
         ..Default::default()


### PR DESCRIPTION
Based on https://github.com/chipsalliance/caliptra-sw/pull/722

Also changes FMC to extend PCRs only on cold or update reset, as per https://github.com/chipsalliance/caliptra-sw/issues/776.