### PR TITLE
CFI derive: Use closures for inner function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ serde_json = "1.0"
 sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
 sha3 = "0.10.8"
 smlang = "0.6.0"
-syn = "1.0.107"
+syn = { version = "1.0.107", features = ["visit-mut"] }
 tinytemplate = "1.1"
 tock-registers = { git = "https://github.com/tock/tock.git"}
 toml = "0.7.0"

--- a/cfi/derive/Cargo.toml
+++ b/cfi/derive/Cargo.toml
@@ -10,7 +10,7 @@ proc-macro = true
 doctest = false
 
 [dependencies]
-syn = { version = "1.0.107", features = ["extra-traits", "full"] }
+syn.workspace = true
 quote = "1.0.23"
 proc-macro2 = "1.0.51"
 paste = "1.0.11"

--- a/cfi/derive/src/lib.rs
+++ b/cfi/derive/src/lib.rs
@@ -20,6 +20,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 use syn::parse_quote;
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::FnArg;
 use syn::ItemFn;
 
 #[proc_macro_attribute]
@@ -41,6 +44,23 @@ fn cfi_fn(_mod_fn: bool, input: TokenStream) -> TokenStream {
     // the closure instead.
     f.attrs.retain(|a| !a.path.is_ident("inline"));
 
+    // For some silly reason, LLVM doesn't optimize well if let the closure
+    // capture the arguments. It seems to be fine to let it capture self,
+    // however.
+    let params: Punctuated<_, Comma> = f
+        .sig
+        .inputs
+        .iter()
+        .filter(|f| matches!(f, FnArg::Typed(_)))
+        .collect();
+    let args: Punctuated<_, Comma> = params
+        .iter()
+        .map(|f| match f {
+            FnArg::Typed(a) => &a.pat,
+            _ => unreachable!(),
+        })
+        .collect();
+
     let orig_block = std::mem::replace(&mut f.block, parse_quote!({}));
     f.block.stmts = parse_quote!(
         // This is necessary to allow the inline attribute to be placed on the
@@ -50,10 +70,10 @@ fn cfi_fn(_mod_fn: bool, input: TokenStream) -> TokenStream {
         }
         let __cfi_saved_ctr = caliptra_cfi_lib::CfiCounter::read();
         caliptra_cfi_lib::CfiCounter::delay();
-        let __cfi_ret = __cfi_move(#inline_attr move || {
+        let __cfi_ret = __cfi_move(#inline_attr move |#params| {
             caliptra_cfi_lib::CfiCounter::increment();
             #orig_block
-        })();
+        })(#args);
         caliptra_cfi_lib::CfiCounter::delay();
         let __cfi_new_ctr = caliptra_cfi_lib::CfiCounter::decrement();
         caliptra_cfi_lib::CfiCounter::assert_eq(__cfi_saved_ctr, __cfi_new_ctr);

--- a/cfi/derive/src/lib.rs
+++ b/cfi/derive/src/lib.rs
@@ -17,11 +17,9 @@ References:
 --*/
 
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
-use syn::__private::TokenStream2;
+use quote::quote;
 use syn::parse_macro_input;
 use syn::parse_quote;
-use syn::FnArg;
 use syn::ItemFn;
 
 #[proc_macro_attribute]
@@ -34,63 +32,37 @@ pub fn cfi_impl_fn(_args: TokenStream, input: TokenStream) -> TokenStream {
     cfi_fn(false, input)
 }
 
-fn cfi_fn(mod_fn: bool, input: TokenStream) -> TokenStream {
-    let mut wrapper_fn: ItemFn = parse_macro_input!(input as ItemFn);
-    let mut orig_fn = wrapper_fn.clone();
-    orig_fn.sig.ident = format_ident!("__cfi_{}", wrapper_fn.sig.ident);
-    orig_fn.attrs.retain(|a| a.path.is_ident("inline"));
-    orig_fn.vis = syn::Visibility::Inherited;
+fn cfi_fn(_mod_fn: bool, input: TokenStream) -> TokenStream {
+    let mut f: ItemFn = parse_macro_input!(input as ItemFn);
 
-    wrapper_fn.attrs.retain(|a| !a.path.is_ident("inline"));
+    let inline_attr = f.attrs.iter().find(|a| a.path.is_ident("inline")).cloned();
 
-    let fn_name = format_ident!("{}", orig_fn.sig.ident);
+    // Remove the inline attribute from the wrapper function; we'll put this on
+    // the closure instead.
+    f.attrs.retain(|a| !a.path.is_ident("inline"));
 
-    let param_names: Vec<TokenStream2> = orig_fn
-        .sig
-        .inputs
-        .iter()
-        .map(|input| match input {
-            FnArg::Receiver(r) => r.self_token.to_token_stream(),
-            FnArg::Typed(p) => p.pat.to_token_stream(),
-        })
-        .collect();
-
-    let fn_call = if mod_fn {
-        quote!(#fn_name( #(#param_names,)* ))
-    } else {
-        quote!(Self::#fn_name( #(#param_names,)* ))
-    };
-
-    wrapper_fn.block.stmts.clear();
-    wrapper_fn.block.stmts = parse_quote!(
-        let saved_ctr = caliptra_cfi_lib::CfiCounter::read();
+    let orig_block = std::mem::replace(&mut f.block, parse_quote!({}));
+    f.block.stmts = parse_quote!(
+        // This is necessary to allow the inline attribute to be placed on the
+        // closure
+        fn __cfi_move<R>(r: R) -> R {
+            r
+        }
+        let __cfi_saved_ctr = caliptra_cfi_lib::CfiCounter::read();
         caliptra_cfi_lib::CfiCounter::delay();
-        let ret = #fn_call;
-        caliptra_cfi_lib::CfiCounter::delay();
-        let new_ctr = caliptra_cfi_lib::CfiCounter::decrement();
-        caliptra_cfi_lib::CfiCounter::assert_eq(saved_ctr, new_ctr);
-        ret
-    );
-
-    // Add inline attribute to the wrapper function.
-    let inline_attr = parse_quote! {
-    #[inline(always)]
-     };
-
-    wrapper_fn.attrs.insert(wrapper_fn.attrs.len(), inline_attr);
-
-    // Add CFI counter increment statement to the beginning of the original function.
-    orig_fn.block.stmts.insert(
-        0,
-        parse_quote!(
+        let __cfi_ret = __cfi_move(#inline_attr move || {
             caliptra_cfi_lib::CfiCounter::increment();
-        ),
+            #orig_block
+        })();
+        caliptra_cfi_lib::CfiCounter::delay();
+        let __cfi_new_ctr = caliptra_cfi_lib::CfiCounter::decrement();
+        caliptra_cfi_lib::CfiCounter::assert_eq(__cfi_saved_ctr, __cfi_new_ctr);
+        __cfi_ret
     );
 
-    let code = quote! {
-            #wrapper_fn
-            #orig_fn
-    };
-
-    code.into()
+    quote! {
+        #[inline(always)]
+        #f
+    }
+    .into()
 }

--- a/rom/dev/src/rom.ld
+++ b/rom/dev/src/rom.ld
@@ -31,7 +31,7 @@ CFI_STATE_ORG      = 0x500003E4;
  * applied. To prevent legitimate overflows, caliptra_builder::elf2rom() will
  * ensure that the sections fit within the true 48k ROM size.
  */
-ROM_RELAXATION_PADDING = 4k;
+ROM_RELAXATION_PADDING = 8k;
 ROM_SIZE          = 48K;
 ICCM_SIZE         = 128K;
 DCCM_SIZE         = 128K;


### PR DESCRIPTION
This makes it possible to use this derive when implementing traits.

The first commit is super simple, but unfortunately the compiler has a hard time optimizing it, leading to significant bloat. 

The second commit is arguably simpler than head, and only bloats us up by 40 bytes. 

The third commit renames self so it can be passed to the closure, and only bloats (vs main) 4 additional bytes. Unfortunately, it's quite a bit more complex.