### PR TITLE
GCE CI: Disable unattended upgrades in ephemeral VMs

### DIFF
--- a/ci-tools/github-runner/scripts/tweak_runner_image.sh
+++ b/ci-tools/github-runner/scripts/tweak_runner_image.sh
@@ -27,6 +27,10 @@ set -x
         binutils-riscv64-unknown-elf pkg-config libssl-dev jq libtinfo5 \
         gcc-aarch64-linux-gnu squashfs-tools
 
+    # Disable unattended upgrades, as these can interfere with jobs. This image
+    # is regenerated once a week so the security risk is minimal.
+    apt-get -y remove unattended-upgrades
+
     echo Retrieving latest GHA runner version
     RUNNER_VERSION="$(curl https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name[1:]')"
     echo Using runner version ${RUNNER_VERSION}


### PR DESCRIPTION
The background upgrades can interfere with GHA jobs, which sometimes install packages. The image is regenerated once a week (with the latest updates) so the security risk is minimal.