### PR TITLE
[fix] Update the 'Spec Opens' section in ROM README.md

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -17,10 +17,8 @@
 
 ## 2. Spec Opens
 
-- Update the spec with adding certificate expiration times for vendor and owner
 - Update the firmware image format to include the runtime configuration section
 - Ability to run production signed firmware that can only run in debug mode
-- Add certificate section
 
 ## 3. Scope
 
@@ -37,7 +35,6 @@ following topics:
    - Update Reset Flow
    - Unknown/Spurious Reset Flow
 5. Cryptographic Derivations
-6. Certificate Formats
 
 ## 4. Glossary
 


### PR DESCRIPTION
This change removes the following opens:
1. 'Update the spec with adding certificate expiration times for vendor and owner '
The 'not before' and 'not after' certificate validity times are already described in section 8.1.2

2. 'Add certificate section' 
Certificate formats are described in the main Caliptra specification at https://github.com/chipsalliance/Caliptra/blob/main/doc/Caliptra.md#certificate-format, hence removing this open.