### PR TITLE
GCE CI: Increase the maximum VM duration to 49 hours.

### DIFF
--- a/ci-tools/github-runner/cleanup.go
+++ b/ci-tools/github-runner/cleanup.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const maxVmDuration = 36 * time.Hour
+const maxVmDuration = 49 * time.Hour
 
 func cleanupInstances(ctx context.Context) error {
 	instanceSvc, err := compute.NewInstancesRESTClient(ctx)


### PR DESCRIPTION
The verilator nightly test needs more time.