### PR TITLE
Initialize SHA hardware before PCR extensions in SHA384 driver

### DIFF
--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -165,6 +165,10 @@ impl Sha384 {
         // Wait for the registers to be ready
         wait::until(|| status_reg.read().ready());
 
+        // Initialize SHA hardware to clear write lock
+        reg.ctrl().write(|w| w.init(true));
+        wait::until(|| status_reg.read().ready());
+
         if status_reg.read().valid() {
             Ok(reg.gen_pcr_hash_digest().read().into())
         } else {

--- a/drivers/test-fw/src/bin/sha384_tests.rs
+++ b/drivers/test-fw/src/bin/sha384_tests.rs
@@ -264,6 +264,11 @@ fn test_pcr_hash_extend_single_block() {
     ];
     pcr_bank.erase_all_pcrs();
 
+    // Call gen_pcr_hash first to ensure that software workaround for
+    // https://github.com/chipsalliance/caliptra-rtl/issues/375 in SHA
+    // driver works as expected.
+    let _ = sha384.gen_pcr_hash([0; 32].into());
+
     // Round 1: PCR is all zeros.
     let result = sha384.pcr_extend(PcrId::PcrId0, &data);
     assert!(result.is_ok());


### PR DESCRIPTION
To workaround https://github.com/chipsalliance/caliptra-rtl/issues/375, the SHA512 peripheral must be reinitialized between gen_pcr_hash and pcr_extend. To simplify when the registers get cleared, always reinitialize the hardware before calling pcr_extend. This isn't done at the end of gen_pcr_hash since other code in firmware still expects to be able to read the PCR hash (such as for signing) after gen_pcr_hash is called.