### PR TITLE
CI: Update APT index before installing packages

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Install required packages
         run: |
+          sudo apt-get update
           sudo apt-get install libftdi1-dev libusb-1.0-0-dev golang-1.20-go
 
       - name: Restore sccache binary


### PR DESCRIPTION
This can prevent 404 errors when the index is horribly out of date.