### PR TITLE
nightly CI: Don't timeout test_generate_csr_stress.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,10 @@ failure-output = "immediate-final"
 fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 6 }
 
+[[profile.nightly.overrides]]
+filter = 'test(test_generate_csr_stress)'
+slow-timeout = { period = "30s", terminate-after = 140 }
+
 [profile.nightly.junit]
 path = "/tmp/junit.xml"
 store-success-output = true


### PR DESCRIPTION
This test can take up to an hour to run when built with the slow_tests feature, so let it run...