### PR TITLE
CI: Fix regression in #1083 that ignores test failures. 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -141,7 +141,8 @@ jobs:
 
       - name: Run tests
         run: |
-          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked && CPTRA_COVERAGE_PATH=/tmp cargo run --manifest-path ./coverage/Cargo.toml
+          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked
+          CPTRA_COVERAGE_PATH=/tmp cargo run --manifest-path ./coverage/Cargo.toml
 
           CARGO_TARGET_DIR=target cargo --config "$EXTRA_CARGO_CONFIG" test --locked --manifest-path ci-tools/fpga-boss/Cargo.toml
           sccache --show-stats

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Run tests
         run: |
           CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked
-          CPTRA_COVERAGE_PATH=/tmp cargo run --manifest-path ./coverage/Cargo.toml
+          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" run --manifest-path ./coverage/Cargo.toml
 
           CARGO_TARGET_DIR=target cargo --config "$EXTRA_CARGO_CONFIG" test --locked --manifest-path ci-tools/fpga-boss/Cargo.toml
           sccache --show-stats

--- a/ci.sh
+++ b/ci.sh
@@ -104,7 +104,7 @@ if task_enabled "test"; then
   else
     CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked
   fi
-  CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" CPTRA_COVERAGE_PATH="${cov_dir}" cargo run --manifest-path ./coverage/Cargo.toml
+  CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" CPTRA_COVERAGE_PATH="${cov_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" run --manifest-path ./coverage/Cargo.toml
 fi
 
 if task_enabled "check_frozen_images"; then


### PR DESCRIPTION
`&&` prevents `-e` from exiting the script or error.

For example:

```
$ cat f.sh
#!/bin/bash
set -e
false && true
echo Still alive

$ bash f.sh
Still alive
```

Fix this by putting the coverage step on a separate line.

Also, set --extra_cargo_config when running coverage tool. This makes cargo use the same settings as everything else, preventing the need to re-build already-built crates (and clobbering the previous crates), slowing things down.