### PR TITLE
Code coverage infra-structure test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
 name = "caliptra-hw-model"
 version = "0.1.0"
 dependencies = [
+ "bit-vec",
  "bitfield",
  "caliptra-builder",
  "caliptra-emu-bus",
@@ -713,12 +714,14 @@ version = "0.1.0"
 name = "caliptra-test"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "asn1",
  "caliptra-builder",
  "caliptra-hw-model",
  "caliptra-hw-model-types",
  "caliptra-runtime",
  "caliptra_common",
+ "elf",
  "openssl",
  "zerocopy",
 ]

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -15,6 +15,7 @@ itrng = ["caliptra-verilated?/itrng"]
 
 [dependencies]
 bitfield.workspace = true
+bit-vec.workspace = true
 caliptra_common = { workspace = true, default-features = false }
 caliptra-emu-bus.workspace = true
 caliptra-emu-cpu.workspace = true

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -56,6 +56,12 @@ pub struct ModelEmulated {
     cpu_enabled: Rc<Cell<bool>>,
 }
 
+impl ModelEmulated {
+    pub fn code_coverage_bitmap(&self) -> &bit_vec::BitVec {
+        self.cpu.code_coverage.code_coverage_bitmap()
+    }
+}
+
 impl crate::HwModel for ModelEmulated {
     type TBus<'a> = EmulatedApbBus<'a>;
 

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -50,6 +50,10 @@ impl CodeCoverage {
             }
         }
     }
+
+    pub fn code_coverage_bitmap(&self) -> &BitVec {
+        &self.bit_vec
+    }
 }
 
 #[derive(PartialEq)]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -8,16 +8,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow.workspace = true
 asn1.workspace = true
+caliptra-builder.workspace = true
 caliptra_common = { workspace = true, default-features = false }
 caliptra-hw-model-types.workspace = true
 caliptra-runtime = { workspace = true, default-features = false }
+elf.workspace = true
 openssl.workspace = true
 zerocopy.workspace = true
+caliptra-hw-model.workspace = true
 
 [dev-dependencies]
 caliptra-builder.workspace = true
-caliptra-hw-model.workspace = true
 openssl.workspace = true
 
 [features]

