### PR TITLE
nightly-release: Run tests with combinations of itrng/etrng, logging/no-logging, and sw-emulator/fpga_realtime

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -6,6 +6,17 @@ on:
     branches: ["main"]
   pull_request:
   workflow_call:
+    inputs:
+      artifact-suffix:
+        type: string
+        required: false
+      extra-features:
+        default:
+        type: string
+      rom-logging:
+        default: true
+        type: boolean
+
   workflow_dispatch:
 
 
@@ -56,7 +67,7 @@ jobs:
         if: steps.restore_rtl_cache.outputs.cache-hit
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-fpga-bitstream
+          name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream/caliptra_fpga.bin
           retention-days: 7
 
@@ -64,12 +75,9 @@ jobs:
         if: steps.restore_kmod_cache.outputs.cache-hit
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-fpga-kmod
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
           retention-days: 1
-
-
-
 
   build_test_binaries:
     runs-on: [e2-standard-32]
@@ -136,7 +144,7 @@ jobs:
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--sysroot=$FARGO_SYSROOT"
           cargo nextest archive \
-            --features=fpga_realtime \
+            --features=fpga_realtime,${{ inputs.extra-features }} \
             --release \
             --target=aarch64-unknown-linux-gnu \
             --archive-file=/tmp/caliptra-test-binaries.tar.zst
@@ -148,7 +156,7 @@ jobs:
       - name: 'Upload test binaries artifact'
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-test-binaries
+          name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
           retention-days: 1
 
@@ -160,7 +168,7 @@ jobs:
       - name: 'Upload test firmware artifact'
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-test-firmware
+          name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
           retention-days: 1
 
@@ -223,7 +231,7 @@ jobs:
       - name: 'Upload kernel module artifacts'
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-fpga-kmod
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
           retention-days: 1
 
@@ -258,7 +266,7 @@ jobs:
       - name: 'Upload FPGA bitstream artifact'
         uses: actions/upload-artifact@v3
         with:
-          name: caliptra-fpga-bitstream
+          name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: hw-latest/fpga/caliptra_build/caliptra_fpga.bin
 
   cache_fpga_bitstream_artifact:
@@ -274,7 +282,7 @@ jobs:
       - name: 'Download FPGA Bitstream Artifact'
         uses: actions/download-artifact@v3
         with:
-          name: caliptra-fpga-bitstream
+          name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream
 
       - name: Save FPGA bitstream to cache
@@ -304,25 +312,25 @@ jobs:
       - name: 'Download FPGA Bitstream Artifact'
         uses: actions/download-artifact@v3
         with:
-          name: caliptra-fpga-bitstream
+          name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream
 
       - name: 'Download kernel driver artifacts'
         uses: actions/download-artifact@v3
         with:
-          name: caliptra-fpga-kmod
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
 
       - name: 'Download Test Binaries Artifact'
         uses: actions/download-artifact@v3
         with:
-          name: caliptra-test-binaries
+          name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
 
       - name: 'Download Test Firmware Artifact'
         uses: actions/download-artifact@v3
         with:
-          name: caliptra-test-firmware
+          name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
 
       - name: Mount binaries
@@ -372,6 +380,16 @@ jobs:
           TEST_BIN=/tmp/caliptra-test-binaries
           VARS="CPTRA_UIO_NUM=4 CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware CALIPTRA_IMAGE_NO_GIT_REVISION=1"
 
