### PR TITLE
caliptra-builder: Create target dir if it doesn't exist.

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -150,6 +150,7 @@ pub fn build_firmware_elf_uncached(id: &FwId) -> io::Result<Vec<u8>> {
     // from other threads or processes, hold a lock until we've read the output
     // binary from the filesystem (it's possible that another thread will build
     // the same binary with different features before we get a chance to read it).
+    let _ = fs::create_dir(workspace_dir.join("target"));
     let lock = File::create(workspace_dir.join("target/.caliptra-builder.lock"))?;
     nix::fcntl::flock(lock.as_raw_fd(), FlockArg::LockExclusive)?;
 

--- a/ci-tools/size-history/src/main.rs
+++ b/ci-tools/size-history/src/main.rs
@@ -22,7 +22,7 @@ use crate::{cache_gha::GithubActionCache, util::other_err};
 
 // Increment with non-backwards-compatible changes are made to the cache record
 // format
-const CACHE_FORMAT_VERSION: &str = "v1";
+const CACHE_FORMAT_VERSION: &str = "v2";
 
 #[derive(Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 struct Sizes {


### PR DESCRIPTION
This fixes the "No such file or directory" size-history workflow regression caused by #815. Spoil the cache key to regenerate everything.