### PR TITLE
Auto-initialize DPE with the RT Journey PCR

### DIFF
--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -59,12 +59,6 @@ impl StashMeasurementCmd {
                     target_locality: locality,
                 }
                 .execute(&mut pdata_mut.dpe, &mut env, locality);
-                // clear tags for retired contexts
-                Drivers::clear_tags_for_non_active_contexts(
-                    &mut pdata_mut.dpe,
-                    &mut pdata_mut.context_has_tag,
-                    &mut pdata_mut.context_tags,
-                );
 
                 match derive_child_resp {
                     Ok(_) => DpeErrorCode::NoError,

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -91,7 +91,7 @@ fn test_boot_tci_data() {
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order
-    let measurements_to_be_hashed = [[0u8; 48], rt_journey_pcr, valid_pauser_hash].concat();
+    let measurements_to_be_hashed = [rt_journey_pcr, valid_pauser_hash].concat();
     let expected_measurement_hash = model
         .mailbox_execute(0x4000_0000, measurements_to_be_hashed.as_bytes())
         .unwrap()
@@ -151,8 +151,7 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order
-    let measurements_to_be_hashed =
-        [[0u8; 48], rt_journey_pcr, valid_pauser_hash, measurement].concat();
+    let measurements_to_be_hashed = [rt_journey_pcr, valid_pauser_hash, measurement].concat();
     let expected_measurement_hash = model
         .mailbox_execute(0x4000_0000, measurements_to_be_hashed.as_bytes())
         .unwrap()

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -112,11 +112,11 @@ fn test_pl1_derive_child_dpe_context_thresholds() {
     let mut handle = init_ctx_resp.handle;
 
     // Call DeriveChild with PL1 enough times to breach the threshold on the last iteration.
-    // Note that this loop runs exactly PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 2 times. When we initialize
-    // DPE, we measure the RT journey PCR and the mailbox valid pausers in Caliptra's locality: 0xFFFFFFFF,
-    // which counts as a PL1 locality. Then, we initialize a simulation context in locality 1. Thus, we can call derive child
-    // from PL1 exactly 16 - 3 = 13 times, and the last iteration of this loop, is expected to throw a threshold breached error.
-    let num_iterations = InvokeDpeCmd::PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 2;
+    // Note that this loop runs exactly PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 1 times. When we initialize
+    // DPE, we measure the RT journey PCR in Caliptra's locality: 0xFFFFFFFF, which counts as a PL1 locality.
+    // Then, we initialize a simulation context in locality 1. Thus, we can call derive child
+    // from PL1 exactly 16 - 2 = 14 times, and the last iteration of this loop, is expected to throw a threshold breached error.
+    let num_iterations = InvokeDpeCmd::PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 1;
     for i in 0..num_iterations {
         let derive_child_cmd = DeriveChildCmd {
             handle,
@@ -194,12 +194,13 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    let num_iterations = InvokeDpeCmd::PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 1;
+    let num_iterations = InvokeDpeCmd::PL1_DPE_ACTIVE_CONTEXT_THRESHOLD;
     for i in 0..num_iterations {
         let init_ctx_cmd = InitCtxCmd::new_simulation();
 
-        // InitCtx should fail on the PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 2nd iteration since
-        // RT initialization creates two contexts in Caliptra's locality, which is PL1.
+        // InitCtx should fail on the PL1_DPE_ACTIVE_CONTEXT_THRESHOLD - 1st iteration since
+        // RT initialization creates the RT journey measurement context in Caliptra's locality,
+        // which is PL1.
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -1,5 +1,9 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_builder::{
+    firmware::{self, FMC_WITH_UART},
+    ImageOptions,
+};
 use caliptra_common::mailbox_api::{
     CommandId, MailboxReq, MailboxReqHeader, StashMeasurementReq, StashMeasurementResp,
 };
@@ -17,10 +21,11 @@ fn test_stash_measurement() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
+    let measurement = [1u8; 48];
     let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
         hdr: MailboxReqHeader { chksum: 0 },
         metadata: [0u8; 4],
-        measurement: [0u8; 48],
+        measurement,
         context: [0u8; 48],
         svn: 0,
     });
@@ -40,4 +45,35 @@ fn test_stash_measurement() {
             .into_ref();
 
     assert_eq!(resp_hdr.dpe_result, 0);
+
+    // create a new fw image with the runtime replaced by the mbox responder
+    let updated_fw_image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &firmware::runtime_tests::MBOX,
+        ImageOptions::default(),
+    )
+    .unwrap()
+    .to_bytes()
+    .unwrap();
+
+    // trigger an update reset so we can use commands in mbox responder
+    model
+        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .unwrap();
+
+    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
+    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+
+    let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
+    let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
+
+    // hash expected DPE measurements in order to check that stashed measurement was added to DPE
+    let measurements_to_be_hashed = [rt_journey_pcr, valid_pauser_hash, measurement].concat();
+    let expected_measurement_hash = model
+        .mailbox_execute(0x4000_0000, measurements_to_be_hashed.as_bytes())
+        .unwrap()
+        .unwrap();
+
+    let dpe_measurement_hash = model.mailbox_execute(0x3000_0000, &[]).unwrap().unwrap();
+    assert_eq!(expected_measurement_hash, dpe_measurement_hash);
 }

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -212,10 +212,44 @@ fn test_tagging_destroyed_context() {
 fn test_tagging_retired_context() {
     let mut model = run_rt_test(None, None, None);
 
-    // Tag default context
+    // retire context via DeriveChild
+    let derive_child_cmd = DeriveChildCmd {
+        handle: ContextHandle::default(),
+        data: [0u8; DPE_PROFILE.get_hash_size()],
+        flags: DeriveChildFlags::empty(),
+        tci_type: 0,
+        target_locality: 0,
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveChild(derive_child_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::DeriveChild(derive_child_resp)) = resp else {
+        panic!("Wrong response type!");
+    };
+    let new_handle = derive_child_resp.handle;
+
+    // check that we cannot tag retired context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
         handle: DEFAULT_HANDLE,
+        tag: TAG,
+    });
+    cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::DPE_TAG_TCI), cmd.as_bytes().unwrap())
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_TAGGING_FAILURE,
+        resp,
+    );
+
+    // tag new context
+    let mut cmd = MailboxReq::TagTci(TagTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        handle: new_handle.0,
         tag: TAG,
     });
     cmd.populate_chksum().unwrap();
