### PR TITLE
Add CFI instrumentation to FMC

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -428,6 +428,7 @@ impl CaliptraError {
     pub const ADDRESS_NOT_IN_ICCM: CaliptraError = CaliptraError::new_const(0x000F000B);
     pub const FMC_HANDOFF_NOT_READY_FOR_RT: CaliptraError = CaliptraError::new_const(0x000F000C);
     pub const FMC_GLOBAL_WDT_EXPIRED: CaliptraError = CaliptraError::new_const(0x000F000D);
+    pub const FMC_UNKNOWN_RESET: CaliptraError = CaliptraError::new_const(0x000F000E);
 
     /// TRNG_EXT Errors
     pub const DRIVER_TRNG_EXT_TIMEOUT: CaliptraError = CaliptraError::new_const(0x00100001);

--- a/fmc/src/flow/crypto.rs
+++ b/fmc/src/flow/crypto.rs
@@ -6,6 +6,7 @@ Abstract:
     Crypto helper routines
 --*/
 use crate::fmc_env::FmcEnv;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::{crypto::Ecc384KeyPair, keyids::KEY_ID_TMP};
 use caliptra_drivers::{
     hmac384_kdf, okref, Array4x12, Array4x5, Array4x8, CaliptraResult, Ecc384PrivKeyIn,
@@ -40,6 +41,7 @@ impl Crypto {
     /// # Returns
     ///
     /// * `Array4x8` - Digest
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(always)]
     pub fn sha256_digest(env: &mut FmcEnv, data: &[u8]) -> CaliptraResult<Array4x8> {
         env.sha256.digest(data)
@@ -55,6 +57,7 @@ impl Crypto {
     /// # Returns
     ///
     /// * `Array4x12` - Digest
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn sha384_digest(env: &mut FmcEnv, data: &[u8]) -> CaliptraResult<Array4x12> {
         env.sha384.digest(data)
     }
@@ -68,6 +71,7 @@ impl Crypto {
     /// * `label` - Input label
     /// * `context` - Input context
     /// * `output` - Key slot to store the output
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn hmac384_kdf(
         env: &mut FmcEnv,
         key: KeyId,
@@ -103,6 +107,7 @@ impl Crypto {
     /// # Returns
     ///
     /// * `Ecc384KeyPair` - Private Key slot id and public key pairs
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn ecc384_key_gen(
         env: &mut FmcEnv,
         cdi: KeyId,
@@ -143,6 +148,7 @@ impl Crypto {
     /// # Returns
     ///
     /// * `Ecc384Signature` - Signature
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn ecdsa384_sign(
         env: &mut FmcEnv,
         priv_key: KeyId,
@@ -170,6 +176,7 @@ impl Crypto {
     /// # Returns
     ///
     /// * `bool` - True on success, false otherwise
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn ecdsa384_verify(
         env: &mut FmcEnv,
         pub_key: &Ecc384PubKey,

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -23,13 +23,13 @@ Note:
 use crate::flow::tci::Tci;
 use crate::fmc_env::FmcEnv;
 use crate::HandOff;
+use caliptra_cfi_derive::cfi_mod_fn;
+use caliptra_common::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 use caliptra_drivers::{
     okref,
     pcr_log::{PcrLogEntry, PcrLogEntryId},
     CaliptraResult, PersistentData,
 };
-
-use caliptra_common::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 use caliptra_error::CaliptraError;
 use zerocopy::AsBytes;
 
@@ -39,8 +39,7 @@ use zerocopy::AsBytes;
 ///
 /// * `env` - FMC Environment
 /// * `pcr_id` - PCR slot to extend the data into
-///
-/// TODO: Add CFI instrumentation
+#[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 pub fn extend_pcr_common(env: &mut FmcEnv) -> CaliptraResult<()> {
     // Calculate RT TCI (Hash over runtime code)
     let rt_tci: [u8; 48] = HandOff::rt_tci(env).into();
@@ -59,7 +58,7 @@ pub fn extend_pcr_common(env: &mut FmcEnv) -> CaliptraResult<()> {
 }
 
 /// Extend `data` into both the current and journey PCRs, and updates the PCR log.
-/// TODO: Add CFI instrumentation
+#[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 fn extend_and_log(env: &mut FmcEnv, entry_id: PcrLogEntryId, data: &[u8]) -> CaliptraResult<()> {
     env.pcr_bank
         .extend_pcr(RT_FW_CURRENT_PCR, &mut env.sha384, data)?;
@@ -74,7 +73,7 @@ fn extend_and_log(env: &mut FmcEnv, entry_id: PcrLogEntryId, data: &[u8]) -> Cal
     )
 }
 
-// TODO: Add CFI instrumentation
+#[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]
 fn log_pcr(
     persistent_data: &mut PersistentData,
     pcr_entry_id: PcrLogEntryId,

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -13,6 +13,7 @@ File Name:
 
 use crate::flow::dice::DiceOutput;
 use crate::fmc_env::FmcEnv;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::{handle_fatal_error, DataStore::*};
 use caliptra_common::{DataStore, FirmwareHandoffTable, HandOffDataHandle, Vault};
 use caliptra_drivers::{cprintln, memory_layout, Array4x12, Ecc384Signature, KeyId};
@@ -215,6 +216,7 @@ impl HandOff {
         }
     }
 
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn set_and_lock_rt_min_svn(env: &mut FmcEnv, min_svn: u32) -> CaliptraResult<()> {
         let ds: DataStore =
             Self::fht(env)
@@ -239,10 +241,12 @@ impl HandOff {
     }
 
     /// Store runtime Dice Signature
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn set_rt_dice_signature(env: &mut FmcEnv, sig: &Ecc384Signature) {
         Self::fht_mut(env).rt_dice_sign = *sig;
     }
 
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn set_rtalias_tbs_size(env: &mut FmcEnv, rtalias_tbs_size: usize) {
         Self::fht_mut(env).rtalias_tbs_size = rtalias_tbs_size as u16;
     }
@@ -267,11 +271,13 @@ impl HandOff {
     }
 
     #[allow(dead_code)]
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn set_rt_hash_chain_max_svn(env: &mut FmcEnv, max_svn: u16) {
         Self::fht_mut(env).rt_hash_chain_max_svn = max_svn;
     }
 
     #[allow(dead_code)]
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn set_rt_hash_chain_kv_hdl(env: &mut FmcEnv, kv_slot: KeyId) {
         Self::fht_mut(env).rt_hash_chain_kv_hdl = Self::key_id_to_handle(kv_slot)
     }
@@ -282,6 +288,7 @@ impl HandOff {
     }
 
     /// Update HandOff Table with RT Parameters
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn update(env: &mut FmcEnv, out: DiceOutput) -> CaliptraResult<()> {
         // update fht.rt_cdi_kv_hdl
         Self::fht_mut(env).rt_cdi_kv_hdl = Self::key_id_to_handle(out.cdi);


### PR DESCRIPTION
FMC binary size delta is + 1604 bytes

CFI criteria: Added CFI to any functions that deal with crypto drivers, mutating persistent data, locking registers, or extending PCRs since altering control flow to these sorts of functions could cause security issues. Also added cfi_asserts to places where we check the ResetReason to make sure nothing gets optimized out and instructions don't get skipped via a fault injection. For the most part, I just followed the CFI criteria in ROM and RT. 