### PR TITLE
Allow Fake ROM to work with production mode

### DIFF
--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -163,10 +163,20 @@ impl SocIfc {
 
     /// Check if verification is turned on for fake-rom
     pub fn verify_in_fake_mode(&self) -> bool {
+        // Bit 31 indicates to perform verification flow in fake ROM
+        const FAKE_ROM_VERIFY_EN_BIT: u32 = 31;
         let soc_ifc_regs = self.soc_ifc.regs();
         let val = soc_ifc_regs.cptra_dbg_manuf_service_reg().read();
-        // Bit 31 indicates to perform verification flow in fake ROM
-        ((val >> 31) & 1) != 0
+        ((val >> FAKE_ROM_VERIFY_EN_BIT) & 1) != 0
+    }
+
+    /// Check if production mode is enabled for fake-rom
+    pub fn prod_en_in_fake_mode(&self) -> bool {
+        // Bit 30 indicates production mode is allowed in fake ROM
+        const FAKE_ROM_PROD_EN_BIT: u32 = 30;
+        let soc_ifc_regs = self.soc_ifc.regs();
+        let val = soc_ifc_regs.cptra_dbg_manuf_service_reg().read();
+        ((val >> FAKE_ROM_PROD_EN_BIT) & 1) != 0
     }
 
     #[inline(always)]

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -70,7 +70,7 @@ Following are the main FUSE & Architectural Registers used by the Caliptra ROM f
 | FUSE_RUNTIME_SVN                | 128          | Runtime Security Version Number                         |
 | FUSE_ANTI_ROLLBACK_DISABLE      | 1            | Disable SVN checking for FMC & Runtime when bit is set  |
 | FUSE_IDEVID_CERT_ATTR           | 768          | FUSE containing information for generating IDEVID CSR  <br> **Word 0**: X509 Key Id Algorithm (2 bits) 1: SHA1, 2: SHA256, 2: SHA384, 3: Fuse <br> **Word 1,2,3,4,5**: Subject Key Id <br> **Words 7,8**: Unique Endpoint ID  |
-| CPTRA_DBG_MANUF_SERVICE_REG     | 16           | Manufacturing Services: <br> **Bit 0**: IDEVID CSR upload  <br> **Bit 1**: Random Number Generator Unavailable <br> **Bit 31**: Fake ROM image verify enable           |
+| CPTRA_DBG_MANUF_SERVICE_REG     | 16           | Manufacturing Services: <br> **Bit 0**: IDEVID CSR upload  <br> **Bit 1**: Random Number Generator Unavailable <br> **Bit 30**: Fake ROM enable in production lifecycle mode <br> **Bit 31**: Fake ROM image verify enable           |
 
 ## 5. Firmware Image Bundle
 
@@ -704,7 +704,7 @@ The following are the pre-conditions that should be satisfied:
 
 Fake ROM is a variation of the ROM intended to be used in the verification/enabling stages of development. The purpose is to greatly reduce the boot time for pre-Si environments by eliminating certain steps from the boot flow. Outside of these omissions, the behavior is intended to be the same as normal ROM.
 
-Fake ROM is not available in production mode as it is not secure and breaks/bypasses the core use-cases of Caliptra as a RoT.
+Fake ROM is only available in production mode if the enable bit is set in the CPTRA_DBG_MANUF_SERVICE_REG (see section above).
 
 **Differences from normal ROM:**
 Fake ROM reduces boot time by doing the following:

--- a/rom/dev/src/flow/mod.rs
+++ b/rom/dev/src/flow/mod.rs
@@ -63,8 +63,10 @@ pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
     } else {
         let _result: CaliptraResult<()> = Err(CaliptraError::ROM_GLOBAL_PANIC);
 
-        if env.soc_ifc.lifecycle() == caliptra_drivers::Lifecycle::Production {
-            cprintln!("Fake ROM in Production lifecycle prohibited");
+        if (env.soc_ifc.lifecycle() == caliptra_drivers::Lifecycle::Production)
+            && !(env.soc_ifc.prod_en_in_fake_mode())
+        {
+            cprintln!("Fake ROM in Production lifecycle not enabled");
             handle_fatal_error(CaliptraError::ROM_GLOBAL_FAKE_ROM_IN_PRODUCTION.into());
         }
 


### PR DESCRIPTION
- Defines bit 30 in the dbg_manuf_service_reg to enable production mode for fake ROM
- Overrides the ROM version to 0xFFFF in fake ROM