### PR TITLE
Caliptra C API libcaliptra asynchronous send/receive support

### DIFF
--- a/libcaliptra/examples/generic/main.c
+++ b/libcaliptra/examples/generic/main.c
@@ -60,50 +60,73 @@ int main(int argc, char *argv[])
 
     // Load Image Bundle
     // FW_PATH is defined on the compiler command line
-    caliptra_upload_fw(&image_bundle);
+    status = caliptra_upload_fw(&image_bundle, false);
 
-    // Run Until RT is ready to receive commands
-    struct caliptra_fips_version version;
-    while(1) {
-        caliptra_wait();
-        status = caliptra_get_fips_version(&version);
+    if (status)
+    {
+        printf("FW Load Failed: %x\n", status);
+    }
+    else
+    {
+        printf("FW Load: OK\n");
+    }
+
+    // Send a FIPS version command in async mode
+    if (!status) {
+        struct caliptra_fips_version version;
+        // Send async
+        status = caliptra_get_fips_version(&version, true);
+
+        if (status) {
+            printf("Get FIPS Version send failed: %x\n", status);
+        } else {
+            // Wait indefinitely for completion
+            while (!caliptra_test_for_completion()){
+                caliptra_wait();
+            }
+
+            status = caliptra_complete();
+        }
+
         if (status)
         {
-            printf("Get FIPS Version failed!\n");
-            break;
+            printf("Get FIPS Version failed: %x\n", status);
         }
         else
         {
             printf("FIPS_VERSION = mode: 0x%x, fips_rev (0x%x, 0x%x, 0x%x), name %s \n", version.mode,
                 version.fips_rev[0], version.fips_rev[1], version.fips_rev[2], version.name);
         }
+    }
 
+    // Send a stash measurement command with async off
+    if (!status) {
         // Need some representative values for these, see below.
         struct caliptra_stash_measurement_req r = {0};
         struct caliptra_stash_measurement_resp c = {0};
 
-        status = caliptra_stash_measurement(&r, &c);
+        status = caliptra_stash_measurement(&r, &c, false);
 
         if (status)
         {
-            printf("Stash measurement failed!\n");
+            printf("Stash measurement failed: %x\n", status);
         }
         else
         {
             printf("Stash measurement: OK\n");
         }
-
-        break;
     }
 
     if (status)
     {
-        printf("Caliptra C API Integration Test Failed: %x\n", status);
+        printf("Caliptra C API Integration Test Failed: 0x%x\n", status);
+        printf("Caliptra FW error non-fatal code is 0x%x\n", caliptra_read_fw_non_fatal_error());
+        printf("Caliptra FW error fatal code is 0x%x\n", caliptra_read_fw_fatal_error());
     }
     else
     {
-        printf("Caliptr a C API Integration Test Passed!\n");
+        printf("Caliptra C API Integration Test Passed!\n");
     }
 
-    return 0;
+    return status;
 }

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -11,32 +11,87 @@
 #define ARRAY_SIZE(array) ((size_t)(sizeof(array) / sizeof(array[0])))
 
 // Write into Caliptra BootFSM Go Register
+// returns: 0                       - Success
 int caliptra_bootfsm_go();
 
 // Determine if Caliptra is ready to program fuses
 bool caliptra_ready_for_fuses(void);
 
 // Program calpitra_fuse object contents to caliptra fuses
+// returns: 0                       - Success
+//          INVALID_PARAMS          - Pointer to fuse struct is NULL
+//          NOT_READY_FOR_FUSES     - Flow status does not indicate ready for fuses before initializing
+//          STILL_READY_FOR_FUSES   - Flow status still indicates ready for fuses after writing fuse done
 int caliptra_init_fuses(struct caliptra_fuses *fuses);
 
 // Query if ROM is ready for firmware
 bool caliptra_ready_for_firmware(void);
 
-// Upload Caliptra Firmware
-int caliptra_upload_fw(struct caliptra_buffer *fw_buffer);
+// Read the value of the caliptra FW non-fatal error code
+// returns: Caliptra error code (see error/src/lib.rs)
+uint32_t caliptra_read_fw_non_fatal_error();
 
-// Read Caliptra FIPS Version
-int caliptra_get_fips_version(struct caliptra_fips_version *version);
+// Read the value of the caliptra FW fatal error code
+// returns: Caliptra error code (see error/src/lib.rs)
+uint32_t caliptra_read_fw_fatal_error();
 
