### PR TITLE
Set PL0 PAUSER to 1 for test image bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ hw-latest/fpga/caliptra_build/
 hw-latest/fpga/build_fpga.log
 hw-latest/fpga/vivado*.jou
 hw-latest/fpga/vivado*.log
+
+# libcaliptra build artifacts
+libcaliptra/libcaliptra.a

--- a/image/fake-keys/src/lib.rs
+++ b/image/fake-keys/src/lib.rs
@@ -338,7 +338,7 @@ pub const VENDOR_CONFIG_KEY_0: ImageGeneratorVendorConfig = ImageGeneratorVendor
     priv_keys: Some(VENDOR_PRIVATE_KEYS),
     not_before: [0u8; 15],
     not_after: [0u8; 15],
-    pl0_pauser: None,
+    pl0_pauser: Some(0x1),
 };
 
 pub const VENDOR_CONFIG_KEY_1: ImageGeneratorVendorConfig = ImageGeneratorVendorConfig {


### PR DESCRIPTION
HwModel currently defaults to setting the caller to be PAUSER 1 in all cases.

Set the PL0 PAUSER to 1 so that DPE can be fully tested with this configuration. Some DPE features are only available to the PL0 PAUSER.