### PR TITLE
test-matrix: Fix tedious layout issues

### DIFF
--- a/ci-tools/test-matrix/src/html/matrix.js
+++ b/ci-tools/test-matrix/src/html/matrix.js
@@ -27,7 +27,9 @@
                 }
                 selectedCell = e.target;
                 selectedCell.classList.add("selected"); 
-                var top = (selectedCell.offsetTop + selectedCell.offsetHeight);
+                var top = (selectedCell.getBoundingClientRect().top + 
+                           document.documentElement.scrollTop +
+                           selectedCell.offsetHeight);
                 log.style.display = "block";
                 log.style.position = "absolute";
                 log.style.top = "" + top + "px";

--- a/ci-tools/test-matrix/src/html/style.css
+++ b/ci-tools/test-matrix/src/html/style.css
@@ -52,7 +52,8 @@ table.caliptra-test-matrix td.na {
     background-color: #e0e0e0;
 }
 table.caliptra-test-matrix td.selected {
-    border: solid black 1px;
+    outline: 2px solid black;
+    outline-offset: -2px;
 }
 
 pre {


### PR DESCRIPTION
* The location of the log popup when clicking on a test run doesn't account for the position of the title header (due to adding the header at the last minute), putting it in the wrong location.

* The border of a selected cell makes the row 2 pixels taller, causing everything to shift slightly when you click on the cell.

Demo:

https://korran-testorg.github.io/caliptra-sw/