+// MAILBOX COMMANDS
+// Asynchronous operation:
+//  - All commands have an option for asynchronous usage as their last param
+//  - Setting this will cause the command function to return once the request has been issued to caliptra
+//  - The caller should then poll for completion using caliptra_test_for_completion
+//  - After successfully polling, the caller should use caliptra_complete to finish the transaction
+//    and populate the response buffer originally provided.
+//  - The caller MUST ensure the response buffer provided remains available until caliptra_complete returns
 
-// Stash Measurement command
-int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp);
+// Mailbox error codes
+// returns: 0                           - Success
+//          MBX_BUSY                    - Mailbox is still busy when trying to send, the previous operation was never completed
+//          INVALID_PARAMS              - Params provided were null when not accepted or otherwise invalid
+//          MBX_COMPLETE_NOT_READY      - Mailbox is still busy (poll on caliptra_test_for_completion before calling)
+//          MBX_NO_MSG_PENDING          - No mailbox request has been issued
+//          MBX_STATUS_FAILED           - Mailbox HW status was set to CMD_FAILURE by caliptra FW
+//          MBX_STATUS_UNKNOWN          - Mailbox HW status is not a known/expected value
+//          MBX_STATUS_NOT_IDLE         - Mailbox status did not return to idle after clearing execute
+//          MBX_RESP_NO_HEADER          - The response buffer is too small to contain a header
+//          MBX_RESP_CHKSUM_INVALID     - The checksum in the response is not valid
+//          MBX_RESP_FIPS_NOT_APPROVED  - FIPS status in the response was not "approved"
+//          API_INTERNAL_ERROR          - The API internal state no longer matches the HW state (should not be possible)
 
-// Get IDEV CSR
-int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp);
+// Test for completion of the previously issued mailbox command
+// returns: True   - Mailbox status is not busy
+//          False  - Mailbox status shows busy
+bool caliptra_test_for_completion();
 
-// Get LDEV Cert
-int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp);
+// Resets the mailbox and SW state
+// Populates the response buffer provided when issuing the command if applicable
+// (See note above on return codes)
+int caliptra_complete();
 
 // Execute Mailbox Command
-int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);
+// Generic function for sending and receiving a command with raw, user-defined command and buffers
+// NOT RECOMMENDED to be used directly when avoidable - use the functions below for the specific command
+// (See notes above on asynchronous operation and return codes)
+int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer, bool async);
+
+// Upload Caliptra Firmware
+// (See notes above on asynchronous operation and return codes)
+int caliptra_upload_fw(struct caliptra_buffer *fw_buffer, bool async);
+
+// Read Caliptra FIPS Version
+// (See notes above on asynchronous operation and return codes)
+int caliptra_get_fips_version(struct caliptra_fips_version *version, bool async);
+
+// Stash Measurement command
+// (See notes above on asynchronous operation and return codes)
+int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async);
+
+// Get IDEV CSR
+// (See notes above on asynchronous operation and return codes)
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async);
+
+// Get LDEV Cert
+// (See notes above on asynchronous operation and return codes)
+int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp, bool async);
+
+

--- a/libcaliptra/inc/caliptra_enums.h
+++ b/libcaliptra/inc/caliptra_enums.h
@@ -5,6 +5,31 @@
 #include <stdbool.h>
 
 /**
+ * libcaliptra_error
+ *
+ * Error codes for all possible lib caliptra failures
+ */
+enum libcaliptra_error {
+    NO_ERROR = 0,
+    // General
+    INVALID_PARAMS              = 0x100,
+    API_INTERNAL_ERROR          = 0x101,
+    // Fuse
+    NOT_READY_FOR_FUSES         = 0x200,
+    STILL_READY_FOR_FUSES       = 0x201,
+    // Mailbox
+    MBX_BUSY                    = 0x300,
+    MBX_NO_MSG_PENDING          = 0x301,
+    MBX_COMPLETE_NOT_READY      = 0x302,
+    MBX_STATUS_FAILED           = 0x303,
+    MBX_STATUS_UNKNOWN          = 0x304,
+    MBX_STATUS_NOT_IDLE         = 0x305,
+    MBX_RESP_NO_HEADER          = 0x306,
+    MBX_RESP_CHKSUM_INVALID     = 0x307,
+    MBX_RESP_FIPS_NOT_APPROVED  = 0x308,
+};
+
+/**
  * device_lifecycle
  *
  * Device life cycle states

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -56,6 +56,7 @@ struct caliptra_stash_measurement_req {
     caliptra_checksum checksum;
     uint8_t           metadata[4];
     uint8_t           measurement[48];
+    uint8_t           context[48];
     uint32_t          svn;
 };
 

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -9,8 +9,11 @@
 #include "caliptra_api.h"
 #include "caliptra_fuses.h"
 #include "caliptra_mbox.h"
+#include "caliptra_enums.h"
 
 #define CALIPTRA_STATUS_NOT_READY 0
+
+struct caliptra_buffer g_mbox_pending_rx_buffer = {NULL, 0};
 
 /**
  * calculate_caliptra_checksum
@@ -21,8 +24,10 @@
  * @param[in] cmd The command being sent to the caliptra device
  * @param[in] buffer A pointer, if applicable, to the buffer being sent
  * @param[in] len The size of the buffer
+ *
+ * @return Checksum value
  */
