### PR TITLE
Add ROM stress test for generating idev CSR.

### DIFF
--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -58,6 +58,7 @@ verilator = ["caliptra-hw-model/verilator"]
 no-fmc = []
 fake-rom = []
 no-cfi = []
+slow_tests = []
 
 [[bin]]
 name = "asm_tests"

--- a/rom/dev/doc/test-coverage/test-coverage.md
+++ b/rom/dev/doc/test-coverage/test-coverage.md
@@ -70,6 +70,7 @@ Check value in ColdResetEntry4::RomColdBootStatus datavault register | **test_ch
 Check if entries are correctly added in Firmware Handoff table | **test_fht_info**   | N/A
 Check if LMS Vendor PubKey Index in datavault is 0xFFFFFFFF when LMS verification is not enabled | **test_check_no_lms_info_in_datavault_on_lms_unavailable**   | N/A
 Check if boot statuses are correctly reported | **test_cold_reset_status_reporting** | N/A
+Stress test: Boot caliptra 1000 times with a different UDS identity each time, and confirm generated certs are valid. This should expose x509 serialization bugs. |**test_generate_csr_stress** | N/A
 
 <br><br>
 # **Firmware Downloader Tests**
@@ -127,7 +128,6 @@ Validate fix for #817: warm reset during hitless update | N/A | N/A
 Validate fix for #628: warm reset during cold reset | N/A | N/A
 Add test for watchdog failure, and that extended error info is populated correctly | N/A | N/A
 Add test for CPU fault, and that extended error info is populated correctly | N/A | N/A
-Stress test: Boot caliptra 1000 times with a different UDS identity each time, and confirm generated certs are valid. This should expose x509 serialization bugs. | N/A | N/A
 Stress test: Perform many hitless updates in a row | N/A | N/A
 Ensure that boot ROM can load a 128k bundle into ICCM (assert ICCM contents in test) | N/A | N/A
 Ensure that hitless update flow can update an entire 128k bundle with completely different ICCM contents than original boot | N/A | N/A

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -2,16 +2,15 @@
 
 use caliptra_builder::ImageOptions;
 use caliptra_drivers::{IdevidCertAttr, MfgFlags, X509KeyIdAlgo};
-use caliptra_hw_model::{Fuses, HwModel};
+use caliptra_hw_model::{DefaultHwModel, Fuses, HwModel};
+use caliptra_image_types::ImageBundle;
+use openssl::{rand::rand_bytes, x509::X509Req};
 use std::io::Write;
 
 use crate::helpers;
 
-#[test]
-fn test_generate_csr() {
+fn generate_csr(hw: &mut DefaultHwModel, image_bundle: &ImageBundle) -> Csrs {
     let mut output = vec![];
-    let (mut hw, image_bundle) =
-        helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
 
     // Set gen_idev_id_csr to generate CSR.
     let flags = MfgFlags::GENERATE_IDEVID_CSR;
@@ -20,7 +19,7 @@ fn test_generate_csr() {
         .write(|_| flags.bits());
 
     // Download the CSR from the mailbox.
-    let csr_downloaded = helpers::get_csr(&mut hw).unwrap();
+    let downloaded = helpers::get_csr(hw).unwrap();
 
     // Wait for uploading firmware.
     hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_fw());
@@ -35,8 +34,22 @@ fn test_generate_csr() {
         .unwrap();
     let output = String::from_utf8_lossy(&output);
     let csr_str = helpers::get_data("[idev] CSR = ", &output);
-    let csr_uploaded = hex::decode(csr_str).unwrap();
-    assert_eq!(csr_uploaded, csr_downloaded);
+    let uploaded = hex::decode(csr_str).unwrap();
+    Csrs {
+        uploaded,
+        downloaded,
+    }
+}
+
+#[test]
+fn test_generate_csr() {
+    let (mut hw, image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
+    let Csrs {
+        uploaded,
+        downloaded,
+    } = generate_csr(&mut hw, &image_bundle);
+    assert_eq!(uploaded, downloaded);
 }
 
 #[test]
@@ -53,4 +66,58 @@ fn test_idev_subj_key_id_algo() {
         hw.step_until_output_contains("Caliptra RT listening for mailbox commands...")
             .unwrap();
     }
+}
+
+fn fuses_with_random_uds() -> Fuses {
+    const UDS_LEN: usize = core::mem::size_of::<u32>() * 12;
+    let mut uds_bytes = [0; UDS_LEN];
+    rand_bytes(&mut uds_bytes).unwrap();
+    let mut uds_seed = [0u32; 12];
+
+    for (word, bytes) in uds_seed.iter_mut().zip(uds_bytes.chunks_exact(4)) {
+        *word = u32::from_be_bytes(bytes.try_into().unwrap());
+    }
+    Fuses {
+        uds_seed,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_generate_csr_stress() {
+    let num_tests = if cfg!(feature = "slow_tests") {
+        1000
+    } else {
+        1
+    };
+
+    for _ in 0..num_tests {
+        let fuses = fuses_with_random_uds();
+        let (mut hw, image_bundle) =
+            helpers::build_hw_model_and_image_bundle(fuses, ImageOptions::default());
+
+        let Csrs {
+            uploaded,
+            downloaded: _,
+        } = generate_csr(&mut hw, &image_bundle);
+
+        // Ensure CSR is valid X.509
+        let req = X509Req::from_der(&uploaded).unwrap_or_else(|_| {
+            panic!(
+                "Failed to create a valid X509 cert with UDS seed {:?}",
+                fuses.uds_seed
+            )
+        });
+        let pub_key = req.public_key().unwrap();
+        assert!(
+            req.verify(&pub_key).unwrap(),
+            "Invalid public key. Unable to verify CSR with UDS seed {:?}",
+            fuses.uds_seed
+        );
+    }
+}
+
+struct Csrs {
+    uploaded: Vec<u8>,
+    downloaded: Vec<u8>,
 }


### PR DESCRIPTION
Boots Calitpra 1000 times with different UDS values to confirm valid CSR generation and expose possible serialization bugs.