### PR TITLE
hw-model: Print out model details to stdout.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "libc",
  "nix 0.26.2",
  "rand",
+ "sha2",
  "uio",
  "ureg",
  "zerocopy",

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -25,6 +25,7 @@ caliptra-api.workspace = true
 caliptra-registers.workspace = true
 caliptra-verilated = { workspace = true, optional = true }
 rand.workspace = true
+sha2.workspace = true
 uio = { workspace = true, optional = true }
 ureg.workspace = true
 zerocopy.workspace = true

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -14,7 +14,8 @@ use api::mailbox::{MailboxReqHeader, MailboxRespHeader, Response};
 use caliptra_api as api;
 use caliptra_emu_bus::Bus;
 use caliptra_hw_model_types::{
-    ErrorInjectionMode, EtrngResponse, RandomEtrngResponses, RandomNibbles, DEFAULT_CPTRA_OBF_KEY,
+    ErrorInjectionMode, EtrngResponse, HexBytes, HexSlice, RandomEtrngResponses, RandomNibbles,
+    DEFAULT_CPTRA_OBF_KEY,
 };
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unalign};
 
@@ -25,6 +26,7 @@ use caliptra_registers::soc_ifc::regs::{
 };
 
 use rand::{rngs::StdRng, SeedableRng};
+use sha2::Digest;
 
 pub mod mmio;
 mod model_emulated;
@@ -81,7 +83,16 @@ pub type DefaultHwModel = ModelFpgaRealtime;
 /// is not yet ready to execute code in the microcontroller. Most test cases
 /// should use [`new`] instead.
 pub fn new_unbooted(params: InitParams) -> Result<DefaultHwModel, Box<dyn Error>> {
-    DefaultHwModel::new_unbooted(params)
+    let summary = params.summary();
+    DefaultHwModel::new_unbooted(params).map(|hw| {
+        println!(
+            "Using hardware-model {} trng={:?}",
+            hw.type_name(),
+            hw.trng_mode()
+        );
+        println!("{summary:#?}");
+        hw
+    })
 }
 
 /// Constructs an HwModel based on the cargo features and environment variables,
@@ -94,7 +105,7 @@ pub fn new(params: BootParams) -> Result<DefaultHwModel, Box<dyn Error>> {
     DefaultHwModel::new(params)
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TrngMode {
     // soc_ifc_reg.CPTRA_HW_CONFIG.iTRNG_en will be true.
     // When running with the verlated hw-model, the itrng compile-time feature
@@ -159,7 +170,6 @@ pub struct InitParams<'a> {
     // will be used
     pub trace_path: Option<PathBuf>,
 }
-
 impl<'a> Default for InitParams<'a> {
     fn default() -> Self {
         let seed = std::env::var("CPTRA_TRNG_SEED")
@@ -191,6 +201,31 @@ impl<'a> Default for InitParams<'a> {
             random_sram_puf: true,
             trace_path: None,
         }
+    }
+}
+
+impl<'a> InitParams<'a> {
+    fn summary(&self) -> InitParamsSummary {
+        InitParamsSummary {
+            rom_sha384: sha2::Sha384::digest(self.rom).into(),
+            obf_key: self.cptra_obf_key,
+            security_state: self.security_state,
+        }
+    }
+}
+
+pub struct InitParamsSummary {
+    rom_sha384: [u8; 48],
+    obf_key: [u32; 8],
+    security_state: SecurityState,
+}
+impl std::fmt::Debug for InitParamsSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InitParamsSummary")
+            .field("rom_sha384", &HexBytes(&self.rom_sha384))
+            .field("obf_key", &HexSlice(&self.obf_key))
+            .field("security_state", &self.security_state)
+            .finish()
     }
 }
 
