### PR TITLE
Point dpe submodule at a real commit.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "asn1"


### PR DESCRIPTION
This fixes error "fatal: Fetched in submodule path 'dpe', but it did not contain ccb914569cf119da3f46731ae4e102c58322de58. Direct fetching of that commit failed."