### PR TITLE
Fix subject/issuer mismatch between RT and FMC Alias

### DIFF
--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -130,15 +130,17 @@ impl RtAliasLayer {
     /// # Returns
     ///
     /// * `DiceInput` - DICE Layer Input
-    fn dice_input_from_hand_off(env: &FmcEnv) -> CaliptraResult<DiceInput> {
+    fn dice_input_from_hand_off(env: &mut FmcEnv) -> CaliptraResult<DiceInput> {
+        let auth_pub = HandOff::fmc_pub_key(env);
+        let auth_serial_number = X509::subj_sn(env, &auth_pub)?;
         // Create initial output
         let input = DiceInput {
             cdi: HandOff::fmc_cdi(env),
             auth_key_pair: Ecc384KeyPair {
                 priv_key: HandOff::fmc_priv_key(env),
-                pub_key: HandOff::fmc_pub_key(env),
+                pub_key: auth_pub,
             },
-            auth_sn: [0u8; 64],
+            auth_sn: auth_serial_number,
             auth_key_id: [0u8; 20],
         };
 

--- a/runtime/test-fw/src/cert_tests.rs
+++ b/runtime/test-fw/src/cert_tests.rs
@@ -47,8 +47,15 @@ fn mbox_responder() {
                 mbox.write_response(&fmc).unwrap();
                 mbox.set_status(MboxStatusE::DataReady);
             }
-            // Send IDevID Public Key
+            // Send RT Alias Cert
             CommandId(0x3000_0000) => {
+                let mut rt = [0u8; 1024];
+                dice::copy_rt_alias_cert(drivers.persistent_data.get(), &mut rt).unwrap();
+                mbox.write_response(&rt).unwrap();
+                mbox.set_status(MboxStatusE::DataReady);
+            }
+            // Send IDevID Public Key
+            CommandId(0x4000_0000) => {
                 mbox.write_response(
                     drivers
                         .persistent_data

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -106,6 +106,6 @@ fn gen_rt_alias_cert(out_dir: &str) {
                 digest: &[0xCD; 48],
             },
         }]);
-    let template = bldr.tbs_template("Caliptra Rt Alias", "Caliptra FMC");
+    let template = bldr.tbs_template("Caliptra Rt Alias", "Caliptra FMC Alias");
     CodeGen::gen_code("RtAliasCertTbs", template, out_dir);
 }


### PR DESCRIPTION
X.509 requires that the subject name of a cert exactly matches the issuer name of the key that signed it.

* Populate issuer serial number in RT Alias Cert
* Correct issuer common name in RT Alias Cert
* Add tests that make sure subject/issuer names match