### PR TITLE
Do not borrow mbox from drivers during the mbox_responder loop.

### DIFF
--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -13,12 +13,35 @@ use caliptra_drivers::{
 };
 use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc::SocIfcReg};
 use caliptra_runtime::{
-    ContextState, DpeInstance, Drivers, RtBootStatus, TciMeasurement, U8Bool, MAX_HANDLES,
+    mailbox::Mailbox, ContextState, DpeInstance, Drivers, RtBootStatus, TciMeasurement, U8Bool,
+    MAX_HANDLES,
 };
 use caliptra_test_harness::{runtime_handlers, test_suite};
 use zerocopy::{AsBytes, FromBytes};
 
-const FW_LOAD_CMD_OPCODE: u32 = CommandId::FIRMWARE_LOAD.0;
+const OPCODE_READ_RT_FW_JOURNEY: u32 = 0x1000_0000;
+const OPCODE_READ_MBOX_PAUSER_HASH: u32 = 0x2000_0000;
+const OPCODE_HASH_DPE_TCI_DATA: u32 = 0x3000_0000;
+const OPCODE_READ_STASHED_MEASUREMENT_PCR: u32 = 0x5000_0000;
+const OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT: u32 = 0x6000_0000;
+const OPCODE_READ_DPE_TAGS: u32 = 0x7000_0000;
+const OPCODE_CORRUPT_CONTEXT_TAGS: u32 = 0x8000_0000;
+const OPCODE_CORRUPT_CONTEXT_HAS_TAG: u32 = 0x9000_0000;
+const OPCODE_READ_DPE_INSTANCE: u32 = 0xA000_0000;
+const OPCODE_CORRUPT_DPE_INSTANCE: u32 = 0xB000_0000;
+const OPCODE_READ_PCR_RESET_COUNTER: u32 = 0xC000_0000;
+const OPCODE_CORRUPT_DPE_ROOT_TCI: u32 = 0xD000_0000;
+const OPCODE_FW_LOAD: u32 = CommandId::FIRMWARE_LOAD.0;
+
+fn read_request(mbox: &Mailbox) -> &[u8] {
+    let size = mbox.dlen() as usize;
+    &mbox.raw_mailbox_contents()[..size]
+}
+
+fn write_response(mbox: &mut Mailbox, data: &[u8]) {
+    mbox.write_response(data).unwrap();
+    mbox.set_status(MboxStatusE::DataReady);
+}
 
 const BANNER: &str = r#"
   ____      _ _       _               ____ _____
@@ -82,23 +105,18 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
 }
 
 pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
