### PR TITLE
CI: Add --locked flag when installing sccache

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
         run: |
-          cargo install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha
+          cargo install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
 
       - name: Save sccache binary
         uses: actions/cache/save@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install sccache
         if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
         run: |
-          cargo install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha
+          cargo install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha --locked
 
       # Save the sccache binary immediately so we can reuse it in future runs
       # even if the rest of the current run fails.


### PR DESCRIPTION
Unfortunately, the gha-toolkit crate made a breaking API change without updating semantic versioning correctly, leading to this compile error if we have to regenerate the cached binary:

```
error[E0277]: expected a `Fn<(reqwest::Request, &'a mut task_local_extensions::extensions::Extensions, reqwest_middleware::Next<'a>)>` closure, found `RetryAfterMiddleware`
   -- index.crates.io-6f17d22bba15001f/gha-toolkit-0.3.1/src/cache.rs:405:19
<snip>
```

By using the `--locked` flag, cargo will use the upstream Cargo.lock, making the build more reproducible, and preventing the compilation error.