### PR TITLE
Check that DPE used context limits are not breached upon reset

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -399,6 +399,10 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E0039);
     pub const RUNTIME_INCREMENT_PCR_RESET_MAX_REACHED: CaliptraError =
         CaliptraError::new_const(0x000E003A);
+    pub const RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED: CaliptraError =
+        CaliptraError::new_const(0x000E003B);
+    pub const RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED: CaliptraError =
+        CaliptraError::new_const(0x000E003C);
 
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -11,14 +11,8 @@ use caliptra_drivers::{
 pub struct DisableAttestationCmd;
 impl DisableAttestationCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
-        drivers
-            .key_vault
-            .erase_key(KEY_ID_RT_CDI)
-            .map_err(|_| CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED)?;
-        drivers
-            .key_vault
-            .erase_key(KEY_ID_RT_PRIV_KEY)
-            .map_err(|_| CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED)?;
+        drivers.key_vault.erase_key(KEY_ID_RT_CDI)?;
+        drivers.key_vault.erase_key(KEY_ID_RT_PRIV_KEY)?;
 
         Self::zero_rt_cdi(drivers)?;
         Self::generate_dice_key(drivers)?;

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -39,7 +39,14 @@ pub extern "C" fn entry_point() -> ! {
     cprintln!("{}", BANNER);
     let mut drivers = unsafe {
         Drivers::new_from_registers().unwrap_or_else(|e| {
-            caliptra_common::report_handoff_error_and_halt("Runtime can't load drivers", e.into())
+            // treat global exception as a fatal error
+            match e {
+                CaliptraError::RUNTIME_GLOBAL_EXCEPTION => handle_fatal_error(e.into()),
+                _ => caliptra_common::report_handoff_error_and_halt(
+                    "Runtime can't load drivers",
+                    e.into(),
+                ),
+            }
         })
     };
     caliptra_common::stop_wdt(&mut drivers.soc_ifc);

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -18,26 +18,6 @@ pub struct TagTciCmd;
 impl TagTciCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if let Some(cmd) = TagTciReq::read_from(cmd_args) {
-            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-            let pdata = drivers.persistent_data.get();
-            let rt_pub_key = pdata.fht.rt_dice_pub_key;
-            let mut crypto = DpeCrypto::new(
-                &mut drivers.sha384,
-                &mut drivers.trng,
-                &mut drivers.ecc384,
-                &mut drivers.hmac384,
-                &mut drivers.key_vault,
-                rt_pub_key,
-            );
-            let mut env = DpeEnv::<CptraDpeTypes> {
-                crypto,
-                platform: DpePlatform::new(
-                    pdata.manifest1.header.pl0_pauser,
-                    hashed_rt_pub_key,
-                    &mut drivers.cert_chain,
-                ),
-            };
-
             let pdata_mut = drivers.persistent_data.get_mut();
             let mut dpe = &mut pdata_mut.dpe;
             let mut context_has_tag = &mut pdata_mut.context_has_tag;

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -127,6 +127,12 @@ fn mbox_responder() {
                 drivers.persistent_data.get_mut().dpe = corrupted_dpe;
                 mbox.set_status(MboxStatusE::DataReady);
             }
+            // Read PcrResetCounter
+            CommandId(0xC000_0000) => {
+                mbox.write_response(drivers.persistent_data.get().pcr_reset.as_bytes())
+                    .unwrap();
+                mbox.set_status(MboxStatusE::DataReady);
+            }
             CommandId(FW_LOAD_CMD_OPCODE) => {
                 unsafe { SocIfcReg::new() }
                     .regs_mut()

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -671,9 +671,9 @@ fn test_rt_wdt_timeout() {
     let rt_wdt_timeout_cycles = if cfg!(any(feature = "verilator", feature = "fpga_realtime")) {
         27_100_000
     } else if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
-        3_000_000
+        3_100_000
     } else {
-        2_850_000
+        2_900_000
     };
 
     let security_state = *caliptra_hw_model::SecurityState::default().set_debug_locked(true);


### PR DESCRIPTION
Also, add tests for illegal DPE state upon update reset, breached used context limits upon update reset, and pcr reset counter persistence.

fixes #1180 