### PR TITLE
CI: Disable fuzz build tests.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -111,6 +111,8 @@ jobs:
 
       # As fuzzing targets are not part of the workspace, perform their tests explicitly.
       - name: Build test fuzzing targets
+        # Intermittently fails and is too slow
+        if: false
         run: |
           rustup toolchain install nightly-2023-04-15
           cargo +nightly-2023-04-15 install cargo-fuzz cargo-afl


### PR DESCRIPTION
These intermittently crash:

```
error: failed to run custom build command for `openssl-sys v0.9.93`

Caused by:
  process didn't exit successfully: `/home/runner/work/caliptra-sw/caliptra-sw/dpe/dpe/fuzz/target/debug/build/openssl-sys-f4822ba2ff559cb6/build-script-main` (signal: 4, SIGILL: illegal instruction)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
```

#879 is in progress to potentially address these problems.