-static uint32_t calculate_caliptra_checksum(uint32_t cmd, uint8_t *buffer, uint32_t len)
+static uint32_t calculate_caliptra_checksum(uint32_t cmd, const uint8_t *buffer, uint32_t len)
 {
     uint32_t i, sum = 0;
 
@@ -45,6 +50,13 @@ static uint32_t calculate_caliptra_checksum(uint32_t cmd, uint8_t *buffer, uint3
     return (0 - sum);
 }
 
+/**
+ * caliptra_read_status
+ *
+ * HELPER - Reads the caliptra flow status register
+ *
+ * @return Status value
+ */
 static inline uint32_t caliptra_read_status(void)
 {
     uint32_t status;
@@ -98,19 +110,19 @@ bool caliptra_ready_for_fuses(void)
  *
  * @param[in] fuses Valid caliptra_fuses structure
  *
- * @return int 0 if successful, -EINVAL if fuses is null, -EPERM if caliptra is not ready for fuses, -EIO if still ready after fuses are written
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
  */
 int caliptra_init_fuses(struct caliptra_fuses *fuses)
 {
     // Parameter check
     if (!fuses)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     // Check whether caliptra is ready for fuses
     if (!caliptra_ready_for_fuses())
-        return -EPERM;
+        return NOT_READY_FOR_FUSES;
 
     // Write Fuses
     caliptra_fuse_array_write(GENERIC_AND_FUSE_REG_FUSE_UDS_SEED_0, fuses->uds_seed, ARRAY_SIZE(fuses->uds_seed));
@@ -130,168 +142,33 @@ int caliptra_init_fuses(struct caliptra_fuses *fuses)
 
     // No longer ready for fuses
     if (caliptra_ready_for_fuses())
-        return -EIO;
-
-    return 0;
-}
-
-
-/**
- * caliptra_mailbox_write_fifo
- *
- * Transfer contents of buffer into the mailbox FIFO
- *
- * @param[in] buffer Pointer to a valid caliptra_buffer struct
- *
- * @return int -EINVAL if the buffer is too large.
- */
-static int caliptra_mailbox_write_fifo(struct caliptra_buffer *buffer)
-{
-    // Check if buffer is not null.
-    if (buffer == NULL)
-    {
-        return -EINVAL;
-    }
-
-    if (buffer->len > CALIPTRA_MAILBOX_MAX_SIZE)
-    {
-        return -EINVAL;
-    }
-
-    // Write DLEN to transition to the next state.
-    caliptra_mbox_write_dlen(buffer->len);
-
-    if (buffer->len == 0)
-    {
-        // We can return early, there is no payload.
-        // dlen needs to be written to transition the state machine,
-        // even if it is zero.
-        return 0;
-    }
-
-    // We have data to write, better check if have a place to read it
-    // from.
-    if (buffer->data == NULL)
-    {
-        return -EINVAL;
-    }
-
-    uint32_t remaining_len = buffer->len;
-    uint32_t *data_dw = (uint32_t *)buffer->data;
-
-    // Copy DWord multiples
-    while (remaining_len > sizeof(uint32_t))
-    {
-        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, *data_dw++);
-        remaining_len -= sizeof(uint32_t);
-    }
-
-    // if un-aligned dword remainder...
-    if (remaining_len)
-    {
-        uint32_t data = 0;
-        memcpy(&data, data_dw, remaining_len);
-        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, data);
-    }
+        return STILL_READY_FOR_FUSES;
 
     return 0;
 }
 
 /**
- * caliptra_mailbox_read_buffer
+ * caliptra_read_fw_non_fatal_error
  *
- * Read a mailbxo FIFO into a buffer
+ * Read value of the FW error non-fatal reg (see error/src/lib.rs)
  *
- * @param[in] buffer A pointer to a valid caliptra_buffer struct
- *
- * @return int 0 if successful, -EINVAL if the buffer is too small or the buffer pointer is invalid.
+ * @return Caliptra FW Error code
  */
