### PR TITLE
Make test_*_wdt_timeout() deterministic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "caliptra_common",
  "elf",
  "openssl",
+ "rand",
  "zerocopy",
 ]
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -19,6 +19,7 @@ caliptra-image-types.workspace = true
 caliptra-runtime = { workspace = true, default-features = false }
 elf.workspace = true
 openssl.workspace = true
+rand.workspace = true
 zerocopy.workspace = true
 caliptra-hw-model.workspace = true
 

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -5,7 +5,7 @@ use caliptra_common::mailbox_api::{
     GetFmcAliasCertReq, GetLdevCertReq, GetRtAliasCertReq, ResponseVarSize,
 };
 use caliptra_hw_model::{BootParams, HwModel, InitParams, SecurityState};
-use caliptra_hw_model_types::{DeviceLifecycle, Fuses};
+use caliptra_hw_model_types::{DeviceLifecycle, Fuses, RandomEtrngResponses, RandomNibbles};
 use caliptra_test::{derive, redact_cert, run_test, RedactOpts, UnwrapSingle};
 use caliptra_test::{
     derive::{DoeInput, DoeOutput, FmcAliasKey, IDevId, LDevId, Pcr0, Pcr0Input},
@@ -14,6 +14,8 @@ use caliptra_test::{
 };
 use openssl::nid::Nid;
 use openssl::sha::{sha384, Sha384};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use std::mem;
 use zerocopy::AsBytes;
 
@@ -679,6 +681,8 @@ fn test_rt_wdt_timeout() {
         rom: &rom,
         security_state,
         wdt_timeout_cycles: rt_wdt_timeout_cycles,
+        itrng_nibbles: Box::new(RandomNibbles(StdRng::seed_from_u64(0))),
+        etrng_responses: Box::new(RandomEtrngResponses(StdRng::seed_from_u64(0))),
         ..Default::default()
     };
 
@@ -726,6 +730,8 @@ fn test_fmc_wdt_timeout() {
         rom: &rom,
         security_state,
         wdt_timeout_cycles: fmc_wdt_timeout_cycles,
+        itrng_nibbles: Box::new(RandomNibbles(StdRng::seed_from_u64(0))),
+        etrng_responses: Box::new(RandomEtrngResponses(StdRng::seed_from_u64(0))),
         ..Default::default()
     };
 


### PR DESCRIPTION
These tests have hard-coded cycle counts in them, but the exact cycle counts differ depending on the CFI entropy, leading to flaky tests if the hard-coded cycle count is close to the edge. By setting consistent TNRG seeds for these tests, we can stop them from being flaky.