### PR TITLE
WIP: Use newer rust version and set clippy args in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,3 +197,12 @@ opt-level = 3
 opt-level = 3
 [profile.test.package.caliptra-drivers]
 opt-level = 3
+
+[workspace.lints.clippy]
+warnings = "deny"
+
+[workspace.lints.rust]
+warnings = "deny"
+
+[lints]
+workspace = true

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,3 +14,7 @@ zerocopy.workspace = true
 
 [features]
 test_only_commands = []
+
+[lints]
+workspace = true
+

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -28,3 +28,6 @@ slow_tests = []
 [[bin]]
 name = "image"
 path = "bin/image_gen.rs"
+
+[lints]
+workspace = true

--- a/cfi/derive/Cargo.toml
+++ b/cfi/derive/Cargo.toml
@@ -14,3 +14,6 @@ syn = { version = "1.0.107", features = ["extra-traits", "full"] }
 quote = "1.0.23"
 proc-macro2 = "1.0.51"
 paste = "1.0.11"
+
+[lints]
+workspace = true

--- a/cfi/lib/Cargo.toml
+++ b/cfi/lib/Cargo.toml
@@ -23,3 +23,5 @@ cfi = []
 cfi-counter = []
 cfi-test = []
 
+[lints]
+workspace = true

--- a/ci-tools/file-header-fix/Cargo.toml
+++ b/ci-tools/file-header-fix/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/ci-tools/fpga-boss/Cargo.toml
+++ b/ci-tools/fpga-boss/Cargo.toml
@@ -14,3 +14,6 @@ libftdi1-sys = { version = "1.1.2", features = ["libusb1-sys"] }
 libusb1-sys = "0.6.4"
 libc = "0.2.147"
 rusb = "0.9.3"
+
+[lints]
+workspace = true

--- a/ci-tools/size-history/Cargo.toml
+++ b/ci-tools/size-history/Cargo.toml
@@ -12,3 +12,6 @@ caliptra-builder.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tinytemplate.workspace = true
+
+[lints]
+workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,3 +23,6 @@ default = ["std"]
 emu = ["caliptra-drivers/emu"]
 std = []
 test_only_commands = ["caliptra-api/test_only_commands"]
+
+[lints]
+workspace = true

--- a/coverage/Cargo.toml
+++ b/coverage/Cargo.toml
@@ -16,3 +16,6 @@ rand.workspace = true
 bit-vec = { workspace = true, features = ["serde"] }
 caliptra-builder.workspace = true
 elf.workspace = true
+
+[lints]
+workspace = true

