### PR TITLE
Test that memcpy-like functions are not called before CFI init in ROM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,7 @@ dependencies = [
  "caliptra-x509",
  "caliptra_common",
  "cfg-if 1.0.0",
+ "elf",
  "hex",
  "memoffset 0.8.0",
  "openssl",

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-579b802ebe5e118a83947fc57a8d4b40d0d468d1d093500e4c356ccee4b944b52cb598882255c8b3a70c847756a51259  caliptra-rom-no-log.bin
-5a32bf1488f94634aeefb027ddb338d3de33602c83762aed44e62c78a1f27f358c1f2e4af760107d783f0fffdab85df6  caliptra-rom-with-log.bin
+61fe1910f551e4349960f7470e888c08da73ca198088de0eb2774421383aa7f3c8e427f2d2f604faf07ed57262770f45  caliptra-rom-no-log.bin
+6ece85186f5b6d1dc248be35e0957a95ac78609b5f1dc1cee507ccee5b4f88bdfbf39c0524ecbd645b46f1d0d6c2c142  caliptra-rom-with-log.bin

--- a/common/src/boot_status.rs
+++ b/common/src/boot_status.rs
@@ -77,8 +77,9 @@ pub enum RomBootStatus {
     UpdateResetComplete = UPDATE_RESET_BOOT_STATUS_BASE + 7,
 
     // ROM Global Boot Statues
-    KatStarted = ROM_GLOBAL_BOOT_STATUS_BASE,
-    KatComplete = ROM_GLOBAL_BOOT_STATUS_BASE + 1,
+    CfiInitialized = ROM_GLOBAL_BOOT_STATUS_BASE,
+    KatStarted = ROM_GLOBAL_BOOT_STATUS_BASE + 1,
+    KatComplete = ROM_GLOBAL_BOOT_STATUS_BASE + 2,
 }
 
 impl From<RomBootStatus> for u32 {

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -36,6 +36,7 @@ caliptra-image-gen.workspace = true
 caliptra-image-openssl.workspace = true
 caliptra-image-types.workspace = true
 caliptra-test.workspace = true
+elf.workspace = true
 hex.workspace = true
 memoffset.workspace = true
 openssl.workspace = true

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -17,12 +17,14 @@ Abstract:
 
 use crate::{lock::lock_registers, print::HexBytes};
 use caliptra_cfi_lib::{cfi_assert_eq, CfiCounter};
+use caliptra_common::RomBootStatus;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use core::hint::black_box;
 
 use caliptra_drivers::{
-    cprintln, report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError, Ecc384, Hmac384,
-    KeyVault, Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, ShaAccLockState, SocIfc, Trng,
+    cprintln, report_boot_status, report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError,
+    Ecc384, Hmac384, KeyVault, Mailbox, ResetReason, Sha256, Sha384, Sha384Acc, ShaAccLockState,
+    SocIfc, Trng,
 };
 use caliptra_error::CaliptraResult;
 use caliptra_image_types::RomInfo;
@@ -93,6 +95,8 @@ pub extern "C" fn rom_entry() -> ! {
         !env.soc_ifc.hw_config_internal_trng(),
         matches!(env.trng, Trng::External(_)),
     );
+
+    report_boot_status(RomBootStatus::CfiInitialized.into());
 
     let _lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -4,6 +4,7 @@ mod helpers;
 
 mod rv32_unit_tests;
 mod test_capabilities;
+mod test_cfi;
 mod test_dice_derivations;
 mod test_fake_rom;
 mod test_fmcalias_derivation;

--- a/rom/dev/tests/rom_integration_tests/test_cfi.rs
+++ b/rom/dev/tests/rom_integration_tests/test_cfi.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{
+    elf_symbols,
+    firmware::{ROM, ROM_WITH_UART},
+    Symbol,
+};
+use caliptra_common::RomBootStatus;
+use caliptra_hw_model::{BootParams, HwModel, InitParams};
+
+fn find_symbol<'a>(symbols: &'a [Symbol<'a>], name: &str) -> &'a Symbol<'a> {
+    symbols
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("Could not find symbol {name}"))
+}
+
+fn find_symbol_containing<'a>(symbols: &'a [Symbol<'a>], search: &str) -> &'a Symbol<'a> {
+    let mut matching_symbols = symbols.iter().filter(|s| s.name.contains(search));
+    let Some(result) = matching_symbols.next() else {
+        panic!("Could not find symbol with substring {search:?}");
+    };
+    if let Some(second_match) = matching_symbols.next() {
+        panic!(
+            "Multiple symbols matching substring {search:?}: {:?}, {:?}",
+            result.name, second_match.name
+        );
+    }
+    result
+}
+
+fn assert_symbol_not_called(hw: &caliptra_hw_model::ModelEmulated, symbol: &Symbol) {
+    assert!(
+        !hw.code_coverage_bitmap()[symbol.value as usize],
+        "{}() was called before the boot status changed to KatStarted. This is a CFI risk, as glitching a function like that could lead to an out-of-bounds write", symbol.name);
+}
+
+#[test]
+fn test_memcpy_not_called_before_cfi_init() {
+    for fwid in &[&ROM_WITH_UART, &ROM] {
+        println!("Runing with firmware {:?}", fwid);
+        let elf_bytes = caliptra_builder::build_firmware_elf(fwid).unwrap();
+        let symbols = elf_symbols(&elf_bytes).unwrap();
+
+        let rom = caliptra_builder::elf2rom(&elf_bytes).unwrap();
+
+        let mut hw = caliptra_hw_model::ModelEmulated::new(BootParams {
+            init_params: InitParams {
+                rom: &rom,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .unwrap();
+
+        hw.step_until_boot_status(RomBootStatus::CfiInitialized.into(), true);
+
+        assert_symbol_not_called(&hw, find_symbol(&symbols, "memcpy"));
+        assert_symbol_not_called(&hw, find_symbol(&symbols, "memset"));
+        assert_symbol_not_called(&hw, find_symbol_containing(&symbols, "read_volatile_slice"));
+        assert_symbol_not_called(
+            &hw,
+            find_symbol_containing(&symbols, "write_volatile_slice"),
+        );
+    }
+}

--- a/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
+++ b/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
@@ -13,6 +13,7 @@ fn test_cold_reset_status_reporting() {
     let (mut hw, image_bundle) =
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
 
+    hw.step_until_boot_status(CfiInitialized.into(), false);
     hw.step_until_boot_status(KatStarted.into(), false);
     hw.step_until_boot_status(KatComplete.into(), false);
     hw.step_until_boot_status(ColdResetStarted.into(), false);

--- a/rom/dev/tests/rom_integration_tests/test_fake_rom.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fake_rom.rs
@@ -37,6 +37,7 @@ fn test_skip_kats() {
     })
     .unwrap();
 
+    hw.step_until_boot_status(caliptra_common::RomBootStatus::CfiInitialized.into(), false);
     // If KatStarted boot status is posted before ColResetStarted, the statement below will trigger panic.
     hw.step_until_boot_status(
         caliptra_common::RomBootStatus::ColdResetStarted.into(),

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -229,6 +229,7 @@ fn test_update_reset_boot_status() {
     .unwrap();
 
     if cfg!(not(feature = "fpga_realtime")) {
+        hw.step_until_boot_status(CfiInitialized.into(), false);
         hw.step_until_boot_status(KatStarted.into(), false);
         hw.step_until_boot_status(KatComplete.into(), false);
         hw.step_until_boot_status(UpdateResetStarted.into(), false);

--- a/rom/dev/tests/rom_integration_tests/test_wdt_activation_and_stoppage.rs
+++ b/rom/dev/tests/rom_integration_tests/test_wdt_activation_and_stoppage.rs
@@ -5,7 +5,7 @@ use caliptra_builder::{
     firmware::{self, APP_WITH_UART},
     ImageOptions,
 };
-use caliptra_common::RomBootStatus::KatStarted;
+use caliptra_common::RomBootStatus::{self, KatStarted};
 use caliptra_hw_model::{DeviceLifecycle, HwModel, SecurityState};
 
 #[test]
@@ -79,6 +79,7 @@ fn test_wdt_not_enabled_on_debug_part() {
     // Confirm security state is as expected.
     assert!(!hw.soc_ifc().cptra_security_state().read().debug_locked());
 
+    hw.step_until_boot_status(RomBootStatus::CfiInitialized.into(), false);
     hw.step_until_boot_status(KatStarted.into(), false);
 
     // Make sure the wdt1 timer is disabled.


### PR DESCRIPTION
This helps us ensure that the compiler heuristics don't do something undesirable in the future and regress our fixes for https://github.com/chipsalliance/caliptra-sw/issues/922, and was called out as a gap in nickg-ca's review: https://github.com/chipsalliance/caliptra-sw/pull/989#issuecomment-1778000390

To make writing this test possible, I had to add a new CfiInitialized boot status to the ROM (as memcpy is called between then and the KatStarted boot status).