### PR TITLE
Fix standalone crate test failures.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "caliptra-builder",
+ "caliptra-cfi-lib",
  "caliptra-cpu",
  "caliptra-drivers",
  "caliptra-error",

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -19,6 +19,7 @@ caliptra-cfi-derive.workspace = true
 
 [dev-dependencies]
 caliptra_common = { path = "../../common", default-features = false }
+caliptra-cfi-lib = { workspace = true, features = ["cfi-test" ] }
 
 [features]
 default = ["std"]

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -15,7 +15,7 @@ Abstract:
 use core::num::NonZeroU32;
 
 use crate::*;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(all(not(test), not(feature = "no-cfi")))]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_eq, cfi_assert_ge, cfi_assert_le, cfi_assert_ne, cfi_launder,
@@ -79,7 +79,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     /// # Returns
     ///
     /// * `ImageVerificationInfo` - Image verification information success
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     #[inline(never)]
     pub fn verify(
         &mut self,
@@ -138,7 +138,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify Preamble
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     fn verify_preamble<'a>(
         &mut self,
         preamble: &'a ImagePreamble,
@@ -379,7 +379,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify Header
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     fn verify_header<'a>(
         &mut self,
         header: &'a ImageHeader,
@@ -558,7 +558,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify Table of Contents
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     fn verify_toc<'a>(
         &mut self,
         manifest: &'a ImageManifest,
@@ -663,7 +663,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify FMC
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     fn verify_fmc(
         &mut self,
         verify_info: &ImageTocEntry,
@@ -753,7 +753,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
     }
 
     /// Verify Runtime
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(all(not(test), not(feature = "no-cfi")), cfi_impl_fn)]
     fn verify_runtime(
         &mut self,
         verify_info: &ImageTocEntry,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -36,6 +36,7 @@ caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-openssl.workspace = true
 caliptra-image-serde.workspace = true
+caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
 openssl.workspace = true
 wycheproof.workspace = true
 


### PR DESCRIPTION
This makes `cargo test -p caliptra-image-verify` and `cargo test -p caliptra-runtime` pass.