### PR TITLE
Remove ROM logic that inspects deprecated min-SVN field.

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-7ac78c78fc377fe06fc1d9d80a13c42d2318a68321ce85bb1edad071a02c28b47e922b945eb571c6c331e83dd71e3c1a  caliptra-rom-no-log.bin
-80a4ae9b3ed0f05ea7576a270ae7efb5994e6631aaa9863c0cd569288eb20217ccb56138c4fc1bf0a4c5374ef79fa25f  caliptra-rom-with-log.bin
+2a100e3c39eab47ddef54e3e5ff8be2cbb5738ebe9a04475ac38103d821430cec039d281715329d0981435c6c61d9033  caliptra-rom-no-log.bin
+dafb37aba484bb43ba8d7558678b92294866890d15bbae5cf467cb4e2602abe709290eb2281d5605f34a23d6607f679d  caliptra-rom-with-log.bin

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -714,11 +714,6 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
                 Err(CaliptraError::IMAGE_VERIFIER_ERR_FMC_SVN_GREATER_THAN_MAX_SUPPORTED)?;
             }
 
-            // TODO: remove this check.
-            if verify_info.svn < verify_info.reserved {
-                Err(CaliptraError::IMAGE_VERIFIER_ERR_FMC_SVN_LESS_THAN_MIN_SUPPORTED)?;
-            }
-
             if cfi_launder(verify_info.svn) < self.env.fmc_fuse_svn() {
                 Err(CaliptraError::IMAGE_VERIFIER_ERR_FMC_SVN_LESS_THAN_FUSE)?;
             } else {
@@ -803,13 +798,10 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
                 Err(CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_SVN_GREATER_THAN_MAX_SUPPORTED)?;
             }
 
-            // TODO: remove this check
-            if verify_info.svn < verify_info.reserved {
-                Err(CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_SVN_LESS_THAN_MIN_SUPPORTED)?;
-            }
-
-            if verify_info.svn < self.env.runtime_fuse_svn() {
+            if cfi_launder(verify_info.svn) < self.env.runtime_fuse_svn() {
                 Err(CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_SVN_LESS_THAN_FUSE)?;
+            } else {
+                cfi_assert_ge(verify_info.svn, self.env.runtime_fuse_svn());
             }
         }
 


### PR DESCRIPTION
This PR also adds CFI logic to the RT FW SVN check, which was previously only present on the FMC SVN check.