### PR TITLE
caliptra-rom: Don't use MailboxResp. 

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-417f3d492dec902bb20d3f54fe54374a236e8f8aa5ae250d7de08dda6d12ea0c6f009d4ccbf83c6963c321a771788ea2  caliptra-rom-no-log.bin
-544c6e5244a35d6a39ba85fc8b90c3ef7816bb385d28ee46accf0475924a835b42418d9b10f6ad3e090fcfc25e1f0f1a  caliptra-rom-with-log.bin
+7ac78c78fc377fe06fc1d9d80a13c42d2318a68321ce85bb1edad071a02c28b47e922b945eb571c6c331e83dd71e3c1a  caliptra-rom-no-log.bin
+80a4ae9b3ed0f05ea7576a270ae7efb5994e6631aaa9863c0cd569288eb20217ccb56138c4fc1bf0a4c5374ef79fa25f  caliptra-rom-with-log.bin

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -54,7 +54,17 @@ impl From<CommandId> for u32 {
 /// and response type.
 pub trait Request: AsBytes + FromBytes {
     const ID: CommandId;
-    type Resp: FromBytes;
+    type Resp: Response;
+}
+
+pub trait Response: AsBytes + FromBytes
+where
+    Self: Sized,
+{
+    /// The minimum size (in bytes) of this response. Transports that receive at
+    /// least this much data should pad the missing data with zeroes. If they
+    /// receive fewer bytes than MIN_SIZE, they should error.
+    const MIN_SIZE: usize = core::mem::size_of::<Self>();
 }
 
 // Contains all the possible mailbox response structs
@@ -237,6 +247,7 @@ pub struct MailboxRespHeader {
     pub chksum: u32,
     pub fips_status: u32,
 }
+impl Response for MailboxRespHeader {}
 
 impl MailboxRespHeader {
     pub const FIPS_STATUS_APPROVED: u32 = 0;
@@ -325,6 +336,9 @@ impl GetLdevCertResp {
         self.data.get(..self.data_size as usize)
     }
 }
+impl Response for GetLdevCertResp {
+    const MIN_SIZE: usize = size_of::<MailboxRespHeader>() + size_of::<u32>();
+}
 
 // ECDSA384_SIGNATURE_VERIFY
 #[repr(C)]
@@ -390,6 +404,7 @@ pub struct StashMeasurementResp {
     pub hdr: MailboxRespHeader,
     pub dpe_result: u32,
 }
+impl Response for StashMeasurementResp {}
 
 // DISABLE_ATTESTATION
 // No command-specific input args
@@ -443,6 +458,9 @@ impl InvokeDpeResp {
         &mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count]
     }
 }
