### PR TITLE
ci: update apt package list before installing deps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install required packages
         run: |
+          sudo apt update -y
           sudo apt-get install libftdi1-dev libusb-1.0-0-dev golang-1.20-go
 
       - name: Restore sccache binary


### PR DESCRIPTION
Although the CI uses the latest version of the ubuntu container as the base container image for the CI build, it's package list is not updated. This can lead to CI failures [1].

[1]: https://github.com/chipsalliance/caliptra-sw/actions/runs/7505680208/job/20435452704?pr=1111