### PR TITLE
nightly-release: Fix rtl-repo-sync permission error.

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,6 +10,9 @@ jobs:
   rtl-repo-sync:
     name: RTL Repo Sync
     uses: ./.github/workflows/rtl-repo-sync.yml
+    permissions:
+      contents: write
+      pull-requests: write
 
   find-latest-release:
     name: Find Latest Release


### PR DESCRIPTION
Whoops, #1271 broke the nightly build:

```
github/workflows/nightly-release.yml (Line: 10, Col: 3):
Error calling workflow
'chipsalliance/caliptra-sw/.github/workflows/rtl-repo-sync.yml@d51627a91130c6d5f7c1151ab0e5304e9153753a'.
The workflow is requesting 'contents: write, pull-requests: write',
but is only allowed 'contents: read, pull-requests: none'.
```

Give the rtl-repo-sync job the necessary permissions to create the pull-request.