### PR TITLE
Use sha2::Sha384 to hash in RT tests instead of mbox responder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "dpe",
  "openssl",
  "platform",
+ "sha2",
  "ufmt",
  "wycheproof",
  "zerocopy",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -38,6 +38,7 @@ caliptra-image-openssl.workspace = true
 caliptra-image-serde.workspace = true
 caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
 openssl.workspace = true
+sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
 wycheproof.workspace = true
 
 [features]

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_builder::{
-    firmware::{self, FMC_WITH_UART},
+    firmware::{self, APP_WITH_UART, FMC_WITH_UART},
     ImageOptions,
 };
 use caliptra_common::mailbox_api::{
@@ -9,6 +9,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
+use sha2::{Digest, Sha384};
 use zerocopy::{AsBytes, LayoutVerified};
 
 use crate::common::run_rt_test;
@@ -68,12 +69,91 @@ fn test_stash_measurement() {
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order to check that stashed measurement was added to DPE
-    let measurements_to_be_hashed = [rt_journey_pcr, valid_pauser_hash, measurement].concat();
-    let expected_measurement_hash = model
-        .mailbox_execute(0x4000_0000, measurements_to_be_hashed.as_bytes())
-        .unwrap()
-        .unwrap();
+    let mut hasher = Sha384::new();
+    hasher.update(rt_journey_pcr);
+    hasher.update(valid_pauser_hash);
+    hasher.update(measurement);
+    let expected_measurement_hash = hasher.finalize();
 
     let dpe_measurement_hash = model.mailbox_execute(0x3000_0000, &[]).unwrap().unwrap();
-    assert_eq!(expected_measurement_hash, dpe_measurement_hash);
+    assert_eq!(expected_measurement_hash.as_bytes(), dpe_measurement_hash);
+}
+
+#[test]
+fn test_pcr31_extended_upon_stash_measurement() {
+    let mut model = run_rt_test(Some(&firmware::runtime_tests::MBOX), None, None);
+
+    // Read PCR_ID_STASH_MEASUREMENT
+    let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
+    let pcr_31: [u8; 48] = pcr_31_resp.as_bytes().try_into().unwrap();
+
+    // update reset to the real runtime image
+    let updated_fw_image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap()
+    .to_bytes()
+    .unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .unwrap();
+
+    // stash a measurement
+    let measurement = [2u8; 48];
+    let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        metadata: [0u8; 4],
+        measurement,
+        context: [0u8; 48],
+        svn: 0,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let _ = model
+        .mailbox_execute(
+            u32::from(CommandId::STASH_MEASUREMENT),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    // update reset back to mbox responder
+    let updated_fw_image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &firmware::runtime_tests::MBOX,
+        ImageOptions::default(),
+    )
+    .unwrap()
+    .to_bytes()
+    .unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .unwrap();
+
+    let updated_fw_image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &firmware::runtime_tests::MBOX,
+        ImageOptions::default(),
+    )
+    .unwrap()
+    .to_bytes()
+    .unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .unwrap();
+
+    // Read extended PCR_ID_STASH_MEASUREMENT
+    let extended_pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
+    let extended_pcr_31: [u8; 48] = extended_pcr_31_resp.as_bytes().try_into().unwrap();
+
+    // no need to flip endianness here since PCRs are already in same endianness
+    // as sha2 hashes
+    let mut hasher = Sha384::new();
+    hasher.update(pcr_31);
+    hasher.update(measurement);
+    let expected_pcr_31 = hasher.finalize();
+
+    assert_eq!(expected_pcr_31.as_bytes(), extended_pcr_31);
 }


### PR DESCRIPTION
Previously, we were using the sha384 driver via mbox responder for hashing in RT tests since the sha2::Sha384 hash wasn't matching what we were getting from the driver. I discovered that this is due to the endianness being different.

Now, we can use sha2::Sha384 instead of mbox responder if we just flip the endianness of the sha2::Sha384 hash.

Also, add a test to check that PCR31 is extended in stash_measurement. This was previously attempted, but I couldn't get the test to pass, again due to endianness being flipped. 

fixes #1166 
fixes #1125 