### PR TITLE
Add persistent data tests in RT

### DIFF
--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -361,6 +361,11 @@ pub mod runtime_tests {
         bin_name: "mbox",
         ..RUNTIME_TEST_FWID_BASE
     };
+
+    pub const PERSISTENT_RT: FwId = FwId {
+        bin_name: "persistent_rt",
+        ..RUNTIME_TEST_FWID_BASE
+    };
 }
 
 pub const REGISTERED_FW: &[&FwId] = &[
@@ -421,4 +426,5 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &fmc_tests::MOCK_RT_INTERACTIVE,
     &runtime_tests::BOOT,
     &runtime_tests::MBOX,
+    &runtime_tests::PERSISTENT_RT,
 ];

--- a/runtime/test-fw/Cargo.toml
+++ b/runtime/test-fw/Cargo.toml
@@ -29,6 +29,11 @@ name = "mbox"
 path = "src/mbox_responder.rs"
 required-features = ["riscv"]
 
+[[bin]]
+name = "persistent_rt"
+path = "src/persistent_tests.rs"
+required-features = ["riscv", "runtime"]
+
 [build-dependencies]
 caliptra_common = { workspace = true, default-features = false }
 caliptra-gen-linker-scripts.workspace = true

--- a/runtime/test-fw/src/persistent_tests.rs
+++ b/runtime/test-fw/src/persistent_tests.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]
+#![no_main]
+
+use caliptra_drivers::{PersistentData, PersistentDataAccessor};
+use caliptra_test_harness::{runtime_handlers, test_suite};
+
+fn test_persistent_data_layout() {
+    PersistentData::assert_matches_layout();
+}
+
+fn test_read_write() {
+    {
+        let mut accessor = unsafe { PersistentDataAccessor::new() };
+        accessor.get_mut().fht.fht_marker = 0xfe9cd1c0;
+    }
+    {
+        let accessor = unsafe { PersistentDataAccessor::new() };
+        assert_eq!(accessor.get().fht.fht_marker, 0xfe9cd1c0);
+    }
+}
+
+test_suite! {
+    test_persistent_data_layout,
+    test_read_write,
+}

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -34,6 +34,15 @@ fn test_boot() {
 }
 
 #[test]
+/// This test differs from the drivers' test_persistent() in that it is ran with the "runtime" flag so
+/// it allows us to test conditionally compiled runtime-only persistent data that ROM/FMC may have corrupted.
+fn test_persistent_data() {
+    let mut model = run_rt_test(Some(&firmware::runtime_tests::PERSISTENT_RT), None, None);
+
+    model.step_until_exit_success().unwrap();
+}
+
+#[test]
 fn test_fw_version() {
     let mut model = run_rt_test(None, None, None);
     model.step_until(|m| {


### PR DESCRIPTION
The PersistentData struct uses the "runtime" cfg flag to add new persistent data without changing the ROM binary. The driver test for persistent data layout calls
PersistentData::assert_matches_layout() without the "runtime" feature. This PR adds a runtime test that calls assert_matches_layout() so that we can test the fields in PersistentData behind the "runtime" flag.

fixes #1185 