### PR TITLE
[TESTONLY] Break extending PCR using PCR digest

### DIFF
--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -264,6 +264,9 @@ fn test_pcr_hash_extend_single_block() {
     ];
     pcr_bank.erase_all_pcrs();
 
+    // Why does this break extending PCR on FPGA??
+    let _ = sha384.gen_pcr_hash([0; 32].into());
+
     // Round 1: PCR is all zeros.
     let result = sha384.pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());

--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -31,6 +31,9 @@ fn test_digest0() {
         0x98, 0xB9, 0x5B,
     ];
 
+    // Why does this break extending PCR on FPGA??
+    let _ = sha384.gen_pcr_hash([0; 32].into());
+
     let data = &[];
     let digest = sha384.digest(data).unwrap();
     assert_eq!(digest, Array4x12::from(expected));


### PR DESCRIPTION
Using the PCR digest operation before extending PCRs breaks extending PCRs.