### PR TITLE
Add #[inline(never)] to some CFI-wrapped functions

### DIFF
--- a/cfi/derive/src/lib.rs
+++ b/cfi/derive/src/lib.rs
@@ -38,8 +38,10 @@ fn cfi_fn(mod_fn: bool, input: TokenStream) -> TokenStream {
     let mut wrapper_fn: ItemFn = parse_macro_input!(input as ItemFn);
     let mut orig_fn = wrapper_fn.clone();
     orig_fn.sig.ident = format_ident!("__cfi_{}", wrapper_fn.sig.ident);
-    orig_fn.attrs.clear();
+    orig_fn.attrs.retain(|a| a.path.is_ident("inline"));
     orig_fn.vis = syn::Visibility::Inherited;
+
+    wrapper_fn.attrs.retain(|a| !a.path.is_ident("inline"));
 
     let fn_name = format_ident!("{}", orig_fn.sig.ident);
 

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -79,6 +79,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     ///
     /// * `ImageVerificationInfo` - Image verification information success
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub fn verify(
         &mut self,
         manifest: &ImageManifest,

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -104,6 +104,7 @@ impl ColdResetFlow {
 /// # Returns
 ///     CaliptraResult
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
+#[inline(never)]
 pub fn copy_tbs(tbs: &[u8], tbs_type: TbsType, env: &mut RomEnv) -> CaliptraResult<()> {
     let mut persistent_data = env.persistent_data.get_mut();
     let dst = match tbs_type {

--- a/rom/dev/src/fuse.rs
+++ b/rom/dev/src/fuse.rs
@@ -27,6 +27,7 @@ use zerocopy::AsBytes;
 /// * `Err(GlobalErr::FuseLogUpsupportedDataLength)` - Unsupported data length
 ///
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
+#[inline(never)]
 pub fn log_fuse_data(
     log: &mut FuseLogArray,
     entry_id: FuseLogEntryId,

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -41,6 +41,7 @@ struct PcrExtender<'a> {
 }
 impl PcrExtender<'_> {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn extend(&mut self, data: &[u8], pcr_entry_id: PcrLogEntryId) -> CaliptraResult<()> {
         self.pcr_bank
             .extend_pcr(PCR_ID_FMC_CURRENT, self.sha384, data)?;
@@ -58,6 +59,7 @@ impl PcrExtender<'_> {
 ///
 /// * `env` - ROM Environment
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
+#[inline(never)]
 pub(crate) fn extend_pcrs(
     env: &mut FirmwareImageVerificationEnv,
     info: &ImageVerificationInfo,


### PR DESCRIPTION
These functions were being called multiple times in the ROM, and the compiler heuristics were bloating the code by inlining them when it shouldn't have.

Also, make sure that the cfi derive passes explicit inline attributes to the inner function.