-static int caliptra_mailbox_read_buffer(struct caliptra_buffer *buffer)
+uint32_t caliptra_read_fw_non_fatal_error()
 {
-    uint32_t remaining_len = caliptra_mbox_read_dlen();
-
-    // Check that the buffer is not null
-    if (buffer == NULL)
-        return -EINVAL;
-
-    // Check we have enough room in the buffer
-    if (buffer->len < remaining_len || !buffer->data)
-        return -EINVAL;
-
-    uint32_t *data_dw = (uint32_t *)buffer->data;
-
-    // Copy DWord multiples
-    while (remaining_len >= sizeof(uint32_t))
-    {
-        *data_dw++ = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
-        remaining_len -= sizeof(uint32_t);
-    }
-
-    // if un-aligned dword reminder...
-    if (remaining_len)
-    {
-        uint32_t data = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
-        memcpy(data_dw, &data, remaining_len);
-    }
-    return 0;
+    return caliptra_read_fw_error_non_fatal();
 }
 
 /**
- * caliptra_mailbox_execute
+ * caliptra_read_fw_fatal_error
  *
- * Execute a mailbox command and send/retrieve a buffer
+ * Read value of the FW error fatal reg (see error/src/lib.rs)
  *
- * @param[in] cmd Caliptra command opcode
- * @param[in] mbox_tx_buffer Transmit buffer
- * @param[in] mbox_rx_buffer Receive buffer
- *
- * @return 0 if successful, -EBUSY if the mailbox is locked, -EIO if the command has failed or data is not available or the FSM is not include
+ * @return Caliptra FW Error code
  */
