### PR TITLE
Libcaliptra hwmodel test fixes

### DIFF
--- a/hw-model/c-binding/examples/smoke_test.c
+++ b/hw-model/c-binding/examples/smoke_test.c
@@ -81,6 +81,7 @@ int main(int argc, char *argv[])
       .rom = read_file_or_die(rom_path),
       .dccm = {.data = NULL, .len = 0},
       .iccm = {.data = NULL, .len = 0},
+      .security_state = CALIPTRA_SEC_STATE_DBG_UNLOCKED_UNPROVISIONED,
     };
 
     // Initialize Model

--- a/hw-model/c-binding/src/caliptra_model.rs
+++ b/hw-model/c-binding/src/caliptra_model.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_emu_bus::Bus;
-use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, SecurityState};
 use std::ffi::*;
 use std::slice;
 
@@ -26,7 +26,13 @@ pub struct caliptra_model_init_params {
     pub rom: caliptra_buffer,
     pub dccm: caliptra_buffer,
     pub iccm: caliptra_buffer,
+    pub security_state: u8,
 }
+
+pub const CALIPTRA_SEC_STATE_DBG_UNLOCKED_UNPROVISIONED: c_int = 0b000;
+pub const CALIPTRA_SEC_STATE_DBG_LOCKED_MANUFACTURING: c_int = 0b101;
+pub const CALIPTRA_SEC_STATE_DBG_UNLOCKED_PRODUCTION: c_int = 0b011;
+pub const CALIPTRA_SEC_STATE_DBG_LOCKED_PRODUCTION: c_int = 0b111;
 
 pub const CALIPTRA_MODEL_STATUS_OK: c_int = 0;
 
@@ -44,6 +50,7 @@ pub unsafe extern "C" fn caliptra_model_init_default(
             rom: slice::from_raw_parts(params.rom.data, params.rom.len),
             dccm: slice::from_raw_parts(params.dccm.data, params.dccm.len),
             iccm: slice::from_raw_parts(params.iccm.data, params.iccm.len),
+            security_state: SecurityState::from(params.security_state as u32),
             ..Default::default()
         })
         .unwrap(),

--- a/libcaliptra/examples/generic/main.c
+++ b/libcaliptra/examples/generic/main.c
@@ -47,10 +47,10 @@ static int set_fuses()
 
     for (int x = 0; x < SHA384_DIGEST_WORD_SIZE; x++)
     {
+        // Pub key hash fuses are stored as big-endian
         fuses.owner_pk_hash[x] = __builtin_bswap32(((uint32_t*)opk_hash)[x]);
+        fuses.key_manifest_pk_hash[x] = __builtin_bswap32(((uint32_t*)vpk_hash)[x]);
     }
-
-    memcpy(&fuses.key_manifest_pk_hash, &vpk_hash, SHA384_DIGEST_BYTE_SIZE);
 
     if ((status = caliptra_init_fuses(&fuses)) != 0)
     {
@@ -549,9 +549,9 @@ int main(int argc, char *argv[])
     run_test(rt_test_all_commands, "Test all Runtime commmands");
 
     if (global_test_result) {
-        printf("libcaliptra test failures reported");
+        printf("\t\tlibcaliptra test failures reported\n");
     } else {
-        printf("All libcaliptra tests passed");
+        printf("\t\tAll libcaliptra tests passed\n");
     }
 
     return global_test_result;

--- a/libcaliptra/examples/hwmodel/interface.c
+++ b/libcaliptra/examples/hwmodel/interface.c
@@ -85,6 +85,7 @@ struct caliptra_model* hwmod_get_or_init(void)
             .rom = read_file_or_exit(rom_path),
             .dccm = {.data = NULL, .len = 0},
             .iccm = {.data = NULL, .len = 0},
+            .security_state = CALIPTRA_SEC_STATE_DBG_LOCKED_MANUFACTURING,
         };
 
         int status = caliptra_model_init_default(init_params, &model);


### PR DESCRIPTION
- fixing endianness for vendor pub key hash in test
- updating security state for libcaliptra hwmodel test to "manufacturing" since vendor pub key hash check is skipped in unprovisioned mode