### PR TITLE
runtime: Add tests for Pic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-hw-model-heavy-test-fw"
+version = "0.1.0"
+dependencies = [
+ "caliptra-cpu",
+ "caliptra-drivers",
+ "caliptra-gen-linker-scripts",
+ "caliptra-registers",
+ "caliptra-runtime",
+ "caliptra-test-harness",
+ "caliptra_common",
+ "cfg-if 1.0.0",
+ "ufmt",
+]
+
+[[package]]
 name = "caliptra-hw-model-test-fw"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "hw/verilated",
   "hw-model",
   "hw-model/test-fw",
+  "hw-model/heavy-test-fw",
   "hw-model/types",
   "hw-model/c-binding",
   "registers",

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -143,6 +143,16 @@ pub mod hw_model_tests {
     };
 }
 
+pub mod hw_model_tests_heavy {
+    use super::*;
+
+    pub const PIC: FwId = FwId {
+        crate_name: "caliptra-hw-model-heavy-test-fw",
+        bin_name: "pic",
+        features: &["emu", "riscv", "runtime"],
+    };
+}
+
 pub mod driver_tests {
     use super::*;
 
@@ -400,6 +410,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &hw_model_tests::TEST_DCCM_DOUBLE_BIT_ECC,
     &hw_model_tests::TEST_UNITIALIZED_READ,
     &hw_model_tests::TEST_PCR_EXTEND,
+    &hw_model_tests_heavy::PIC,
     &driver_tests::DOE,
     &driver_tests::ECC384,
     &driver_tests::ECC384_SIGN_VALIDATION_FAILURE,

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -352,6 +352,14 @@ impl SocIfc {
             .notif_internal_intr_r()
             .write(|w| w.notif_cmd_avail_sts(true));
     }
+
+    pub fn soft_trigger_mbox_notif(&mut self) {
+        let soc_ifc = self.soc_ifc.regs_mut();
+        soc_ifc
+            .intr_block_rf()
+            .notif_intr_trig_r()
+            .write(|w| w.notif_cmd_avail_trig(true));
+    }
 }
 
 bitflags::bitflags! {

--- a/hw-model/heavy-test-fw/Cargo.toml
+++ b/hw-model/heavy-test-fw/Cargo.toml
@@ -1,0 +1,41 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-hw-model-heavy-test-fw"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+runtime = ["caliptra-test-harness/runtime"]
+riscv = [
+    "caliptra-cpu/riscv",
+    "caliptra-runtime/riscv",
+    "caliptra-test-harness/riscv",
+]
+emu = [
+    "caliptra-drivers/emu",
+    "caliptra-runtime/emu",
+    "caliptra-test-harness/emu",
+]
+fpga_realtime = ["caliptra-runtime/fpga_realtime"]
+
+[[bin]]
+name = "pic"
+path = "src/pic_tests.rs"
+required-features = ["riscv"]
+
+[build-dependencies]
+caliptra_common = { workspace = true, default-features = false }
+caliptra-gen-linker-scripts.workspace = true
+cfg-if.workspace = true
+
+[dependencies]
+caliptra_common = { workspace = true, default-features = false }
+caliptra-cpu.workspace = true
+caliptra-drivers.workspace = true
+caliptra-registers.workspace = true
+caliptra-runtime = { workspace = true, default-features = false }
+caliptra-test-harness.workspace = true
+cfg-if.workspace = true
+ufmt.workspace = true
+#zerocopy.workspace = true

--- a/hw-model/heavy-test-fw/build.rs
+++ b/hw-model/heavy-test-fw/build.rs
@@ -1,0 +1,31 @@
+// Licensed under the Apache-2.0 license
+
+fn main() {
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "std"))] {
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "runtime")] {
+                    use std::env;
+                    use std::fs;
+                    use std::path::PathBuf;
+                    use caliptra_gen_linker_scripts::gen_memory_x;
+
+                    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    // Put the linker script somewhere the linker can find it.
+                    fs::write(out_dir.join("memory.x"),gen_memory_x(caliptra_common::RUNTIME_ORG, caliptra_common::RUNTIME_SIZE)
+                    .as_bytes())
+                    .expect("Unable to generate memory.x");
+                    println!("cargo:rustc-link-search={}", out_dir.display());
+
+                    println!("cargo:rerun-if-changed=memory.x");
+                    println!("cargo:rustc-link-arg=-Tmemory.x");
+
+                    println!("cargo:rustc-link-arg=-Tlink.x");
+                } else {
+                    println!("cargo:rerun-if-changed=../../test-harness/scripts/rom.ld");
+                    println!("cargo:rustc-link-arg=-Ttest-harness/scripts/rom.ld");
+                }
+            }
+        }
+    }
+}

