### PR TITLE
[fix] TOCTOU Condition in SHA-512 Accelerator Lock Acquisition

### DIFF
--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -34,7 +34,10 @@ impl<'a> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a> {
     /// Calculate Digest using SHA-384 Accelerator
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest> {
         loop {
-            if let Some(mut txn) = self.sha384_acc.try_start_operation() {
+            if let Some(mut txn) = self
+                .sha384_acc
+                .try_start_operation(ShaAccLockState::NotAcquired)?
+            {
                 let mut digest = Array4x12::default();
                 txn.digest(len, offset, false, &mut digest)?;
                 return Ok(digest.0);

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -86,7 +86,7 @@ pub use persistent::{
 pub use sha1::{Sha1, Sha1Digest, Sha1DigestOp};
 pub use sha256::{Sha256, Sha256Alg, Sha256DigestOp};
 pub use sha384::{Sha384, Sha384Digest, Sha384DigestOp};
-pub use sha384acc::{Sha384Acc, Sha384AccOp};
+pub use sha384acc::{Sha384Acc, Sha384AccOp, ShaAccLockState};
 pub use soc_ifc::{report_boot_status, Lifecycle, MfgFlags, ResetReason, SocIfc};
 pub use trng::Trng;
 

--- a/drivers/test-fw/src/bin/sha384acc_tests.rs
+++ b/drivers/test-fw/src/bin/sha384acc_tests.rs
@@ -15,7 +15,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
-use caliptra_drivers::{Array4x12, Mailbox, Sha384Acc};
+use caliptra_drivers::{Array4x12, Mailbox, Sha384Acc, ShaAccLockState};
 use caliptra_kat::Sha384AccKat;
 use caliptra_registers::mbox::MboxCsr;
 use caliptra_registers::sha512_acc::Sha512AccCsr;
@@ -41,7 +41,10 @@ fn test_digest0() {
         assert!(txn.send_request(CMD, &data).is_ok());
 
         let mut digest = Array4x12::default();
-        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+        if let Some(mut sha_acc_op) = sha_acc
+            .try_start_operation(ShaAccLockState::NotAcquired)
+            .unwrap()
+        {
             let result = sha_acc_op.digest(data.len() as u32, 0, false, (&mut digest).into());
             assert!(result.is_ok());
             assert_eq!(digest, Array4x12::from(expected));
@@ -70,7 +73,10 @@ fn test_digest1() {
         assert!(txn.send_request(CMD, &data).is_ok());
 
         let mut digest = Array4x12::default();
-        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+        if let Some(mut sha_acc_op) = sha_acc
+            .try_start_operation(ShaAccLockState::NotAcquired)
+            .unwrap()
+        {
             let result = sha_acc_op.digest(data.len() as u32, 0, false, (&mut digest).into());
             assert!(result.is_ok());
             assert_eq!(digest, Array4x12::from(expected));
@@ -100,7 +106,10 @@ fn test_digest2() {
         const CMD: u32 = 0x1c;
         assert!(txn.send_request(CMD, &data).is_ok());
 
-        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+        if let Some(mut sha_acc_op) = sha_acc
+            .try_start_operation(ShaAccLockState::NotAcquired)
+            .unwrap()
+        {
             let result = sha_acc_op.digest(data.len() as u32, 0, false, (&mut digest).into());
             assert!(result.is_ok());
             assert_eq!(digest, Array4x12::from(expected));
@@ -130,7 +139,10 @@ fn test_digest_offset() {
         const CMD: u32 = 0x1c;
         assert!(txn.send_request(CMD, &data).is_ok());
 
-        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+        if let Some(mut sha_acc_op) = sha_acc
+            .try_start_operation(ShaAccLockState::NotAcquired)
+            .unwrap()
+        {
             let result = sha_acc_op.digest(8, 4, false, (&mut digest).into());
             assert!(result.is_ok());
             assert_eq!(digest, Array4x12::from(expected));
@@ -153,7 +165,10 @@ fn test_digest_zero_size_buffer() {
     ];
 
     let mut digest = Array4x12::default();
-    if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+    if let Some(mut sha_acc_op) = sha_acc
+        .try_start_operation(ShaAccLockState::NotAcquired)
+        .unwrap()
+    {
         let result = sha_acc_op.digest(0, 0, true, (&mut digest).into());
         assert!(result.is_ok());
         assert_eq!(digest, Array4x12::from(expected));
@@ -174,7 +189,10 @@ fn test_digest_max_mailbox_size() {
     ];
 
     let mut digest = Array4x12::default();
-    if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+    if let Some(mut sha_acc_op) = sha_acc
+        .try_start_operation(ShaAccLockState::NotAcquired)
+        .unwrap()
+    {
         let result = sha_acc_op.digest(
             MAX_MAILBOX_CAPACITY_BYTES as u32,
             0,
@@ -191,7 +209,12 @@ fn test_digest_max_mailbox_size() {
 
 fn test_kat() {
     let mut sha_acc = unsafe { Sha384Acc::new(Sha512AccCsr::new()) };
-    assert_eq!(Sha384AccKat::default().execute(&mut sha_acc).is_ok(), true);
+    assert_eq!(
+        Sha384AccKat::default()
+            .execute(&mut sha_acc, ShaAccLockState::AssumedLocked)
+            .is_ok(),
+        true
+    );
 }
 
 test_suite! {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -52,6 +52,10 @@ impl CaliptraError {
     pub const DRIVER_SHA384_INDEX_OUT_OF_BOUNDS: CaliptraError =
         CaliptraError::new_const(0x0003000B);
 
+    /// Driver Error: SHA384ACC
+    pub const DRIVER_SHA384ACC_UNEXPECTED_ACQUIRED_LOCK_STATE: CaliptraError =
+        CaliptraError::new_const(0x00038000);
+
     /// Driver Error: HMAC384
     pub const DRIVER_HMAC384_READ_KEY_KV_READ: CaliptraError = CaliptraError::new_const(0x00040001);
     pub const DRIVER_HMAC384_READ_KEY_KV_WRITE: CaliptraError =

--- a/kat/src/kats_env.rs
+++ b/kat/src/kats_env.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_drivers::{Ecc384, Hmac384, Lms, Sha1, Sha256, Sha384, Sha384Acc, Trng};
+use caliptra_drivers::{
+    Ecc384, Hmac384, Lms, Sha1, Sha256, Sha384, Sha384Acc, ShaAccLockState, Trng,
+};
 
 pub struct KatsEnv<'a> {
     // SHA1 Engine
@@ -26,4 +28,7 @@ pub struct KatsEnv<'a> {
 
     /// Ecc384 Engine
     pub ecc384: &'a mut Ecc384,
+
+    /// SHA Acc Lock State
+    pub sha_acc_lock_state: ShaAccLockState,
 }

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -53,7 +53,7 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
     Sha384Kat::default().execute(env.sha384)?;
 
     cprintln!("[kat] SHA2-384-ACC");
-    Sha384AccKat::default().execute(env.sha384_acc)?;
+    Sha384AccKat::default().execute(env.sha384_acc, env.sha_acc_lock_state)?;
 
     cprintln!("[kat] ECC-384");
     Ecc384Kat::default().execute(env.ecc384, env.trng)?;

--- a/kat/src/sha384acc_kat.rs
+++ b/kat/src/sha384acc_kat.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 use crate::sha384_kat::SHA384_EXPECTED_DIGEST;
-use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult, Sha384Acc};
+use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult, Sha384Acc, ShaAccLockState};
 
 #[derive(Default)]
 pub struct Sha384AccKat {}
@@ -26,19 +26,28 @@ impl Sha384AccKat {
     /// # Arguments
     ///
     /// * `sha_acc` - SHA2-384 Accelerator Driver
+    /// * `lock_state` - SHA Acc Lock State
     ///
     /// # Returns
     ///
     /// * `CaliptraResult` - Result denoting the KAT outcome.
-    pub fn execute(&self, sha_acc: &mut Sha384Acc) -> CaliptraResult<()> {
-        self.kat_no_data(sha_acc)?;
+    pub fn execute(
+        &self,
+        sha_acc: &mut Sha384Acc,
+        lock_state: ShaAccLockState,
+    ) -> CaliptraResult<()> {
+        self.kat_no_data(sha_acc, lock_state)?;
         Ok(())
     }
 
-    fn kat_no_data(&self, sha_acc: &mut Sha384Acc) -> CaliptraResult<()> {
+    fn kat_no_data(
+        &self,
+        sha_acc: &mut Sha384Acc,
+        lock_state: ShaAccLockState,
+    ) -> CaliptraResult<()> {
         let mut digest = Array4x12::default();
 
-        if let Some(mut sha_acc_op) = sha_acc.try_start_operation() {
+        if let Some(mut sha_acc_op) = sha_acc.try_start_operation(lock_state)? {
             sha_acc_op
                 .digest(0, 0, false, &mut digest)
                 .map_err(|_| CaliptraError::ROM_KAT_SHA384_ACC_DIGEST_FAILURE)?;

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -86,6 +86,9 @@ impl FirmwareProcessor {
 
             /// Ecc384 Engine
             ecc384: &mut env.ecc384,
+
+            /// SHA Acc lock state
+            sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };
         // Process mailbox commands.
         let mut txn = Self::process_mailbox_commands(

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -22,7 +22,7 @@ use core::hint::black_box;
 
 use caliptra_drivers::{
     cprintln, report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError, Ecc384, Hmac384,
-    KeyVault, Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, SocIfc,
+    KeyVault, Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, ShaAccLockState, SocIfc,
 };
 use caliptra_error::CaliptraResult;
 use caliptra_image_types::RomInfo;
@@ -101,6 +101,8 @@ pub extern "C" fn rom_entry() -> ! {
     // Start the watchdog timer
     wdt::start_wdt(&mut env.soc_ifc);
 
+    let reset_reason = env.soc_ifc.reset_reason();
+
     if !cfg!(feature = "fake-rom") {
         let mut kats_env = caliptra_kat::KatsEnv {
             // SHA1 Engine
@@ -126,14 +128,22 @@ pub extern "C" fn rom_entry() -> ! {
 
             /// Ecc384 Engine
             ecc384: &mut env.ecc384,
+
+            /// SHA Acc lock state.
+            /// SHA Acc is guaranteed to be locked on Cold and Warm Resets;
+            /// On an Update Reset, it is expected to be unlocked.
+            /// Not having it unlocked will result in a fatal error.
+            sha_acc_lock_state: if reset_reason == ResetReason::UpdateReset {
+                ShaAccLockState::NotAcquired
+            } else {
+                ShaAccLockState::AssumedLocked
+            },
         };
         let result = run_fips_tests(&mut kats_env);
         if let Err(err) = result {
             handle_fatal_error(err.into());
         }
     }
-
-    let reset_reason = env.soc_ifc.reset_reason();
 
     if let Err(err) = flow::run(&mut env) {
         //

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -46,7 +46,7 @@ pub mod fips_self_test_cmd {
     use caliptra_common::{
         verifier::FirmwareImageVerificationEnv, FMC_ORG, FMC_SIZE, RUNTIME_ORG, RUNTIME_SIZE,
     };
-    use caliptra_drivers::ResetReason;
+    use caliptra_drivers::{ResetReason, ShaAccLockState};
     use caliptra_image_types::RomInfo;
     use caliptra_image_verify::ImageVerifier;
     use zerocopy::AsBytes;
@@ -145,6 +145,9 @@ pub mod fips_self_test_cmd {
 
             /// Ecc384 Engine
             ecc384: &mut env.ecc384,
+
+            /// SHA Acc Lock State
+            sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };
 
         caliptra_kat::execute_kat(&mut kats_env)?;


### PR DESCRIPTION
This fix addresses https://github.com/chipsalliance/caliptra-sw/issues/841 On a Cold/Warm Reset, the SHA accelerator is guaranteed to be locked for Caliptra. On a hitless update (aka Update Reset), it is expected that the SOC keeps the SHA Acc. unlocked. Given these guarantees, this change addresses the issue by passing the lock state information to the SHA Acc driver, which then acts on it by either attempting to acquire the SHA acc. lock or assuming it is already locked.