### PR TITLE
Allocate fields for communicating hash chain slot to RT FW.

### DIFF
--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -27,6 +27,7 @@ caliptra-cfi-derive.workspace = true
 [features]
 emu = []
 runtime = ["dep:dpe"]
+fmc = []
 fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -289,7 +289,19 @@ pub struct FirmwareHandoffTable {
     /// RtAlias TBS Size.
     pub rtalias_tbs_size: u16,
 
+    /// Maximum value RT FW SVN can take.
+    #[cfg(any(feature = "fmc", feature = "runtime"))]
+    pub rt_hash_chain_max_svn: u16,
+
+    /// Index of RT hash chain value in the Key Vault.
+    #[cfg(any(feature = "fmc", feature = "runtime"))]
+    pub rt_hash_chain_kv_hdl: HandOffDataHandle,
+
     /// Reserved for future use.
+    #[cfg(any(feature = "fmc", feature = "runtime"))]
+    pub reserved: [u8; 1636],
+
+    #[cfg(not(any(feature = "fmc", feature = "runtime")))]
     pub reserved: [u8; 1642],
 }
 
@@ -331,6 +343,15 @@ impl Default for FirmwareHandoffTable {
             idev_dice_pub_key: Ecc384PubKey::default(),
             rom_info_addr: RomAddr::new(FHT_INVALID_ADDRESS),
             rtalias_tbs_size: 0,
+
+            #[cfg(any(feature = "fmc", feature = "runtime"))]
+            rt_hash_chain_max_svn: 0,
+            #[cfg(any(feature = "fmc", feature = "runtime"))]
+            rt_hash_chain_kv_hdl: HandOffDataHandle(0),
+            #[cfg(any(feature = "fmc", feature = "runtime"))]
+            reserved: [0u8; 1636],
+
+            #[cfg(not(any(feature = "fmc", feature = "runtime")))]
             reserved: [0u8; 1642],
         }
     }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -407,6 +407,8 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E003D);
     pub const RUNTIME_PRIV_KEY_KV_HDL_HANDOFF_FAILED: CaliptraError =
         CaliptraError::new_const(0x000E003E);
+    pub const RUNTIME_HASH_CHAIN_HANDOFF_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E003F);
 
     /// PCR Runtime Errors
     pub const RUNTIME_PCR_RESERVED: CaliptraError = CaliptraError::new_const(0x000E003D);

--- a/fmc/Cargo.toml
+++ b/fmc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 caliptra_common = { workspace = true, default-features = false, features = ["fmc"] }
 caliptra-cpu.workspace = true
-caliptra-drivers.workspace = true
+caliptra-drivers = { workspace = true, features = ["fmc"] }
 caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false  }
 caliptra-registers.workspace = true

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -285,6 +285,15 @@ This field provides the address of the RomInfo structure.
 
 This field provides the size of the *To Be Signed* portion of the Runtime Alias certificate.
 
+### rt_hash_chain_max_svn
+
+This field informs firmware of the maximum RT SVN, which value was used
+to determine the length of RT FW's hash chain.
+
+### rt_hash_chain_kv_hdl
+
+This field provides the Handle into the Key Vault where RT's hash chain is stored.
+
 ### reserved
 
 This area is reserved for definition of additional fields that may be added during Minor version updates of the FHT.

--- a/fmc/src/boot_status.rs
+++ b/fmc/src/boot_status.rs
@@ -14,6 +14,9 @@ pub enum FmcBootStatus {
     RtAliasSubjKeyIdGenerationComplete = RTALIAS_BOOT_STATUS_BASE + 4,
     RtAliasCertSigGenerationComplete = RTALIAS_BOOT_STATUS_BASE + 5,
     RtAliasDerivationComplete = RTALIAS_BOOT_STATUS_BASE + 6,
+
+    // Hash chain statuses
+    RtHashChainComplete = RTALIAS_BOOT_STATUS_BASE + 7,
 }
 
 impl From<FmcBootStatus> for u32 {

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -266,20 +266,26 @@ impl HandOff {
         }
     }
 
