### PR TITLE
[fix] Add CFI checks to svn_check_required in verifier library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,6 @@ dependencies = [
  "caliptra-cfi-derive",
  "caliptra-drivers",
  "caliptra-registers",
- "caliptra_common",
  "serial_test",
  "ufmt",
 ]
@@ -562,6 +561,7 @@ name = "caliptra-image-verify"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
+ "caliptra-cfi-lib",
  "caliptra-drivers",
  "caliptra-image-types",
  "caliptra_common",

--- a/cfi/lib/Cargo.toml
+++ b/cfi/lib/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-caliptra_common = { workspace = true, default-features = false }
 caliptra-drivers.workspace = true
 caliptra-registers.workspace = true
 ufmt.workspace = true

--- a/cfi/lib/src/cfi_counter.rs
+++ b/cfi/lib/src/cfi_counter.rs
@@ -19,7 +19,7 @@ References:
 use crate::cfi::{cfi_panic, CfiPanicInfo};
 use crate::xoshiro::Xoshiro128;
 #[cfg(not(feature = "cfi-test"))]
-use caliptra_common::memory_layout::{CFI_MASK_ORG, CFI_VAL_ORG};
+use caliptra_drivers::memory_layout::{CFI_MASK_ORG, CFI_VAL_ORG};
 use core::default::Default;
 
 #[cfg(feature = "cfi-test")]

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-drivers.workspace = true
 caliptra-image-types = { workspace = true, default-features = false }
 memoffset.workspace = true
 zerocopy.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false, features = ["cfi"] }
 
 [dev-dependencies]
 caliptra_common = { path = "../../common", default-features = false }

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -98,6 +98,13 @@ fn runtime_panic(_: &core::panic::PanicInfo) -> ! {
     handle_fatal_error(caliptra_drivers::CaliptraError::RUNTIME_GLOBAL_PANIC.into());
 }
 
+#[no_mangle]
+extern "C" fn cfi_panic_handler(code: u32) -> ! {
+    cprintln!("RT CFI Panic code=0x{:08X}", code);
+
+    handle_fatal_error(code);
+}
+
 #[allow(clippy::empty_loop)]
 fn handle_fatal_error(code: u32) -> ! {
     cprintln!("RT Fatal Error: 0x{:08X}", code);


### PR DESCRIPTION
Addresses Issue: https://github.com/chipsalliance/caliptra-sw/issues/910

CFI check confirmation:
000002c8 <caliptra_image_verify::verifier::ImageVerifier<Env>::svn_check_required::h0ebe396502ecf1b7>:
     2c8: 41 11        	c.addi	sp, -16
     2ca: 06 c6        	c.swsp	ra, 12(sp)
     2cc: 37 05 03 30  	lui	a0, 196656
     2d0: 6c 41        	c.lw	a1, 68(a0)
     2d2: 8d 89        	c.andi	a1, 3
     2d4: 2e c2        	c.swsp	a1, 4(sp)
     2d6: 4c 00        	c.addi4spn	a1, sp, 4
     2d8: 92 45        	c.lwsp	a1, 4(sp)
     2da: 99 c9        	c.beqz	a1, 0x2f0 <.LBB4_2>
     2dc: 83 25 85 2c  	lw	a1, 712(a0)
     2e0: 85 89        	c.andi	a1, 1
     2e2: a3 05 b1 00  	sb	a1, 11(sp)
     2e6: 93 05 b1 00  	addi	a1, sp, 11
     2ea: 83 45 b1 00  	lbu	a1, 11(sp)
     2ee: 91 cd        	c.beqz	a1, 0x30a <.LBB4_6>

000002f0 <.LBB4_2>:
     2f0: 68 41        	c.lw	a0, 68(a0)
     2f2: 0d 89        	c.andi	a0, 3
     2f4: 19 c5        	c.beqz	a0, 0x302 <.LBB4_4>
     2f6: 37 05 03 30  	lui	a0, 196656
     2fa: 03 25 85 2c  	lw	a0, 712(a0)
     2fe: 05 89        	c.andi	a0, 1
     300: 11 a0        	c.j	0x304 <.LBB4_5>

00000302 <.LBB4_4>:
     302: 05 45        	c.li	a0, 1

00000304 <.LBB4_5>:
     304: bd 3f        	c.jal	0x282 <caliptra_cfi_lib::cfi::cfi_assert_eq::he67f64a571fd9c89>
     306: 01 45        	c.li	a0, 0
     308: 11 a0        	c.j	0x30c <.LBB4_7>