### PR TITLE
Expand FPGA KV to 16 keys and report_utilization during build

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -24,6 +24,7 @@ zerocopy.workspace = true
 
 [features]
 slow_tests = []
+fpga_realtime = []
 
 [[bin]]
 name = "image"

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -142,6 +142,12 @@ pub fn build_firmware_elfs_uncached<'a>(
             }
             features_csv.push_str("riscv");
         }
+        if cfg!(feature = "fpga_realtime") {
+            if !features_csv.is_empty() {
+                features_csv.push(',');
+            }
+            features_csv.push_str("fpga_realtime");
+        }
 
         let workspace_dir = workspace_dir.unwrap_or_else(|| Path::new(THIS_WORKSPACE_DIR));
 

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -25,7 +25,7 @@ zeroize.workspace = true
 [features]
 emu = []
 runtime = ["dep:dpe"]
-fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
+fpga_realtime = ["caliptra-hw-model/fpga_realtime", "caliptra-builder/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -18,6 +18,7 @@ zerocopy.workspace = true
 
 [features]
 emu = ["caliptra-test-harness/emu"]
+fpga_realtime = []
 
 # This feature is used to filter all these binary targets during normal builds
 # (targets must be built with cargo arguments:

--- a/drivers/test-fw/src/bin/keyvault_tests.rs
+++ b/drivers/test-fw/src/bin/keyvault_tests.rs
@@ -19,6 +19,7 @@ use caliptra_drivers::{KeyId, KeyUsage, KeyVault};
 use caliptra_registers::kv::KvReg;
 use caliptra_test_harness::test_suite;
 
+#[cfg(not(feature = "fpga_realtime"))]
 const KEY_IDS: [KeyId; 32] = [
     KeyId::KeyId0,
     KeyId::KeyId1,
@@ -52,6 +53,26 @@ const KEY_IDS: [KeyId; 32] = [
     KeyId::KeyId29,
     KeyId::KeyId30,
     KeyId::KeyId31,
+];
+
+#[cfg(feature = "fpga_realtime")]
+const KEY_IDS: [KeyId; 16] = [
+    KeyId::KeyId0,
+    KeyId::KeyId1,
+    KeyId::KeyId2,
+    KeyId::KeyId3,
+    KeyId::KeyId4,
+    KeyId::KeyId5,
+    KeyId::KeyId6,
+    KeyId::KeyId7,
+    KeyId::KeyId8,
+    KeyId::KeyId9,
+    KeyId::KeyId10,
+    KeyId::KeyId11,
+    KeyId::KeyId12,
+    KeyId::KeyId13,
+    KeyId::KeyId14,
+    KeyId::KeyId15,
 ];
 
 fn test_write_lock_and_erase_keys() {

--- a/hw-latest/fpga/fpga_configuration.tcl
+++ b/hw-latest/fpga/fpga_configuration.tcl
@@ -309,6 +309,7 @@ if {$BUILD} {
   launch_runs impl_1 -jobs 10
   wait_on_runs impl_1
   open_run impl_1
+  report_utilization -file $outputDir/utilization.txt
   # Embed git hash in USR_ACCESS register for bitstream identification.
   set_property BITSTREAM.CONFIG.USR_ACCESS 0x$VERSION [current_design]
   write_bitstream -bin_file $outputDir/caliptra_fpga

--- a/hw-latest/fpga/src/kv_reg.sv
+++ b/hw-latest/fpga/src/kv_reg.sv
@@ -1,6 +1,6 @@
 // FPGA replacement for KV with a configurable depth to use less resources
 
-`define KV_DEPTH 8
+`define KV_DEPTH 16
 
 module kv_reg (
         input wire clk,


### PR DESCRIPTION
Restrict KV tests to 16 keys for fpga_realtime