### PR TITLE
FPGA CI: Fix NTP clock sync, panic-after-softlock, and systemd init order

### DIFF
--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -42,7 +42,7 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c 'echo iface end0 inet6 auto >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo nameserver 2001:4860:4860::6464 > /etc/resolv.conf'
   chroot out/rootfs bash -c 'echo nameserver 2001:4860:4860::64 >> /etc/resolv.conf'
-  chroot out/rootfs bash -c 'echo kernel.softlockup_panic = 60 >> /etc/sysctl.conf'
+  chroot out/rootfs bash -c 'echo kernel.softlockup_panic = 1 >> /etc/sysctl.conf'
   chroot out/rootfs bash -c 'echo kernel.sysrq = 1 >> /etc/sysctl.conf'
 
   # Comment this line out if you don't trust folks with physical access to the

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -23,7 +23,7 @@ fi
 if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   (rm -rf out/rootfs || true)
   mkdir -p out/rootfs
-  debootstrap --include git,curl,ca-certificates,locales,libicu72,sudo,vmtouch,fping,rdnssd --arch arm64 --foreign bookworm out/rootfs
+  debootstrap --include git,curl,ca-certificates,locales,libicu72,sudo,vmtouch,fping,rdnssd,dbus,systemd-timesyncd --arch arm64 --foreign bookworm out/rootfs
   chroot out/rootfs /debootstrap/debootstrap --second-stage
   chroot out/rootfs useradd runner --shell /bin/bash --create-home
 
@@ -44,6 +44,8 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c 'echo nameserver 2001:4860:4860::64 >> /etc/resolv.conf'
   chroot out/rootfs bash -c 'echo kernel.softlockup_panic = 1 >> /etc/sysctl.conf'
   chroot out/rootfs bash -c 'echo kernel.sysrq = 1 >> /etc/sysctl.conf'
+  chroot out/rootfs bash -c 'echo "[Time]" > /etc/systemd/timesyncd.conf'
+  chroot out/rootfs bash -c 'echo "NTP=time.google.com" >> /etc/systemd/timesyncd.conf'
 
   # Comment this line out if you don't trust folks with physical access to the
   # uart

--- a/ci-tools/fpga-image/startup-script.service
+++ b/ci-tools/fpga-image/startup-script.service
@@ -6,7 +6,8 @@ Wants=network-online.target
 Conflicts=serial-getty@ttyPS0.service
 
 [Service]
-Type=oneshot
+Type=idle
+Restart=no
 StandardInput=tty-force
 StandardOutput=tty-force
 StandardError=tty-force


### PR DESCRIPTION
## fpga-image: Synchronize clock via NTP.
    
GitHub rejects runners with a local clock that varies by more than 15
minutes. Unfortunately, the RTC on the zcu104 boards is terrible,
drifting more than 30 seconds a day.

## fpga-image: Run startup script after everything else.
    
Before this change, systemd hadn't fully initialized when the startup
script was run (as it was blocking continued startup).

## fpga-image: Use softlock_panic sysctl correctly.
    
Previously, we were setting this as if it was a timeout value, but it's
actually just a boolean.

See
https://www.infradead.org/~mchehab/kernel_docs/admin-guide/sysctl/kernel.html#softlockup-panic