-    let mbox = &mut drivers.mbox;
-
     loop {
-        while !mbox.is_cmd_ready() {
+        while !drivers.mbox.is_cmd_ready() {
             // Wait for a request from the SoC.
         }
-        let cmd = mbox.cmd();
+        let cmd = drivers.mbox.cmd();
 
         match cmd {
-            // Read RT_FW_JOURNEY_PCR
-            CommandId(0x1000_0000) => {
+            CommandId(OPCODE_READ_RT_FW_JOURNEY) => {
                 let rt_journey_pcr: [u8; 48] = drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR).into();
-                mbox.write_response(&rt_journey_pcr).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &rt_journey_pcr);
             }
-            // Reconstruct valid mbox pauser hash
-            CommandId(0x2000_0000) => {
+            CommandId(OPCODE_READ_MBOX_PAUSER_HASH) => {
                 const PAUSER_COUNT: usize = 5;
                 let mbox_valid_pauser: [u32; PAUSER_COUNT] = drivers.soc_ifc.mbox_valid_pauser();
                 let mbox_pauser_lock: [bool; PAUSER_COUNT] = drivers.soc_ifc.mbox_pauser_lock();
@@ -111,11 +129,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
 
                 let mut valid_pauser_hash = Array4x12::default();
                 digest_op.finalize(&mut valid_pauser_hash).unwrap();
-                mbox.write_response(valid_pauser_hash.as_bytes()).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, valid_pauser_hash.as_bytes());
             }
-            // Hash DPE TCI data
-            CommandId(0x3000_0000) => {
+            CommandId(OPCODE_HASH_DPE_TCI_DATA) => {
                 let mut hasher = drivers.sha384.digest_init().unwrap();
                 for context in drivers.persistent_data.get().dpe.contexts {
                     if context.state != ContextState::Inactive {
@@ -124,30 +140,23 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 }
                 let mut digest = Array4x12::default();
                 hasher.finalize(&mut digest).unwrap();
-                let out: [u8; 48] = digest.into();
-                mbox.write_response(&out).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &<[u8; 48]>::from(digest));
             }
-            // Read PCR_ID_STASH_MEASUREMENT
-            CommandId(0x5000_0000) => {
+            CommandId(OPCODE_READ_STASHED_MEASUREMENT_PCR) => {
                 let pcr_id_stash_measurement: [u8; 48] =
                     drivers.pcr_bank.read_pcr(PCR_ID_STASH_MEASUREMENT).into();
-                mbox.write_response(&pcr_id_stash_measurement).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &pcr_id_stash_measurement);
             }
-            // Read DPE root context measurement
-            CommandId(0x6000_0000) => {
+            CommandId(OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT) => {
                 let root_idx =
                     Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
                 let root_measurement = drivers.persistent_data.get().dpe.contexts[root_idx]
                     .tci
                     .tci_current
                     .as_bytes();
-                mbox.write_response(root_measurement).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, root_measurement);
             }
-            // Read tags
-            CommandId(0x7000_0000) => {
+            CommandId(OPCODE_READ_DPE_TAGS) => {
                 let context_tags = drivers.persistent_data.get().context_tags;
                 let context_has_tag = drivers.persistent_data.get().context_has_tag;
                 const CONTEXT_TAGS_SIZE: usize = MAX_HANDLES * size_of::<u32>();
@@ -155,69 +164,60 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 let mut tags_info = [0u8; CONTEXT_TAGS_SIZE + CONTEXT_HAS_TAG_SIZE];
                 tags_info[..CONTEXT_TAGS_SIZE].copy_from_slice(context_tags.as_bytes());
                 tags_info[CONTEXT_TAGS_SIZE..].copy_from_slice(context_has_tag.as_bytes());
-                mbox.write_response(tags_info.as_bytes()).unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, tags_info.as_bytes());
             }
-            // Corrupt context_tags
-            CommandId(0x8000_0000) => {
-                let size = mbox.dlen() as usize;
-                let input_bytes = &mbox.raw_mailbox_contents()[..size];
+            CommandId(OPCODE_CORRUPT_CONTEXT_TAGS) => {
+                let input_bytes = read_request(&drivers.mbox);
 
                 let corrupted_context_tags = <[u32; MAX_HANDLES]>::read_from(input_bytes).unwrap();
                 drivers.persistent_data.get_mut().context_tags = corrupted_context_tags;
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &[]);
             }
-            // Corrupt context_has_tag
-            CommandId(0x9000_0000) => {
-                let size = mbox.dlen() as usize;
-                let input_bytes = &mbox.raw_mailbox_contents()[..size];
+            CommandId(OPCODE_CORRUPT_CONTEXT_HAS_TAG) => {
+                let input_bytes = read_request(&drivers.mbox);
 
                 let corrupted_context_has_tag =
                     <[U8Bool; MAX_HANDLES]>::read_from(input_bytes).unwrap();
                 drivers.persistent_data.get_mut().context_has_tag = corrupted_context_has_tag;
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &[]);
             }
-            // Read DpeInstance
-            CommandId(0xA000_0000) => {
-                mbox.write_response(drivers.persistent_data.get().dpe.as_bytes())
-                    .unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+            CommandId(OPCODE_READ_DPE_INSTANCE) => {
+                write_response(
+                    &mut drivers.mbox,
+                    drivers.persistent_data.get().dpe.as_bytes(),
+                );
             }
-            // Corrupt DpeInstance
-            CommandId(0xB000_0000) => {
-                let size = mbox.dlen() as usize;
-                let input_bytes = &mbox.raw_mailbox_contents()[..size];
+            CommandId(OPCODE_CORRUPT_DPE_INSTANCE) => {
+                let input_bytes = read_request(&drivers.mbox);
 
                 let corrupted_dpe = DpeInstance::read_from(input_bytes).unwrap();
                 drivers.persistent_data.get_mut().dpe = corrupted_dpe;
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &[]);
             }
-            // Read PcrResetCounter
-            CommandId(0xC000_0000) => {
-                mbox.write_response(drivers.persistent_data.get().pcr_reset.as_bytes())
-                    .unwrap();
-                mbox.set_status(MboxStatusE::DataReady);
+            CommandId(OPCODE_READ_PCR_RESET_COUNTER) => {
+                write_response(
+                    &mut drivers.mbox,
+                    drivers.persistent_data.get().pcr_reset.as_bytes(),
+                );
             }
-            // Corrupt DPE Root Context TCI
-            CommandId(0xD000_0000) => {
-                let size = mbox.dlen() as usize;
-                let input_bytes = &mbox.raw_mailbox_contents()[..size];
+            CommandId(OPCODE_CORRUPT_DPE_ROOT_TCI) => {
+                let input_bytes = read_request(&drivers.mbox);
 
                 let root_idx =
                     Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
                 drivers.persistent_data.get_mut().dpe.contexts[root_idx]
                     .tci
                     .tci_current = TciMeasurement(input_bytes.try_into().unwrap());
-                mbox.set_status(MboxStatusE::DataReady);
+                write_response(&mut drivers.mbox, &[]);
             }
-            CommandId(FW_LOAD_CMD_OPCODE) => {
+            CommandId(OPCODE_FW_LOAD) => {
                 unsafe { SocIfcReg::new() }
                     .regs_mut()
                     .internal_fw_update_reset()
                     .write(|w| w.core_rst(true));
             }
             _ => {
-                mbox.set_status(MboxStatusE::CmdFailure);
+                drivers.mbox.set_status(MboxStatusE::CmdFailure);
             }
         }
     }


### PR DESCRIPTION
This allows future commands to call helpers that borrow `drivers`.

In addition, add helpers for reading requests / writing responses, for brevity.