### PR TITLE
Add test triggering CPU fault in RT

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -25,6 +25,7 @@ impl CommandId {
     pub const QUOTE_PCRS: Self = Self(0x50435251); // "PCRQ"
 
     pub const TEST_ONLY_HMAC384_VERIFY: Self = Self(0x484D4143); // "HMAC"
+    pub const TEST_ONLY_TRIGGER_CPU_FAULT: Self = Self(0x54504355); // "TCPU"
 
     /// FIPS module commands.
     /// The status command.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -156,6 +156,15 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::QUOTE_PCRS => GetPcrQuoteCmd::execute(drivers, cmd_bytes),
         #[cfg(feature = "test_only_commands")]
         CommandId::TEST_ONLY_HMAC384_VERIFY => HmacVerifyCmd::execute(drivers, cmd_bytes),
+        #[cfg(feature = "test_only_commands")]
+        CommandId::TEST_ONLY_TRIGGER_CPU_FAULT => {
+            // the print is necessary to ensure the compiler doesn't optimize out the unsafe code below
+            cprintln!("Unsafe write to null mutable pointer");
+            unsafe { core::ptr::null_mut::<i32>().write(42) };
+
+            // this error code is unreached
+            Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND)
+        }
         CommandId::VERSION => {
             FipsVersionCmd::execute(&drivers.soc_ifc).map(MailboxResp::FipsVersion)
         }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -3,6 +3,7 @@
 mod common;
 mod test_boot;
 mod test_certs;
+mod test_cpu_fault;
 mod test_disable;
 mod test_ecdsa;
 mod test_fips;

--- a/runtime/tests/runtime_integration_tests/test_cpu_fault.rs
+++ b/runtime/tests/runtime_integration_tests/test_cpu_fault.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+use zerocopy::AsBytes;
+
+use crate::common::{assert_error, run_rt_test};
+
+#[test]
+fn test_cpu_fault() {
+    let mut model = run_rt_test(None, None, None);
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::TEST_ONLY_TRIGGER_CPU_FAULT),
+            &[],
+        ),
+    };
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::TEST_ONLY_TRIGGER_CPU_FAULT),
+            payload.as_bytes(),
+        )
+        .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_GLOBAL_EXCEPTION, resp);
+
+    let mcause = model.soc_ifc().cptra_fw_extended_error_info().at(0).read();
+    let mscause = model.soc_ifc().cptra_fw_extended_error_info().at(1).read();
+    let mepc = model.soc_ifc().cptra_fw_extended_error_info().at(2).read();
+    let ra = model.soc_ifc().cptra_fw_extended_error_info().at(3).read();
+
+    // mcause must be illegal instruction
+    assert_eq!(mcause, 0x2);
+    // no mscause
+    assert_eq!(mscause, 0);
+    // program counter won't be 0
+    assert_ne!(mepc as usize, 0);
+    // return address won't be 0
+    assert_ne!(ra, 0);
+
+    #[cfg(feature = "verilator")]
+    assert!(model.v.output.cptra_error_fatal);
+}

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -671,9 +671,9 @@ fn test_rt_wdt_timeout() {
     let rt_wdt_timeout_cycles = if cfg!(any(feature = "verilator", feature = "fpga_realtime")) {
         27_100_000
     } else if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
-        3_000_000
+        3_100_000
     } else {
-        2_850_000
+        2_900_000
     };
 
     let security_state = *caliptra_hw_model::SecurityState::default().set_debug_locked(true);


### PR DESCRIPTION
This test differs from the ROM cpu fault test in that it uses a test only mailbox command to make an unsafe write to a null pointer, thereby triggering a cpu fault and the
RUNTIME_GLOBAL_EXCEPTION.

We can't copy the ROM cpu fault test due to image verification - any changes to the RT firmware image will be caught upon cold reset and an error will be thrown before triggering a cpu fault.

fixes #1176 