### PR TITLE
CI: Upgrade from upload-artifact v3 to v4

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -37,7 +37,7 @@ jobs:
           sudo bash build.sh
 
       - name: 'Upload image as artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-fpga-image
           path: ci-tools/fpga-image/out/image.img

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: 'Upload FPGA bitstream artifact'
         if: steps.restore_rtl_cache.outputs.cache-hit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream/caliptra_fpga.bin
@@ -84,7 +84,7 @@ jobs:
 
       - name: 'Upload kernel module artifacts'
         if: steps.restore_kmod_cache.outputs.cache-hit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
@@ -171,7 +171,7 @@ jobs:
           mksquashfs /tmp/caliptra-test-binaries /tmp/caliptra-test-binaries.sqsh -comp zstd
 
       - name: 'Upload test binaries artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
@@ -183,7 +183,7 @@ jobs:
           cargo run --release -p caliptra-builder -- --all_elfs /tmp/caliptra-test-firmware
 
       - name: 'Upload test firmware artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
@@ -246,7 +246,7 @@ jobs:
           key: ${{ needs.check_cache.outputs.kmod_cache_key }}
 
       - name: 'Upload kernel module artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
@@ -286,7 +286,7 @@ jobs:
           fi
 
       - name: 'Upload FPGA bitstream artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: hw-latest/fpga/caliptra_build/caliptra_fpga.bin
@@ -302,7 +302,7 @@ jobs:
 
     steps:
       - name: 'Download FPGA Bitstream Artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream
@@ -332,25 +332,25 @@ jobs:
           git submodule update --init dpe
 
       - name: 'Download FPGA Bitstream Artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: caliptra-fpga-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-bitstream
 
       - name: 'Download kernel driver artifacts'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-fpga-kmod/
 
       - name: 'Download Test Binaries Artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
 
       - name: 'Download Test Firmware Artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
@@ -433,7 +433,7 @@ jobs:
               --profile=nightly
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: caliptra-test-results${{ inputs.artifact-suffix }}

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -81,7 +81,7 @@ jobs:
             --profile=nightly
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: caliptra-test-results${{ inputs.artifact-suffix }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -179,7 +179,7 @@ jobs:
           mv ./release/release.zip ./release/caliptra_${{ needs.find-latest-release.outputs.new_release_tag }}.zip
 
       - name: 'Download all artifacts'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: /tmp/artifacts
 
@@ -209,7 +209,7 @@ jobs:
           echo "caliptra_${{ needs.find-latest-release.outputs.new_release_tag }}.zip" > /tmp/release-info/zip-file-name
 
       - name: Write artifact with release info
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-info
           path: /tmp/release-info

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check that the ROM hash matches the frozen one
         run: ./ci.sh check_frozen_images
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: caliptra-rom.elf

--- a/.github/workflows/reusable-aflplusplus.yml
+++ b/.github/workflows/reusable-aflplusplus.yml
@@ -152,13 +152,13 @@ jobs:
           key: ${{ inputs.name }}-${{ env.CACHE_BUSTER }}
 
       - name: Archive test cases dir
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_cases
           path: ${{ inputs.fuzz_target_path }}/test_cases/
 
       - name: Archive fuzzing coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: plot
           path: ${{ inputs.fuzz_target_path }}/plot/

--- a/.github/workflows/reusable-libfuzzer.yml
+++ b/.github/workflows/reusable-libfuzzer.yml
@@ -115,13 +115,13 @@ jobs:
           key: ${{ inputs.name }}-${{ env.CACHE_BUSTER }}
 
       - name: Archive test cases dir
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_cases
           path: ${{ inputs.fuzz_target_path }}/test_cases/
 
       - name: Archive fuzzing coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: ${{ inputs.fuzz_target_path }}/index.html


### PR DESCRIPTION
Release workflow tested here:
https://github.com/korran-testorg/caliptra-sw/actions/runs/7748254301

This should make the test log artifacts available for download immediately, allowing the test-matrix to include the most recent test results.

Details:

https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/