### PR TITLE
Diversify Runtime error codes

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -369,10 +369,36 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E0027);
     pub const RUNTIME_LDEVID_CERT_HANDOFF_FAILED: CaliptraError =
         CaliptraError::new_const(0x000E0028);
-    pub const RUNTIME_CONTEXT_TAG_VALIDATION_FAILED: CaliptraError =
+    pub const RUNTIME_CONTEXT_TAGS_VALIDATION_FAILED: CaliptraError =
         CaliptraError::new_const(0x000E0029);
-    pub const RUNTIME_INCREMENT_PCR_RESET_MAX_REACHED: CaliptraError =
+    pub const RUNTIME_COULD_NOT_GET_DPE_PROFILE: CaliptraError =
         CaliptraError::new_const(0x000E002A);
+    pub const RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E002B);
+    pub const RUNTIME_GET_LDEVID_CERT_FAILED: CaliptraError = CaliptraError::new_const(0x000E002C);
+    pub const RUNTIME_GET_FMC_ALIAS_CERT_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E002D);
+    pub const RUNTIME_GET_RT_ALIAS_CERT_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E002E);
+    pub const RUNTIME_CMD_BUSY_DURING_WARM_RESET: CaliptraError =
+        CaliptraError::new_const(0x000E002F);
+    pub const RUNTIME_RT_SVN_HANDOFF_FAILED: CaliptraError = CaliptraError::new_const(0x000E0030);
+    pub const RUNTIME_RT_MIN_SVN_HANDOFF_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0031);
+    pub const RUNTIME_FMC_SVN_HANDOFF_FAILED: CaliptraError = CaliptraError::new_const(0x000E0032);
+    pub const RUNTIME_CONTEXT_HAS_TAG_VALIDATION_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0033);
+    pub const RUNTIME_LDEV_ID_CERT_TOO_BIG: CaliptraError = CaliptraError::new_const(0x000E0034);
+    pub const RUNTIME_FMC_ALIAS_CERT_TOO_BIG: CaliptraError = CaliptraError::new_const(0x000E0035);
+    pub const RUNTIME_RT_ALIAS_CERT_TOO_BIG: CaliptraError = CaliptraError::new_const(0x000E0036);
+    pub const RUNTIME_COMPUTE_RT_ALIAS_SN_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0037);
+    pub const RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0038);
+    pub const RUNTIME_UNABLE_TO_FIND_DPE_ROOT_CONTEXT: CaliptraError =
+        CaliptraError::new_const(0x000E0039);
+    pub const RUNTIME_INCREMENT_PCR_RESET_MAX_REACHED: CaliptraError =
+        CaliptraError::new_const(0x000E003A);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/src/handoff.rs
+++ b/runtime/src/handoff.rs
@@ -14,22 +14,25 @@ impl RtHandoff<'_> {
         match ds {
             DataVaultNonSticky4(dv_entry) => Ok(self.data_vault.read_warm_reset_entry4(dv_entry)),
             DataVaultSticky4(dv_entry) => Ok(self.data_vault.read_cold_reset_entry4(dv_entry)),
-            _ => Err(CaliptraError::RUNTIME_HANDOFF_INVALID_PARM),
+            _ => Err(CaliptraError::RUNTIME_INTERNAL),
         }
     }
 
     /// Retrieve runtime SVN.
     pub fn rt_svn(&self) -> CaliptraResult<u32> {
         self.read_from_ds(self.fht.rt_svn_dv_hdl.try_into()?)
+            .map_err(|_| CaliptraError::RUNTIME_RT_SVN_HANDOFF_FAILED)
     }
 
     /// Retrieve runtime minimum SVN.
     pub fn rt_min_svn(&self) -> CaliptraResult<u32> {
         self.read_from_ds(self.fht.rt_min_svn_dv_hdl.try_into()?)
+            .map_err(|_| CaliptraError::RUNTIME_RT_MIN_SVN_HANDOFF_FAILED)
     }
 
     /// Retrieve FMC SVN.
     pub fn fmc_svn(&self) -> CaliptraResult<u32> {
         self.read_from_ds(self.fht.fmc_svn_dv_hdl.try_into()?)
+            .map_err(|_| CaliptraError::RUNTIME_FMC_SVN_HANDOFF_FAILED)
     }
 }

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -49,7 +49,7 @@ impl InvokeDpeCmd {
 
             let locality = drivers.mbox.user();
             let command = Command::deserialize(&cmd.data[..cmd.data_size as usize])
-                .map_err(|_| CaliptraError::RUNTIME_INVOKE_DPE_FAILED)?;
+                .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
             let flags = pdata.manifest1.header.flags;
 
             let pdata_mut = drivers.persistent_data.get_mut();
@@ -59,7 +59,7 @@ impl InvokeDpeCmd {
             let resp = match command {
                 Command::GetProfile => Ok(Response::GetProfile(
                     dpe.get_profile(&mut env.platform)
-                        .map_err(|_| CaliptraError::RUNTIME_INVOKE_DPE_FAILED)?,
+                        .map_err(|_| CaliptraError::RUNTIME_COULD_NOT_GET_DPE_PROFILE)?,
                 )),
                 Command::InitCtx(cmd) => {
                     // InitCtx can only create new contexts if they are simulation contexts.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -195,7 +195,12 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         if reset_reason == ResetReason::WarmReset {
             let mut result = DisableAttestationCmd::execute(drivers);
             match result {
-                Ok(_) => cprintln!("Disabled attestation due to cmd busy during warm reset"),
+                Ok(_) => {
+                    cprintln!("Disabled attestation due to cmd busy during warm reset");
+                    caliptra_drivers::report_fw_error_non_fatal(
+                        CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET.into(),
+                    );
+                }
                 Err(e) => {
                     cprintln!("{}", e.0);
                     return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -135,7 +135,7 @@ fn test_context_tags_validation() {
 
     model.step_until(|m| {
         m.soc_ifc().cptra_fw_error_non_fatal().read()
-            == u32::from(CaliptraError::RUNTIME_CONTEXT_TAG_VALIDATION_FAILED)
+            == u32::from(CaliptraError::RUNTIME_CONTEXT_TAGS_VALIDATION_FAILED)
     });
 }
 
@@ -167,7 +167,7 @@ fn test_context_has_tag_validation() {
 
     model.step_until(|m| {
         m.soc_ifc().cptra_fw_error_non_fatal().read()
-            == u32::from(CaliptraError::RUNTIME_CONTEXT_TAG_VALIDATION_FAILED)
+            == u32::from(CaliptraError::RUNTIME_CONTEXT_HAS_TAG_VALIDATION_FAILED)
     });
 }
 
@@ -198,6 +198,10 @@ fn test_dpe_validation() {
     model
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_fw_error_non_fatal().read()
+            == u32::from(CaliptraError::RUNTIME_DPE_VALIDATION_FAILED)
+    });
 
     // check attestation disabled via FW_INFO
     let payload = MailboxReqHeader {


### PR DESCRIPTION
Also, in places where we disable attestation, signal a non fatal error to SoC so there is some way to find out what went wrong, other than looking at UART.

After this, we still need to find a way to pass DPE error code info up to runtime, instead of throwing it away by using map_err.