### PR TITLE
Removing generation of ROM hex files from release

### DIFF
--- a/ci-tools/release/build_release.sh
+++ b/ci-tools/release/build_release.sh
@@ -10,8 +10,6 @@ mkdir -p $WORKSPACE_DIR
 
 # Generate ROM and Image Bundle Binary
 cargo run --manifest-path=builder/Cargo.toml --bin image -- --rom-with-log $WORKSPACE_DIR/caliptra-rom.bin --fw $WORKSPACE_DIR/image-bundle.bin
-# Generate ROM Hex
-objcopy -I binary -O verilog $WORKSPACE_DIR/caliptra-rom.bin $WORKSPACE_DIR/caliptra-rom.hex
 # Copy ROM ELF
 cp -a target/riscv32imc-unknown-none-elf/firmware/caliptra-rom $WORKSPACE_DIR/caliptra-rom.elf
 # Copy FMC ELF
@@ -21,8 +19,6 @@ cp -a target/riscv32imc-unknown-none-elf/firmware/caliptra-runtime $WORKSPACE_DI
 
 # Generate fake ROM and Image Bundle Binary
 cargo run --manifest-path=builder/Cargo.toml --bin image -- --fake-rom $WORKSPACE_DIR/fake-caliptra-rom.bin --fake-fw $WORKSPACE_DIR/fake-image-bundle.bin
-# Generate fake ROM Hex
-objcopy -I binary -O verilog $WORKSPACE_DIR/fake-caliptra-rom.bin $WORKSPACE_DIR/fake-caliptra-rom.hex
 # Copy fake ROM ELF
 cp -a target/riscv32imc-unknown-none-elf/firmware/caliptra-rom $WORKSPACE_DIR/fake-caliptra-rom.elf
 # Copy fake FMC ELF
@@ -45,13 +41,11 @@ echo -e "Caliptra-SW Rev: $(git rev-parse HEAD)" >> $WORKSPACE_DIR/release_notes
 echo -e "Content:" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tRTL: caliptra-rtl/" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tROM Bin: caliptra-rom.bin" >> $WORKSPACE_DIR/release_notes.txt
-echo -e "\tROM Hex: caliptra-rom.hex" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tROM ELF: caliptra-rom.elf" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tImage Bundle Bin: image-bundle.bin" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tFMC ELF: caliptra-fmc.elf" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tRTFW ELF: caliptra-runtime.elf" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tFake ROM Bin: fake-caliptra-rom.bin" >> $WORKSPACE_DIR/release_notes.txt
-echo -e "\tFake ROM Hex: fake-caliptra-rom.hex" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tFake ROM ELF: fake-caliptra-rom.elf" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tFake Image Bundle Bin: fake-image-bundle.bin" >> $WORKSPACE_DIR/release_notes.txt
 echo -e "\tFake FMC ELF: fake-caliptra-fmc.elf" >> $WORKSPACE_DIR/release_notes.txt


### PR DESCRIPTION
Different hex formats for the ROM (and fake-ROM) are needed by different integrators. Providing any single hex format will not satisfy most users needs and has caused some confusion as integrators have assumed it is their needed format. This PR would remove the hex generation altogether and require integrators to generate their needed format from the provided raw, binary files.