-int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer)
+uint32_t caliptra_read_fw_fatal_error()
 {
-    // If mbox already locked return
-    if (caliptra_mbox_is_lock())
-    {
-        return -EBUSY;
-    }
-
-    // Write Cmd and Tx Buffer
-    caliptra_mbox_write_cmd(cmd);
-    caliptra_mailbox_write_fifo(mbox_tx_buffer);
-
-    // Set Execute bit and wait
-    caliptra_mbox_write_execute_busy_wait(true);
-
-    // Check the Mailbox Status
-    uint32_t status = caliptra_mbox_read_status();
-    if (status == CALIPTRA_MBOX_STATUS_CMD_FAILURE)
-    {
-        caliptra_mbox_write_execute(false);
-        return -EIO;
-    }
-    else if (status == CALIPTRA_MBOX_STATUS_CMD_COMPLETE)
-    {
-        caliptra_mbox_write_execute(false);
-        return 0;
-    }
-    else if (status != CALIPTRA_MBOX_STATUS_DATA_READY)
-    {
-        return -EIO;
-    }
-
-    // Read Buffer
-    caliptra_mailbox_read_buffer(mbox_rx_buffer);
-
-    // Execute False
-    caliptra_mbox_write_execute(false);
-
-    // Wait
-    caliptra_wait();
-
-    if (caliptra_mbox_read_status_fsm() != CALIPTRA_MBOX_STATUS_FSM_IDLE)
-        return -EIO;
-
-    return 0;
+    return caliptra_read_fw_error_fatal();
 }
 
 /**
@@ -324,6 +201,345 @@ bool caliptra_ready_for_firmware(void)
 }
 
 /**
+ * caliptra_mailbox_write_fifo
+ *
+ * HELPER - Transfer contents of buffer into the mailbox FIFO
+ *
+ * @param[in] buffer Pointer to a valid caliptra_buffer struct
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+static int caliptra_mailbox_write_fifo(struct caliptra_buffer *buffer)
+{
+    // Check if buffer is not null.
+    if (buffer == NULL)
+    {
+        return INVALID_PARAMS;
+    }
+
+    if (buffer->len > CALIPTRA_MAILBOX_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
+    // Write DLEN to transition to the next state.
+    caliptra_mbox_write_dlen(buffer->len);
+
+    if (buffer->len == 0)
+    {
+        // We can return early, there is no payload.
+        // dlen needs to be written to transition the state machine,
+        // even if it is zero.
+        return 0;
+    }
+
+    // We have data to write, better check if have a place to read it
+    // from.
+    if (buffer->data == NULL)
+    {
+        return INVALID_PARAMS;
+    }
+
+    uint32_t remaining_len = buffer->len;
+    uint32_t *data_dw = (uint32_t *)buffer->data;
+
+    // Copy DWord multiples
+    while (remaining_len > sizeof(uint32_t))
+    {
+        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, *data_dw++);
+        remaining_len -= sizeof(uint32_t);
+    }
+
+    // if un-aligned dword remainder...
+    if (remaining_len)
+    {
+        uint32_t data = 0;
+        memcpy(&data, data_dw, remaining_len);
+        caliptra_mbox_write(MBOX_CSR_MBOX_DATAIN, data);
+    }
+
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_read_fifo
+ *
+ * HELPER - Read a mailbox FIFO into a buffer
+ *
+ * @param[in] buffer A pointer to a valid caliptra_buffer struct
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+static int caliptra_mailbox_read_fifo(struct caliptra_buffer *buffer)
+{
+    uint32_t remaining_len = caliptra_mbox_read_dlen();
+
+    // Check that the buffer is not null
+    if (buffer == NULL)
+        return INVALID_PARAMS;
+
+    // Check we have enough room in the buffer
+    if (buffer->len < remaining_len || !buffer->data)
+        return INVALID_PARAMS;
+
+    uint32_t *data_dw = (uint32_t *)buffer->data;
+
+    // Copy DWord multiples
+    while (remaining_len >= sizeof(uint32_t))
+    {
+        *data_dw++ = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
+        remaining_len -= sizeof(uint32_t);
+    }
+
+    // if un-aligned dword reminder...
+    if (remaining_len)
+    {
+        uint32_t data = caliptra_mbox_read(MBOX_CSR_MBOX_DATAOUT);
+        memcpy(data_dw, &data, remaining_len);
+    }
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_send
+ *
+ * HELPER - Send the message to caliptra
+ *
+ * @param[in] cmd Caliptra command opcode
+ * @param[in] mbox_tx_buffer Transmit buffer
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_mailbox_send(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer)
+{
+    // If mbox already locked return
+    if (caliptra_mbox_is_lock())
+    {
+        return MBX_BUSY;
+    }
+
+    // Write Cmd and Tx Buffer
+    caliptra_mbox_write_cmd(cmd);
+    caliptra_mailbox_write_fifo(mbox_tx_buffer);
+
+    // Set Execute bit
+    caliptra_mbox_write_execute(true);
+
+    return 0;
+};
+
+/**
+ * caliptra_check_status_get_response
+ *
+ * HELPER - Checks the HW mailbox status for "complete" or "data ready" and populates the response
+ * buffer with a response if applicable
+ *
+ * @param[in] mbox_rx_buffer Buffer for the response, NULL if no response is expected
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_check_status_get_response(struct caliptra_buffer *mbox_rx_buffer)
+{
+    // Check the Mailbox Status
+    uint32_t mbx_status = caliptra_mbox_read_status();
+    if (mbx_status == CALIPTRA_MBOX_STATUS_CMD_FAILURE)
+    {
+        caliptra_mbox_write_execute(false);
+        return MBX_STATUS_FAILED;
+    }
+    else if (mbx_status == CALIPTRA_MBOX_STATUS_CMD_COMPLETE)
+    {
+        caliptra_mbox_write_execute(false);
+        return 0;
+    }
+    else if (mbx_status != CALIPTRA_MBOX_STATUS_DATA_READY)
+    {
+        return MBX_STATUS_UNKNOWN;
+    }
+
+    // Read Buffer
+    int status = caliptra_mailbox_read_fifo(mbox_rx_buffer);
+
+    // Execute False
+    caliptra_mbox_write_execute(false);
+
+    // Wait (HW model is halted whenever we aren't calling wait())
+    caliptra_wait();
+
+    if (caliptra_mbox_read_status_fsm() != CALIPTRA_MBOX_STATUS_FSM_IDLE)
+        return MBX_STATUS_NOT_IDLE;
+
+    return status;
+}
+
+/**
+ * check_command_response
+ *
+ * HELPER - Verifies the checksum and checks that the FIPS status is approved for the message response
+ *
+ * @param[in] buffer Buffer for the full response
+ * @param[in] buffer_size Size of the full response in bytes
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+static inline int check_command_response(const uint8_t *buffer, const size_t buffer_size)
+{
+    if (buffer_size < sizeof(struct caliptra_completion)) {
+        return MBX_RESP_NO_HEADER;
+    }
+    struct caliptra_completion *cpl = (struct caliptra_completion*)buffer;
+
+    uint32_t calc_checksum = calculate_caliptra_checksum(0, buffer + sizeof(uint32_t), buffer_size - sizeof(uint32_t));
+
+    bool checksum_valid = !(cpl->checksum - calc_checksum);
+    bool fips_approved  = (cpl->fips == FIPS_STATUS_APPROVED);
+
+    if (checksum_valid == false) {
+        return MBX_RESP_CHKSUM_INVALID;
+    }
+    if (fips_approved == false) {
+        return MBX_RESP_FIPS_NOT_APPROVED;
+    }
+
+    return 0;
+}
+
+/**
+ * caliptra_mailbox_execute
+ *
+ * Send the command with caliptra_mailbox_send. If async is false, wait for completion and call caliptra_complete to get result
+ *
+ * @param[in] cmd 32 bit command identifier to be sent to caliptra
+ * @param[in] mbox_tx_buffer caliptra_buffer struct containing the pointer and length of the send buffer
+ * @param[in] mbox_rx_buffer caliptra_buffer struct containing the pointer and length of the receive buffer
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_mailbox_execute(uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer, bool async)
+{
+    int status = caliptra_mailbox_send(cmd, mbox_tx_buffer);
+    if (status) {
+        return status;
+    }
+
+    // HW lock should prevent this from happening
+    if (g_mbox_pending_rx_buffer.data != NULL) {
+        return API_INTERNAL_ERROR;
+    }
+
+    // Store buffer info
+    if (mbox_rx_buffer != NULL) {
+        g_mbox_pending_rx_buffer = *mbox_rx_buffer;
+    }
+
+    // Stop here if this is async (user will poll and complete)
+    if (async) {
+        return status;
+    }
+
+    // Wait indefinitely for completion
+    while (!caliptra_test_for_completion()){
+        caliptra_wait();
+    }
+
+    return caliptra_complete();
+}
+
+/**
+ * pack_and_execute_command
+ *
+ * HELPER - Create the caliptra buffer structs and call caliptra_mailbox_execute
+ *
+ * @param[in] parcel struct with tx and rx buffers for the transactions
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+static int pack_and_execute_command(struct parcel *parcel, bool async)
+{
+    if (parcel == NULL)
+    {
+        return INVALID_PARAMS;
+    }
+
+    // Parcels will always have, at a minimum:
+    //  > 4 byte tx buffer, for the checksum
+    //  > 8 byte rx buffer, for the checksum and FIPS status
+    if (!parcel->tx_buffer || !parcel->rx_buffer)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_buffer tx_buf = {
+        .data = parcel->tx_buffer,
+        .len  = parcel->tx_bytes,
+    };
+
+    struct caliptra_buffer rx_buf = {
+        .data = parcel->rx_buffer,
+        .len  = parcel->rx_bytes,
+    };
+
+    // Calculate and populate the checksum field
+    *((caliptra_checksum*)tx_buf.data) = calculate_caliptra_checksum(parcel->command, tx_buf.data, tx_buf.len);
+
+    return caliptra_mailbox_execute(parcel->command, &tx_buf, &rx_buf, async);
+}
+
+/**
+ * caliptra_test_for_completion
+ *
+ * Checks if there is an active command being processed by caliptra FW
+ *
+ * @return True if no command is pending, false if a command is pending
+ */
+bool caliptra_test_for_completion()
+{
+    return !caliptra_mbox_is_busy();
+}
+
+/**
+ * caliptra_complete
+ *
+ * Check result, read back the response to the rx_buffer originally provided if necessary
+ * Complete transaction with mbx HW by clearing execute
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_complete()
+{
+    // Return an error if no message is pending (execute is not set)
+    if (caliptra_mbox_read_execute() == 0) {
+        return MBX_NO_MSG_PENDING;
+    }
+
+    // Make sure the request is complete
+    if (!caliptra_test_for_completion()) {
+        return MBX_BUSY;
+    }
+
+    // Store the buffer locally and clear the global var
+    // The global should never be set when we don't have the mbx HW lock
+    // (HW lock protects this from race conditions)
+    struct caliptra_buffer rx_buffer = g_mbox_pending_rx_buffer;
+    g_mbox_pending_rx_buffer = (struct caliptra_buffer){NULL, 0};
+
+    // Complete the transaction and read back a response if applicable
+    int status = caliptra_check_status_get_response(&rx_buffer);
+
+    if (status)
+    {
+        return status;
+    }
+
+    // Verify the header data from the response
+    if (rx_buffer.data != NULL) {
+        return check_command_response(rx_buffer.data, rx_buffer.len);
+    }
+}
+
+/**
  * caliptra_upload_fw
  *
  * Upload firmware to the Caliptra device
@@ -332,67 +548,13 @@ bool caliptra_ready_for_firmware(void)
  *
  * @return See caliptra_mailbox, mb_resultx_execute for possible results.
  */
