### PR TITLE
Use nextest for FPGA workflow.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+# Licensed under the Apache-2.0 license
+
+[profile.nightly]
+failure-output = "immediate-final"
+fail-fast = false
+
+[profile.nightly.junit]
+path = "/tmp/junit.xml"
+store-success-output = true
+store-failure-output = true
+

--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt-get update
-          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools
+          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools gcc-aarch64-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
 
       - name: Build SD image
         run: |

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -133,14 +133,16 @@ jobs:
 
       - name: Build test binaries
         run: |
-          cargo \
-            --config "target.aarch64-unknown-linux-gnu.rustflags = [\"-C\", \"link-arg=--sysroot=/tmp/caliptra-fpga-sysroot\"]" \
-            --config "target.aarch64-unknown-linux-gnu.linker = \"aarch64-linux-gnu-gcc\"" \
-            test --features=fpga_realtime --release --no-run --target=aarch64-unknown-linux-gnu --message-format=json > /tmp/caliptra-cargo.json
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--sysroot=$FARGO_SYSROOT"
+          cargo nextest archive \
+            --features=fpga_realtime \
+            --release \
+            --target=aarch64-unknown-linux-gnu \
+            --archive-file=/tmp/caliptra-test-binaries.tar.zst
+
           mkdir /tmp/caliptra-test-binaries/
-          cat /tmp/caliptra-cargo.json | jq -r '.executable | select(. != null)' | while read line; do
-            cp "$line" /tmp/caliptra-test-binaries/
-          done
+          tar xvf /tmp/caliptra-test-binaries.tar.zst -C /tmp/caliptra-test-binaries/
           mksquashfs /tmp/caliptra-test-binaries /tmp/caliptra-test-binaries.sqsh -comp zstd
 
       - name: 'Upload test binaries artifact'
@@ -292,6 +294,13 @@ jobs:
       (needs.build_kernel_modules.result == 'success' || needs.build_kernel_modules.result == 'skipped')
 
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Pull dpe submodule
+        run: |
+          git submodule update --init dpe
+
       - name: 'Download FPGA Bitstream Artifact'
         uses: actions/download-artifact@v3
         with:
@@ -363,11 +372,32 @@ jobs:
           TEST_BIN=/tmp/caliptra-test-binaries
           VARS="CPTRA_UIO_NUM=4 CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware CALIPTRA_IMAGE_NO_GIT_REVISION=1"
 
-          sudo ${VARS} "${TEST_BIN}/caliptra_integration_tests-"*
-          sudo ${VARS} "${TEST_BIN}/caliptra_hw_model-"*
-          sudo ${VARS} "${TEST_BIN}/model_tests-"*
-          sudo ${VARS} "${TEST_BIN}/drivers_integration_tests-"*
-          sudo ${VARS} "${TEST_BIN}/rom_integration_tests-"*
-          sudo ${VARS} "${TEST_BIN}/fmc_integration_tests-"*
-          sudo ${VARS} "${TEST_BIN}/runtime_integration_tests-"*
-          sudo ${VARS} "${TEST_BIN}/fips_test_suite-"*
+          COMMON_ARGS=(
+              --cargo-metadata="${TEST_BIN}/target/nextest/cargo-metadata.json"
+              --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
+              --target-dir-remap="${TEST_BIN}/target"
+              --workspace-remap=.
+              -E 'not (package(/caliptra-emu-.*/) |
+                       package(caliptra-builder) |
+                       package(caliptra-cfi-derive) |
+                       package(caliptra-file-header-fix) |
+                       package(compliance-test))'
+          )
+
+          cargo-nextest nextest list \
+              "${COMMON_ARGS[@]}" \
+              --message-format json > /tmp/nextest-list.json
+
+          sudo ${VARS} cargo-nextest nextest run \
+              "${COMMON_ARGS[@]}" \
+              --test-threads=1 \
+              --no-fail-fast \
+              --profile=nightly
+
+      - name: 'Upload test results'
+        uses: actions/upload-artifact@v3
+        with:
+          name: caliptra-test-results
+          path: |
+            /tmp/junit.xml
+            /tmp/nextest-list.json

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -56,6 +56,18 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c "su runner -c \"cd /home/runner && tar xvzf actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz && rm -f actions-runner-linux-arm64-${RUNNER_VERSION}.tar.gz\""
 fi
 
+su $SUDO_USER -c "
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=\"aarch64-linux-gnu-gcc\" \
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS=\"-C link-arg=--sysroot=$PWD/out/rootfs\" \
+  ~/.cargo/bin/cargo install cargo-nextest@0.9.62 \
+    --locked \
+    --no-default-features \
+    --features=default-no-update \
+    --target=aarch64-unknown-linux-gnu \
+    --root /tmp/cargo-nextest"
+
+cp /tmp/cargo-nextest/bin/cargo-nextest out/rootfs/usr/bin/
+
 chroot out/rootfs bash -c 'echo ::1 caliptra-fpga >> /etc/hosts'
 cp startup-script.sh out/rootfs/usr/bin/
 chroot out/rootfs chmod 755 /usr/bin/startup-script.sh

--- a/ci-tools/github-runner/scripts/tweak_runner_image.sh
+++ b/ci-tools/github-runner/scripts/tweak_runner_image.sh
@@ -42,6 +42,8 @@ set -x
     echo Installing Rust Toolchain
     su runner -c "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=1.70"
     su runner -c "/home/runner/.cargo/bin/rustup target add riscv32imc-unknown-none-elf"
+    echo Installing cargo-nextest
+    su runner -c "/home/runner/.cargo/bin/cargo install cargo-nextest@0.9.62 --locked --no-default-features --features=default-no-update"
 
     mkdir sw
     (


### PR DESCRIPTION
This has two benefits:

- nextest will archive all the binaries for us, and we don't have to manually decide which ones to call in the workflow (a new test binary will be automatically called) 

- nextest generates the junit.xml file which can be used to inform a future test dashboard.