--- a/hw-model/heavy-test-fw/src/ext_intr.S
+++ b/hw-model/heavy-test-fw/src/ext_intr.S
@@ -1,0 +1,177 @@
+// Licensed under the Apache-2.0 license
+
+// This files contains 2 external interrupt handler vector tables.
+// One in ICCM and one in DCCM.
+// Generating external interrupts with a table in ICCM results in NMI.
+
+
+.section .init.text, "ax"
+.align 2
+_ext_intr_handler:
+    // Save sp to mscratch
+    csrw mscratch, sp
+
+    // Switch to exception stack
+    la sp, _snstack
+
+    // Allocate space for all relevant registers (ra, sp, a0-7, t0-6, mepc, mcause, mscause, mstatus, mtval)
+    addi sp, sp, -88
+
+    // Save relevant registers to stack except x2(sp) since that is in mscratch
+    sw ra,  0x0(sp)
+    // Skipping 0x4(sp) for now to store sp later
+    sw a0, 0x8(sp)
+    sw a1, 0xC(sp)
+    sw a2, 0x10(sp)
+    sw a3, 0x14(sp)
+    sw a4, 0x18(sp)
+    sw a5, 0x1C(sp)
+    sw a6, 0x20(sp)
+    sw a7, 0x24(sp)
+    sw t0, 0x28(sp)
+    sw t1, 0x2C(sp)
+    sw t2, 0x30(sp)
+    sw t3, 0x34(sp)
+    sw t4, 0x38(sp)
+    sw t5, 0x3C(sp)
+    sw t6, 0x40(sp)
+
+    // Save original sp to 0x4(sp)
+    csrr t0, mscratch // Load mscratch (original sp) to t0
+    sw t0, 0x4(sp)
+
+    // Save mepc to 0x44(sp)
+    csrr t0, mepc // Load mepc to t0
+    sw t0, 0x44(sp)
+
+    // Save mcause to 0x48(sp)
+    csrr t0, mcause // Load mcause to t0
+    sw t0, 0x48(sp)
+
+    # // Save mscause to 0x4C(sp)
+    // MSCAUSE = 0x7FF
+    csrr t0, 0x7FF // Load mscause to t0
+    sw t0, 0x4C(sp)
+
+    // Save mstatus to 0x50(sp)
+    csrr t0, mstatus // Load mstatus to t0
+    sw t0, 0x50(sp)
+
+    // Save mtval to 0x54(sp)
+    csrr t0, mtval // Load mtval to t0
+    sw t0, 0x54(sp)
+
+    // Call the rust nmi handler with the stack pointer as the parameter
+    addi a0, sp, 0
+    jal ext_int_handler
+
+    // Clear MPIE: ensures that interrupts are disabled again after mret
+    li t0, 0x80
+    csrc mstatus, t0
+
+    // Restore relevant registers except x2(sp)
+    lw ra,  0x0(sp)
+    // Skipping 0x4(sp) for now to store sp later
+    lw a0, 0x8(sp)
+    lw a1, 0xC(sp)
+    lw a2, 0x10(sp)
+    lw a3, 0x14(sp)
+    lw a4, 0x18(sp)
+    lw a5, 0x1C(sp)
+    lw a6, 0x20(sp)
+    lw a7, 0x24(sp)
+    lw t0, 0x28(sp)
+    lw t1, 0x2C(sp)
+    lw t2, 0x30(sp)
+    lw t3, 0x34(sp)
+    lw t4, 0x38(sp)
+    lw t5, 0x3C(sp)
+    lw t6, 0x40(sp)
+
+    // Restore original sp from 0x4(sp)
+    lw sp,  0x4(sp)
+
+    mret
+
+// meivt must point at an address in DCCM
+.section .data
+// meivt must be 1024-byte aligned
+.balign 1024
+_ext_intr_vector:
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+
+// meivt not pointing to DCCM. Should result in NMI
+.section .rodata
+// meivt must be 1024-byte aligned
+.balign 1024
+_ext_intr_vector_iccm:
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler
+    .word _ext_intr_handler