-    /// The FMC CDI is stored in a 32-bit DataVault sticky register.
-    fn rt_cdi_store(rt_cdi: KeyId) -> HandOffDataHandle {
-        HandOffDataHandle(((Vault::KeyVault as u32) << 12) | rt_cdi as u32)
+    #[allow(dead_code)]
+    pub fn set_rt_hash_chain_max_svn(env: &mut FmcEnv, max_svn: u16) {
+        Self::fht_mut(env).rt_hash_chain_max_svn = max_svn;
     }
 
-    fn rt_priv_key_store(rt_priv_key: KeyId) -> HandOffDataHandle {
-        HandOffDataHandle(((Vault::KeyVault as u32) << 12) | rt_priv_key as u32)
+    #[allow(dead_code)]
+    pub fn set_rt_hash_chain_kv_hdl(env: &mut FmcEnv, kv_slot: KeyId) {
+        Self::fht_mut(env).rt_hash_chain_kv_hdl = Self::key_id_to_handle(kv_slot)
+    }
+
+    /// The FMC CDI is stored in a 32-bit DataVault sticky register.
+    fn key_id_to_handle(key_id: KeyId) -> HandOffDataHandle {
+        HandOffDataHandle(((Vault::KeyVault as u32) << 12) | key_id as u32)
     }
 
     /// Update HandOff Table with RT Parameters
     pub fn update(env: &mut FmcEnv, out: DiceOutput) -> CaliptraResult<()> {
         // update fht.rt_cdi_kv_hdl
-        Self::fht_mut(env).rt_cdi_kv_hdl = Self::rt_cdi_store(out.cdi);
-        Self::fht_mut(env).rt_priv_key_kv_hdl = Self::rt_priv_key_store(out.subj_key_pair.priv_key);
+        Self::fht_mut(env).rt_cdi_kv_hdl = Self::key_id_to_handle(out.cdi);
+        Self::fht_mut(env).rt_priv_key_kv_hdl = Self::key_id_to_handle(out.subj_key_pair.priv_key);
         Self::fht_mut(env).rt_dice_pub_key = out.subj_key_pair.pub_key;
         Ok(())
     }

--- a/runtime/src/handoff.rs
+++ b/runtime/src/handoff.rs
@@ -12,8 +12,8 @@ Abstract:
 
 --*/
 
-use caliptra_common::DataStore::{DataVaultNonSticky4, DataVaultSticky4};
-use caliptra_drivers::{hand_off::DataStore, DataVault, FirmwareHandoffTable};
+use caliptra_common::DataStore::{DataVaultNonSticky4, DataVaultSticky4, KeyVaultSlot};
+use caliptra_drivers::{hand_off::DataStore, DataVault, FirmwareHandoffTable, KeyId};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 pub struct RtHandoff<'a> {
@@ -39,6 +39,13 @@ impl RtHandoff<'_> {
         }
     }
 
+    fn read_as_kv(&self, ds: DataStore) -> CaliptraResult<KeyId> {
+        match ds {
+            KeyVaultSlot(key_id) => Ok(key_id),
+            _ => Err(CaliptraError::RUNTIME_INTERNAL),
+        }
+    }
+
     /// Retrieve runtime SVN.
     pub fn rt_svn(&self) -> CaliptraResult<u32> {
         self.read_from_ds(self.fht.rt_svn_dv_hdl.try_into()?)
@@ -55,5 +62,11 @@ impl RtHandoff<'_> {
     pub fn fmc_svn(&self) -> CaliptraResult<u32> {
         self.read_from_ds(self.fht.fmc_svn_dv_hdl.try_into()?)
             .map_err(|_| CaliptraError::RUNTIME_FMC_SVN_HANDOFF_FAILED)
+    }
+
+    /// Retrieve the RT FW hash chain.
+    pub fn rt_hash_chain(&self) -> CaliptraResult<KeyId> {
+        self.read_as_kv(self.fht.rt_hash_chain_kv_hdl.try_into()?)
+            .map_err(|_| CaliptraError::RUNTIME_HASH_CHAIN_HANDOFF_FAILED)
     }
 }


### PR DESCRIPTION
As the last pre-existing field was not word-aligned, this also allocates a 16-bit field for communicating the max SVN used by FMC when deriving the hash chain, as a purely informative value.

A follow-up commit will populate these fields from FMC.