### PR TITLE
Ecc384::key_pair: make ecc_private_key_usage mandatory.

### DIFF
--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -35,7 +35,7 @@ fn export_result_from_kv(ecc: &mut Ecc384, trng: &mut Trng, key_id: KeyId) -> Ec
         &KeyReadArgs::new(key_id).into(),
         &Array4x12::default(),
         trng,
-        KeyWriteArgs::new(KeyId::KeyId3, KeyUsage::default()).into(),
+        KeyWriteArgs::new(KeyId::KeyId3, KeyUsage::default().set_ecc_private_key_en()).into(),
     )
     .unwrap()
 }

--- a/drivers/test-fw/src/bin/hmac384_tests.rs
+++ b/drivers/test-fw/src/bin/hmac384_tests.rs
@@ -130,7 +130,13 @@ fn test_kv_hmac(seed: &[u8; 48], data: &[u8], out_pub_x: &[u8; 48], out_pub_y: &
         &Ecc384Seed::from(&Ecc384Scalar::from(seed)),
         &Array4x12::default(),
         &mut trng,
-        KeyWriteArgs::new(KeyId::KeyId0, KeyUsage::default().set_hmac_key_en()).into(),
+        KeyWriteArgs::new(
+            KeyId::KeyId0,
+            KeyUsage::default()
+                .set_hmac_key_en()
+                .set_ecc_private_key_en(),
+        )
+        .into(),
     )
     .unwrap();
 
@@ -151,7 +157,7 @@ fn test_kv_hmac(seed: &[u8; 48], data: &[u8], out_pub_x: &[u8; 48], out_pub_y: &
             &KeyReadArgs::new(KeyId::KeyId1).into(),
             &Array4x12::default(),
             &mut trng,
-            KeyWriteArgs::new(KeyId::KeyId2, KeyUsage::default()).into(),
+            KeyWriteArgs::new(KeyId::KeyId2, KeyUsage::default().set_ecc_private_key_en()).into(),
         )
         .unwrap();
 
@@ -274,7 +280,9 @@ fn test_hmac5() {
     let seed = [0u8; 48];
     let key_out_1 = KeyWriteArgs {
         id: KeyId::KeyId0,
-        usage: KeyUsage::default().set_hmac_key_en(),
+        usage: KeyUsage::default()
+            .set_hmac_key_en()
+            .set_ecc_private_key_en(),
     };
     let result = ecc.key_pair(
         &Ecc384Seed::from(&Ecc384Scalar::from(seed)),
@@ -388,7 +396,7 @@ fn test_kdf(
     )
     .unwrap();
 
-    let ecc_out = KeyWriteArgs::new(KeyId::KeyId2, KeyUsage::default());
+    let ecc_out = KeyWriteArgs::new(KeyId::KeyId2, KeyUsage::default().set_ecc_private_key_en());
 
     let pub_key = ecc
         .key_pair(

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -112,6 +112,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x0005000e);
     pub const DRIVER_ECC384_SCALAR_RANGE_CHECK_FAILED: CaliptraError =
         CaliptraError::new_const(0x0005000f);
+    pub const DRIVER_ECC384_KEYGEN_BAD_USAGE: CaliptraError = CaliptraError::new_const(0x00050010);
 
     pub const DRIVER_KV_ERASE_USE_LOCK_SET_FAILURE: CaliptraError =
         CaliptraError::new_const(0x00060001);


### PR DESCRIPTION
The real firmware always sets this, and making this mandatory gets rid of the branch around the pairwise-consistency check, which was a CFI risk.

No change to the ROM machine code, as the optimizer appears to have realized that the firmware never took this branch.