### PR TITLE
Update frozen image hashes

### DIFF
--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,6 +1,8 @@
 name: Policy
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
 
 jobs:

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-1bb333b8c0942365b906662ce8232c4cc1f0fae651645b4db58509c63afd9e32505d8decd10145a3124806626a39aef2  caliptra-rom-no-log.bin
-31abfb343aa4650bca59502f7a51be0a6a7a980bfafd6a644946fab75296f609af5bb69be18481c76779119c580889fc  caliptra-rom-with-log.bin
+4b908ac3ac03883f055fe00b18e72d01c661ff1d17cc40788b7dd076c69b288bcc68a944f17e94356a2204d56a7b698a  caliptra-rom-no-log.bin
+bb2e2f5cf85055128615467fc456e76ee67a13ad46719f45560c11eecdc41e79b86b184d80637e2eb61f3232a5d18350  caliptra-rom-with-log.bin


### PR DESCRIPTION
PR #1015 didn't update these to the correct value. The policy check on that PR failed:

https://github.com/chipsalliance/caliptra-sw/actions/runs/6723263310/job/18272960952?pr=1015

Unfortunately, at the time that wasn't a required check, and didn't block the auto-merge. That's rectified now in the repo settings.

Also, this commit runs the policy check on all pushes to main, to make it clear in the commit history that it is passing at head.