### PR TITLE
caliptra-api: Use u32 instead of i32 for checksum type.

### DIFF
--- a/api/src/checksum.rs
+++ b/api/src/checksum.rs
@@ -1,21 +1,21 @@
 // Licensed under the Apache-2.0 license
 
 /// Verify checksum
-pub fn verify_checksum(checksum: i32, cmd: u32, data: &[u8]) -> bool {
+pub fn verify_checksum(checksum: u32, cmd: u32, data: &[u8]) -> bool {
     calc_checksum(cmd, data) == checksum
 }
 
 /// Calculate the checksum
 /// 0 - (SUM(command code bytes) + SUM(request/response bytes))
-pub fn calc_checksum(cmd: u32, data: &[u8]) -> i32 {
-    let mut checksum = 0i32;
+pub fn calc_checksum(cmd: u32, data: &[u8]) -> u32 {
+    let mut checksum = 0u32;
     for c in cmd.to_le_bytes().iter() {
-        checksum = checksum.wrapping_add(*c as i32);
+        checksum = checksum.wrapping_add(*c as u32);
     }
     for d in data {
-        checksum = checksum.wrapping_add(*d as i32);
+        checksum = checksum.wrapping_add(*d as u32);
     }
-    0i32.wrapping_sub(checksum)
+    0u32.wrapping_sub(checksum)
 }
 
 #[cfg(all(test, target_family = "unix"))]
@@ -24,26 +24,34 @@ mod tests {
 
     #[test]
     fn test_calc_checksum() {
-        assert_eq!(calc_checksum(0xe8dc3994, &[0x83, 0xe7, 0x25]), -1056);
+        assert_eq!(calc_checksum(0xe8dc3994, &[0x83, 0xe7, 0x25]), 0xfffffbe0);
     }
 
     #[test]
     fn test_checksum_overflow() {
         let data = vec![0xff; 16843007];
-        assert_eq!(calc_checksum(0xe8dc3994, &data), -146);
-        assert!(verify_checksum(-146, 0xe8dc3994, &data));
+        assert_eq!(calc_checksum(0xe8dc3994, &data), 0xffffff6e);
+        assert!(verify_checksum(0xffffff6e, 0xe8dc3994, &data));
     }
 
     #[test]
     fn test_verify_checksum() {
-        assert!(verify_checksum(-1056, 0xe8dc3994, &[0x83, 0xe7, 0x25]));
-        assert!(!verify_checksum(-1057, 0xe8dc3994, &[0x83, 0xe7, 0x25]));
-        assert!(!verify_checksum(-1055, 0xe8dc3994, &[0x83, 0xe7, 0x25]));
+        assert!(verify_checksum(0xfffffbe0, 0xe8dc3994, &[0x83, 0xe7, 0x25]));
+        assert!(!verify_checksum(
+            0xfffffbdf,
+            0xe8dc3994,
+            &[0x83, 0xe7, 0x25]
+        ));
+        assert!(!verify_checksum(
+            0xfffffbe1,
+            0xe8dc3994,
+            &[0x83, 0xe7, 0x25]
+        ));
 
         // subtraction overflow; would panic in debug mode if non-wrapping
         // subtraction was used.
         assert!(!verify_checksum(
-            2147483647,
+            0xffffffff,
             0xe8dc3994,
             &[0x83, 0xe7, 0x25]
         ));

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -111,7 +111,7 @@ impl MailboxResp {
     /// Takes into account the size override for variable-lenth payloads
     pub fn populate_chksum(&mut self) -> CaliptraResult<()> {
         // Calc checksum, use the size override if provided
-        let checksum = crate::checksum::calc_checksum(0, &self.as_bytes()[size_of::<i32>()..]);
+        let checksum = crate::checksum::calc_checksum(0, &self.as_bytes()[size_of::<u32>()..]);
 
         // cast as header struct
         let hdr: &mut MailboxRespHeader = LayoutVerified::<&mut [u8], MailboxRespHeader>::new(
@@ -228,13 +228,13 @@ impl MailboxReq {
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
 pub struct MailboxReqHeader {
-    pub chksum: i32,
+    pub chksum: u32,
 }
 
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
 pub struct MailboxRespHeader {
-    pub chksum: i32,
+    pub chksum: u32,
     pub fips_status: u32,
 }
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -244,7 +244,7 @@ pub enum ModelError {
     MailboxReqTypeTooSmall,
     MailboxRespTypeTooSmall,
     MailboxUnexpectedResponseLen { expected: u32, actual: u32 },
-    MailboxRespInvalidChecksum { expected: i32, actual: i32 },
+    MailboxRespInvalidChecksum { expected: u32, actual: u32 },
     MailboxRespInvalidFipsStatus(u32),
 }
 impl Error for ModelError {}
@@ -1538,7 +1538,7 @@ mod tests {
             resp,
             TestResp {
                 hdr: MailboxRespHeader {
-                    chksum: -211,
+                    chksum: 0xffffff2d,
                     fips_status: 0
                 },
                 data: *b"HI!!",
@@ -1578,8 +1578,8 @@ mod tests {
         assert_eq!(
             resp,
             Err(ModelError::MailboxRespInvalidChecksum {
-                expected: -210,
-                actual: -211
+                expected: 0xffffff2e,
+                actual: 0xffffff2d
             })
         );
 


### PR DESCRIPTION
No change to ROM machine code.