--- a/hw-model/heavy-test-fw/src/pic_tests.rs
+++ b/hw-model/heavy-test-fw/src/pic_tests.rs
@@ -1,0 +1,231 @@
+// Licensed under the Apache-2.0 license
+
+//! Simple tests to validate external interrupts both with a correct and incorrect setup
+
+#![no_main]
+#![no_std]
+
+use caliptra_drivers::{cprintln, Pic, SocIfc};
+use caliptra_registers::{el2_pic_ctrl::El2PicCtrl, soc_ifc::SocIfcReg};
+use caliptra_test_harness::test_suite;
+
+#[cfg(target_arch = "riscv32")]
+core::arch::global_asm!(include_str!("ext_intr.S"));
+
+#[macro_export]
+macro_rules! runtime_handlers {
+    () => {};
+}
+
+use caliptra_cpu::{log_trap_record, TrapRecord};
+
+#[no_mangle]
+#[inline(never)]
+extern "C" fn exception_handler(trap_record: &TrapRecord) {
+    cprintln!(
+        "TEST EXCEPTION mcause=0x{:08X} mscause=0x{:08X} mepc=0x{:08X} ra=0x{:08X}",
+        trap_record.mcause,
+        trap_record.mscause,
+        trap_record.mepc,
+        trap_record.ra,
+    );
+    log_trap_record(trap_record, None);
+
+    // Signal non-fatal error to SOC
+    caliptra_drivers::report_fw_error_fatal(
+        caliptra_drivers::CaliptraError::RUNTIME_GLOBAL_EXCEPTION.into(),
+    );
+
+    assert!(false);
+}
+
+const MCAUSE_NON_DCCM_NMI: u32 = 0xF000_1002;
+const MCAUSE_MACHINE_EXT_INT: u32 = 0x8000_000B;
+
+#[no_mangle]
+#[inline(never)]
+extern "C" fn nmi_handler(trap_record: &TrapRecord) {
+    let mut soc_ifc = unsafe { SocIfcReg::new() };
+
+    // If the NMI was fired by caliptra instead of the uC, this register
+    // contains the reason(s)
+    let err_interrupt_status = u32::from(
+        soc_ifc
+            .regs()
+            .intr_block_rf()
+            .error_internal_intr_r()
+            .read(),
+    );
+    log_trap_record(trap_record, Some(err_interrupt_status));
+    if trap_record.mcause == MCAUSE_NON_DCCM_NMI {
+        // Clear interrupt
+        soc_ifc
+            .regs_mut()
+            .intr_block_rf()
+            .notif_internal_intr_r()
+            .write(|w| w.notif_cmd_avail_sts(true));
+        return;
+    }
+
+    assert!(false);
+}
+
+#[no_mangle]
+#[inline(never)]
+extern "C" fn ext_int_handler(trap_record: &TrapRecord) {
+    let mut soc_ifc = unsafe { SocIfcReg::new() };
+
+    let notif_interrupt_status = u32::from(
+        soc_ifc
+            .regs()
+            .intr_block_rf()
+            .notif_internal_intr_r()
+            .read(),
+    );
+    log_trap_record(trap_record, Some(notif_interrupt_status));
+    #[cfg(target_arch = "riscv32")]
+    let meihap: usize = unsafe {
+        let csr;
+        // Load a good address in DCCM this time
+        core::arch::asm!(
+            "csrr {rd}, 0xfc8",
+            rd = out(reg) csr
+        );
+        csr
+    };
+    let claimid = (meihap >> 2) & 0xff;
+    const MBOX_NOTIF_CLAIM_ID: usize = 20;
+    assert_eq!(claimid, MBOX_NOTIF_CLAIM_ID);
+
+    // Clear interrupt
+    soc_ifc
+        .regs_mut()
+        .intr_block_rf()
+        .notif_internal_intr_r()
+        .write(|w| w.notif_cmd_avail_sts(true));
+}
+
+fn setup_mailbox_wfi(soc_ifc: &mut SocIfc, pic: &mut Pic) {
+    use caliptra_drivers::IntSource;
+
+    caliptra_cpu::csr::mie_enable_external_interrupts();
+
+    // Set highest priority so that Int can wake CPU
+    pic.int_set_max_priority(IntSource::SocIfcNotif);
+    pic.int_enable(IntSource::SocIfcNotif);
+
+    soc_ifc.enable_mbox_notif_interrupts();
+}
+
+#[cfg(feature = "riscv")]
+fn global_enable_interrupts() {
+    const MIE: usize = 1 << 3;
+    unsafe {
+        core::arch::asm!("csrrs zero, mstatus, {r}", r = in(reg) MIE);
+    }
+}
+
+// Test if soft triggering an external interrupt results in an NMI
+fn test_pic_nmi() {
+    let (mut soc_ifc, mut pic) =
+        unsafe { (SocIfc::new(SocIfcReg::new()), Pic::new(El2PicCtrl::new())) };
+    setup_mailbox_wfi(&mut soc_ifc, &mut pic);
+
+    // Clear up the status bit before triggering
+    soc_ifc.clear_mbox_notif_status();
+
+    println!("Running test against MEIVT in ICCM, using software generated interrupt");
+    #[cfg(target_arch = "riscv32")]
+    unsafe {
+        // Write meivt (External Interrupt Vector Table Register)
+        // VeeR has been instantiated with RV_FAST_INTERRUPT_REDIRECT,
+        // so external interrupts always bypass the standard risc-v dispatch logic
+        // and instead load the destination address from this table in DCCM.
+        // Here we load a wrong address and expect an NMI
+        core::arch::asm!(
+            "la {tmp}, _ext_intr_vector_iccm",
+            "csrw 0xbc8, {tmp}",
+            tmp = out(reg) _,
+        );
+    }
+
+    soc_ifc.soft_trigger_mbox_notif();
+    global_enable_interrupts();
+
+    // Do nothing for a few cycles to make sure int hits before the next code runs
+    for _ in 0..100 {
+        unsafe {
+            #[cfg(target_arch = "riscv32")]
+            core::arch::asm!("nop");
+        }
+    }
+
+    let soc_ifc_regs = unsafe { SocIfcReg::new() };
+    let fw_err = soc_ifc_regs.regs().cptra_fw_extended_error_info().read();
+    let mcause = fw_err[0];
+    assert_eq!(mcause, MCAUSE_NON_DCCM_NMI);
+}
+
+fn ext_int_was_handled() {
+    let soc_ifc_regs = unsafe { SocIfcReg::new() };
+    let fw_err = soc_ifc_regs.regs().cptra_fw_extended_error_info().read();
+    let mcause = fw_err[0];
+    let mbox_cmd_status = (fw_err[4] & 1) == 1;
+    assert_eq!(mcause, MCAUSE_MACHINE_EXT_INT);
+    assert!(mbox_cmd_status);
+}
+
+// Test soft triggering external interrupt with fast interrupt redirect
+// Test if soft triggering an external interrupt results in waking from halt
+fn test_pic_ext_int() {
+    let mut soc_ifc = unsafe { SocIfc::new(SocIfcReg::new()) };
+
+    #[cfg(target_arch = "riscv32")]
+    unsafe {
+        // Load a good address in DCCM this time
+        core::arch::asm!(
+            "la {tmp}, _ext_intr_vector",
+            "csrw 0xbc8, {tmp}",
+            tmp = out(reg) _,
+        );
+    }
+
+    soc_ifc.soft_trigger_mbox_notif();
+    global_enable_interrupts();
+    // We are woken up by the interrupt if this is reached
+
+    // Do nothing for a few cycles to make sure int hits before the next code runs
+    for _ in 0..100 {
+        unsafe {
+            #[cfg(target_arch = "riscv32")]
+            core::arch::asm!("nop");
+        }
+    }
+    ext_int_was_handled();
+}
+
+// Test if soft triggering an external interrupt results in waking from halt
+fn test_pic_ext_int_wake() {
+    let mut soc_ifc = unsafe { SocIfc::new(SocIfcReg::new()) };
+
+    soc_ifc.soft_trigger_mbox_notif();
+
+    caliptra_cpu::csr::mpmc_halt_and_enable_interrupts();
+    // We are woken up by the interrupt if this is reached
+
+    // Do nothing for a few cycles to make sure int hits before the next code runs
+    for _ in 0..100 {
+        unsafe {
+            #[cfg(target_arch = "riscv32")]
+            core::arch::asm!("nop");
+        }
+    }
+
+    ext_int_was_handled();
+}
+
+test_suite! {
+    test_pic_nmi,
+    test_pic_ext_int,
+    test_pic_ext_int_wake,
+}


### PR DESCRIPTION
This adds 2 tests:
- Check that a wrongly configured ext int vector table results in an NMI
- Properly configured external interrupts wake from halt

Follow-up patches will use this to get accurate sw-emulation right.