### PR TITLE
Validate DPE Instance in SRAM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 [[package]]
 name = "platform"
 version = "0.1.0"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -344,6 +344,8 @@ impl CaliptraError {
     pub const RUNTIME_FMC_CERT_HANDOFF_FAILED: CaliptraError = CaliptraError::new_const(0x000E0019);
     pub const RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL: CaliptraError =
         CaliptraError::new_const(0x000E001A);
+    pub const RUNTIME_DPE_VALIDATION_FAILED: CaliptraError = CaliptraError::new_const(0x000E001B);
+    pub const RUNTIME_UNKNOWN_RESET_FLOW: CaliptraError = CaliptraError::new_const(0x000E001C);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -3,6 +3,7 @@
 use core::cmp::min;
 
 use arrayvec::ArrayVec;
+use caliptra_drivers::cprintln;
 use crypto::Digest;
 use dpe::{
     x509::{Name, X509CertWriter},
@@ -92,5 +93,10 @@ impl Platform for DpePlatform<'_> {
             .map_err(|_| PlatformError::IssuerNameError)?;
 
         Ok(issuer_len)
+    }
+
+    fn write_str(&mut self, str: &str) -> Result<(), PlatformError> {
+        cprintln!("{}", str);
+        Ok(())
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -179,11 +179,12 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         let reset_reason = drivers.soc_ifc.reset_reason();
         if reset_reason == ResetReason::WarmReset {
             let mut result = DisableAttestationCmd::execute(drivers);
-            if result.is_ok() {
-                cprintln!("Disabled attestation due to cmd busy during warm reset");
-                drivers.mbox.set_status(MboxStatusE::DataReady);
-            } else {
-                return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+            match result {
+                Ok(_) => cprintln!("Disabled attestation due to cmd busy during warm reset"),
+                Err(e) => {
+                    cprintln!("{}", e.0);
+                    return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+                }
             }
         }
     }

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -39,9 +39,11 @@ const BANNER: &str = r#"
 #[allow(clippy::empty_loop)]
 pub extern "C" fn entry_point() -> ! {
     cprintln!("{}", BANNER);
-    let mut drivers = unsafe { Drivers::new_from_registers() }.unwrap_or_else(|e| {
-        caliptra_common::report_handoff_error_and_halt("Runtime can't load drivers", e.into())
-    });
+    let mut drivers = unsafe {
+        Drivers::new_from_registers().unwrap_or_else(|e| {
+            caliptra_common::report_handoff_error_and_halt("Runtime can't load drivers", e.into())
+        })
+    };
     if !drivers.persistent_data.get().fht.is_valid() {
         caliptra_common::report_handoff_error_and_halt(
             "Runtime can't load FHT",


### PR DESCRIPTION
In RT-fw, if we are not in a cold reset, we are expected to use the DPE instance in SRAM. Before we use it, we need to validate it to ensure that the DPE context tree is well-formed (the array representing the contexts is actually a tree) and verify that the current TCI measurement of the root TCI node matches the latest runtime PCR value. Otherwise, we disable attestation.