### PR TITLE
Stop copying when initializing DPE in RT

### DIFF
--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -32,7 +32,7 @@ pub struct DpeCrypto<'a> {
     ecc384: &'a mut Ecc384,
     hmac384: &'a mut Hmac384,
     key_vault: &'a mut KeyVault,
-    rt_pub_key: Ecc384PubKey,
+    rt_pub_key: &'a mut Ecc384PubKey,
     key_id_rt_cdi: KeyId,
     key_id_rt_priv_key: KeyId,
 }
@@ -45,7 +45,7 @@ impl<'a> DpeCrypto<'a> {
         ecc384: &'a mut Ecc384,
         hmac384: &'a mut Hmac384,
         key_vault: &'a mut KeyVault,
-        rt_pub_key: Ecc384PubKey,
+        rt_pub_key: &'a mut Ecc384PubKey,
         key_id_rt_cdi: KeyId,
         key_id_rt_priv_key: KeyId,
     ) -> Self {

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -33,8 +33,8 @@ use crate::MAX_CERT_CHAIN_SIZE;
 
 pub struct DpePlatform<'a> {
     auto_init_locality: u32,
-    hashed_rt_pub_key: Digest,
-    cert_chain: &'a mut ArrayVec<u8, MAX_CERT_CHAIN_SIZE>,
+    hashed_rt_pub_key: &'a Digest,
+    cert_chain: &'a ArrayVec<u8, MAX_CERT_CHAIN_SIZE>,
     not_before: &'a NotBefore,
     not_after: &'a NotAfter,
 }
@@ -45,8 +45,8 @@ pub const VENDOR_SKU: u32 = u32::from_be_bytes(*b"CTRA");
 impl<'a> DpePlatform<'a> {
     pub fn new(
         auto_init_locality: u32,
-        hashed_rt_pub_key: Digest,
-        cert_chain: &'a mut ArrayVec<u8, 4096>,
+        hashed_rt_pub_key: &'a Digest,
+        cert_chain: &'a ArrayVec<u8, 4096>,
         not_before: &'a NotBefore,
         not_after: &'a NotAfter,
     ) -> Self {
@@ -109,7 +109,7 @@ impl Platform for DpePlatform<'_> {
 
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
-        Digest::write_hex_str(&self.hashed_rt_pub_key, &mut serial)
+        Digest::write_hex_str(self.hashed_rt_pub_key, &mut serial)
             .map_err(|e| PlatformError::IssuerNameError(e.get_error_detail().unwrap_or(0)))?;
 
         let name = Name {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -43,27 +43,25 @@ impl InvokeDpeCmd {
             let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
             let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
             let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
-            let pdata = drivers.persistent_data.get();
-            let mut crypto = DpeCrypto::new(
+            let pdata = drivers.persistent_data.get_mut();
+            let crypto = DpeCrypto::new(
                 &mut drivers.sha384,
                 &mut drivers.trng,
                 &mut drivers.ecc384,
                 &mut drivers.hmac384,
                 &mut drivers.key_vault,
-                pdata.fht.rt_dice_pub_key,
+                &mut pdata.fht.rt_dice_pub_key,
                 key_id_rt_cdi,
                 key_id_rt_priv_key,
             );
-            let pdata = drivers.persistent_data.get();
-            let image_header = &pdata.manifest1.header;
             let pl0_pauser = pdata.manifest1.header.pl0_pauser;
             let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
             let mut env = DpeEnv::<CptraDpeTypes> {
                 crypto,
                 platform: DpePlatform::new(
                     pl0_pauser,
-                    hashed_rt_pub_key,
-                    &mut drivers.cert_chain,
+                    &hashed_rt_pub_key,
+                    &drivers.cert_chain,
                     &nb,
                     &nf,
                 ),
@@ -74,10 +72,9 @@ impl InvokeDpeCmd {
                 .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
             let flags = pdata.manifest1.header.flags;
 
-            let pdata_mut = drivers.persistent_data.get_mut();
-            let mut dpe = &mut pdata_mut.dpe;
-            let mut context_has_tag = &mut pdata_mut.context_has_tag;
-            let mut context_tags = &mut pdata_mut.context_tags;
+            let mut dpe = &mut pdata.dpe;
+            let mut context_has_tag = &mut pdata.context_has_tag;
+            let mut context_tags = &mut pdata.context_tags;
             let resp = match command {
                 Command::GetProfile => Ok(Response::GetProfile(
                     dpe.get_profile(&mut env.platform)

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -75,12 +75,14 @@ impl GetTaggedTciCmd {
     pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if let Some(cmd) = GetTaggedTciReq::read_from(cmd_args) {
             let persistent_data = drivers.persistent_data.get();
+            let context_has_tag = &persistent_data.context_has_tag;
+            let context_tags = &persistent_data.context_tags;
             let idx = (0..MAX_HANDLES)
                 .find(|i| {
-                    *i < persistent_data.context_has_tag.len()
-                        && *i < persistent_data.context_tags.len()
-                        && persistent_data.context_has_tag[*i].get()
-                        && persistent_data.context_tags[*i] == cmd.tag
+                    *i < context_has_tag.len()
+                        && *i < context_tags.len()
+                        && context_has_tag[*i].get()
+                        && context_tags[*i] == cmd.tag
                 })
                 .ok_or(CaliptraError::RUNTIME_TAGGING_FAILURE)?;
             if idx >= persistent_data.dpe.contexts.len() {


### PR DESCRIPTION
No need to copy rt_dice_pub_key and hashed_rt_pub_key, just take their address.