-int caliptra_upload_fw(struct caliptra_buffer *fw_buffer)
+int caliptra_upload_fw(struct caliptra_buffer *fw_buffer, bool async)
 {
     // Parameter check
     if (fw_buffer == NULL)
-        return -EINVAL;
+        return INVALID_PARAMS;
 
-    return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL);
-}
-
-static inline int check_command_response(struct caliptra_completion *cpl, uint8_t *buffer, size_t buffer_size)
-{
-    uint32_t calc_checksum = calculate_caliptra_checksum(0, buffer + sizeof(uint32_t), buffer_size - sizeof(uint32_t));
-
-    bool checksum_valid = !(cpl->checksum - calc_checksum);
-    bool fips_approved  = (cpl->fips == FIPS_STATUS_APPROVED);
-
-    if ((checksum_valid == false) || (fips_approved == false))
-    {
-        return -EBADMSG;
-    }
-
-    return 0;
-}
-
-static int pack_and_send_command(struct parcel *parcel)
-{
-    if (parcel == NULL)
-    {
-        return -EINVAL;
-    }
-
-    // Parcels will always have, at a minimum:
-    //  > 4 byte tx buffer, for the checksum
-    //  > 8 byte rx buffer, for the checksum and FIPS status
-    if (!parcel->tx_buffer || !parcel->rx_buffer)
-    {
-        return -EINVAL;
-    }
-
-    struct caliptra_buffer in_buf = {
-        .data = parcel->tx_buffer,
-        .len  = parcel->tx_bytes,
-    };
-
-    struct caliptra_buffer out_buf = {
-        .data = parcel->rx_buffer,
-        .len  = parcel->rx_bytes,
-    };
-
-    *((caliptra_checksum*)parcel->tx_buffer) = calculate_caliptra_checksum(parcel->command, parcel->tx_buffer, parcel->tx_bytes);
-
-    int status = caliptra_mailbox_execute(parcel->command, &in_buf, &out_buf);
-
-    if (status)
-    {
-        return status;
-    }
-
-    struct caliptra_completion *cpl = (struct caliptra_completion*)parcel->rx_buffer;
-
-    return check_command_response(cpl, parcel->rx_buffer, parcel->rx_bytes);
+    return caliptra_mailbox_execute(OP_CALIPTRA_FW_LOAD, fw_buffer, NULL, async);
 }
 
 /**
@@ -400,16 +562,17 @@ static int pack_and_send_command(struct parcel *parcel)
  *
  * Read Caliptra FIPS Version
  *
- * @param[out] version pointer to fips_version unsigned integer
+ * @param[out] version pointer to fips_version command response
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
  *
- * @return See caliptra_mailbox, mb_resultx_execute for possible results.
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
  */
