### PR TITLE
Update zerocopy to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.1"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -2721,13 +2721,13 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.3.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
 wycheproof = "0.5.1"
 x509-parser = "0.15.0"
-zerocopy = "0.6.1"
+zerocopy = "0.6.6"
 serial_test = "2.0.0"
 nix = "0.26.2"
 libc = "0.2"

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-2a100e3c39eab47ddef54e3e5ff8be2cbb5738ebe9a04475ac38103d821430cec039d281715329d0981435c6c61d9033  caliptra-rom-no-log.bin
-dafb37aba484bb43ba8d7558678b92294866890d15bbae5cf467cb4e2602abe709290eb2281d5605f34a23d6607f679d  caliptra-rom-with-log.bin
+8d27981af3d8b6cd587b3ba32d41d83ed34ea42646c339a0555d8bbd5f8b5ad24479440e61237c9df7b80961d7c33dfd  caliptra-rom-no-log.bin
+95d0079625905d680ceffb1bf1f57c68d74eeac5696d18e144bf4801ec5334340e0326dc36006ca40e82facacb8262b4  caliptra-rom-with-log.bin

--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -320,6 +320,7 @@ mod fifo {
     }
 
     /// Writes buf.len() bytes to the mailbox datain reg as dwords
+    #[inline(never)]
     pub fn enqueue(mbox: &mut MboxCsr, buf: &[u8]) -> CaliptraResult<()> {
         if mbox.regs().dlen().read() as usize != buf.len() {
             return Err(CaliptraError::DRIVER_MAILBOX_ENQUEUE_ERR);


### PR DESCRIPTION
Update zerocopy to resolve https://github.com/chipsalliance/caliptra-sw/security/dependabot/15

Both ROM and RT use the ref functions mentioned in the report. This update modifies the ROM binary, although it is not yet clear what exactly changed.