### PR TITLE
Repair Verilator-Nightly workflow

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,34 @@ path = "/tmp/junit.xml"
 store-success-output = true
 store-failure-output = true
 
+
+[profile.verilator]
+failure-output = "immediate-final"
+fail-fast = false
+# Fail after 12 hours
+slow-timeout = { period = "30m", terminate-after = 24 }
+
+[[profile.verilator.overrides]]
+filter = 'test(test_preamble_vendor_ecc_pubkey_revocation)'
+# Fail after 24 hours
+slow-timeout = { period = "30m", terminate-after = 40 }
+
+[[profile.verilator.overrides]]
+filter = 'test(test_sha256)'
+# Fail after 16 hours
+slow-timeout = { period = "30m", terminate-after = 32 }
+
+[[profile.verilator.overrides]]
+filter = 'test(test_sha384)'
+# Fail after 16 hours
+slow-timeout = { period = "30m", terminate-after = 32 }
+
+[[profile.verilator.overrides]]
+filter = 'test(test_sha1)'
+# Fail after 16 hours
+slow-timeout = { period = "30m", terminate-after = 32 }
+
+[profile.verilator.junit]
+path = "/tmp/junit.xml"
+store-success-output = true
+store-failure-output = true

--- a/.github/workflows/nightly-verilator.yml
+++ b/.github/workflows/nightly-verilator.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # cron format "minutes hours day-of-month month day-of-week"
-    # 5:30 PM Pacific monday-friday
-    - cron: '30 0 * * 2-6'
+    # 5:30 PM Pacific on tuesday and friday
+    - cron: '30 0 * * 3,6'
 
 jobs:
   smoke_test:

--- a/.github/workflows/nightly-verilator.yml
+++ b/.github/workflows/nightly-verilator.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   smoke_test:
     name: Smoke Test
-    runs-on: n2d-highcpu-64
+    runs-on: n2d-highcpu-96
     timeout-minutes: 2800
 
     env:

--- a/.github/workflows/nightly-verilator.yml
+++ b/.github/workflows/nightly-verilator.yml
@@ -48,4 +48,27 @@ jobs:
 
       - name: Run all tests inside verilator (will take hours)
         run: |
-          cargo nextest run --no-fail-fast --features=verilator,itrng --release
+          COMMON_ARGS=(
+              --features=verilator,itrng
+              --release
+          )
+
+          # Workaround https://github.com/nextest-rs/nextest/issues/267
+          export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+
+          cargo-nextest nextest list \
+              "${COMMON_ARGS[@]}" \
+              --message-format json > /tmp/nextest-list.json
+
+          cargo nextest run \
+              "${COMMON_ARGS[@]}" \
+              --profile=verilator
+
+      - name: 'Upload test results'
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: caliptra-test-results
+          path: |
+            /tmp/junit.xml
+            /tmp/nextest-list.json

--- a/ci-tools/github-runner/cleanup.go
+++ b/ci-tools/github-runner/cleanup.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const maxVmDuration = 36 * time.Hour
+const maxVmDuration = 61 * time.Hour
 
 func cleanupInstances(ctx context.Context) error {
 	instanceSvc, err := compute.NewInstancesRESTClient(ctx)

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -96,6 +96,11 @@ impl ModelVerilated {
     pub fn stop_tracing(&mut self) {
         self.v.stop_tracing();
     }
+
+    /// Set all mailbox SRAM cells to value with double-bit ECC errors
+    pub fn corrupt_mailbox_ecc_double_bit(&mut self) {
+        self.v.corrupt_mailbox_ecc_double_bit();
+    }
 }
 
 fn ahb_txn_size(ty: AhbTxnType) -> RvSize {

--- a/hw-model/tests/model_tests.rs
+++ b/hw-model/tests/model_tests.rs
@@ -240,6 +240,9 @@ fn test_uninitialized_mbox_read() {
             .unwrap(),
     );
 
+    #[cfg(feature = "verilator")]
+    model.corrupt_mailbox_ecc_double_bit();
+
     const MBOX_ADDR: u32 = 0x3000_0000;
 
     model.soc_ifc().cptra_rsvd_reg().at(0).write(|_| MBOX_ADDR);


### PR DESCRIPTION
### GCE CI: Increase the maximum VM duration to 61 hours.
    
The verilator nightly test needs more time. This gives us enough time to run all weekend if necessary.

### verilator nightly: Only run on tuesdays and fridays
    
As we add test-cases, these are getting more expensive to run, and folks aren't looking at the results very often.

### verilator nightly: Increase VM from 64 cores to 96 cores.
    
The run has been timing out, as the number of tests has increased.

### verilator nightly: Configure nextest.
    
* Export test result artifact. This can be used by a future version of the test matrix to include verilator results.

* Add reasonable timeouts for FPGA tests. This ensures that we get useful output when a test hangs.

### hw-model verilated: Don't scramble mailbox SRAM.
    
In response to chipsalliance/caliptra-rtl#399, the plan is to require integrators to initialize the SRAMs. Thus, to stop the verilator tests from failing, we need to stop scrambling mailbox SRAM by default.

Instead, provide a corrupt_mailbox_ecc_double_bit() function that can be used by specific tests to simulate corrupted mailbox SRAM.