+impl Response for InvokeDpeResp {
+    const MIN_SIZE: usize = size_of::<MailboxRespHeader>() + size_of::<u32>();
+}
 
 impl Default for InvokeDpeResp {
     fn default() -> Self {
@@ -495,6 +513,7 @@ pub struct FipsVersionResp {
     pub fips_rev: [u32; 3],
     pub name: [u8; 12],
 }
+impl Response for FipsVersionResp {}
 
 // FW_INFO
 // No command-specific input args
@@ -519,6 +538,7 @@ pub struct CapabilitiesResp {
     pub hdr: MailboxRespHeader,
     pub capabilities: [u8; crate::capabilities::Capabilities::SIZE_IN_BYTES],
 }
+impl Response for CapabilitiesResp {}
 
 // POPULATE_IDEV_CERT
 // No command-specific output args

--- a/common/src/fips.rs
+++ b/common/src/fips.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::cprintln;
-use crate::mailbox_api::{FipsVersionResp, MailboxResp, MailboxRespHeader};
+use crate::mailbox_api::{FipsVersionResp, MailboxRespHeader};
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::SocIfc;
 
@@ -10,16 +10,14 @@ impl FipsVersionCmd {
     pub const NAME: [u8; 12] = *b"Caliptra RTM";
     pub const MODE: u32 = 0x46495053;
 
-    pub fn execute(soc_ifc: &SocIfc) -> CaliptraResult<MailboxResp> {
+    pub fn execute(soc_ifc: &SocIfc) -> CaliptraResult<FipsVersionResp> {
         cprintln!("[rt] FIPS Version");
 
-        let resp = FipsVersionResp {
+        Ok(FipsVersionResp {
             hdr: MailboxRespHeader::default(),
             mode: Self::MODE,
             fips_rev: soc_ifc.get_version(),
             name: Self::NAME,
-        };
-
-        Ok(MailboxResp::FipsVersion(resp))
+        })
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -22,7 +22,7 @@ use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::capabilities::Capabilities;
 use caliptra_common::fips::FipsVersionCmd;
 use caliptra_common::mailbox_api::{
-    CapabilitiesResp, CommandId, MailboxReqHeader, MailboxResp, MailboxRespHeader,
+    CapabilitiesResp, CommandId, MailboxReqHeader, MailboxRespHeader, Response,
     StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_common::pcr::PCR_ID_STASH_MEASUREMENT;
@@ -209,7 +209,7 @@ impl FirmwareProcessor {
                         Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
 
                         let mut resp = FipsVersionCmd::execute(soc_ifc)?;
-                        resp.populate_chksum()?;
+                        resp.populate_chksum();
                         txn.send_response(resp.as_bytes())?;
                     }
                     CommandId::SELF_TEST_START => {
@@ -221,8 +221,8 @@ impl FirmwareProcessor {
                             txn.complete(false)?;
                         } else {
                             run_fips_tests(env)?;
-                            let mut resp = MailboxResp::default();
-                            resp.populate_chksum()?;
+                            let mut resp = MailboxRespHeader::default();
+                            resp.populate_chksum();
                             txn.send_response(resp.as_bytes())?;
                             self_test_in_progress = true;
                         }
@@ -235,8 +235,8 @@ impl FirmwareProcessor {
                             // TODO: set non-fatal error register?
                             txn.complete(false)?;
                         } else {
-                            let mut resp = MailboxResp::default();
-                            resp.populate_chksum()?;
+                            let mut resp = MailboxRespHeader::default();
+                            resp.populate_chksum();
                             txn.send_response(resp.as_bytes())?;
                             self_test_in_progress = false;
                         }
@@ -245,8 +245,8 @@ impl FirmwareProcessor {
                         let mut request = MailboxReqHeader::default();
                         Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
 
-                        let mut resp = MailboxResp::default();
-                        resp.populate_chksum()?;
+                        let mut resp = MailboxRespHeader::default();
+                        resp.populate_chksum();
                         txn.send_response(resp.as_bytes())?;
 
                         // Causing a ROM Fatal Error will zeroize the module
@@ -259,11 +259,11 @@ impl FirmwareProcessor {
                         let mut capabilities = Capabilities::default();
                         capabilities |= Capabilities::ROM_BASE;
 
-                        let mut resp = MailboxResp::Capabilities(CapabilitiesResp {
+                        let mut resp = CapabilitiesResp {
                             hdr: MailboxRespHeader::default(),
                             capabilities: capabilities.to_bytes(),
-                        });
-                        resp.populate_chksum()?;
+                        };
+                        resp.populate_chksum();
                         txn.send_response(resp.as_bytes())?;
                         continue;
                     }
@@ -279,11 +279,11 @@ impl FirmwareProcessor {
                         Self::stash_measurement(pcr_bank, env.sha384, persistent_data, &mut txn)?;
 
                         // Generate and send response (with FIPS approved status)
-                        let mut resp = MailboxResp::StashMeasurement(StashMeasurementResp {
+                        let mut resp = StashMeasurementResp {
                             hdr: MailboxRespHeader::default(),
                             dpe_result: 0, // DPE_STATUS_SUCCESS
-                        });
-                        resp.populate_chksum()?;
+                        };
+                        resp.populate_chksum();
                         txn.send_response(resp.as_bytes())?;
                     }
                     _ => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,12 +34,10 @@ pub use invoke_dpe::InvokeDpeCmd;
 pub use stash_measurement::StashMeasurementCmd;
 pub use verify::EcdsaVerifyCmd;
 pub mod packet;
-use caliptra_common::mailbox_api::CommandId;
+use caliptra_common::mailbox_api::{CommandId, MailboxResp};
 use packet::Packet;
 
 use caliptra_common::cprintln;
-#[cfg(feature = "fips_self_test")]
-use caliptra_common::mailbox_api::MailboxResp;
 
 use caliptra_drivers::{CaliptraError, CaliptraResult, ResetReason};
 use caliptra_registers::mbox::enums::MboxStatusE;
@@ -146,7 +144,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::TEST_ONLY_GET_FMC_ALIAS_CERT => TestGetFmcAliasCertCmd::execute(drivers),
         #[cfg(feature = "test_only_commands")]
         CommandId::TEST_ONLY_HMAC384_VERIFY => HmacVerifyCmd::execute(drivers, cmd_bytes),
-        CommandId::VERSION => FipsVersionCmd::execute(&drivers.soc_ifc),
+        CommandId::VERSION => {
+            FipsVersionCmd::execute(&drivers.soc_ifc).map(MailboxResp::FipsVersion)
+        }
         #[cfg(feature = "fips_self_test")]
         CommandId::SELF_TEST_START => match drivers.self_test_status {
             SelfTestStatus::Idle => {


### PR DESCRIPTION
This has two benefits:

* We avoid ROM binary changes when the size of MailboxResp changes in the future.

* This reduces stack consumption, as MailboxResp reserves lots of stack
  space, even when sending tiny responses (which is the case in the
  ROM).

The "hw-model: Allow some mailbox responses to be padded" commit from #1076 is included in this PR as we need the Response trait. 