### PR TITLE
runtime::test_idev_id_cert: Fix flaky test.

### DIFF
--- a/runtime/tests/runtime_integration_tests/integration_tests.rs
+++ b/runtime/tests/runtime_integration_tests/integration_tests.rs
@@ -29,7 +29,6 @@ use dpe::{
 };
 use openssl::{
     asn1::{Asn1Integer, Asn1Time},
-    bn::BigNumRef,
     hash::MessageDigest,
     x509::{X509Name, X509NameBuilder},
 };
@@ -1074,12 +1073,8 @@ fn test_idev_id_cert() {
     // Extract the r and s values of the signature
     let sig_bytes = cert.signature().as_slice();
     let signature = EcdsaSig::from_der(sig_bytes).unwrap();
-    let r = BigNumRef::to_vec(signature.r());
-    let s = BigNumRef::to_vec(signature.s());
-    let mut signature_r = [0u8; 48];
-    let mut signature_s = [0u8; 48];
-    signature_r.copy_from_slice(&r);
-    signature_s.copy_from_slice(&s);
+    let signature_r: [u8; 48] = signature.r().to_vec_padded(48).unwrap().try_into().unwrap();
+    let signature_s: [u8; 48] = signature.s().to_vec_padded(48).unwrap().try_into().unwrap();
 
     // Extract tbs from cert
     let mut tbs = [0u8; GetIdevCertReq::DATA_MAX_SIZE];


### PR DESCRIPTION
This test was assuming that BigNumRef::to_vec() would pad out the number to 48 bytes, which it doesn't. Use BigNumRef::to_vec_padded(48) instead.

Example Failure:

```
---- integration_tests::test_idev_id_cert stdout ----
thread 'integration_tests::test_idev_id_cert' panicked at 'source slice length (47) does not match destination slice length (48)', runtime/tests/runtime_integration_tests/integration_tests.rs:1081:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
````