### PR TITLE
Populate extended error info

### DIFF
--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -83,7 +83,7 @@ impl Platform for DpePlatform<'_> {
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
         Digest::write_hex_str(&self.hashed_rt_pub_key, &mut serial)
-            .map_err(|_| PlatformError::IssuerNameError)?;
+            .map_err(|e| PlatformError::IssuerNameError(e.get_error_detail().unwrap_or(0)))?;
 
         let name = Name {
             cn: DirectoryString::Utf8String(CALIPTRA_CN),
@@ -91,7 +91,7 @@ impl Platform for DpePlatform<'_> {
         };
         let issuer_len = issuer_writer
             .encode_rdn(&name)
-            .map_err(|_| PlatformError::IssuerNameError)?;
+            .map_err(|e| PlatformError::IssuerNameError(e.get_error_detail().unwrap_or(0)))?;
 
         Ok(issuer_len)
     }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -74,7 +74,7 @@ impl StashMeasurementCmd {
 
             Ok(MailboxResp::StashMeasurement(StashMeasurementResp {
                 hdr: MailboxRespHeader::default(),
-                dpe_result: dpe_result as u32,
+                dpe_result: dpe_result.get_error_code(),
             }))
         } else {
             Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)

--- a/test/dpe_verification/dpe_test.go
+++ b/test/dpe_verification/dpe_test.go
@@ -9,15 +9,32 @@ import (
 )
 
 func TestRunAll(t *testing.T) {
-	for _, test := range verification.TestCases {
-		t.Run(test.Name, func(t *testing.T) {
-			var d verification.TestDPEInstance = &CptraModel{}
+	var d verification.TestDPEInstance = &CptraModel{}
 
+	// Power on Caliptra
+	err := d.PowerOn()
+	if err != nil {
+		t.Fatalf("Could not power on the target: %v", err)
+	}
+	defer d.PowerOff()
+
+	for _, test := range verification.AllTestCases {
+		t.Run(test.Name, func(t *testing.T) {
 			if !verification.HasSupportNeeded(d, test.SupportNeeded) {
 				t.Skipf("Warning: Target does not have required support, skipping test.")
 			}
 
-			test.Run(d, t)
+			profile, err := verification.GetTransportProfile(d)
+			if err != nil {
+				t.Fatalf("Could not get profile: %v", err)
+			}
+
+			c, err := verification.NewClient(d, profile)
+			if err != nil {
+				t.Fatalf("Could not initialize client: %v", err)
+			}
+
+			test.Run(d, c, t)
 		})
 	}
 }

--- a/test/dpe_verification/transport.go
+++ b/test/dpe_verification/transport.go
@@ -193,7 +193,6 @@ func (s *CptraModel) GetSupport() *verification.Support {
 		Simulation:    true,
 		ExtendTci:     true,
 		AutoInit:      true,
-		Tagging:       true,
 		RotateContext: true,
 		X509:          true,
 		Csr:           true,
@@ -207,6 +206,11 @@ func (s *CptraModel) GetSupport() *verification.Support {
 func (s *CptraModel) GetSupportedLocalities() []uint32 {
 	// TODO: Make this configurable, since it will be SoC specific
 	return []uint32{0, 1}
+}
+
+func (s *CptraModel) HasLocalityControl() bool {
+	// TODO: Hook this up to HwModel
+	return false
 }
 
 func (s *CptraModel) SetLocality(locality uint32) {
@@ -236,4 +240,13 @@ func (s *CptraModel) GetProfileVendorId() uint32 {
 
 func (s *CptraModel) GetProfileVendorSku() uint32 {
 	return binary.BigEndian.Uint32([]byte{'C', 'T', 'R', 'A'})
+}
+
+func (s *CptraModel) GetIsInitialized() bool {
+	// Always auto initialized
+	return true
+}
+
+func (s *CptraModel) SetIsInitialized(isInitialized bool) {
+	// no-op. Always initialized
 }

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -341,11 +341,11 @@ fn test_rt_wdt_timeout() {
 
     // TODO: Don't hard-code these; maybe measure from a previous boot?
     let rt_wdt_timeout_cycles = if cfg!(any(feature = "verilator", feature = "fpga_realtime")) {
-        27_000_000
+        27_100_000
     } else if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
-        2_900_000
+        3_000_000
     } else {
-        2_700_000
+        2_800_000
     };
 
     let security_state = *caliptra_hw_model::SecurityState::default().set_debug_locked(true);
@@ -371,9 +371,9 @@ fn test_fmc_wdt_timeout() {
 
     // TODO: Don't hard-code these; maybe measure from a previous boot?
     let fmc_wdt_timeout_cycles = if cfg!(any(feature = "verilator", feature = "fpga_realtime")) {
-        25_000_000
+        25_100_000
     } else {
-        2_620_000
+        2_720_000
     };
 
     let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();


### PR DESCRIPTION
DPE errors carry Caliptra error codes from the platform/crypto layers if applicable. When returning the response for a failed DPE command, populate the extended fw error info register.

Note: added 100K cycles to the WDT timeout to acommodate for a larger RT image (due to RT being larger). The ~5K RT size increase is due to a new DPE feature (CertifyKey CSR format) unrelated to this PR.

Fixes https://github.com/chipsalliance/caliptra-sw/issues/956