### PR TITLE
DPE: Use DPE as a dependency crate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,10 +35,6 @@ jobs:
         run: |
           echo "Build-Test: release_ref=$(git rev-parse HEAD)"
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Install required packages
         run: |
           sudo apt-get install libftdi1-dev libusb-1.0-0-dev golang-1.20-go

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -327,10 +327,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: 'Download FPGA Bitstream Artifact'
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -45,10 +45,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Build firmware
         run: |
           mkdir /tmp/caliptra-test-firmware

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -13,10 +13,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Check that the ROM hash matches the frozen one
         run: ./ci.sh check_frozen_images
 

--- a/.github/workflows/size-history.yml
+++ b/.github/workflows/size-history.yml
@@ -27,10 +27,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Configure actions-cache environment variables
         uses: actions/github-script@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ hw-latest/fpga/vivado*.log
 
 # libcaliptra build artifacts
 libcaliptra/libcaliptra.a
+
+test/dpe_verification/go.sum

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,3 @@
 	path = hw-latest/caliptra-rtl
 	url = https://github.com/chipsalliance/caliptra-rtl
 	branch = main
-[submodule "dpe"]
-	path = dpe
-	url = https://github.com/chipsalliance/caliptra-dpe.git
-	branch = main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
 [[package]]
 name = "crypto"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git#473b75685022df19b711437d7d5d6bc1d36fa755"
 dependencies = [
  "arrayvec",
  "zeroize",
@@ -1146,6 +1147,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git#473b75685022df19b711437d7d5d6bc1d36fa755"
 dependencies = [
  "bitflags 2.4.0",
  "constant_time_eq",
@@ -1822,6 +1824,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 [[package]]
 name = "platform"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git#473b75685022df19b711437d7d5d6bc1d36fa755"
 dependencies = [
  "ufmt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,6 @@ resolver = "2"
 exclude = [
   # Uses a custom .cargo/config
   "sw-emulator/example",
-  "dpe/dpe",
-  "dpe/crypto",
-  "dpe/platform",
-  "dpe/simulator",
-  "dpe/tools",
 
   # fpga-boss depends on crates with annoying system deps like libusb and
   # libftdi, so keep it in its own workspace
@@ -131,9 +126,9 @@ cfg-if = "1.0.0"
 chrono = "0.4.24"
 clap = { version = "3.2.14", default-features = false, features = ["std"] }
 convert_case = "0.6.0"
-dpe = { path = "dpe/dpe", default-features = false, features = ["dpe_profile_p384_sha384"] }
-crypto = { path = "dpe/crypto", default-features = false }
-platform = { path = "dpe/platform", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", default-features = false, features = ["dpe_profile_p384_sha384"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", default-features = false }
 elf = "0.7.2"
 gdbstub = "0.6.3"
 gdbstub_arch = "0.2.4"

--- a/test/dpe_verification/Makefile
+++ b/test/dpe_verification/Makefile
@@ -3,6 +3,8 @@ HW_MODEL_C_DIR = ../../hw-model/c-binding
 TARGET_DIR = ../../target
 BUILDER_DIR = ../../builder
 
+DPE_VERSION = $(shell cargo tree -p dpe | head -1 | sed -e 's/.*#//' -e 's/.$$//' )
+
 ROM_FILE = /tmp/caliptra_rom.bin
 FW_FILE  = /tmp/image_bundle.bin
 
@@ -25,5 +27,10 @@ $(LIB_HW_MODEL):
 $(FW_FILE) $(ROM_FILE):
 	cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_DIR)/Cargo.toml --bin image -- --fw $(FW_FILE) --rom-no-log=$(ROM_FILE)
 
+# update the go.mod file to the current DPE commit
 run: $(LIBCALIPTRA) $(LIB_HW_MODEL) $(FW_FILE) $(ROM_FILE)
+	cp go.mod go.mod.backup; cp go.sum go.sum.backup
+	go get github.com/chipsalliance/caliptra-dpe/verification@$(DPE_VERSION)
+	go mod tidy
 	ROM_PATH=$(ROM_FILE) FW_PATH=$(FW_FILE) go test -v
+	mv go.mod.backup go.mod; mv go.sum.backup go.sum

--- a/test/dpe_verification/go.mod
+++ b/test/dpe_verification/go.mod
@@ -2,9 +2,7 @@ module dpe
 
 go 1.20
 
-replace github.com/chipsalliance/caliptra-dpe/verification => ../../dpe/verification
-
-require github.com/chipsalliance/caliptra-dpe/verification v0.0.0-20231002193428-bb19016edf87
+require github.com/chipsalliance/caliptra-dpe/verification v0.0.0-20231213032344-473b75685022
 
 require (
 	github.com/google/go-sev-guest v0.7.0 // indirect


### PR DESCRIPTION
Rather use DPE as a crate dependency than a git submodule, as it makes it easier to handle.