### PR TITLE
Implement ROM freeze policy.

### DIFF
--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,0 +1,26 @@
+name: Policy
+
+on:
+  pull_request:
+
+jobs:
+  check_policy:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Pull dpe submodule
+        run: |
+          git submodule update --init dpe
+
+      - name: Check that the ROM hash matches the frozen one
+        run: ./ci.sh check_frozen_images
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: caliptra-rom.elf
+          path: target/riscv32imc-unknown-none-elf/firmware/caliptra-rom
+

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,0 +1,3 @@
+# WARNING: Do not update this file without the approval of the Caliptra TAC
+02cacb47219b317eb1f83a42269d38cd358e90a1e346397bf1ebcc14e309d21f4fd82fd54745d67537c67eb9ca4c67e3  caliptra-rom-no-log.bin
+dd5769fdafa3ec59eac0b49017a2410b1091693c68583962f67fd73a72380cfd9b0b384c141f67a87160ef108d8e69ba  caliptra-rom-with-log.bin

--- a/builder/no_meta_rustc_wrapper.sh
+++ b/builder/no_meta_rustc_wrapper.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Licensed under the Apache-2.0 license
+
+set -e
+
+is_firmware="false"
+for arg in "$@"; do
+    if [[ ${last_arg} == "--target" ]] && [[ ${arg} == "riscv32imc-unknown-none-elf" ]]; then
+      is_firmware="true"
+    fi
+    last_arg="${arg}"
+done
+
+if [[ $is_firmware == "false" ]]; then
+  # Don't do anything special for non-firmware targets.
+  exec "$@"
+  exit $?
+fi
+
+# rustc accepts a "-C metadata=<DATA>" flag, which is use to feed entropy into the
+# name mangling hash. This is useful in complex Rust software that imports
+# multiple versions of the same crate, as the hash prevents symbol collisions.
+# Unfortunately, Cargo mixes the identity of non-firmware dependencies like
+# openssl used by build.rs into this hash.  There is no way to opt out other
+# than rewriting the rustc arguments with a RUSTC_WRAPPER script (this
+# solution), or using a build system other than Cargo.
+#
+# We can't allow the name mangling hash to change, as that can cause some
+# symbols to be re-ordered by the linker when otherwise
+# non-firmware-binary-affecting build-time deps like openssl are upgraded (for
+# security fixes and whatnot).
+#
+# See https://doc.rust-lang.org/rustc/codegen-options/index.html#metadata for
+# more information
+args=()
+for arg in "$@"; do
+    if [[ ${#args[@]} -gt 0 ]] && [[ ${args[-1]} == "-C" ]] && [[ ${arg} == metadata=* ]]; then
+        # Remove -C
+        unset args[-1]
+    else
+        args+=("${arg}")
+    fi
+done
+
+exec "${args[@]}"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -155,6 +155,12 @@ pub fn build_firmware_elfs_uncached<'a>(
 
         let mut cmd = Command::new(env!("CARGO"));
         cmd.current_dir(workspace_dir);
+
+        cmd.env(
+            "RUSTC_WRAPPER",
+            workspace_dir.join("builder/no_meta_rustc_wrapper.sh"),
+        );
+
         if option_env!("GITHUB_ACTIONS").is_some() {
             // In continuous integration, warnings are always errors.
             cmd.arg("--config")

--- a/ci-tools/release/build_release.sh
+++ b/ci-tools/release/build_release.sh
@@ -9,7 +9,7 @@ rm -rf release
 mkdir -p $WORKSPACE_DIR
 
 # Generate ROM and Image Bundle Binary
-cargo run --manifest-path=builder/Cargo.toml --bin image -- --rom $WORKSPACE_DIR/caliptra-rom.bin --fw $WORKSPACE_DIR/image-bundle.bin
+cargo run --manifest-path=builder/Cargo.toml --bin image -- --rom-with-log $WORKSPACE_DIR/caliptra-rom.bin --fw $WORKSPACE_DIR/image-bundle.bin
 # Generate ROM Hex
 objcopy -I binary -O verilog $WORKSPACE_DIR/caliptra-rom.bin $WORKSPACE_DIR/caliptra-rom.hex
 # Copy ROM ELF
@@ -20,7 +20,7 @@ cp -a target/riscv32imc-unknown-none-elf/firmware/caliptra-fmc $WORKSPACE_DIR/ca
 cp -a target/riscv32imc-unknown-none-elf/firmware/caliptra-runtime $WORKSPACE_DIR/caliptra-runtime.elf
 
 # Generate fake ROM and Image Bundle Binary
-cargo run --manifest-path=builder/Cargo.toml --bin image -- --rom $WORKSPACE_DIR/fake-caliptra-rom.bin --fw $WORKSPACE_DIR/fake-image-bundle.bin --fake
+cargo run --manifest-path=builder/Cargo.toml --bin image -- --fake-rom $WORKSPACE_DIR/fake-caliptra-rom.bin --fake-fw $WORKSPACE_DIR/fake-image-bundle.bin
 # Generate fake ROM Hex
 objcopy -I binary -O verilog $WORKSPACE_DIR/fake-caliptra-rom.bin $WORKSPACE_DIR/fake-caliptra-rom.hex
 # Copy fake ROM ELF

--- a/ci.sh
+++ b/ci.sh
@@ -1,53 +1,123 @@
+#!/bin/bash
+#
 # Licensed under the Apache-2.0 license
 
-#!/bin/bash
 set -e
 
 # Set current directory to script location
 cd "${0%/*}"
+
+ARGC=$#
+ARGV=$@
+
+WORK_DIR="$(mktemp -d)"
+function cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+function optional_task_enabled() {
+    for i in "${ARGV[@]}"; do
+        if [[ $i == $1 ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function task_enabled() {
+    if [ $ARGC -eq 0 ]; then 
+      # If no arguments, run all the non-optional tasks
+      return 0
+    fi
+    optional_task_enabled "$1"
+}
+
+FROZEN_IMAGE_FILE="${PWD}/FROZEN_IMAGES.sha384sum"
 
 # Tell caliptra-builder to make warnings errors
 export GITHUB_ACTIONS=1
 
 EXTRA_CARGO_CONFIG="target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
 
-fw_dir="$(mktemp -d -t caliptra-fw.XXXXXXXXXXX)"
-function cleanup() {
-  rm -rf "${fw_dir}"
-}
-trap cleanup EXIT
+fw_dir="${WORK_DIR}/fw"
+mkdir -p "${fw_dir}"
 
 mkdir -p target-ci
 
 export CARGO_TARGET_DIR="${PWD}/target-ci"
 
-cargo tree --locked > /dev/null || (
-  echo "Please include required changes to Cargo.lock in your pull request"
-  # Without the --locked flag, cargo will do the minimal possible update to Cargo.lock
-  cargo tree > /dev/null 2> /dev/null
-  # Print out the differences to ease debugging
-  git diff Cargo.lock
-  exit 1
-)
+function build_rom_images() {
+    rm -rf "${CARGO_TARGET_DIR}/riscv32imc-unknown-none-elf"
+    CALIPTRA_IMAGE_NO_GIT_REVISION=1 cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-builder -- \
+        --rom-with-log "${WORK_DIR}/caliptra-rom-with-log.bin"
+    rm -rf "${CARGO_TARGET_DIR}/riscv32imc-unknown-none-elf"
+    CALIPTRA_IMAGE_NO_GIT_REVISION=1 cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-builder -- \
+        --rom-no-log "${WORK_DIR}/caliptra-rom-no-log.bin"
+}
 
-echo Check source code formatting
-cargo fmt --check --all
 
-echo Clippy lint check
-RUSTFLAGS="-Dwarnings" cargo clippy --locked --all-targets -- -D warnings
+if task_enabled "check_cargo_lock"; then
+  cargo tree --locked > /dev/null || (
+    echo "Please include required changes to Cargo.lock in your pull request"
+    # Without the --locked flag, cargo will do the minimal possible update to Cargo.lock
+    cargo tree > /dev/null 2> /dev/null
+    # Print out the differences to ease debugging
+    git diff Cargo.lock
+    exit 1
+  )
+fi
 
-echo Check license headers 
-cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-file-header-fix --locked -- --check
+if task_enabled "check_fmt"; then
+  echo Check source code formatting
+  cargo fmt --check --all
+fi
 
-echo Build
-cargo --config "${EXTRA_CARGO_CONFIG}" build --locked
 
-echo Build firmware images
-cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-builder  -- --all_elfs "${fw_dir}"
+if task_enabled "check_lint"; then
+  echo Clippy lint check
+  RUSTFLAGS="-Dwarnings" cargo clippy --locked --all-targets -- -D warnings
+fi
 
-echo Run tests
-if cargo nextest help > /dev/null 2>/dev/null; then
-  CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked
-else
-  CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked
+if task_enabled "check_license"; then
+  echo Check license headers
+  cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-file-header-fix --locked -- --check
+fi
+
+if task_enabled "build"; then
+  echo Build
+  cargo --config "${EXTRA_CARGO_CONFIG}" build --locked
+fi
+
+if task_enabled "build_fw"; then
+  echo Build firmware images
+  cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-builder  -- --all_elfs "${fw_dir}"
+fi
+
+if task_enabled "test"; then
+  echo Run tests
+  if cargo nextest help > /dev/null 2>/dev/null; then
+    CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked
+  else
+    CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked
+  fi
+fi
+
+if task_enabled "check_frozen_images"; then
+    echo Checking frozen images
+    build_rom_images
+    (cd "${WORK_DIR}" && sha384sum -c "${FROZEN_IMAGE_FILE}") || (
+        echo "The Caliptra ROM is frozen; changes that affect the binary"
+        echo "require approval from the TAC."
+        echo
+        echo "If you have approval, run ./ci.sh update_frozen_images"
+        false
+    )
+fi
+if optional_task_enabled "update_frozen_images"; then
+    echo "Updating frozen images"
+    build_rom_images
+
+    echo "# WARNING: Do not update this file without the approval of the Caliptra TAC" > "${FROZEN_IMAGE_FILE}"
+    (cd "${WORK_DIR}" && sha384sum caliptra-rom-no-log.bin caliptra-rom-with-log.bin) >> "${FROZEN_IMAGE_FILE}"
 fi

--- a/hw-model/c-binding/examples/Makefile
+++ b/hw-model/c-binding/examples/Makefile
@@ -43,6 +43,6 @@ clean:
 	$(RM) -rf $(OUT)
 
 run: $(TARGET)
-	cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom $(OUT)/caliptra_rom.bin --fw $(OUT)/image_bundle.bin
+	cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom-with-log $(OUT)/caliptra_rom.bin --fw $(OUT)/image_bundle.bin
 	$(TARGET) -r $(OUT)/caliptra_rom.bin -f $(OUT)/image_bundle.bin
 

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -47,7 +47,7 @@ $(ROM_FILE) $(FW_FILE):
 	@echo [IMAGE] caliptra_rom.bin image_bundle.bin
 	$(Q)make -C ../../../rom/dev
 	$(Q)cd ../../../runtime && ./build.sh
-	$(Q)cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom $(ROM_FW_DIR)/caliptra_rom.bin --fw $(ROM_FW_DIR)/image_bundle.bin
+	$(Q)cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom-with-log $(ROM_FW_DIR)/caliptra_rom.bin --fw $(ROM_FW_DIR)/image_bundle.bin
 
 $(HWMODEL_BINDING_LIB_OBJ):
 	@echo "[CARGO] c-binding"

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -109,7 +109,7 @@ build-rom:
 	cargo \
 		"--config=$(EXTRA_CARGO_CONFIG)" \
 		run -p caliptra-builder -- \
-		--rom $(TARGET_DIR)/caliptra-rom.bin \
+		--rom-with-log $(TARGET_DIR)/caliptra-rom.bin \
 		--fw /dev/null
 
 run: build-emu build-fw-image build-rom


### PR DESCRIPTION
Please review each commit independently.

The desired ROM digests are stored in caliptra-sw/FROZEN_IMAGES.sha384sum. They can be updated with `./ci.sh update_frozen_images`, but PR reviewers should ensure that this file isn't changed unless the TAC has approved the change (and the file contains a warning comment to this effect).

Once this PR is merged I will go into the GitHub repo settings and make this policy check required for merge. We can add additional codeowners restrictions against FROZEN_IMAGES.sha384sum in a future PR if desired. 

Example failure:

https://github.com/chipsalliance/caliptra-sw/actions/runs/6231914917/job/16914186158?pr=812