### PR TITLE
Adding comments on the use of the lms_sign function

### DIFF
--- a/image/openssl/src/lib.rs
+++ b/image/openssl/src/lib.rs
@@ -87,6 +87,10 @@ impl ImageGeneratorCrypto for OsslCrypto {
         Ok(image_sig)
     }
 
+    // This function is here as a convenience for creating test images.
+    // This function uses the same Q value for each signature which is
+    // insecure, a Q value must be used at most one time.  In practice
+    // the digest should be passed to a FIPS approved HSM for signature.
     fn lms_sign(
         &self,
         digest: &ImageDigest,


### PR DESCRIPTION
Adding comments to the lms_sign function to clarify that this function is only used as a convenience and the reuse of a Q value is only for testing purposes.  Real images should be signed by a FIPS certified HSM.