### PR TITLE
nightly CI: Don't timeout test_stress_update.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,6 +9,10 @@ slow-timeout = { period = "30s", terminate-after = 6 }
 filter = 'test(test_generate_csr_stress)'
 slow-timeout = { period = "30s", terminate-after = 140 }
 
+[[profile.nightly.overrides]]
+filter = 'test(test_stress_update)'
+slow-timeout = { period = "30s", terminate-after = 17 }
+
 [profile.nightly.junit]
 path = "/tmp/junit.xml"
 store-success-output = true


### PR DESCRIPTION
This test takes almost 400 seconds when the slow_tests features is enabled.