-int caliptra_get_fips_version(struct caliptra_fips_version *version)
+int caliptra_get_fips_version(struct caliptra_fips_version *version, bool async)
 {
     // Parameter check
     if (version == NULL)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     caliptra_checksum checksum = 0;
@@ -422,14 +585,25 @@ int caliptra_get_fips_version(struct caliptra_fips_version *version)
         .rx_bytes  = sizeof(struct caliptra_fips_version),
     };
 
-    return pack_and_send_command(&p);
+    return pack_and_execute_command(&p, async);
 }
 
-int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp)
+/**
+ * caliptra_stash_measurement
+ *
+ * Stash a measurement with Caliptra
+ *
+ * @param[out] req pointer to request struct
+ * @param[out] resp pointer to response struct
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async)
 {
     if (!req || !resp)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     struct parcel p = {
@@ -440,14 +614,24 @@ int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struc
         .rx_bytes  = sizeof(struct caliptra_stash_measurement_resp),
     };
 
-    return pack_and_send_command(&p);
+    return pack_and_execute_command(&p, async);
 }
 
-int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp)
+/**
+ * caliptra_get_idev_csr
+ *
+ * Get the IDEV certificate signing request
+ *
+ * @param[out] resp pointer to response struct
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async)
 {
     if (!resp)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     caliptra_checksum checksum = 0;
@@ -460,14 +644,24 @@ int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp)
         .rx_bytes  = sizeof(struct caliptra_get_idev_csr_resp),
     };
 
-    return pack_and_send_command(&p);
+    return pack_and_execute_command(&p, async);
 }
 
-int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp)
+/**
+ * caliptra_get_ldev_cert
+ *
+ * Get the LDEV certificate
+ *
+ * @param[out] resp pointer to response struct
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp, bool async)
 {
     if (!resp)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     caliptra_checksum checksum = 0;
@@ -480,14 +674,25 @@ int caliptra_get_ldev_cert(struct caliptra_get_ldev_cert_resp *resp)
         .rx_bytes  = sizeof(struct caliptra_get_ldev_cert_resp),
     };
 
-    return pack_and_send_command(&p);
+    return pack_and_execute_command(&p, async);
 }
 
-int caliptra_dpe_command(struct caliptra_dpe_req *req, struct caliptra_dpe_resp *resp)
+/**
+ * caliptra_dpe_command
+ *
+ * Send a DPE command and receive its response
+ *
+ * @param[out] req pointer to request struct
+ * @param[out] resp pointer to response struct
+ * @param[in] async If true, return after sending command. If false, wait for command to complete and handle response
+ *
+ * @return 0 for success, non-zero for failure (see enum libcaliptra_error)
+ */
+int caliptra_dpe_command(struct caliptra_dpe_req *req, struct caliptra_dpe_resp *resp, bool async)
 {
     if (!req || !resp)
     {
-        return -EINVAL;
+        return INVALID_PARAMS;
     }
 
     // While it will likely cause no harm, there's no sense in writing more
@@ -503,6 +708,5 @@ int caliptra_dpe_command(struct caliptra_dpe_req *req, struct caliptra_dpe_resp 
         .rx_bytes  = sizeof(struct caliptra_dpe_resp),
     };
 
-    return pack_and_send_command(&p);
+    return pack_and_execute_command(&p, async);
 }
