### PR TITLE
mailbox: add EXTEND_PCR command

### DIFF
--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -305,13 +305,15 @@ pub struct ExtendPcrReq {
 pub type ExtendPcrReqErr = ();
 impl ExtendPcrReq {
     pub const DATA_MAX_SIZE: usize = 48;
+}
 
-    pub fn new(
-        hdr: MailboxReqHeader,
-        pcr_idx: u32,
-        data: [u8; 48],
-    ) -> Result<Self, ExtendPcrReqErr> {
-        Ok(ExtendPcrReq { hdr, pcr_idx, data })
+impl Default for ExtendPcrReq {
+    fn default() -> Self {
+        Self {
+            hdr: Default::default(),
+            pcr_idx: u32::default(),
+            data: [0u8; ExtendPcrReq::DATA_MAX_SIZE],
+        }
     }
 }
 // No command-specific output args

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -302,10 +302,26 @@ pub struct ExtendPcrReq {
     pub pcr_idx: u32,
     pub data_size: u32,
     pub data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
+    _pad: [u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4)],
 }
 // No command-specific output args
 impl ExtendPcrReq {
-    pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE;
+    pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE - 1;
+
+    pub fn new(
+        hdr: MailboxReqHeader,
+        pcr_idx: u32,
+        data_size: u32,
+        data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
+    ) -> Self {
+        ExtendPcrReq {
+            hdr,
+            pcr_idx,
+            data_size,
+            data,
+            _pad: [0u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4)],
+        }
+    }
 }
 
 #[repr(C)]

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -301,19 +301,17 @@ pub struct ExtendPcrReq {
     pub hdr: MailboxReqHeader,
     pub pcr_idx: u32,
     pub data_size: u32,
-    pub data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
-    _pad: [u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4) % 4],
+    pub data: [u8; 48],
 }
 pub type ExtendPcrReqErr = ();
 impl ExtendPcrReq {
-    // pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE - 1;
-    pub const DATA_MAX_SIZE: usize = 192;
+    pub const DATA_MAX_SIZE: usize = 48;
 
     pub fn new(
         hdr: MailboxReqHeader,
         pcr_idx: u32,
         data_size: u32,
-        data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
+        data: [u8; 48],
     ) -> Result<Self, ExtendPcrReqErr> {
         let data_size = match data_size {
             0 | 255 => {
@@ -327,7 +325,6 @@ impl ExtendPcrReq {
             pcr_idx,
             data_size,
             data,
-            _pad: [0u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4)],
         })
     }
 }

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -302,9 +302,9 @@ pub struct ExtendPcrReq {
     pub pcr_idx: u32,
     pub data_size: u32,
     pub data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
-    _pad: [u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4)],
+    _pad: [u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4) % 4],
 }
-// No command-specific output args
+pub type ExtendPcrReqErr = ();
 impl ExtendPcrReq {
     pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE - 1;
 
@@ -313,16 +313,24 @@ impl ExtendPcrReq {
         pcr_idx: u32,
         data_size: u32,
         data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
-    ) -> Self {
-        ExtendPcrReq {
+    ) -> Result<Self, ExtendPcrReqErr> {
+        let data_size = match data_size {
+            0 | 255 => {
+                return Err(());
+            }
+            ds => ds,
+        };
+
+        Ok(ExtendPcrReq {
             hdr,
             pcr_idx,
             data_size,
             data,
             _pad: [0u8; 4 - (ExtendPcrReq::DATA_MAX_SIZE % 4)],
-        }
+        })
     }
 }
+// No command-specific output args
 
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_drivers::{CaliptraError, CaliptraResult};
+use caliptra_drivers::{sha384, CaliptraError, CaliptraResult};
 use core::mem::size_of;
 use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 
