### PR TITLE
[fix] Skip nightly release if calitpra-rtl submodule is stale

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -42,7 +42,7 @@ jobs:
           if git tag | grep ${TAG_PREFIX} > /dev/null; then
               MOST_RECENT_RELEASE=$(git tag | grep ${TAG_PREFIX} | sort -r | head -1)
           fi
-          if [ "$MOST_RECENT_RELEASE" == "None" ] && [ !"$CHECK_RELEASE_SYNC" ]; then
+          if [ "$MOST_RECENT_RELEASE" == "None" ] && [ -z "$CHECK_RELEASE_SYNC" ]; then
               echo "create_release=true" >> $GITHUB_OUTPUT
           else
               COMMITS_AFTER_LAST_RELEASE=$(git rev-list --count $MOST_RECENT_RELEASE..HEAD)


### PR DESCRIPTION
Last night, the release workflow made a release, even though the caliptra-rtl submodule was not up-to-date:

https://github.com/chipsalliance/caliptra-sw/actions/runs/6875915531

The syntax !"$CHECK_RELEASE_SYNC" does not work as intended; we should use -z instead.