### PR TITLE
Fix race when building same binary with different features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "clap",
  "elf",
  "hex",
+ "nix 0.26.2",
  "once_cell",
  "openssl",
  "zerocopy",

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -17,6 +17,7 @@ caliptra-image-types.workspace = true
 clap.workspace = true
 elf.workspace = true
 hex.workspace = true
+nix.workspace = true
 once_cell.workspace = true
 openssl.workspace = true
 zerocopy.workspace = true


### PR DESCRIPTION
To prevent a race condition with concurrent calls to caliptra-builder from other threads or processes, we now hold a lock until we've read the output binary from the filesystem (it's possible that another concurrent process will build the same binary with different features before we get a chance to read it).

I believe this race condition is responsible for intermittent test failures of the FMC's test_fht_info() and test_pcr_log() tests in the GHA environment.