### PR TITLE
gce-ci: Increase maximum VM duration to 36 hours.

### DIFF
--- a/ci-tools/github-runner/cleanup.go
+++ b/ci-tools/github-runner/cleanup.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const maxVmDuration = 12 * time.Hour
+const maxVmDuration = 36 * time.Hour
 
 func cleanupInstances(ctx context.Context) error {
 	instanceSvc, err := compute.NewInstancesRESTClient(ctx)


### PR DESCRIPTION
This should give us enough time to run all of the verilator tests on a 32 core machine.