--- a/test/src/coverage.rs
+++ b/test/src/coverage.rs
@@ -1,0 +1,155 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::Context;
+use caliptra_builder::{build_firmware_elf, FwId};
+use elf::endian::AnyEndian;
+use elf::ElfBytes;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+pub fn collect_instr_pcs(id: &FwId<'static>) -> anyhow::Result<Vec<u32>> {
+    let elf_bytes = build_firmware_elf(id).unwrap();
+
+    let elf_file = ElfBytes::<AnyEndian>::minimal_parse(&elf_bytes)
+        .with_context(|| "Failed to parse elf file")?;
+
+    let (load_addr, text_section) = read_section(&elf_file, ".text", true).unwrap();
+
+    let mut index = 0_usize;
+
+    let mut instr_pcs = Vec::<u32>::new();
+
+    while index < text_section.len() {
+        let instruction = &text_section[index..index + 2];
+        let instruction = u16::from_le_bytes([instruction[0], instruction[1]]);
+
+        match instruction & 0b11 {
+            0 | 1 | 2 => {
+                index += 2;
+            }
+            _ => {
+                index += 4;
+            }
+        }
+        instr_pcs.push(load_addr + index as u32);
+    }
+    Ok(instr_pcs)
+}
+
+/// Read a section from ELF file
+fn read_section<'a>(
+    elf_file: &'a ElfBytes<AnyEndian>,
+    name: &str,
+    required: bool,
+) -> anyhow::Result<(u32, &'a [u8])> {
+    let load_addr: u32;
+    let section = elf_file
+        .section_header_by_name(name)
+        .with_context(|| format!("Failed to find {name} section"))?;
+    if let Some(section) = section {
+        let data = elf_file
+            .section_data(&section)
+            .with_context(|| format!("Failed to read {name} section"))?
+            .0;
+        load_addr = section.sh_addr as u32;
+        Ok((load_addr, data))
+    } else {
+        if required {
+            anyhow::bail!("{} section not found", name)
+        }
+        Ok((0, &[]))
+    }
+}
+
+pub fn parse_trace_file(trace_file_path: &str) -> HashSet<u32> {
+    let mut unique_pcs = HashSet::new();
+
+    // Open the trace file
+    if let Ok(file) = File::open(trace_file_path) {
+        let reader = BufReader::new(file);
+
+        // Iterate through each line in the trace file
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    // Check if the line starts with "pc="
+                    if line.starts_with("pc=") {
+                        // Extract the PC by splitting the line at '=' and parsing the hexadecimal value
+                        if let Some(pc_str) = line.strip_prefix("pc=") {
+                            if let Ok(pc) = u32::from_str_radix(pc_str.trim_start_matches("0x"), 16)
+                            {
+                                unique_pcs.insert(pc);
+                            }
+                        }
+                    }
+                }
+                Err(_) => println!("Trace is malformed"),
+            }
+        }
+    }
+
+    unique_pcs
+}
+
+#[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
+pub mod calculator {
+    use super::*;
+
+    pub fn coverage_from_bitmap(hw: &caliptra_hw_model::ModelEmulated, instr_pcs: &[u32]) -> i32 {
+        let coverage = hw.code_coverage_bitmap();
+
+        let mut hit = 0;
+        for pc in instr_pcs {
+            if coverage[*pc as usize] {
+                hit += 1;
+            }
+        }
+        hit
+    }
+
+    pub fn coverage_from_instr_trace(trace_path: &str, instr_pcs: &[u32]) -> i32 {
+        // Count the nunmer of instructions executed
+        let unique_executed_pcs = parse_trace_file(trace_path);
+        let mut hit = 0;
+        for pc in unique_executed_pcs.iter() {
+            if instr_pcs.contains(pc) {
+                hit += 1;
+            }
+        }
+        hit
+    }
+}
+
+#[test]
+fn test_parse_trace_file() {
+    // Create a temporary trace file for testing
+    let temp_trace_file = "temp_trace.txt";
+    let trace_data = vec![
+        "SoC write4 *0x300300bc <- 0x0",
+        "SoC write4 *0x30030110 <- 0x2625a00",
+        "SoC write4 *0x30030114 <- 0x0",
+        "SoC write4 *0x300300b8 <- 0x1",
+        "pc=0x0",
+        "pc=0x4",
+        "pc=0x4",
+        "pc=0x4",
+        "pc=0x0",
+    ];
+
+    // Write the test data to the temporary trace file
+    std::fs::write(temp_trace_file, trace_data.join("\n"))
+        .expect("Failed to write test trace file");
+
+    // Call the function to parse the test trace file
+    let unique_pcs = parse_trace_file(temp_trace_file);
+
+    // Define the expected unique PCs based on the test data
+    let expected_pcs: HashSet<u32> = vec![0x0, 0x4].into_iter().collect();
+
+    // Assert that the result matches the expected unique PCs
+    assert_eq!(unique_pcs, expected_pcs);
+
+    // Clean up: remove the temporary trace file
+    std::fs::remove_file(temp_trace_file).expect("Failed to remove test trace file");
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+pub mod coverage;
 pub mod crypto;
 pub mod derive;
 pub mod x509;

--- a/test/tests/test_code_coverage.rs
+++ b/test/tests/test_code_coverage.rs
@@ -1,0 +1,39 @@
+// Licensed under the Apache-2.0 license
+#[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
+#[test]
+fn test_emu_coverage() {
+    use caliptra_builder::firmware::ROM_WITH_UART;
+    use caliptra_hw_model::HwModel;
+    use caliptra_hw_model::{BootParams, InitParams};
+    use caliptra_test::coverage::{calculator, collect_instr_pcs};
+
+    const TRACE_PATH: &str = "/tmp/caliptra_coverage_trace.txt";
+
+    std::env::set_var("CPTRA_TRACE_PATH", TRACE_PATH);
+    let instr_pcs = collect_instr_pcs(&ROM_WITH_UART).unwrap();
+
+    let coverage_from_bitmap = {
+        let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+        let mut hw = caliptra_hw_model::new(BootParams {
+            init_params: InitParams {
+                rom: &rom,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .unwrap();
+        // Upload FW
+        hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_fw());
+        calculator::coverage_from_bitmap(&hw, &instr_pcs)
+    };
+
+    println!(
+        "Test coverage using different methods {} , {}",
+        coverage_from_bitmap,
+        calculator::coverage_from_instr_trace(TRACE_PATH, &instr_pcs)
+    );
+    assert_eq!(
+        coverage_from_bitmap,
+        calculator::coverage_from_instr_trace(TRACE_PATH, &instr_pcs)
+    );
+}


### PR DESCRIPTION
This change validates code coverage bitmap support in the sw-emulator using the  sw-emulator's instruction trace feature. 

It derives code coverage for sw-emulator runs by parsing the instruction trace log from the sw-emulator, collecting unique PC executions from the trace and intersecting with the set of PCs from the text section of the ROM elf executables.

- Add trace log parser to the test crate.
- Adds elf text section parsing to the test crate.
- Adds method to retrieve coverage bitmap to the emulated model
- Creates new test to check code coverage bitmap is working properly.