@@ -440,7 +475,16 @@ pub trait HwModel {
         Self: Sized,
     {
         let wdt_timeout_cycles = run_params.init_params.wdt_timeout_cycles;
+
+        let init_params_summary = run_params.init_params.summary();
+
         let mut hw: Self = HwModel::new_unbooted(run_params.init_params)?;
+        println!(
+            "Using hardware-model {} trng={:?}",
+            hw.type_name(),
+            hw.trng_mode()
+        );
+        println!("{init_params_summary:#?}");
 
         hw.init_fuses(&run_params.fuses);
 
@@ -498,6 +542,12 @@ pub trait HwModel {
         Ok(hw)
     }
 
+    /// The type name of this model
+    fn type_name(&self) -> &'static str;
+
+    /// The TRNG mode used by this model.
+    fn trng_mode(&self) -> TrngMode;
+
     /// Trigger a warm reset and advance the boot
     fn warm_reset_flow(&mut self, fuses: &Fuses) {
         self.warm_reset();
@@ -551,6 +601,7 @@ pub trait HwModel {
                 "Fuses are already locked in place (according to cptra_fuse_wr_done)"
             );
         }
+        println!("Initializing fuses: {:#x?}", fuses);
 
         self.soc_ifc().fuse_uds_seed().write(&fuses.uds_seed);
         self.soc_ifc()

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -57,6 +57,7 @@ pub struct ModelEmulated {
     trace_path: Option<PathBuf>,
 
     image_tag: u64,
+    trng_mode: TrngMode,
 }
 impl Drop for ModelEmulated {
     fn drop(&mut self) {
@@ -156,11 +157,20 @@ impl crate::HwModel for ModelEmulated {
             cpu_enabled,
             trace_path: trace_path_or_env(params.trace_path),
             image_tag,
+            trng_mode,
         };
         // Turn tracing on if the trace path was set
         m.tracing_hint(true);
 
         Ok(m)
+    }
+
+    fn type_name(&self) -> &'static str {
+        "ModelEmulated"
+    }
+
+    fn trng_mode(&self) -> TrngMode {
+        self.trng_mode
     }
 
     fn ready_for_fw(&self) -> bool {

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -18,6 +18,7 @@ use uio::{UioDevice, UioError};
 use crate::EtrngResponse;
 use crate::HwModel;
 use crate::Output;
+use crate::TrngMode;
 
 // UIO mapping indices
 const FPGA_WRAPPER_MAPPING: usize = 0;
@@ -299,6 +300,14 @@ impl HwModel for ModelFpgaRealtime {
         writeln!(m.output().logger(), "ready_for_fuses is high")?;
 
         Ok(m)
+    }
+
+    fn type_name(&self) -> &'static str {
+        "ModelFpgaRealtime"
+    }
+
+    fn trng_mode(&self) -> TrngMode {
+        TrngMode::External
     }
 
     fn apb_bus(&mut self) -> Self::TBus<'_> {

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -239,6 +239,14 @@ impl crate::HwModel for ModelVerilated {
         Ok(m)
     }
 
+    fn type_name(&self) -> &'static str {
+        "ModelVerilated"
+    }
+
+    fn trng_mode(&self) -> TrngMode {
+        self.trng_mode
+    }
+
     fn apb_bus(&mut self) -> Self::TBus<'_> {
         VerilatedApbBus { model: self }
     }


### PR DESCRIPTION
This allows us to manually verify that each test run is configuring the model the way we expect.

Example:

```
$ cargo test -p caliptra-test smoke_test::smoke_test -- --nocapture
<snip>
Using hardware-model ModelEmulated trng=External
InitParamsSummary {
    rom_sha384: "83ee01fe9c9391aaf6bab15dcac3345ac91349a31031d42afed99ce1d6db5c8d28d56c9cab6a45c5d50e6af0b79ca7e8",
    obf_key: [0xa0a1a2a3, 0xb0b1b2b3, 0xc0c1c2c3, 0xd0d1d2d3, 0xe0e1e2e3, 0xf0f1f2f3, 0xa4a5a6a7, 0xb4b5b6b7],
    security_state: SecurityState {
        debug_locked: true,
        device_lifecycle: Production,
    },
}
Initializing fuses: Fuses {
    uds_seed: [0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f, 0x10111213, 0x14151617, 0x18191a1b, 0x1c1d1e1f, 0x20212223, 0x24252627, 0x28292a2b, 0x2c2d2e2f],
    field_entropy: [0x80818283, 0x84858687, 0x88898a8b, 0x8c8d8e8f, 0x90919293, 0x94959697, 0x98999a9b, 0x9c9d9e9f],
    key_manifest_pk_hash: [0x53845724, 0x676e5e2f, 0x649d2c01, 0x8e25c4fb, 0x80c2c28f, 0xcb6d6e93, 0xfb7cf908, 0x930a9953, 0xa9c69c33, 0x83aea9fd, 0x5573cb3d, 0xb1ae0c3b],
    key_manifest_pk_hash_mask: X0,
    owner_pk_hash: [0x421275a8, 0x7a71acf4, 0x34b4f107, 0x6acdd683, 0x77d0a315, 0xf9e2a29b, 0x26b39891, 0x3e89ff33, 0x006c10dc, 0xc4f1bd74, 0x67f1e2c4, 0x1b0a893a],
    fmc_key_manifest_svn: 0x7f,
    runtime_svn: [0x00000000; 4],
    anti_rollback_disable: false,
    idevid_cert_attr: [0x00000000; 24],
    idevid_manuf_hsm_id: [0x00000000; 4],
    life_cycle: Unprovisioned,
    lms_verify: true,
    fuse_lms_revocation: 0x0,
}
          0 writing to cptra_bootfsm_go
     82,032 UART: 
     82,048 UART: Running Caliptra ROM ...
```