### PR TITLE
Adding release directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ hw-latest/fpga/build_fpga.log
 hw-latest/fpga/vivado*.jou
 hw-latest/fpga/vivado*.log
 
+# Files created during release process
+release/
+
 # libcaliptra build artifacts
 libcaliptra/libcaliptra.a


### PR DESCRIPTION
- Fixes issue where creation of release directory caused builds to be "dirty" and the revs in the image TOC were marked dirty as a result