+          if [ "${{ inputs.rom-logging }}" == "true" ] || [ -z "${{ inputs.rom-logging }}" ]; then
+            VARS+=" CPTRA_ROM_TYPE=ROM_WITH_UART"
+          elif [ "${{ inputs.rom-logging }}" == false ]; then
+            VARS+=" CPTRA_ROM_TYPE=ROM_WITHOUT_UART"
+          else
+            echo "Unexpected inputs.rom-logging: ${{ inputs.rom-logging }}"
+            exit 1
+          fi
+          echo CPTRA_ROM_TYPE=${CPTRA_ROM_TYPE}
+
           COMMON_ARGS=(
               --cargo-metadata="${TEST_BIN}/target/nextest/cargo-metadata.json"
               --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
@@ -396,8 +414,9 @@ jobs:
 
       - name: 'Upload test results'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
-          name: caliptra-test-results
+          name: caliptra-test-results${{ inputs.artifact-suffix }}
           path: |
             /tmp/junit.xml
             /tmp/nextest-list.json

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -1,0 +1,91 @@
+
+name: Build and Test Firmware (in emulator)
+
+on:
+  workflow_call:
+    inputs:
+      artifact-suffix:
+        type: string
+        required: false
+      extra-features:
+        default:
+        type: string
+      rom-logging:
+        default: true
+        type: boolean
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-22.04
+
+    env:
+      NEXTEST_VERSION: 0.9.63
+      CACHE_BUSTER: f7c64774f17c
+
+    steps:
+      - name: Restore cargo-nextest binary
+        uses: actions/cache/restore@v3
+        id: nextest_bin_restore
+        with:
+          path: ~/.cargo/bin/cargo-nextest
+          key: nextest-bin-${{ env.NEXTEST_VERSION}}-${{ env.CACHE_BUSTER }}
+
+      - name: Install cargo-nextest
+        if: steps.nextest_bin_restore.outputs.cache-hit != 'true'
+        run: |
+          cargo install cargo-nextest --version ${NEXTEST_VERSION} --locked --no-default-features --features=default-no-update
+
+      - name: Save cargo-nextest binary
+        uses: actions/cache/save@v3
+        if: steps.nextest_bin_restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cargo/bin/cargo-nextest
+          key: ${{ steps.nextest_bin_restore.outputs.cache-primary-key }}
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Pull dpe submodule
+        run: |
+          git submodule update --init dpe
+
+      - name: Build firmware
+        run: |
+          mkdir /tmp/caliptra-test-firmware
+          cargo run -p caliptra-builder -- --all_elfs /tmp/caliptra-test-firmware
+
+      - name: Run tests
+        run: |
+          export CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware
+
+          if [ "${{ inputs.rom-logging }}" == "true" ] || [ -z "${{ inputs.rom-logging }}" ]; then
+            export CPTRA_ROM_TYPE=ROM_WITH_UART
+          elif [ "${{ inputs.rom-logging }}" == false ]; then
+            export CPTRA_ROM_TYPE=ROM_WITHOUT_UART
+          else
+            echo "Unexpected inputs.rom-logging: ${{ inputs.rom-logging }}"
+            exit 1
+          fi
+
+          # Workaround https://github.com/nextest-rs/nextest/issues/267
+          export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+
+          cargo-nextest nextest list \
+            --features="${{ inputs.extra-features }}" \
+            --message-format json \
+            > /tmp/nextest-list.json
+
+          cargo-nextest nextest run \
+            --features="${{ inputs.extra-features }}" \
+            --no-fail-fast \
+            --profile=nightly
+
+      - name: 'Upload test results'
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: caliptra-test-results${{ inputs.artifact-suffix }}
+          path: |
+            /tmp/junit.xml
+            /tmp/nextest-list.json
+

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -80,9 +80,57 @@ jobs:
       extra-features: slow_tests
       rom-logging: false
 
+  sw-emulator-full-suite-etrng-log:
+    name: sw-emulator Suite (etrng, log)
+    needs: find-latest-release
+    if: needs.find-latest-release.outputs.create_release
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -sw-emulator-realtime-etrng-log
+      extra-features: slow_tests
+      rom-logging: true
+
+  sw-emulator-full-suite-etrng-nolog:
+    name: sw-emulator Suite (etrng, nolog)
+    needs: find-latest-release
+    if: needs.find-latest-release.outputs.create_release
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -sw-emulator-realtime-etrng-nolog
+      extra-features: slow_tests
+      rom-logging: false
+
+  sw-emulator-full-suite-itrng-log:
+    name: sw-emulator Suite (itrng, log)
+    needs: find-latest-release
+    if: needs.find-latest-release.outputs.create_release
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -sw-emulator-realtime-itrng-log
+      extra-features: slow_tests,itrng
+      rom-logging: true
+
+  sw-emulator-full-suite-itrng-nolog:
+    name: sw-emulator Suite (itrng, nolog)
+    needs: find-latest-release
+    if: needs.find-latest-release.outputs.create_release
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -sw-emulator-realtime-itrng-nolog
+      extra-features: slow_tests,itrng
+      rom-logging: false
+
   create-release:
     name: Create New Release
-    needs: [find-latest-release, fpga-full-suite-etrng-log, fpga-full-suite-etrng-nolog]
+    needs:
+      - find-latest-release
+      - fpga-full-suite-etrng-log
+      - fpga-full-suite-etrng-nolog
+      - sw-emulator-full-suite-etrng-log
+      - sw-emulator-full-suite-etrng-nolog
+      - sw-emulator-full-suite-itrng-log
+      - sw-emulator-full-suite-itrng-nolog
+
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -60,15 +60,29 @@ jobs:
           echo "release_ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "Current ref $(git rev-parse HEAD) will receive tag ${TAG_BASE}${INDEX} after tests"
 
-  fpga-full-suite:
-    name: FPGA Suite
+  fpga-full-suite-etrng-log:
+    name: FPGA Suite (etrng, log)
     needs: find-latest-release
     if: needs.find-latest-release.outputs.create_release
     uses: ./.github/workflows/fpga.yml
+    with:
+      artifact-suffix: -fpga-realtime-etrng-log
+      extra-features: slow_tests
+      rom-logging: true
+
+  fpga-full-suite-etrng-nolog:
+    name: FPGA Suite (etrng, nolog)
+    needs: find-latest-release
+    if: needs.find-latest-release.outputs.create_release
+    uses: ./.github/workflows/fpga.yml
+    with:
+      artifact-suffix: -fpga-realtime-etrng-nolog
+      extra-features: slow_tests
+      rom-logging: false
 
   create-release:
     name: Create New Release
-    needs: [find-latest-release, fpga-full-suite]
+    needs: [find-latest-release, fpga-full-suite-etrng-log, fpga-full-suite-etrng-nolog]
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
See test run at https://github.com/chipsalliance/caliptra-sw/actions/runs/6963207046