### PR TITLE
Move ROM_INFO after .data.

### DIFF
--- a/rom/dev/src/rom.ld
+++ b/rom/dev/src/rom.ld
@@ -71,9 +71,6 @@ SECTIONS
 
     	. = ALIGN(4);
         _erodata = .;
-
-    	. = ALIGN(64);
-    	CALIPTRA_ROM_INFO = .;
 	} > ROM
 
 	.data : ALIGN(4)
@@ -90,6 +87,11 @@ SECTIONS
 		. = ALIGN(4);
 	    _edata = .;
 	} > DATA AT> ROM
+
+	.rom_info : ALIGN(64)
+	{
+		CALIPTRA_ROM_INFO = .;
+	} > ROM
 
 	.bss (NOLOAD) : ALIGN(4) 
     {


### PR DESCRIPTION
.data is currently empty, so this won't affect the existing image. However, if a future change ever adds anything to .data, it wouldn't be covered by the ROM_INFO hash without this change.

Addresses #846