### PR TITLE
Remove unnecessary vendor key hashing code.

### DIFF
--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -171,27 +171,6 @@ impl ImageManifest {
         span.start as u32 + offset..span.end as u32 + offset
     }
 
-    /// Returns the `Range<u32>` containing the specified vendor public key,
-    /// or an empty range if the index is invalid.
-    pub fn vendor_ecc_pub_key_range(vendor_ecc_pub_key_idx: u32) -> Range<u32> {
-        if vendor_ecc_pub_key_idx > VENDOR_ECC_KEY_COUNT {
-            return 0..0;
-        }
-
-        let pub_key_size = (2 * 4 * ECC384_SCALAR_WORD_SIZE) as u32;
-        let range = Self::vendor_pub_keys_range();
-
-        // Sanity check
-        if (range.len() as u32) < VENDOR_ECC_KEY_COUNT * pub_key_size {
-            return 0..0;
-        }
-
-        let offset = (offset_of!(ImageVendorPubKeys, ecc_pub_keys) as u32)
-            + vendor_ecc_pub_key_idx * pub_key_size;
-
-        range.start + offset..range.start + offset + pub_key_size
-    }
-
     /// Returns `Range<u32>` containing the owner public key
     pub fn owner_pub_key_range() -> Range<u32> {
         let offset = offset_of!(ImageManifest, preamble) as u32;

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -84,9 +84,6 @@ pub struct ImageVerificationInfo {
     /// Vendor LMS public key index
     pub vendor_lms_pub_key_idx: Option<u32>,
 
-    /// Digest of vendor public keys that verified the image
-    pub vendor_pub_keys_digest: ImageDigest,
-
     /// Digest of owner public keys that verified the image
     pub owner_pub_keys_digest: ImageDigest,
 

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -112,7 +112,6 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         let info = ImageVerificationInfo {
             vendor_ecc_pub_key_idx: header_info.vendor_ecc_pub_key_idx,
             vendor_lms_pub_key_idx: header_info.vendor_lms_pub_key_idx,
-            vendor_pub_keys_digest: self.make_vendor_key_digest(header_info)?,
             owner_pub_keys_digest: header_info.owner_pub_keys_digest,
             fmc: fmc_info,
             runtime: runtime_info,
@@ -690,23 +689,6 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         };
 
         Ok((info, log_info))
-    }
-
-    /// Calculates a digest of the vendor key that signed the image.
-    ///
-    /// TODO: include the LMS key in the digest.
-    // Inlined to reduce ROM size
-    #[inline(always)]
-    fn make_vendor_key_digest(&mut self, info: &HeaderInfo) -> CaliptraResult<ImageDigest> {
-        let range = ImageManifest::vendor_ecc_pub_key_range(info.vendor_ecc_pub_key_idx);
-
-        if range.is_empty() {
-            Err(CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS)?;
-        }
-
-        self.env
-            .sha384_digest(range.start, range.len() as u32)
-            .map_err(|_| CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_FAILURE)
     }
 
     /// Calculates the effective fuse SVN.


### PR DESCRIPTION
This is essentially a rollback of https://github.com/chipsalliance/caliptra-sw/pull/233/. The hash was intended to be placed in PCRs and the alias certificate, but this was never implemented, and is actually unneeded because we attest to the vendor key hash as well as the ECC and LMS key indices.