### PR TITLE
fpga_realtime: Service etrng requests from separate thread.

### DIFF
--- a/drivers/tests/integration_tests.rs
+++ b/drivers/tests/integration_tests.rs
@@ -731,7 +731,10 @@ fn trng_nibbles() -> impl Iterator<Item = u8> + Clone {
 }
 
 // Helper function to run CSRNG test binaries with specific entropy nibbles.
-fn test_csrng_with_nibbles(fwid: &FwId<'static>, itrng_nibbles: Box<dyn Iterator<Item = u8>>) {
+fn test_csrng_with_nibbles(
+    fwid: &FwId<'static>,
+    itrng_nibbles: Box<dyn Iterator<Item = u8> + Send>,
+) {
     let rom = caliptra_builder::build_firmware_rom(fwid).unwrap();
 
     let mut model = caliptra_hw_model::new(BootParams {

--- a/hw-model/types/src/lib.rs
+++ b/hw-model/types/src/lib.rs
@@ -2,7 +2,10 @@
 
 use std::array;
 
-use rand::{rngs::ThreadRng, RngCore};
+use rand::{
+    rngs::{StdRng, ThreadRng},
+    RngCore, SeedableRng,
+};
 
 // Rationale behind this choice
 //
@@ -214,9 +217,9 @@ pub struct EtrngResponse {
 }
 
 pub struct RandomEtrngResponses<R: RngCore>(pub R);
-impl RandomEtrngResponses<ThreadRng> {
-    pub fn new_from_thread_rng() -> Self {
-        Self(rand::thread_rng())
+impl RandomEtrngResponses<StdRng> {
+    pub fn new_from_stdrng() -> Self {
+        Self(StdRng::from_entropy())
     }
 }
 impl<R: RngCore> Iterator for RandomEtrngResponses<R> {

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -236,7 +236,7 @@ impl Default for CaliptraRootBusArgs {
             download_idevid_csr_cb: Default::default(),
             cptra_obf_key: words_from_bytes_be(&DEFAULT_DOE_KEY),
             itrng_nibbles: Some(Box::new(RandomNibbles::new_from_thread_rng())),
-            etrng_responses: Box::new(RandomEtrngResponses::new_from_thread_rng()),
+            etrng_responses: Box::new(RandomEtrngResponses::new_from_stdrng()),
         }
     }
 }


### PR DESCRIPTION
We are seeing intermittent failures from tests that let the hardware model run in the background while they do something else. When the test takes longer than 25ms to respond to etrng requests, the firmware times out. Servicing these requests from a separate thread should make things more reliable.