@@ -224,11 +258,11 @@ fn test_tagging_retired_context() {
         .unwrap()
         .expect("We expected a response");
 
-    // retire tagged context via DeriveChild
+    // retire tagged context via derive child
     let derive_child_cmd = DeriveChildCmd {
-        handle: ContextHandle::default(),
+        handle: new_handle,
         data: [0u8; DPE_PROFILE.get_hash_size()],
-        flags: DeriveChildFlags::MAKE_DEFAULT,
+        flags: DeriveChildFlags::empty(),
         tci_type: 0,
         target_locality: 0,
     };
@@ -241,7 +275,7 @@ fn test_tagging_retired_context() {
         panic!("Wrong response type!");
     };
 
-    // check that we cannot get tagged tci for a retired context
+    // check that we can get tagged tci for a retired context
     let mut cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
         tag: TAG,
@@ -252,10 +286,7 @@ fn test_tagging_retired_context() {
             u32::from(CommandId::DPE_GET_TAGGED_TCI),
             cmd.as_bytes().unwrap(),
         )
-        .unwrap_err();
-    assert_error(
-        &mut model,
-        caliptra_drivers::CaliptraError::RUNTIME_TAGGING_FAILURE,
-        resp,
-    );
+        .unwrap()
+        .expect("We expected a response");
+    let _ = GetTaggedTciResp::read_from(resp.as_slice()).unwrap();
 }


### PR DESCRIPTION
Currently, there is a bug in RT where Drivers::get_dpe_root_context_idx returns the incorrect DPE context index. This function searches for the context whose parent is 0xFF, which indicates that that context is the root. However, DPE is auto-initialized and then DeriveChild is called in order to measure the RT journey PCR into a child context. This means the root context does not contain the RT journey PCR which is incorrect.

With the change in https://github.com/chipsalliance/caliptra-dpe/pull/278, we are able to auto-initialize DPE with a measurement. Using that, we now auto-initialize DPE with the RT journey PCR so that we don't have an extraneous default measurement in DPE. 

This PR also updates tagging behavior to allow GET_TAGGED_TCI on retired contexts and disallow TAG_TCI on retired contexts. The test has been updated accordingly.

This PR also adds a test that checks that measurements are stored in DPE when STASH_MEASUREMENT is called.

Fixes #1118 
Fixes #1169