### PR TITLE
Always reset watchdog timer after enabling it to guarantee counting starts from zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-cpu",
  "caliptra-drivers",
+ "caliptra-registers",
  "cfg-if 1.0.0",
  "ufmt",
 ]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,7 +11,6 @@ pub mod fips;
 pub mod keyids;
 pub mod mailbox_api;
 pub mod verifier;
-pub mod wdt;
 
 ///merge imports
 pub use hand_off::{
@@ -37,4 +36,3 @@ pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 96 * 1024;
 
 pub use memory_layout::{DATA_ORG, FHT_ORG, FHT_SIZE, MAN1_ORG};
-pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -47,6 +47,7 @@ mod sha384acc;
 mod soc_ifc;
 mod trng;
 mod trng_ext;
+pub mod wdt;
 
 pub use array::{Array4x12, Array4x4, Array4x5, Array4x8, Array4xN};
 pub use array_concat::array_concat3;
@@ -89,6 +90,7 @@ pub use sha384::{Sha384, Sha384Digest, Sha384DigestOp};
 pub use sha384acc::{Sha384Acc, Sha384AccOp, ShaAccLockState};
 pub use soc_ifc::{report_boot_status, Lifecycle, MfgFlags, ResetReason, SocIfc};
 pub use trng::Trng;
+pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "emu")] {

--- a/drivers/src/wdt.rs
+++ b/drivers/src/wdt.rs
@@ -13,9 +13,7 @@ Abstract:
 
 --*/
 
-use caliptra_drivers::SocIfc;
-
-use crate::cprintln;
+use crate::SocIfc;
 
 pub struct WdtTimeout(pub core::num::NonZeroU64);
 
@@ -62,6 +60,7 @@ const WDT1_MIN_TIMEOUT_IN_CYCLES: u64 = EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES;
 /// # Arguments
 ///
 /// * `soc_ifc` - SOC Interface
+/// * `wdt1_timeout_cycles` - Watchdog timeout in cycles.
 ///
 ///
 pub fn start_wdt(soc_ifc: &mut SocIfc, wdt1_timeout_cycles: WdtTimeout) {
@@ -73,17 +72,18 @@ pub fn start_wdt(soc_ifc: &mut SocIfc, wdt1_timeout_cycles: WdtTimeout) {
 
     // Enable WDT1 only. WDT2 is automatically scheduled (since it is disabled) on WDT1 expiry.
     soc_ifc.configure_wdt1(true);
+
+    // Restart timer from zero.
+    restart_wdt(soc_ifc);
 }
 
 /// Restart the Watchdog Timer
 ///
 /// # Arguments
 ///
-/// * `env` - ROM Environment
+/// * `soc_ifc` - SOC Interface
 ///
 pub fn restart_wdt(soc_ifc: &mut SocIfc) {
-    cprintln!("[state] Restarting the Watchdog Timer");
-
     // Only restart WDT1. WDT2 is automatically scheduled (since it is disabled) on WDT1 expiry.
     soc_ifc.reset_wdt1();
 }

--- a/rom/dev/src/wdt.rs
+++ b/rom/dev/src/wdt.rs
@@ -17,7 +17,6 @@ Environment:
 --*/
 
 use caliptra_cfi_derive::cfi_mod_fn;
-use caliptra_common::WdtTimeout;
 use caliptra_drivers::SocIfc;
 
 use crate::cprintln;
@@ -36,9 +35,11 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
         if wdt_timeout_cycles == 0 {
             wdt_timeout_cycles = 1;
         }
-        caliptra_common::wdt::start_wdt(
+        caliptra_drivers::wdt::start_wdt(
             soc_ifc,
-            WdtTimeout::from(core::num::NonZeroU64::new(wdt_timeout_cycles).unwrap()),
+            caliptra_drivers::WdtTimeout::from(
+                core::num::NonZeroU64::new(wdt_timeout_cycles).unwrap(),
+            ),
         );
     } else {
         cprintln!(
@@ -57,7 +58,7 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
 pub fn stop_wdt(soc_ifc: &mut SocIfc) {
     if soc_ifc.debug_locked() {
         cprintln!("[state] Stopping the Watchdog Timer");
-        caliptra_common::wdt::stop_wdt(soc_ifc);
+        caliptra_drivers::wdt::stop_wdt(soc_ifc);
     } else {
         cprintln!(
             "[state] Watchdog Timer is not stopped because the device is not locked for debugging"

--- a/rom/dev/tests/test_wdt_activation_and_stoppage.rs
+++ b/rom/dev/tests/test_wdt_activation_and_stoppage.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{firmware::APP_WITH_UART, firmware::FMC_WITH_UART, ImageOptions};
+use caliptra_common::RomBootStatus::KatStarted;
+use caliptra_hw_model::{DeviceLifecycle, HwModel, SecurityState};
+
+pub mod helpers;
+
+#[test]
+fn test_wdt_activation_and_stoppage() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Unprovisioned);
+
+    // Build the image we are going to send to ROM to load
+    let image_bundle = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+
+    let rom =
+        caliptra_builder::build_firmware_rom(&caliptra_builder::firmware::ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(caliptra_hw_model::BootParams {
+        init_params: caliptra_hw_model::InitParams {
+            rom: &rom,
+            security_state,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Ensure we are starting to count from zero.
+    hw.step_until(|m: &mut caliptra_hw_model::ModelEmulated| {
+        m.soc_ifc().cptra_wdt_timer1_ctrl().read().timer1_restart()
+    });
+
+    // Make sure the wdt1 timer is enabled.
+    assert_eq!(hw.soc_ifc().cptra_wdt_timer1_en().read().timer1_en(), true);
+
+    // Upload the FW once ROM is at the right point
+    hw.step_until(|m: &mut caliptra_hw_model::ModelEmulated| {
+        m.soc_ifc().cptra_flow_status().read().ready_for_fw()
+    });
+    hw.upload_firmware(&image_bundle.to_bytes().unwrap())
+        .unwrap();
+
+    // Keep going until we launch FMC
+    hw.step_until_output_contains("[exit] Launching FMC")
+        .unwrap();
+
+    // Make sure the wdt1 timer is disabled.
+    assert_eq!(hw.soc_ifc().cptra_wdt_timer1_en().read().timer1_en(), false);
+}
+
+#[test]
+fn test_wdt_not_enabled_on_debug_part() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(false)
+        .set_device_lifecycle(DeviceLifecycle::Unprovisioned);
+
+    let rom =
+        caliptra_builder::build_firmware_rom(&caliptra_builder::firmware::ROM_WITH_UART).unwrap();
+    let mut hw = caliptra_hw_model::new(caliptra_hw_model::BootParams {
+        init_params: caliptra_hw_model::InitParams {
+            rom: &rom,
+            security_state,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+    .unwrap();
+
+    // Confirm security state is as expected.
+    assert!(!hw.soc_ifc().cptra_security_state().read().debug_locked());
+
+    hw.step_until_boot_status(KatStarted.into(), false);
+
+    // Make sure the wdt1 timer is disabled.
+    assert_eq!(hw.soc_ifc().cptra_wdt_timer1_en().read().timer1_en(), false);
+}

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
 ufmt.workspace = true
 
 [build-dependencies]

--- a/rom/dev/tools/test-rt/src/main.rs
+++ b/rom/dev/tools/test-rt/src/main.rs
@@ -14,7 +14,8 @@ Abstract:
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
 
-use caliptra_drivers::Mailbox;
+use caliptra_drivers::{Mailbox, SocIfc};
+use caliptra_registers::soc_ifc::SocIfcReg;
 
 #[cfg(not(feature = "std"))]
 core::arch::global_asm!(include_str!("start.S"));
@@ -37,6 +38,10 @@ const BANNER: &str = r#"
 #[no_mangle]
 pub extern "C" fn rt_entry() -> ! {
     cprintln!("{}", BANNER);
+
+    let mut soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+
+    soc_ifc.assert_ready_for_runtime();
 
     caliptra_drivers::ExitCtrl::exit(0)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -196,9 +196,9 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
 
         if drivers.mbox.is_cmd_ready() {
             // TODO : Move start/stop WDT to wait_for_cmd when NMI is implemented.
-            caliptra_common::wdt::start_wdt(
+            caliptra_drivers::wdt::start_wdt(
                 &mut drivers.soc_ifc,
-                caliptra_common::WdtTimeout::default(),
+                caliptra_drivers::WdtTimeout::default(),
             );
             caliptra_drivers::report_fw_error_non_fatal(0);
             match handle_command(drivers) {
@@ -210,7 +210,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
                     drivers.mbox.set_status(MboxStatusE::CmdFailure);
                 }
             }
-            caliptra_common::wdt::stop_wdt(&mut drivers.soc_ifc);
+            caliptra_drivers::wdt::stop_wdt(&mut drivers.soc_ifc);
         }
     }
     Ok(())

--- a/runtime/test-fw/src/wdt_timeout_tests.rs
+++ b/runtime/test-fw/src/wdt_timeout_tests.rs
@@ -15,8 +15,8 @@ Abstract:
 #![no_std]
 #![no_main]
 
-use caliptra_common::start_wdt;
-use caliptra_common::WdtTimeout;
+use caliptra_drivers::WdtTimeout;
+use caliptra_drivers::{start_wdt, stop_wdt};
 use caliptra_runtime::Drivers;
 use caliptra_test_harness::{runtime_handlers, test_suite};
 
@@ -25,6 +25,9 @@ fn test_wdt_timeout() {
 
     start_wdt(&mut drivers.soc_ifc, WdtTimeout::default());
 
+    stop_wdt(&mut drivers.soc_ifc);
+
+    start_wdt(&mut drivers.soc_ifc, WdtTimeout::default());
     loop {}
 }
 


### PR DESCRIPTION
- Move wdt from common to drivers
- Test activation and stoppage of WDT
- Always reset watchdog timer after enabling it to guarantee counting starts from zero.