### PR TITLE
Set cargo-nextest timeout.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,7 @@
 [profile.nightly]
 failure-output = "immediate-final"
 fail-fast = false
+slow-timeout = { period = "30s", terminate-after = 6 }
 
 [profile.nightly.junit]
 path = "/tmp/junit.xml"


### PR DESCRIPTION
For the FPGA/nightly runs, set a 3-minute timeout on all test cases. This will prevent FPGA resources from being wasted if a test gets stuck in an infinite loop, and forces nextest to print the logs from the failed test, improving debuggability.