--- a/coverage/src/lib.rs
+++ b/coverage/src/lib.rs
@@ -150,7 +150,7 @@ pub fn collect_instr_pcs(id: &FwId<'static>) -> anyhow::Result<Vec<u32>> {
         let instruction = u16::from_le_bytes([instruction[0], instruction[1]]);
 
         match instruction & 0b11 {
-            0 | 1 | 2 => {
+            0..=2 => {
                 index += 2;
             }
             _ => {
@@ -249,7 +249,7 @@ pub mod calculator {
 fn test_parse_trace_file() {
     // Create a temporary trace file for testing
     let temp_trace_file = "temp_trace.txt";
-    let trace_data = vec![
+    let trace_data = [
         "SoC write4 *0x300300bc <- 0x0",
         "SoC write4 *0x30030110 <- 0x2625a00",
         "SoC write4 *0x30030114 <- 0x0",

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -27,3 +27,6 @@ caliptra-registers.workspace = true
 cfg-if.workspace = true
 
 [build-dependencies]
+
+[lints]
+workspace = true

--- a/cpu/gen/Cargo.toml
+++ b/cpu/gen/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 
 [dependencies]
 caliptra_common = { workspace = true, default-features = false }
+
+[lints]
+workspace = true

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -39,3 +39,6 @@ caliptra-hw-model-types.workspace = true
 caliptra-hw-model.workspace = true
 caliptra-test.workspace = true
 openssl.workspace = true
+
+[lints]
+workspace = true

--- a/drivers/fuzz/Cargo.toml
+++ b/drivers/fuzz/Cargo.toml
@@ -46,3 +46,6 @@ name = "fuzz_target_lms"
 path = "src/fuzz_target_lms.rs"
 test = false
 doc = false
+
+[lints]
+workspace = true

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -173,3 +173,5 @@ name = "trng_driver_responder"
 path = "src/bin/trng_driver_responder.rs"
 required-features = ["riscv"]
 
+[lints]
+workspace = true

--- a/drivers/test-fw/scripts/vector_gen/Cargo.toml
+++ b/drivers/test-fw/scripts/vector_gen/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 [dependencies]
 openssl.workspace = true
 caliptra-test.workspace = true
+
+[lints]
+workspace = true

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 [features]
 default = ["std"]
 std = []
+
+[lints]
+workspace = true

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -37,3 +37,6 @@ fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 fake-fmc = []
+
+[lints]
+workspace = true

--- a/fmc/test-fw/test-rt/Cargo.toml
+++ b/fmc/test-fw/test-rt/Cargo.toml
@@ -26,3 +26,6 @@ emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 interactive_test = []
+
+[lints]
+workspace = true

--- a/hw-latest/verilated/Cargo.toml
+++ b/hw-latest/verilated/Cargo.toml
@@ -20,3 +20,6 @@ itrng = []
 
 [dependencies]
 rand.workspace = true
+
+[lints]
+workspace = true

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -36,3 +36,6 @@ caliptra-coverage.workspace = true
 caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-test-harness-types.workspace = true
+
+[lints]
+workspace = true

--- a/hw-model/c-binding/Cargo.toml
+++ b/hw-model/c-binding/Cargo.toml
@@ -19,3 +19,6 @@ verilator = ["caliptra-hw-model/verilator"]
 
 [build-dependencies]
 cbindgen.workspace = true
+
+[lints]
+workspace = true

--- a/hw-model/c-binding/src/caliptra_model.rs
+++ b/hw-model/c-binding/src/caliptra_model.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn caliptra_model_output_peek(model: *mut caliptra_model) 
     assert!(!model.is_null());
     let peek_str = (*{ model as *mut DefaultHwModel }).output().peek();
     caliptra_buffer {
-        data: peek_str.as_ptr() as *const u8,
+        data: peek_str.as_ptr(),
         len: peek_str.len(),
     }
 }

--- a/hw-model/test-fw/Cargo.toml
+++ b/hw-model/test-fw/Cargo.toml
@@ -73,3 +73,6 @@ required-features = ["riscv"]
 name = "test_pcr_extend"
 path = "test_pcr_extend.rs"
 required-features = ["riscv"]
+
+[lints]
+workspace = true

--- a/hw-model/tests/model_tests.rs
+++ b/hw-model/tests/model_tests.rs
@@ -7,7 +7,7 @@ use caliptra_test_harness_types as harness;
 
 fn run_fw_elf(elf: &[u8]) -> DefaultHwModel {
     let rom = caliptra_builder::elf2rom(elf).unwrap();
-    let model = caliptra_hw_model::new(BootParams {
+    caliptra_hw_model::new(BootParams {
         init_params: InitParams {
             rom: &rom,
             random_sram_puf: false,
@@ -15,21 +15,19 @@ fn run_fw_elf(elf: &[u8]) -> DefaultHwModel {
         },
         ..Default::default()
     })
-    .unwrap();
-    model
+    .unwrap()
 }
 
 fn run_fw_elf_with_rand_puf(elf: &[u8]) -> DefaultHwModel {
     let rom = caliptra_builder::elf2rom(elf).unwrap();
-    let model = caliptra_hw_model::new(BootParams {
+    caliptra_hw_model::new(BootParams {
         init_params: InitParams {
             rom: &rom,
             ..Default::default()
         },
         ..Default::default()
     })
-    .unwrap();
-    model
+    .unwrap()
 }
 
 #[test]

--- a/hw-model/types/Cargo.toml
+++ b/hw-model/types/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 
 [dependencies]
 rand.workspace = true
+
+[lints]
+workspace = true

--- a/image/app/Cargo.toml
+++ b/image/app/Cargo.toml
@@ -21,3 +21,6 @@ serde_derive.workspace = true
 serde.workspace = true
 toml.workspace = true
 zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/image/elf/Cargo.toml
+++ b/image/elf/Cargo.toml
@@ -12,3 +12,6 @@ anyhow.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-types.workspace = true
 elf.workspace = true
+
+[lints]
+workspace = true

--- a/image/fake-keys/Cargo.toml
+++ b/image/fake-keys/Cargo.toml
@@ -15,3 +15,6 @@ zerocopy.workspace = true
 
 [dev-dependencies]
 caliptra-image-openssl.workspace = true
+
+[lints]
+workspace = true

--- a/image/gen/Cargo.toml
+++ b/image/gen/Cargo.toml
@@ -15,3 +15,6 @@ caliptra-image-types = { workspace = true, features = ["std"] }
 caliptra-lms-types.workspace = true
 memoffset.workspace = true
 zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/image/openssl/Cargo.toml
+++ b/image/openssl/Cargo.toml
@@ -14,3 +14,6 @@ caliptra-image-types.workspace = true
 caliptra-lms-types.workspace = true
 openssl.workspace = true
 zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/image/openssl/src/lib.rs
+++ b/image/openssl/src/lib.rs
@@ -280,8 +280,8 @@ fn generate_lms_pubkey_helper(
         Some(_) => 1,
         None => (((1 << tree_height) as u32) + q.unwrap()) ^ 1,
     };
-    let mut k = vec![0u8; SHA192_DIGEST_BYTE_SIZE];
-    let zero_k = vec![0u8; SHA192_DIGEST_BYTE_SIZE];
+    let mut k = [0u8; SHA192_DIGEST_BYTE_SIZE];
+    let zero_k = [0u8; SHA192_DIGEST_BYTE_SIZE];
 
     let mut level: usize = 0;
     let mut pub_key_stack = vec![0u8; SHA192_DIGEST_BYTE_SIZE * (tree_height as usize)];

--- a/image/serde/Cargo.toml
+++ b/image/serde/Cargo.toml
@@ -13,3 +13,5 @@ anyhow.workspace = true
 caliptra-image-types = { workspace = true, features = ["std"] }
 zerocopy.workspace = true
 
+[lints]
+workspace = true

--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -19,3 +19,6 @@ zeroize.workspace = true
 [features]
 default = ["std"]
 std = []
+
+[lints]
+workspace = true

--- a/image/verify/Cargo.toml
+++ b/image/verify/Cargo.toml
@@ -25,3 +25,6 @@ caliptra-cfi-lib = { workspace = true, features = ["cfi-test" ] }
 default = ["std"]
 std = ["caliptra-image-types/std"]
 no-cfi = []
+
+[lints]
+workspace = true

--- a/image/verify/fuzz/Cargo.toml
+++ b/image/verify/fuzz/Cargo.toml
@@ -57,3 +57,6 @@ name = "fuzz_target_updatereset"
 path = "src/fuzz_target_updatereset.rs"
 test = false
 doc = false
+
+[lints]
+workspace = true

--- a/kat/Cargo.toml
+++ b/kat/Cargo.toml
@@ -14,3 +14,6 @@ caliptra-drivers.workspace = true
 caliptra-lms-types.workspace = true
 zerocopy.workspace = true
 ufmt.workspace = true
+
+[lints]
+workspace = true

--- a/lms-types/Cargo.toml
+++ b/lms-types/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 arbitrary = { workspace = true, optional = true }
 zerocopy.workspace = true
 zeroize.workspace = true
+
+[lints]
+workspace = true

--- a/registers/Cargo.toml
+++ b/registers/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 
 [dependencies]
 ureg.workspace = true
+
+[lints]
+workspace = true

--- a/registers/bin/generator/Cargo.toml
+++ b/registers/bin/generator/Cargo.toml
@@ -13,3 +13,6 @@ quote.workspace = true
 ureg-codegen.workspace = true
 ureg-schema.workspace = true
 ureg-systemrdl.workspace = true
+
+[lints]
+workspace = true

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -63,3 +63,6 @@ slow_tests = []
 [[bin]]
 name = "asm_tests"
 path = "test-fw/asm_tests.rs"
+
+[lints]
+workspace = true

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -71,16 +71,16 @@ impl FirmwareProcessor {
             // Hmac384 Engine
             hmac384: &mut env.hmac384,
 
-            /// Cryptographically Secure Random Number Generator
+            // Cryptographically Secure Random Number Generator
             trng: &mut env.trng,
 
             // LMS Engine
             lms: &mut env.lms,
 
-            /// Ecc384 Engine
+            // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
-            /// SHA Acc lock state
+            // SHA Acc lock state
             sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };
         // Process mailbox commands.

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -106,7 +106,7 @@ impl ColdResetFlow {
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 #[inline(never)]
 pub fn copy_tbs(tbs: &[u8], tbs_type: TbsType, env: &mut RomEnv) -> CaliptraResult<()> {
-    let mut persistent_data = env.persistent_data.get_mut();
+    let persistent_data = env.persistent_data.get_mut();
     let dst = match tbs_type {
         TbsType::LdevidTbs => {
             persistent_data.fht.ldevid_tbs_size = tbs.len() as u16;

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -130,19 +130,19 @@ pub extern "C" fn rom_entry() -> ! {
             // Hmac384 Engine
             hmac384: &mut env.hmac384,
 
-            /// Cryptographically Secure Random Number Generator
+            // Cryptographically Secure Random Number Generator
             trng: &mut env.trng,
 
             // LMS Engine
             lms: &mut env.lms,
 
-            /// Ecc384 Engine
+            // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
-            /// SHA Acc lock state.
-            /// SHA Acc is guaranteed to be locked on Cold and Warm Resets;
-            /// On an Update Reset, it is expected to be unlocked.
-            /// Not having it unlocked will result in a fatal error.
+            // SHA Acc lock state.
+            // SHA Acc is guaranteed to be locked on Cold and Warm Resets;
+            // On an Update Reset, it is expected to be unlocked.
+            // Not having it unlocked will result in a fatal error.
             sha_acc_lock_state: if reset_reason == ResetReason::UpdateReset {
                 ShaAccLockState::NotAcquired
             } else {

--- a/rom/dev/tools/test-fmc/Cargo.toml
+++ b/rom/dev/tools/test-fmc/Cargo.toml
@@ -25,3 +25,6 @@ interactive_test_fmc = []
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 fake-fmc = []
+
+[lints]
+workspace = true

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -18,3 +18,6 @@ default = ["std"]
 emu = ["caliptra-drivers/emu"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std"]
+
+[lints]
+workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -51,3 +51,6 @@ slow_tests = []
 verilator = ["caliptra-hw-model/verilator"]
 fips_self_test=[]
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
+
+[lints]
+workspace = true

--- a/runtime/test-fw/Cargo.toml
+++ b/runtime/test-fw/Cargo.toml
@@ -43,3 +43,6 @@ caliptra-runtime = { workspace = true, default-features = false }
 caliptra-test-harness.workspace = true
 cfg-if.workspace = true
 zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.70"
+channel = "1.74"
 targets = ["riscv32imc-unknown-none-elf"]
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/sw-emulator/app/Cargo.toml
+++ b/sw-emulator/app/Cargo.toml
@@ -20,3 +20,6 @@ gdbstub_arch.workspace = true
 gdbstub.workspace = true
 hex.workspace = true
 tock-registers.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/compliance-test/Cargo.toml
+++ b/sw-emulator/compliance-test/Cargo.toml
@@ -13,3 +13,6 @@ caliptra-emu-cpu.workspace = true
 caliptra-emu-types.workspace = true
 clap.workspace = true
 getrandom.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/compliance-test/src/main.rs
+++ b/sw-emulator/compliance-test/src/main.rs
@@ -171,7 +171,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         if !is_test_complete(&mut cpu.bus) {
-            return Err(std::io::Error::new(
+            Err(std::io::Error::new(
                 ErrorKind::Other,
                 "test did not complete",
             ))?;

--- a/sw-emulator/example/Cargo.toml
+++ b/sw-emulator/example/Cargo.toml
@@ -15,3 +15,6 @@ lto = true
 [profile.dev]
 panic = "abort"
 lto = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/bus/Cargo.toml
+++ b/sw-emulator/lib/bus/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 caliptra-emu-types.workspace = true
 tock-registers.workspace = true
 ureg.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -13,3 +13,6 @@ bit-vec.workspace = true
 caliptra-emu-bus.workspace = true
 caliptra-emu-types.workspace = true
 lazy_static.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/cpu/src/instr/mod.rs
+++ b/sw-emulator/lib/cpu/src/instr/mod.rs
@@ -92,7 +92,7 @@ impl<TBus: Bus> Cpu<TBus> {
     fn fetch(&mut self) -> Result<Instr, RvException> {
         let instr = self.read_instr(RvSize::HalfWord, self.read_pc())?;
         match instr & 0b11 {
-            0 | 1 | 2 => Ok(Instr::Compressed(instr as u16)),
+            0..=2 => Ok(Instr::Compressed(instr as u16)),
             _ => Ok(Instr::General(
                 self.read_instr(RvSize::Word, self.read_pc())?,
             )),

--- a/sw-emulator/lib/crypto/Cargo.toml
+++ b/sw-emulator/lib/crypto/Cargo.toml
@@ -13,3 +13,6 @@ cbc.workspace = true
 p384.workspace = true
 rfc6979.workspace = true
 sha2.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/derive/Cargo.toml
+++ b/sw-emulator/lib/derive/Cargo.toml
@@ -15,3 +15,6 @@ caliptra-emu-bus.workspace = true
 caliptra-emu-types.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/periph/Cargo.toml
+++ b/sw-emulator/lib/periph/Cargo.toml
@@ -23,3 +23,6 @@ sha3.workspace = true
 smlang.workspace = true
 tock-registers.workspace = true
 zerocopy.workspace = true
+
+[lints]
+workspace = true

--- a/sw-emulator/lib/types/Cargo.toml
+++ b/sw-emulator/lib/types/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/systemrdl/Cargo.toml
+++ b/systemrdl/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/systemrdl/src/scope.rs
+++ b/systemrdl/src/scope.rs
@@ -618,13 +618,12 @@ pub struct Instance {
 }
 impl Instance {
     pub fn element_size(&self) -> u64 {
-        let width = if let Ok(Some(w)) = self.scope.property_val_opt::<u64>("regwidth") {
+        if let Ok(Some(w)) = self.scope.property_val_opt::<u64>("regwidth") {
             w / 8
         } else {
             // According to section 10.1 of the SystemRDL 2.0 spec, the default regwidth is 32-bits
             4
-        };
-        width
+        }
     }
     pub fn total_size(&self) -> Result<'static, u64> {
         let stride = if let Some(stride) = self.stride {

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -15,3 +15,6 @@ runtime = []
 [dependencies]
 caliptra-drivers = { workspace = true, features=["emu"] }
 cfg-if.workspace = true
+
+[lints]
+workspace = true

--- a/test-harness/types/Cargo.toml
+++ b/test-harness/types/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -32,3 +32,6 @@ itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 fips_self_test = ["caliptra-runtime/fips_self_test"]
 test_env_immutable_rom = []
+
+[lints]
+workspace = true

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -12,7 +12,7 @@ fn fips_test_init_base(
     fw_image_override: Option<&[u8]>,
 ) -> DefaultHwModel {
     // Create params if not provided
-    let mut boot_params = boot_params.unwrap_or(BootParams::default());
+    let mut boot_params = boot_params.unwrap_or_default();
 
     // Check that ROM was not provided if the immutable_rom feature is set
     #[cfg(feature = "test_env_immutable_rom")]

--- a/ureg/Cargo.toml
+++ b/ureg/Cargo.toml
@@ -6,3 +6,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/ureg/lib/codegen/Cargo.toml
+++ b/ureg/lib/codegen/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2021"
 ureg-schema = { path = "../schema" }
 quote = "1.0"
 proc-macro2 = "1.0.66"
+
+[lints]
+workspace = true

--- a/ureg/lib/codegen/src/lib.rs
+++ b/ureg/lib/codegen/src/lib.rs
@@ -91,30 +91,6 @@ fn snake_ident(name: &str) -> Ident {
 
     format_ident!("{}", tweak_keywords(result.trim_end_matches('_')))
 }
-#[cfg(test)]
-mod snake_ident_tests {
-    use crate::*;
-
-    #[test]
-    fn test_snake_ident() {
-        assert_eq!("_8_bits", snake_ident("8 bits").to_string());
-        assert_eq!("_16_bits", snake_ident("16_Bits").to_string());
-        assert_eq!("_16_bits", snake_ident("16Bits").to_string());
-        assert_eq!("_16bits", snake_ident("16bits").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("fooBarBaz").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FooBarBaz").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("foo bar baz").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("foo_bar_baz").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FOO BAR BAZ").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FOO_BAR_BAZ").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FOO BAR BAZ.").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FOO BAR.BAZ.").to_string());
-        assert_eq!("foo_bar_baz", snake_ident("FOO BAR..BAZ.").to_string());
-
-        assert_eq!("fn_", snake_ident("fn").to_string());
-        assert_eq!("fn_", snake_ident("FN").to_string());
-    }
-}
 
 fn camel_ident(name: &str) -> Ident {
     let mut result = String::new();
@@ -137,24 +113,6 @@ fn camel_ident(name: &str) -> Ident {
         }
     }
     format_ident!("{}", tweak_keywords(&result))
-}
-
-#[cfg(test)]
-mod camel_ident_tests {
-    use crate::*;
-
-    #[test]
-    fn test_camel_ident() {
-        assert_eq!("_8Bits", camel_ident("8 bits").to_string());
-        assert_eq!("_16Bits", camel_ident("16_bits").to_string());
-        assert_eq!("FooBarBaz", camel_ident("foo bar baz").to_string());
-        assert_eq!("FooBarBaz", camel_ident("foo_bar_baz").to_string());
-        assert_eq!("FooBarBaz", camel_ident("FOO BAR BAZ").to_string());
-        assert_eq!("FooBarBaz", camel_ident("FOO_BAR_BAZ").to_string());
-        assert_eq!("FooBarBaz", camel_ident("FOO BAR BAZ.").to_string());
-        assert_eq!("FooBarBaz", camel_ident("FOO BAR.BAZ.").to_string());
-        assert_eq!("Self_", camel_ident("self").to_string());
-    }
 }
 
 fn generate_enum(e: &Enum) -> TokenStream {
@@ -262,87 +220,6 @@ fn generate_enums<'a>(enums: impl Iterator<Item = &'a Enum>) -> TokenStream {
         pub mod selector {
             #selector_tokens
         }
-    }
-}
-
-#[cfg(test)]
-mod generate_enums_test {
-    use ureg_schema::EnumVariant;
-
-    use crate::*;
-
-    #[test]
-    fn test_generate_enums() {
-        assert_eq!(
-            generate_enums(
-                [Enum {
-                    name: Some("Pull DIR".into()),
-                    bit_width: 2,
-                    variants: vec![
-                        EnumVariant {
-                            name: "down".to_string(),
-                            value: 0
-                        },
-                        EnumVariant {
-                            name: "UP".to_string(),
-                            value: 1
-                        },
-                        EnumVariant {
-                            name: "Hi Z".to_string(),
-                            value: 2
-                        },
-                    ]
-                }]
-                .iter()
-            )
-            .to_string(),
-            quote! {
-                #[derive (Clone , Copy , Eq , PartialEq)]
-                #[repr(u32)]
-                pub enum PullDir {
-                    Down = 0,
-                    Up = 1,
-                    HiZ = 2,
-                    Reserved3 = 3,
-                }
-                impl PullDir {
-                    #[inline(always)]
-                    pub fn down(&self) -> bool { *self == Self::Down }
-                    #[inline(always)]
-                    pub fn up(&self) -> bool { *self == Self::Up }
-                    #[inline(always)]
-                    pub fn hi_z(&self) -> bool { *self == Self::HiZ }
-                }
-                impl TryFrom<u32> for PullDir {
-                    type Error = ();
-                    #[inline (always)]
-                    fn try_from(val : u32) -> Result<PullDir, ()> {
-                        if val < 4 {
-                            Ok(unsafe { core::mem::transmute(val) })
-                        } else {
-                            Err (())
-                        }
-                     }
-                }
-                impl From<PullDir> for u32 {
-                    fn from(val : PullDir) -> Self {
-                        val as u32
-                    }
-                }
-                pub mod selector {
-                    pub struct PullDirSelector();
-                    impl PullDirSelector {
-                        #[inline(always)]
-                        pub fn down(&self) -> super::PullDir { super::PullDir::Down }
-                        #[inline(always)]
-                        pub fn up(&self) -> super::PullDir { super::PullDir::Up }
-                        #[inline(always)]
-                        pub fn hi_z(&self) -> super::PullDir { super::PullDir::HiZ }
-                    }
-                }
-            }
-            .to_string()
-        );
     }
 }
 
@@ -954,5 +831,129 @@ pub fn generate_code(block: &ValidatedRegisterBlock, options: Options) -> TokenS
             #meta_tokens
         }
 
+    }
+}
+
+#[cfg(test)]
+mod snake_ident_tests {
+    use crate::*;
+
+    #[test]
+    fn test_snake_ident() {
+        assert_eq!("_8_bits", snake_ident("8 bits").to_string());
+        assert_eq!("_16_bits", snake_ident("16_Bits").to_string());
+        assert_eq!("_16_bits", snake_ident("16Bits").to_string());
+        assert_eq!("_16bits", snake_ident("16bits").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("fooBarBaz").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FooBarBaz").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("foo bar baz").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("foo_bar_baz").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FOO BAR BAZ").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FOO_BAR_BAZ").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FOO BAR BAZ.").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FOO BAR.BAZ.").to_string());
+        assert_eq!("foo_bar_baz", snake_ident("FOO BAR..BAZ.").to_string());
+
+        assert_eq!("fn_", snake_ident("fn").to_string());
+        assert_eq!("fn_", snake_ident("FN").to_string());
+    }
+}
+
+#[cfg(test)]
+mod camel_ident_tests {
+    use crate::*;
+
+    #[test]
+    fn test_camel_ident() {
+        assert_eq!("_8Bits", camel_ident("8 bits").to_string());
+        assert_eq!("_16Bits", camel_ident("16_bits").to_string());
+        assert_eq!("FooBarBaz", camel_ident("foo bar baz").to_string());
+        assert_eq!("FooBarBaz", camel_ident("foo_bar_baz").to_string());
+        assert_eq!("FooBarBaz", camel_ident("FOO BAR BAZ").to_string());
+        assert_eq!("FooBarBaz", camel_ident("FOO_BAR_BAZ").to_string());
+        assert_eq!("FooBarBaz", camel_ident("FOO BAR BAZ.").to_string());
+        assert_eq!("FooBarBaz", camel_ident("FOO BAR.BAZ.").to_string());
+        assert_eq!("Self_", camel_ident("self").to_string());
+    }
+}
+
+#[cfg(test)]
+mod generate_enums_test {
+    use ureg_schema::EnumVariant;
+
+    use crate::*;
+
+    #[test]
+    fn test_generate_enums() {
+        assert_eq!(
+            generate_enums(
+                [Enum {
+                    name: Some("Pull DIR".into()),
+                    bit_width: 2,
+                    variants: vec![
+                        EnumVariant {
+                            name: "down".to_string(),
+                            value: 0
+                        },
+                        EnumVariant {
+                            name: "UP".to_string(),
+                            value: 1
+                        },
+                        EnumVariant {
+                            name: "Hi Z".to_string(),
+                            value: 2
+                        },
+                    ]
+                }]
+                .iter()
+            )
+            .to_string(),
+            quote! {
+                #[derive (Clone , Copy , Eq , PartialEq)]
+                #[repr(u32)]
+                pub enum PullDir {
+                    Down = 0,
+                    Up = 1,
+                    HiZ = 2,
+                    Reserved3 = 3,
+                }
+                impl PullDir {
+                    #[inline(always)]
+                    pub fn down(&self) -> bool { *self == Self::Down }
+                    #[inline(always)]
+                    pub fn up(&self) -> bool { *self == Self::Up }
+                    #[inline(always)]
+                    pub fn hi_z(&self) -> bool { *self == Self::HiZ }
+                }
+                impl TryFrom<u32> for PullDir {
+                    type Error = ();
+                    #[inline (always)]
+                    fn try_from(val : u32) -> Result<PullDir, ()> {
+                        if val < 4 {
+                            Ok(unsafe { core::mem::transmute(val) })
+                        } else {
+                            Err (())
+                        }
+                     }
+                }
+                impl From<PullDir> for u32 {
+                    fn from(val : PullDir) -> Self {
+                        val as u32
+                    }
+                }
+                pub mod selector {
+                    pub struct PullDirSelector();
+                    impl PullDirSelector {
+                        #[inline(always)]
+                        pub fn down(&self) -> super::PullDir { super::PullDir::Down }
+                        #[inline(always)]
+                        pub fn up(&self) -> super::PullDir { super::PullDir::Up }
+                        #[inline(always)]
+                        pub fn hi_z(&self) -> super::PullDir { super::PullDir::HiZ }
+                    }
+                }
+            }
+            .to_string()
+        );
     }
 }

--- a/ureg/lib/schema/Cargo.toml
+++ b/ureg/lib/schema/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/ureg/lib/schema/src/lib.rs
+++ b/ureg/lib/schema/src/lib.rs
@@ -32,83 +32,6 @@ impl RegisterField {
         ((1u64 << self.width) - 1) << self.position
     }
 }
-#[cfg(test)]
-mod registerfield_tests {
-    use super::*;
-
-    #[test]
-    fn test_mask() {
-        assert_eq!(
-            RegisterField {
-                position: 0,
-                width: 1,
-                ..Default::default()
-            }
-            .mask(),
-            0x00000001
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 0,
-                width: 2,
-                ..Default::default()
-            }
-            .mask(),
-            0x00000003
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 0,
-                width: 3,
-                ..Default::default()
-            }
-            .mask(),
-            0x00000007
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 1,
-                width: 3,
-                ..Default::default()
-            }
-            .mask(),
-            0x0000000e
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 8,
-                width: 3,
-                ..Default::default()
-            }
-            .mask(),
-            0x00000700
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 28,
-                width: 4,
-                ..Default::default()
-            }
-            .mask(),
-            0xf0000000
-        );
-
-        assert_eq!(
-            RegisterField {
-                position: 31,
-                width: 1,
-                ..Default::default()
-            }
-            .mask(),
-            0x80000000
-        );
-    }
-}
 
 /// Represents an memory-mapped I/O register.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -393,5 +316,83 @@ pub fn filter_unused_types(blocks: &mut [&mut ValidatedRegisterBlock]) {
     }
     for block in blocks.iter_mut() {
         block.filter_register_types(|ty| used_types.contains(ty));
+    }
+}
+
+#[cfg(test)]
+mod registerfield_tests {
+    use super::*;
+
+    #[test]
+    fn test_mask() {
+        assert_eq!(
+            RegisterField {
+                position: 0,
+                width: 1,
+                ..Default::default()
+            }
+            .mask(),
+            0x00000001
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 0,
+                width: 2,
+                ..Default::default()
+            }
+            .mask(),
+            0x00000003
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 0,
+                width: 3,
+                ..Default::default()
+            }
+            .mask(),
+            0x00000007
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 1,
+                width: 3,
+                ..Default::default()
+            }
+            .mask(),
+            0x0000000e
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 8,
+                width: 3,
+                ..Default::default()
+            }
+            .mask(),
+            0x00000700
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 28,
+                width: 4,
+                ..Default::default()
+            }
+            .mask(),
+            0xf0000000
+        );
+
+        assert_eq!(
+            RegisterField {
+                position: 31,
+                width: 1,
+                ..Default::default()
+            }
+            .mask(),
+            0x80000000
+        );
     }
 }

--- a/ureg/lib/systemrdl/Cargo.toml
+++ b/ureg/lib/systemrdl/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2021"
 [dependencies]
 ureg-schema = { path = "../schema" }
 caliptra-systemrdl = { path = "../../../systemrdl" }
+
+[lints]
+workspace = true

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -30,3 +30,6 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 std = []
+
+[lints]
+workspace = true

--- a/x509/fuzz/Cargo.toml
+++ b/x509/fuzz/Cargo.toml
@@ -29,3 +29,6 @@ name = "fuzz_target_1"
 path = "src/fuzz_target_1.rs"
 test = false
 doc = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
Fix all the issues clippy finds with the new toolchain.

What about DPE? It's currently set to use the stable toolchain which errors on newer clippy.