### PR TITLE
Output warning message in libcaliptra build if RTL repo isn't specified

### DIFF
--- a/libcaliptra/Makefile
+++ b/libcaliptra/Makefile
@@ -3,11 +3,12 @@ Q=@
 CC=$(CROSS_COMPILE)gcc
 AR=$(CROSS_COMPILE)ar
 
-RTL_SOC_IFC_INCLUDE_PATH ?= ../hw-latest/caliptra-rtl/src/soc_ifc/rtl
-
 ifneq ($(MAKECMDGOALS),clean)
 ifndef RTL_SOC_IFC_INCLUDE_PATH
-$(error RTL_SOC_IFC_INCLUDE_PATH must be defined and point to a location where caliptra_top_reg.h can be found)
+RTL_SOC_IFC_INCLUDE_PATH ?= ../hw-latest/caliptra-rtl/src/soc_ifc/rtl
+
+$(warning RTL_SOC_IFC_INCLUDE_PATH must be defined and point to a location where caliptra_top_reg.h can be found)
+$(warning Defaulting to $(RTL_SOC_IFC_INCLUDE_PATH))
 endif
 endif
 


### PR DESCRIPTION
When libcaliptra is built from inside caliptra-sw, it can default to use the hw-latest submodule. Output a warning that the default behavior is happening. This will help in troubleshooting if the submodule isn't present or is at an unexpected location.