### PR TITLE
Mark nightly releases as prerelease

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -201,6 +201,7 @@ jobs:
             ./release/caliptra_${{ needs.find-latest-release.outputs.new_release_tag }}.zip
             ./release/test_artifacts_${{ needs.find-latest-release.outputs.new_release_tag }}.zip
           tag_name: ${{ needs.find-latest-release.outputs.new_release_tag }}
+          prerelease: true
 
       - name: Write artifact to workflow with release info
         run: |


### PR DESCRIPTION
This will ensure the nightly releases aren't marked as "latest". This will make it easier to find the actual latest release on github.