@@ -305,7 +305,7 @@ pub struct ExtendPcrReq {
 }
 // No command-specific output args
 impl ExtendPcrReq {
-    pub const DATA_MAX_SIZE: usize = 80; // Req max size = (SHA384_BLOCK_BYTE_SIZE - SHA384_HASH_SIZE - 1)
+    pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE;
 }
 
 #[repr(C)]

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -54,7 +54,6 @@ impl From<CommandId> for u32 {
 #[cfg_attr(test, derive(PartialEq, Debug, Eq))]
 #[allow(clippy::large_enum_variant)]
 pub enum MailboxResp {
-    // ExtendPCR(ExtendPCRResp), // ExtendPCR does not return a response
     Header(MailboxRespHeader),
     GetIdevCert(GetIdevCertResp),
     GetIdevCsr(GetIdevCsrResp),

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -17,6 +17,7 @@ impl CommandId {
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
     pub const DISABLE_ATTESTATION: Self = Self(0x4453424C); // "DSBL"
     pub const FW_INFO: Self = Self(0x494E464F); // "INFO"
+    pub const EXTEND_PCR: Self = Self(0x50435245); // "PCRE"
 
     // TODO: Remove this and merge with GET_LDEV_CERT once that is implemented
     pub const TEST_ONLY_GET_LDEV_CERT: Self = Self(0x4345524c); // "CERL"
@@ -53,6 +54,7 @@ impl From<CommandId> for u32 {
 #[cfg_attr(test, derive(PartialEq, Debug, Eq))]
 #[allow(clippy::large_enum_variant)]
 pub enum MailboxResp {
+    // ExtendPCR(ExtendPCRResp), // ExtendPCR does not return a response
     Header(MailboxRespHeader),
     GetIdevCert(GetIdevCertResp),
     GetIdevCsr(GetIdevCsrResp),
@@ -289,6 +291,29 @@ impl Default for InvokeDpeReq {
             hdr: MailboxReqHeader::default(),
             data_size: 0,
             data: [0u8; InvokeDpeReq::DATA_MAX_SIZE],
+        }
+    }
+}
+
+// EXTEND_PCR
+#[repr(C)]
+#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+pub struct ExtendPcrReq {
+    pub hdr: MailboxReqHeader,
+    pub pcr_idx: u32,
+    pub value: [u8; ExtendPcrReq::DATA_MAX_SIZE], // variable length
+}
+// No command-specific output args
+impl ExtendPcrReq {
+    pub const DATA_MAX_SIZE: usize = 512;
+}
+
+impl Default for ExtendPcrReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            pcr_idx: 0,
+            value: [0u8; ExtendPcrReq::DATA_MAX_SIZE],
         }
     }
 }

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -300,21 +300,12 @@ impl Default for InvokeDpeReq {
 pub struct ExtendPcrReq {
     pub hdr: MailboxReqHeader,
     pub pcr_idx: u32,
-    pub value: [u8; ExtendPcrReq::DATA_MAX_SIZE], // variable length
+    pub data_size: u32,
+    pub data: [u8; ExtendPcrReq::DATA_MAX_SIZE],
 }
 // No command-specific output args
 impl ExtendPcrReq {
-    pub const DATA_MAX_SIZE: usize = 512;
-}
-
-impl Default for ExtendPcrReq {
-    fn default() -> Self {
-        Self {
-            hdr: MailboxReqHeader::default(),
-            pcr_idx: 0,
-            value: [0u8; ExtendPcrReq::DATA_MAX_SIZE],
-        }
-    }
+    pub const DATA_MAX_SIZE: usize = 80; // Req max size = (SHA384_BLOCK_BYTE_SIZE - SHA384_HASH_SIZE - 1)
 }
 
 #[repr(C)]

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -300,7 +300,6 @@ impl Default for InvokeDpeReq {
 pub struct ExtendPcrReq {
     pub hdr: MailboxReqHeader,
     pub pcr_idx: u32,
-    pub data_size: u32,
     pub data: [u8; 48],
 }
 pub type ExtendPcrReqErr = ();
@@ -310,22 +309,9 @@ impl ExtendPcrReq {
     pub fn new(
         hdr: MailboxReqHeader,
         pcr_idx: u32,
-        data_size: u32,
         data: [u8; 48],
     ) -> Result<Self, ExtendPcrReqErr> {
-        let data_size = match data_size {
-            0 | 255 => {
-                return Err(());
-            }
-            ds => ds,
-        };
-
-        Ok(ExtendPcrReq {
-            hdr,
-            pcr_idx,
-            data_size,
-            data,
-        })
+        Ok(ExtendPcrReq { hdr, pcr_idx, data })
     }
 }
 // No command-specific output args

--- a/common/src/mailbox_api.rs
+++ b/common/src/mailbox_api.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_drivers::{sha384, CaliptraError, CaliptraResult};
+use caliptra_drivers::{CaliptraError, CaliptraResult};
 use core::mem::size_of;
 use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 
@@ -306,7 +306,8 @@ pub struct ExtendPcrReq {
 }
 pub type ExtendPcrReqErr = ();
 impl ExtendPcrReq {
-    pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE - 1;
+    // pub const DATA_MAX_SIZE: usize = sha384::SHA384_BLOCK_BYTE_SIZE - sha384::SHA384_HASH_SIZE - 1;
+    pub const DATA_MAX_SIZE: usize = 192;
 
     pub fn new(
         hdr: MailboxReqHeader,

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -42,7 +42,7 @@ mod persistent;
 pub mod printer;
 mod sha1;
 mod sha256;
-mod sha384;
+pub mod sha384;
 mod sha384acc;
 mod soc_ifc;
 mod trng;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -42,7 +42,7 @@ mod persistent;
 pub mod printer;
 mod sha1;
 mod sha256;
-pub mod sha384;
+mod sha384;
 mod sha384acc;
 mod soc_ifc;
 mod trng;

--- a/drivers/src/pcr_bank.rs
+++ b/drivers/src/pcr_bank.rs
@@ -116,9 +116,9 @@ impl PcrBank {
     pub fn new(pv: PvReg) -> Self {
         Self { pv }
     }
-    /// Erase all the pcrs in the pcr vault
+    /// Erase all the PCRs in the PCR vault
     ///
-    /// Note: The pcrs that have "use" lock set will not be erased
+    /// Note: The PCRs that have "use" lock set will not be erased
     pub fn erase_all_pcrs(&mut self) {
         const PCR_IDS: [PcrId; 32] = [
             PcrId::PcrId0,
@@ -163,7 +163,7 @@ impl PcrBank {
         }
     }
 
-    /// Erase specified pcr
+    /// Erase specified PCR
     ///
     /// # Arguments
     ///

--- a/drivers/src/pcr_bank.rs
+++ b/drivers/src/pcr_bank.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use crate::sha384::{SHA384_BLOCK_BYTE_SIZE, SHA384_HASH_SIZE};
 use crate::{Array4x12, CaliptraError, CaliptraResult, Sha384};
 use caliptra_registers::pv::PvReg;
 
@@ -241,8 +242,43 @@ impl PcrBank {
     /// * `id`   - PCR ID
     /// * `sha`  - SHA2-384 Engine
     /// * `data` - Data to extend
-    ///
     pub fn extend_pcr(&self, id: PcrId, sha: &mut Sha384, data: &[u8]) -> CaliptraResult<()> {
         sha.pcr_extend(id, data)
+    }
+
+    /// Extend the PCR with specified, variable length data.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`   - PCR ID
+    /// * `sha`  - SHA2-384 Engine
+    /// * `data` - Data to extend
+    pub fn extend_pcr_variable(
+        &self,
+        id: PcrId,
+        sha: &mut Sha384,
+        data: &[u8],
+    ) -> CaliptraResult<()> {
+        let data_block_size = (SHA384_BLOCK_BYTE_SIZE - SHA384_HASH_SIZE - 1) as u32;
+        let blocks: u32 = data.len() as u32 / data_block_size as u32;
+
+        for i in 0..blocks {
+            let d = data
+                .get((i * data_block_size) as usize..((i + 1) * data_block_size) as usize)
+                .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?;
+
+            sha.pcr_extend(id, d)?;
+        }
+
+        // process leftovers
+        if (data.len() as u32 % data_block_size) > 0 {
+            sha.pcr_extend(
+                id,
+                data.get((blocks * data_block_size) as usize..data.len())
+                    .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?,
+            )?;
+        }
+
+        Ok(())
     }
 }

--- a/drivers/src/pcr_bank.rs
+++ b/drivers/src/pcr_bank.rs
@@ -12,7 +12,6 @@ Abstract:
 
 --*/
 
-use crate::sha384::{SHA384_BLOCK_BYTE_SIZE, SHA384_HASH_SIZE};
 use crate::{Array4x12, CaliptraError, CaliptraResult, Sha384};
 use caliptra_registers::pv::PvReg;
 
@@ -244,41 +243,5 @@ impl PcrBank {
     /// * `data` - Data to extend
     pub fn extend_pcr(&self, id: PcrId, sha: &mut Sha384, data: &[u8]) -> CaliptraResult<()> {
         sha.pcr_extend(id, data)
-    }
-
-    /// Extend the PCR with specified, variable length data.
-    ///
-    /// # Arguments
-    ///
-    /// * `id`   - PCR ID
-    /// * `sha`  - SHA2-384 Engine
-    /// * `data` - Data to extend
-    pub fn extend_pcr_variable(
-        &self,
-        id: PcrId,
-        sha: &mut Sha384,
-        data: &[u8],
-    ) -> CaliptraResult<()> {
-        let data_block_size = (SHA384_BLOCK_BYTE_SIZE - SHA384_HASH_SIZE - 1) as u32;
-        let blocks: u32 = data.len() as u32 / data_block_size as u32;
-
-        for i in 0..blocks {
-            let d = data
-                .get((i * data_block_size) as usize..((i + 1) * data_block_size) as usize)
-                .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?;
-
-            sha.pcr_extend(id, d)?;
-        }
-
-        // process leftovers
-        if (data.len() as u32 % data_block_size) > 0 {
-            sha.pcr_extend(
-                id,
-                data.get((blocks * data_block_size) as usize..data.len())
-                    .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?,
-            )?;
-        }
-
-        Ok(())
     }
 }

--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -20,10 +20,10 @@ use crate::{array::Array4x32, wait, Array4x12};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_registers::sha512::Sha512Reg;
 
-const SHA384_BLOCK_BYTE_SIZE: usize = 128;
+pub const SHA384_BLOCK_BYTE_SIZE: usize = 128;
 const SHA384_BLOCK_LEN_OFFSET: usize = 112;
 const SHA384_MAX_DATA_SIZE: usize = 1024 * 1024;
-const SHA384_HASH_SIZE: usize = 48;
+pub const SHA384_HASH_SIZE: usize = 48;
 
 /// SHA-384 Digest
 pub type Sha384Digest<'a> = &'a mut Array4x12;

--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -20,10 +20,10 @@ use crate::{array::Array4x32, wait, Array4x12};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_registers::sha512::Sha512Reg;
 
-pub const SHA384_BLOCK_BYTE_SIZE: usize = 128;
+const SHA384_BLOCK_BYTE_SIZE: usize = 128;
 const SHA384_BLOCK_LEN_OFFSET: usize = 112;
 const SHA384_MAX_DATA_SIZE: usize = 1024 * 1024;
-pub const SHA384_HASH_SIZE: usize = 48;
+const SHA384_HASH_SIZE: usize = 48;
 
 /// SHA-384 Digest
 pub type Sha384Digest<'a> = &'a mut Array4x12;

--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -58,7 +58,6 @@ impl Sha384 {
     /// # Arguments
     ///
     /// * `data` - Data to used to update the digest
-    ///
     pub fn digest(&mut self, buf: &[u8]) -> CaliptraResult<Array4x12> {
         // Check if the buffer is not large
         if buf.len() > SHA384_MAX_DATA_SIZE {
@@ -137,6 +136,12 @@ impl Sha384 {
         Array4x12::read_from_reg(sha.digest().truncate::<12>())
     }
 
+    /// Extend data into PCR Register
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - ID of PCR register to extend data into
+    /// * `data` - Data to extend into PCR register
     pub fn pcr_extend(&mut self, id: PcrId, data: &[u8]) -> CaliptraResult<()> {
         let total_bytes = data.len() + SHA384_HASH_SIZE;
         if total_bytes > (SHA384_BLOCK_BYTE_SIZE - 1) {

--- a/drivers/test-fw/src/bin/pcrbank_tests.rs
+++ b/drivers/test-fw/src/bin/pcrbank_tests.rs
@@ -84,9 +84,12 @@ fn test_write_protection_stickiness() {
     }
 }
 
+fn test_mailbox_pcrextend_cmd() {}
+
 // Maintain the order of the tests.
 test_suite! {
     test_lock_and_erase_pcrs,
     test_erase_all_pcrs,
     test_write_protection_stickiness,
+    test_mailbox_pcrextend_cmd
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -120,6 +120,8 @@ impl CaliptraError {
 
     pub const DRIVER_PCR_BANK_ERASE_WRITE_LOCK_SET_FAILURE: CaliptraError =
         CaliptraError::new_const(0x00070001);
+    pub const DRIVER_PCR_BANK_EXTEND_INVALID_SIZE: CaliptraError =
+        CaliptraError::new_const(0x00070002);
 
     /// Mailbox Errors
     pub const DRIVER_MAILBOX_INVALID_STATE: CaliptraError = CaliptraError::new_const(0x00080001);

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -345,6 +345,10 @@ impl CaliptraError {
     pub const RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL: CaliptraError =
         CaliptraError::new_const(0x000E001A);
 
+    /// PCR Runtime Errors
+    pub const RUNTIME_PCR_RESERVED: CaliptraError = CaliptraError::new_const(0x000E0015);
+    pub const RUNTIME_PCR_INVALID_INDEX: CaliptraError = CaliptraError::new_const(0x000E0016);
+
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);
     pub const FMC_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x000F0002);

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -633,6 +633,20 @@ pub trait HwModel {
         }
     }
 
+    /// A register block that can be used to manipulate the soc_ifc peripheral PCR registers
+    /// over the simulated SoC->Caliptra APB bus.
+    fn soc_ifc_pcr(
+        &mut self,
+        // ) -> caliptra_registers::soc_ifc_trng::RegisterBlock<BusMmio<Self::TBus<'_>>> {
+    ) -> caliptra_registers::pv::RegisterBlock<ureg::RealMmioMut> {
+        unsafe {
+            caliptra_registers::pv::RegisterBlock::new_with_mmio(
+                0x1001a000 as *mut u32,
+                core::default::Default::default(),
+            )
+        }
+    }
+
     /// A register block that can be used to manipulate the mbox peripheral
     /// over the simulated SoC->Caliptra APB bus.
     fn soc_mbox(&mut self) -> caliptra_registers::mbox::RegisterBlock<BusMmio<Self::TBus<'_>>> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,10 +10,10 @@ pub mod fips;
 pub mod handoff;
 pub mod info;
 mod invoke_dpe;
+mod pcr;
 mod stash_measurement;
 mod update;
 mod verify;
-mod pcr;
 
 // Used by runtime tests
 pub mod mailbox;
@@ -104,7 +104,7 @@ fn enter_idle(drivers: &mut Drivers) {
     //}
 }
 
-/// Handles the pending mailbox command and writes the repsonse back to the mailbox
+/// Handles the pending mailbox command and writes the response back to the mailbox
 ///
 /// Returns the mailbox status (DataReady when we send a response) or an error
 fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,7 @@ mod invoke_dpe;
 mod stash_measurement;
 mod update;
 mod verify;
+mod pcr;
 
 // Used by runtime tests
 pub mod mailbox;
@@ -31,6 +32,7 @@ pub use fips::{fips_self_test_cmd, fips_self_test_cmd::SelfTestStatus};
 
 pub use info::{FwInfoCmd, IDevIdCertCmd, IDevIdInfoCmd};
 pub use invoke_dpe::InvokeDpeCmd;
+pub use pcr::ExtendPcrCmd;
 pub use stash_measurement::StashMeasurementCmd;
 pub use verify::EcdsaVerifyCmd;
 pub mod packet;
@@ -134,6 +136,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::GET_LDEV_CERT => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
         CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers, cmd_bytes),
         CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers, cmd_bytes),
+        CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers, cmd_bytes),
         CommandId::DISABLE_ATTESTATION => DisableAttestationCmd::execute(drivers),
         CommandId::FW_INFO => FwInfoCmd::execute(drivers),

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -1,5 +1,7 @@
 // Licensed under the Apache-2.0 license
 
+use core::borrow::BorrowMut;
+
 #[allow(unused_imports)]
 #[allow(dead_code)]
 use crate::Drivers;
@@ -48,16 +50,16 @@ impl ExtendPcrCmd {
             .ok_or(CaliptraError::ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH)?;
 
         let pcr_bank = &mut drivers.pcr_bank;
+        let fht = &mut drivers.persistent_data.get_mut().fht;
 
         let mut pcr_log_entry = PcrLogEntry {
             id: idx as u16,
             pcr_ids: (1 << PCR_ID_FMC_CURRENT as u8) | 1 << PCR_ID_FMC_JOURNEY as u8,
             ..Default::default()
         };
-        pcr_log_entry.pcr_data = pcr_bank.read_pcr(pcr_index).into();
 
-        pcr_bank.log_index += 1;
-        *pcr_log = pcr_log_entry;
+        pcr_log_entry.pcr_data = pcr_bank.read_pcr(pcr_index).into();
+        fht.pcr_log_index += 1;
 
         Ok(MailboxResp::default())
     }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -29,37 +29,13 @@ impl ExtendPcrCmd {
                 pcr_id => pcr_id,
             };
 
-        drivers.pcr_bank.extend_pcr_variable(
+        drivers.pcr_bank.extend_pcr(
             pcr_index,
             &mut drivers.sha384,
             &cmd.data
                 .get(..cmd.data_size as usize)
                 .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?,
         )?;
-
-        // 2. Add log entry
-        if PcrLogEntryId::from(idx as u16) == PcrLogEntryId::Invalid {
-            return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_INVALID_ENTRY_ID);
-        }
-
-        let pcr_log = drivers
-            .persistent_data
-            .get_mut()
-            .pcr_log
-            .get_mut(idx as usize)
-            .ok_or(CaliptraError::ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH)?;
-
-        let pcr_bank = &mut drivers.pcr_bank;
-        let fht = &mut drivers.persistent_data.get_mut().fht;
-
-        let mut pcr_log_entry = PcrLogEntry {
-            id: idx as u16,
-            pcr_ids: (1 << PCR_ID_FMC_CURRENT as u8) | 1 << PCR_ID_FMC_JOURNEY as u8,
-            ..Default::default()
-        };
-
-        pcr_log_entry.pcr_data = pcr_bank.read_pcr(pcr_index).into();
-        fht.pcr_log_index += 1;
 
         Ok(MailboxResp::default())
     }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -16,9 +16,11 @@ impl ExtendPcrCmd {
         let pcr_index: PcrId =
             PcrId::try_from(idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
-        drivers
-            .pcr_bank
-            .extend_pcr(pcr_index, &mut drivers.sha384, &cmd.value)?;
+        drivers.pcr_bank.extend_pcr(
+            pcr_index,
+            &mut drivers.sha384,
+            &cmd.data[..cmd.data_size as usize],
+        )?;
 
         Ok(MailboxResp::default())
     }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -29,13 +29,9 @@ impl ExtendPcrCmd {
                 pcr_id => pcr_id,
             };
 
-        drivers.pcr_bank.extend_pcr(
-            pcr_index,
-            &mut drivers.sha384,
-            &cmd.data
-                .get(..cmd.data_size as usize)
-                .ok_or(CaliptraError::DRIVER_PCR_BANK_EXTEND_INVALID_SIZE)?,
-        )?;
+        drivers
+            .pcr_bank
+            .extend_pcr(pcr_index, &mut drivers.sha384, &cmd.data)?;
 
         Ok(MailboxResp::default())
     }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{Drivers};
+use caliptra_common::mailbox_api::{MailboxResp, ExtendPcrReq};
+use caliptra_drivers::{CaliptraError, CaliptraResult, PcrId, Sha384};
+use caliptra_registers::sha512::Sha512Reg;
+use zerocopy::FromBytes;
+
+pub struct ExtendPcrCmd;
+impl ExtendPcrCmd {
+    pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        if let Some(cmd) = ExtendPcrReq::read_from(cmd_args) {
+            // let sha384_engine: &mut Sha384 = &mut drivers.sha384.;
+            let pcr_sha384_engine: &mut Sha384 = unsafe { &mut Sha384::new(Sha512Reg::new())} ;
+            let pcr_value: [u8; ExtendPcrReq::DATA_MAX_SIZE] = cmd.value;
+            let pcr_index: PcrId = PcrId::try_from(u8::try_from(cmd.pcr_idx).unwrap()).unwrap();
+
+            drivers.pcr_bank.extend_pcr( pcr_index, pcr_sha384_engine, &pcr_value)?;
+        } else {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+        
+        Ok(MailboxResp::default())
+    }
+}

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -1,13 +1,18 @@
 // Licensed under the Apache-2.0 license
 
+#[allow(unused_imports)]
+#[allow(dead_code)]
 use crate::Drivers;
 use caliptra_common::mailbox_api::{ExtendPcrReq, MailboxResp};
+use caliptra_common::pcr::{PCR_ID_FMC_CURRENT, PCR_ID_FMC_JOURNEY};
+use caliptra_common::{PcrLogEntry, PcrLogEntryId};
 use caliptra_drivers::{cprint, CaliptraError, CaliptraResult, PcrId};
-use zerocopy::FromBytes;
+use zerocopy::{transmute, AsBytes, FromBytes};
 
 pub struct ExtendPcrCmd;
 impl ExtendPcrCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        // 1. Extend PCR
         let cmd =
             ExtendPcrReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
@@ -27,6 +32,30 @@ impl ExtendPcrCmd {
             &mut drivers.sha384,
             &cmd.data[..cmd.data_size as usize],
         )?;
+
+        // 2. Add log entry
+        if PcrLogEntryId::from(idx as u16) == PcrLogEntryId::Invalid {
+            return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_INVALID_ENTRY_ID);
+        }
+
+        let pcr_log = drivers
+            .persistent_data
+            .get_mut()
+            .pcr_log
+            .get_mut(idx as usize)
+            .ok_or(CaliptraError::ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH)?;
+
+        let pcr_bank = &mut drivers.pcr_bank;
+
+        let mut pcr_log_entry = PcrLogEntry {
+            id: idx as u16,
+            pcr_ids: (1 << PCR_ID_FMC_CURRENT as u8) | 1 << PCR_ID_FMC_JOURNEY as u8,
+            ..Default::default()
+        };
+        pcr_log_entry.pcr_data = pcr_bank.read_pcr(pcr_index).into();
+
+        pcr_bank.log_index += 1;
+        *pcr_log = pcr_log_entry;
 
         Ok(MailboxResp::default())
     }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -2,7 +2,7 @@
 
 use crate::Drivers;
 use caliptra_common::mailbox_api::{ExtendPcrReq, MailboxResp};
-use caliptra_drivers::{CaliptraError, CaliptraResult, PcrId};
+use caliptra_drivers::{cprint, CaliptraError, CaliptraResult, PcrId};
 use zerocopy::FromBytes;
 
 pub struct ExtendPcrCmd;
@@ -13,8 +13,14 @@ impl ExtendPcrCmd {
 
         let idx =
             u8::try_from(cmd.pcr_idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
         let pcr_index: PcrId =
-            PcrId::try_from(idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+            match PcrId::try_from(idx).map_err(|_| CaliptraError::RUNTIME_PCR_INVALID_INDEX)? {
+                PcrId::PcrId0 | PcrId::PcrId1 | PcrId::PcrId2 | PcrId::PcrId3 => {
+                    return Err(CaliptraError::RUNTIME_PCR_RESERVED)
+                }
+                pcr_id => pcr_id,
+            };
 
         drivers.pcr_bank.extend_pcr(
             pcr_index,

--- a/runtime/test-fw/src/wdt_timeout_tests.rs
+++ b/runtime/test-fw/src/wdt_timeout_tests.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    boot_tests.rs
+    wdt_timeout_tests.rs
 
 Abstract:
 

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -878,26 +878,26 @@ fn test_idev_id_cert() {
 #[test]
 fn test_extend_pcr_cmd() {
     let mut model = run_rt_test(None, None);
+    let payload_data = [0u8; 79];
 
-    let payload_data = [0u8; 80];
-
-    let cmd = ExtendPcrReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        pcr_idx: 0,
-        data: payload_data,
-        // data_size: (payload_data.len() - 1) as u32,
-        data_size: (payload_data.len() - 1) as u32,
-    };
+    let cmd = ExtendPcrReq::new(
+        MailboxReqHeader { chksum: 0 },
+        0,
+        (payload_data.len() - 1) as u32,
+        payload_data,
+    );
 
     let checksum = caliptra_common::checksum::calc_checksum(
         u32::from(CommandId::EXTEND_PCR),
         &cmd.as_bytes()[4..],
     );
 
-    let cmd = ExtendPcrReq {
-        hdr: MailboxReqHeader { chksum: checksum },
-        ..cmd
-    };
+    let cmd = ExtendPcrReq::new(
+        MailboxReqHeader { chksum: checksum },
+        cmd.pcr_idx,
+        cmd.data_size,
+        cmd.data,
+    );
 
     let res = model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), &cmd.as_bytes());
     assert!(res.is_ok());

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -945,7 +945,6 @@ fn test_extend_pcr_cmd() {
         .unwrap();
 
         let res = model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), &cmd.as_bytes());
-        // let error_code: u32 = CaliptraError::RUNTIME_PCR_INVALID_INDEX.0.get();
         assert_eq!(
             res,
             Err(ModelError::MailboxCmdFailed(u32::from(

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -927,6 +927,7 @@ fn test_extend_pcr_cmd() {
     assert!(res.is_ok());
 
     // Testing for high entropy test vector
+    // PCR[4]' = sha384(PCR[4] || extension_data) = sha384(0x0...0 || extension_data)
     let mut model = run_rt_test(None, None);
     let extension_data: [u8; ExtendPcrReq::DATA_MAX_SIZE] = [
         225, 73, 188, 244, 110, 120, 121, 204, 185, 203, 86, 129, 104, 186, 33, 110, 125, 116, 216,
@@ -936,6 +937,7 @@ fn test_extend_pcr_cmd() {
 
     // Get ptr to pcrid = 4
     let pcr = model.soc_ifc_pcr();
+    // let entry = pcr.pcr_entry(); // 384 bit pcr register
     let entry = pcr.pcr_entry(); // 384 bit pcr register
 
     // this should be equal to extension_data_sha384_hash, compare byte by byte

--- a/runtime/tests/integration_tests.rs
+++ b/runtime/tests/integration_tests.rs
@@ -12,6 +12,7 @@ use caliptra_common::mailbox_api::{
     MailboxReqHeader, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_drivers::{
+    cprintln,
     sha384::{SHA384_BLOCK_BYTE_SIZE, SHA384_HASH_SIZE},
     CaliptraError, Ecc384PubKey, PcrId,
 };
@@ -937,23 +938,71 @@ fn test_extend_pcr_cmd() {
     // Testing for high entropy test vector
     let mut model = run_rt_test(None, None);
     let payload_data: [u8; ExtendPcrReq::DATA_MAX_SIZE] = [
-        35, 132, 102, 150, 202, 72, 140, 224, 37, 129, 164, 104, 69, 198, 15, 5, 160, 64, 241, 233,
-        110, 136, 79, 238, 246, 146, 166, 165, 129, 108, 40, 15, 155, 76, 138, 220, 122, 239, 26,
-        182, 215, 239, 9, 244, 123, 192, 213, 72, 247, 223, 97, 50, 203, 98, 85, 255, 185, 136,
-        117, 132, 45, 47, 144, 171, 30, 11, 237, 104, 239, 127, 74, 45, 22, 202, 113, 89, 231, 46,
-        208, 185, 237, 115, 123, 223, 231, 246, 254, 103, 112, 39, 33, 159, 23, 201, 17, 64, 144,
-        24, 179, 34, 251, 43, 5, 215, 169, 71, 118, 156, 103, 123, 101, 170, 5, 38, 190, 72, 75,
-        81, 223, 72, 131, 215, 100, 50, 150, 57, 34, 255, 172, 39, 211, 121, 252, 89, 24, 57, 15,
-        255, 175, 12, 201, 179, 23, 247, 117, 169, 254, 227, 206, 220, 210, 169, 217, 42, 172, 102,
-        146, 234, 16, 51, 40, 9, 37, 177, 251, 80, 134, 0, 113, 8, 244, 140, 23, 133, 119, 94, 216,
-        38, 247, 184, 174, 36, 0, 78, 151, 201, 134, 182, 124, 122, 105, 75,
+        225, 73, 188, 244, 110, 120, 121, 204, 185, 203, 86, 129, 104, 186, 33, 110, 125, 116, 216,
+        80, 244, 199, 184, 21, 127, 187, 78, 122, 18, 26, 32, 48, 171, 251, 17, 20, 67, 224, 15,
+        81, 144, 232, 190, 103, 213, 7, 199, 148,
     ];
 
-    let payload_sha384_hash: [u8; SHA384_HASH_SIZE] = [
-        118, 179, 215, 96, 34, 102, 216, 219, 133, 144, 140, 16, 191, 58, 173, 197, 5, 126, 54,
-        163, 244, 213, 225, 215, 116, 209, 132, 29, 2, 87, 24, 197, 160, 47, 74, 26, 201, 136, 9,
-        191, 67, 83, 40, 3, 130, 199, 197, 47,
+    let payload_sha384_hash: [u8; ExtendPcrReq::DATA_MAX_SIZE] = [
+        135, 126, 138, 147, 42, 97, 39, 88, 246, 50, 229, 201, 61, 152, 223, 8, 10, 25, 211, 158,
+        234, 25, 40, 234, 137, 138, 44, 181, 160, 159, 232, 34, 139, 164, 117, 235, 164, 235, 217,
+        65, 40, 55, 233, 50, 178, 217, 62, 107,
     ];
+
+    // Get ptr to pcrid = 4
+    let pcr = model.soc_ifc_pcr();
+    let entry = pcr.pcr_entry();
+
+    for i in 0..32 {
+        cprintln!("[test-pcr] i = {}", i);
+        // this should be equal to payload_data_sha384_hash
+        let e = entry.at(i as usize);
+        for ii in 0..12 {
+            // this fails, but why?
+            let ee = e.at(ii).read();
+            let ee = 0x00;
+            cprintln!("{}", ee);
+        }
+    }
+
+    // let pcr_4 = pcr.pcr_ctrl().at(4);
+    // let r = pcr_4.read();
+    // let rl = r.lock();
+    // let rb = rl.as_bytes();
+    // for i in 0..32 {
+    //     cprint!("{}", rb[i]);
+    // }
+    // cprintln!("");
+
+    // cprintln!("[test-pcr] cp-1");
+    // unsafe {
+    //     cprintln!("[test-pcr] cp0");
+    //     let pcr = Sha512Reg::new();
+    //     cprintln!("[test-pcr] cp1");
+
+    //     let pcr_regs = pcr.regs();
+    //     cprintln!("[test-pcr] cp2");
+
+    //     for index in 0..12 {
+    //         match pcr_regs.digest().get(index as usize) {
+    //             Some(p) => {
+    //                 cprintln!("[test-pcr] {}", &p.read().as_bytes()[0]);
+    //             }
+    //             _ => {
+    //                 cprintln!("[test-pcr] rip");
+    //             }
+    //         }
+    //     }
+    // }
+
+    // Sha384 is stored in 16x32bit registers (sha512) (TMmio.digest()) aka register block
+    // How to read PCR regs from model?
+    // get pv = PvReg sha512pv.pcr_ctrl().at(id.into()).?
+
+    // prob. similar to drivers/test-fw/src/bin/sha384_tests.rs
+    // fn test_pcr_hash_extend_single_block_3() {
+    //     let mut sha384 = unsafe { Sha384::new(Sha512Reg::new()) };
+    //     let mut pcr_bank = unsafe { PcrBank::new(PvReg::new()) };
 
     let cmd = generate_mailbox_extend_pcr_req(4, payload_data.len(), payload_data).unwrap();
     let res = model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), &cmd.as_bytes());

--- a/ureg/src/lib.rs
+++ b/ureg/src/lib.rs
@@ -331,7 +331,7 @@ pub struct RegRef<TReg: RegType, TMmio: Mmio> {
 impl<TReg: RegType, TMmio: Mmio> RegRef<TReg, TMmio> {
     /// Creates a new RegRef from a raw register pointer and Mmio implementation.
     ///
-    /// Using an Mmio implentation other than RealMmio is primarily for
+    /// Using an Mmio implementation other than RealMmio is primarily for
     /// tests or simulations in the build environment.
     ///
     /// # Safety
@@ -368,7 +368,7 @@ impl<TReg: RegType, TMmio: Mmio + Default> RegRef<TReg, TMmio> {
     /// # Safety
     ///
     /// This pointer can be used for volatile reads and writes at any time
-    /// during the lifetime of Self. Callers are reponsible for ensuring that
+    /// during the lifetime of Self. Callers are responsible for ensuring that
     /// their use doesn't conflict with other accesses to this MMIO register.
     #[inline(always)]
     pub fn ptr(&self) -> *mut TReg::Raw {
@@ -387,7 +387,7 @@ impl<TReg: RegType, TMmio: Mmio> FromMmioPtr for RegRef<TReg, TMmio> {
 }
 
 impl<TReg: ReadableReg, TMmio: Mmio> RegRef<TReg, TMmio> {
-    /// Peforms a volatile load from the underlying MMIO register.
+    /// Performs a volatile load from the underlying MMIO register.
     ///
     /// # Example
     ///
@@ -442,7 +442,7 @@ impl<TReg: ReadableReg, TMmio: Mmio> RegRef<TReg, TMmio> {
 }
 
 impl<TReg: ResettableReg + WritableReg, TMmio: MmioMut> RegRef<TReg, TMmio> {
-    /// Peforms a volatile write to the underlying MMIO register.
+    /// Performs a volatile write to the underlying MMIO register.
     ///
     /// The `f` closure is used to build the the register value. It is
     /// immediately called with the reset value of the register, and returns
@@ -587,7 +587,7 @@ impl<TReg: ReadableReg + WritableReg, TMmio: MmioMut> RegRef<TReg, TMmio> {
         unsafe { self.mmio.write_volatile(self.ptr, val.into()) }
     }
 
-    /// Peforms a load-modify-store with the underlying MMIO register.
+    /// Performs a load-modify-store with the underlying MMIO register.
     ///
     /// Same as [`RegRef::modify`], but the closure is also passed the read
     /// value as a parameter.


### PR DESCRIPTION
Initial implementation for the [`EXTEND_PCR`](https://github.com/chipsalliance/caliptra-sw/tree/main/runtime#extend_pcr) mailbox command.