### PR TITLE
Extend wdt timeout for ROM w/ no UART

### DIFF
--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -671,7 +671,7 @@ fn test_rt_wdt_timeout() {
     } else if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
         3_300_000
     } else {
-        3_100_000
+        3_200_000
     };
 
     let security_state = *caliptra_hw_model::SecurityState::default().set_debug_locked(true);


### PR DESCRIPTION
The RT watchdog test is failing in nightly release builds because the wdt timeout for ROM w/o UART is too short.