### PR TITLE
Change the FHT's reserved field to default to 0xFFs.

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-8d27981af3d8b6cd587b3ba32d41d83ed34ea42646c339a0555d8bbd5f8b5ad24479440e61237c9df7b80961d7c33dfd  caliptra-rom-no-log.bin
-95d0079625905d680ceffb1bf1f57c68d74eeac5696d18e144bf4801ec5334340e0326dc36006ca40e82facacb8262b4  caliptra-rom-with-log.bin
+8163f8e44ffdc96cc21db0ae11e6523c8a86a27676e235dba2d19d777873bdd63af2c242d54e1b38eb63468ae67631eb  caliptra-rom-no-log.bin
+4ef1e205e3f55f0afdb0eeabdf7d8a7b5b2d46872775712120f6d6d490d099da20a7d470fb7bb5199d11c1d3f76c02b2  caliptra-rom-with-log.bin

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -331,7 +331,7 @@ impl Default for FirmwareHandoffTable {
             idev_dice_pub_key: Ecc384PubKey::default(),
             rom_info_addr: RomAddr::new(FHT_INVALID_ADDRESS),
             rtalias_tbs_size: 0,
-            reserved: [0u8; 1642],
+            reserved: [0xFF_u8; 1642],
         }
     }
 }


### PR DESCRIPTION
This allows newly-allocated FHT fields' default values to be considered implicitly invalid.