-

--- a/libcaliptra/src/caliptra_fuses.h
+++ b/libcaliptra/src/caliptra_fuses.h
@@ -13,10 +13,27 @@ static inline void caliptra_fuse_write(uint32_t offset, uint32_t data)
     caliptra_write_u32((offset + CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_BASE_ADDR), data);
 }
 
+static inline uint32_t caliptra_fuse_read(uint32_t offset)
+{
+    uint32_t data;
+    caliptra_read_u32((offset + CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_BASE_ADDR), &data);
+    return data;
+}
+
 static inline void caliptra_fuse_array_write(uint32_t offset, uint32_t *data, size_t size)
 {
     for (uint32_t idx = 0; idx < size; idx ++)
     {
         caliptra_fuse_write((offset + (idx * sizeof(uint32_t))), data[idx]);
     }
+}
+
+static inline uint32_t caliptra_read_fw_error_non_fatal(void)
+{
+    return caliptra_fuse_read(GENERIC_AND_FUSE_REG_CPTRA_FW_ERROR_NON_FATAL);
+}
+
+static inline uint32_t caliptra_read_fw_error_fatal(void)
+{
+    return caliptra_fuse_read(GENERIC_AND_FUSE_REG_CPTRA_FW_ERROR_FATAL);
 }

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -77,6 +77,11 @@ static inline void caliptra_mbox_write_cmd(uint32_t cmd)
     caliptra_mbox_write(MBOX_CSR_MBOX_CMD, cmd);
 }
 
+static inline uint32_t caliptra_mbox_read_execute()
+{
+    caliptra_mbox_read(MBOX_CSR_MBOX_EXECUTE);
+}
+
 static inline void caliptra_mbox_write_execute(bool ex)
 {
     caliptra_mbox_write(MBOX_CSR_MBOX_EXECUTE, ex);
@@ -97,6 +102,11 @@ static inline uint8_t caliptra_mbox_write_execute_busy_wait(bool ex)
 static inline uint8_t caliptra_mbox_read_status(void)
 {
     return (uint8_t)(caliptra_mbox_read(MBOX_CSR_MBOX_STATUS) & MBOX_CSR_MBOX_STATUS_STATUS_MASK);
+}
+
+static inline bool caliptra_mbox_is_busy(void)
+{
+    return caliptra_mbox_read_status() == CALIPTRA_MBOX_STATUS_BUSY;
 }
 
 static inline uint8_t caliptra_mbox_read_status_fsm(void)


### PR DESCRIPTION
- Adds async option for all mbx commands and test/complete functions
- Adds new enum for return codes
- Adds functions to read fatal and non-fatal caliptra FW errors