### PR TITLE
[fix] MailboxSendTxn::drop implementation is not exhaustive.

### DIFF
--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -27,6 +27,11 @@ emu = ["caliptra-test-harness/emu"]
 riscv = ["caliptra-test-harness/riscv"]
 
 [[bin]]
+name = "mbox_send_txn_drop"
+path = "src/bin/mbox_send_txn_drop.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "sha1"
 path = "src/bin/sha1_tests.rs"
 required-features = ["riscv"]
@@ -160,3 +165,4 @@ required-features = ["riscv"]
 name = "trng_driver_responder"
 path = "src/bin/trng_driver_responder.rs"
 required-features = ["riscv"]
+

--- a/drivers/test-fw/src/bin/mbox_send_txn_drop.rs
+++ b/drivers/test-fw/src/bin/mbox_send_txn_drop.rs
@@ -1,0 +1,62 @@
+// Licensed under the Apache-2.0 license
+
+//! A very simple program that uses the driver to send mailbox messages
+
+#![no_main]
+#![no_std]
+
+use caliptra_registers::mbox::MboxCsr;
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::{self, println};
+
+use caliptra_drivers::{self, Mailbox};
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    let mbox = unsafe { MboxCsr::new() };
+    println!(
+        "locked state is  {} mailbox present state is {} is in error {}",
+        mbox.regs().lock().read().lock(),
+        mbox.regs().status().read().mbox_fsm_ps() as u32,
+        mbox.regs().status().read().mbox_fsm_ps().mbox_error() as u32
+    );
+    loop {}
+}
+
+fn mbox_fsm_error() -> bool {
+    let mbox = unsafe { MboxCsr::new() };
+    mbox.regs().status().read().mbox_fsm_ps().mbox_error()
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    let mut mbox = Mailbox::new(unsafe { MboxCsr::new() });
+
+    // Transition from execute to idle
+    let mut txn = mbox.try_start_send_txn().unwrap();
+    txn.write_cmd(0).unwrap();
+    txn.write_dlen(1).unwrap();
+    txn.execute_request().unwrap();
+    drop(txn);
+    assert_eq!(mbox_fsm_error(), false);
+
+    // Transition from rdy_for_data to idle
+    let mut txn = mbox.try_start_send_txn().unwrap();
+    txn.write_cmd(0).unwrap();
+    txn.write_dlen(1).unwrap();
+    drop(txn);
+    assert_eq!(mbox_fsm_error(), false);
+
+    // Transition from rdy_for_dlen to idle
+    let mut txn = mbox.try_start_send_txn().unwrap();
+    txn.write_cmd(0).unwrap();
+    drop(txn);
+    assert_eq!(mbox_fsm_error(), false);
+
+    // Transition from rdy_for_cmd to idle
+    let txn = mbox.try_start_send_txn().unwrap();
+    drop(txn);
+    assert_eq!(mbox_fsm_error(), false);
+    let _ = mbox.try_start_send_txn().unwrap();
+}

--- a/drivers/tests/integration_tests.rs
+++ b/drivers/tests/integration_tests.rs
@@ -1031,3 +1031,8 @@ fn test_uart() {
     model.copy_output_until_exit_success(&mut output).unwrap();
     assert_eq!(&output, b"aaaaaahello");
 }
+
+#[test]
+fn test_mailbox_txn_drop() {
+    run_driver_test("mbox_send_txn_drop");
+}

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -265,15 +265,17 @@ impl MailboxRegs {
 
     // Todo: Implement read_lock callback fn
     pub fn read_lock(&mut self, _size: RvSize) -> Result<u32, BusError> {
-        if self
+        // If state is not idle mailbox is locked.
+        let result = match self.state_machine.state() {
+            States::Idle => Ok(0),
+            _ => Ok(1),
+        };
+        // Deliver event to the state machine.
+        let _ = self
             .state_machine
-            .process_event(Events::RdLock(self.requester))
-            .is_ok()
-        {
-            Ok(0)
-        } else {
-            Ok(1)
-        }
+            .process_event(Events::RdLock(self.requester));
+
+        result
     }
 
     // Todo: Implement read_user callback fn


### PR DESCRIPTION
- The drop implementation of the MailboxSendTxn  type  is not exhaustive. The risk/impact is Caliptra can leave the mailbox locked when aborting a mailbox send transaction. This change address this gap by using the unlock feature of the mailbox.  Unlock operation takes the mailbox state machine to idle regardless of the state.  
- The sw-emulator was not returning the lock state correctly for all cases.
- Tests are included that exercise all transition arcs to idle.

