### PR TITLE
FPGA CI: Always use latest GHA runner version.

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - "ci-tools/fpga-image/**"
 
+  schedule:
+    # 5:13 AM PST tuesday, thursday
+    - cron: '13 13 * * 2,4'
+
   workflow_call:
   workflow_dispatch:
 

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -46,10 +46,14 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   # Comment this line out if you don't trust folks with physical access to the
   # uart
   # chroot out/rootfs bash -c 'echo root:password | chpasswd'
+  #
 
+  echo Retrieving latest GHA runner version
+  RUNNER_VERSION="$(curl https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name[1:]')"
+  echo Using runner version ${RUNNER_VERSION}
   trap - EXIT
-  (cd out/rootfs/home/runner && curl -O -L https://github.com/actions/runner/releases/download/v2.308.0/actions-runner-linux-arm64-2.308.0.tar.gz)
-  chroot out/rootfs bash -c 'su runner -c "cd /home/runner && tar xvzf actions-runner-linux-arm64-2.308.0.tar.gz && rm -f actions-runner-linux-arm64-2.308.0.tar.gz"'
+  (cd out/rootfs/home/runner && curl -O -L "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz")
+  chroot out/rootfs bash -c "su runner -c \"cd /home/runner && tar xvzf actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz && rm -f actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz\""
 fi
 
 chroot out/rootfs bash -c 'echo ::1 caliptra-fpga >> /etc/hosts'


### PR DESCRIPTION
Also, rebuild the FPGA SD image twice a week with the latest GHA runner version.