### PR TITLE
FPGA CI: Add missing 'apt-get update' statement.

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Install sysroot pre-requisites
         if: "!steps.restore_sysroot_cache.outputs.cache-hit"
         run: |
-          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools
+          sudo apt-get update -qy && sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools
 
       - name: build sysroot
         # Note: This is the sysroot for the tiny debian installation we run on the FPGA;


### PR DESCRIPTION
This is necessary to avoid 404 errors due to a stale APT index.