### PR TITLE
Make x509 template generation optional

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -102,6 +102,10 @@ jobs:
           cargo run --locked -p caliptra_registers_generator -- --check hw/latest/rtl registers/bin/extra-rdl  hw/latest/registers/src
           cargo run --locked -p caliptra_registers_generator -- --check hw/1.0/rtl registers/bin/extra-rdl  hw/1.0/registers/src
 
+      - name: Check that generated X.509 templates match default templates
+        run: |
+          cargo test -p caliptra-x509 --features=generate_templates
+
       - name: Build
         run: |
           export RUSTC_WRAPPER=~/.cargo/bin/sccache

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -13,14 +13,14 @@ doctest = false
 zeroize.workspace = true
 
 [build-dependencies]
-asn1.workspace = true
-bitfield.workspace = true
-caliptra_common.workspace = true
-convert_case.workspace = true
-hex.workspace = true
-openssl.workspace = true
-quote.workspace = true
-syn.workspace = true
+asn1 = { workspace = true, optional = true }
+bitfield = { workspace = true, optional = true }
+caliptra_common = { workspace = true, optional = true }
+convert_case = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+openssl = { workspace = true, optional = true }
+quote = { workspace = true, optional = true }
+syn = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true
@@ -30,3 +30,4 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 std = []
+generate_templates = ["dep:asn1", "dep:bitfield", "dep:caliptra_common", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn"]

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -13,29 +13,40 @@ Abstract:
 
 --*/
 
+#[cfg(feature = "generate_templates")]
 mod cert;
+#[cfg(feature = "generate_templates")]
 mod code_gen;
+#[cfg(feature = "generate_templates")]
 mod csr;
+#[cfg(feature = "generate_templates")]
 mod tbs;
+#[cfg(feature = "generate_templates")]
 mod x509;
 
-use code_gen::CodeGen;
-use x509::{EcdsaSha384Algo, Fwid, FwidParam, KeyUsage};
-
-use std::env;
+#[cfg(feature = "generate_templates")]
+use {
+    code_gen::CodeGen,
+    std::env,
+    x509::{EcdsaSha384Algo, Fwid, FwidParam, KeyUsage},
+};
 
 // Main Entry point
 fn main() {
-    let out_dir_os_str = env::var_os("OUT_DIR").unwrap();
-    let out_dir = out_dir_os_str.to_str().unwrap();
+    #[cfg(feature = "generate_templates")]
+    {
+        let out_dir_os_str = env::var_os("OUT_DIR").unwrap();
+        let out_dir = out_dir_os_str.to_str().unwrap();
 
-    gen_init_devid_csr(out_dir);
-    gen_local_devid_cert(out_dir);
-    gen_fmc_alias_cert(out_dir);
-    gen_rt_alias_cert(out_dir);
+        gen_init_devid_csr(out_dir);
+        gen_local_devid_cert(out_dir);
+        gen_fmc_alias_cert(out_dir);
+        gen_rt_alias_cert(out_dir);
+    }
 }
 
 /// Generated Initial DeviceId Cert Signing request Template
+#[cfg(feature = "generate_templates")]
 fn gen_init_devid_csr(out_dir: &str) {
     let mut usage = KeyUsage::default();
     usage.set_key_cert_sign(true);
@@ -48,6 +59,7 @@ fn gen_init_devid_csr(out_dir: &str) {
 }
 
 /// Generate Local DeviceId Certificate Template
+#[cfg(feature = "generate_templates")]
 fn gen_local_devid_cert(out_dir: &str) {
     let mut usage = KeyUsage::default();
     usage.set_key_cert_sign(true);
@@ -59,6 +71,8 @@ fn gen_local_devid_cert(out_dir: &str) {
     CodeGen::gen_code("LocalDevIdCertTbs", template, out_dir);
 }
 
+/// Generate FMC Alias Certificate Template
+#[cfg(feature = "generate_templates")]
 fn gen_fmc_alias_cert(out_dir: &str) {
     let mut usage = KeyUsage::default();
     usage.set_key_cert_sign(true);
@@ -88,6 +102,8 @@ fn gen_fmc_alias_cert(out_dir: &str) {
     CodeGen::gen_code("FmcAliasCertTbs", template, out_dir);
 }
 
+/// Generate FMC Alias Certificate Template
+#[cfg(feature = "generate_templates")]
 fn gen_rt_alias_cert(out_dir: &str) {
     let mut usage = KeyUsage::default();
     // Add KeyCertSign to allow signing of other certs

--- a/x509/build/code_gen.rs
+++ b/x509/build/code_gen.rs
@@ -90,6 +90,16 @@ impl CodeGen {
         let tbs = template.tbs();
 
         quote!(
+            #[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+
             pub struct #param_name<'a> {
                 #(pub #param_vars)*
             }

--- a/x509/build/fmc_alias_cert_tbs.rs
+++ b/x509/build/fmc_alias_cert_tbs.rs
@@ -1,0 +1,208 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+pub struct FmcAliasCertTbsParams<'a> {
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub tcb_info_device_info_hash: &'a [u8; 48usize],
+    pub tcb_info_fmc_tci: &'a [u8; 48usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub ueid: &'a [u8; 17usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+    pub tcb_info_flags: &'a [u8; 4usize],
+    pub tcb_info_fmc_svn: &'a [u8; 1usize],
+    pub tcb_info_fmc_svn_fuses: &'a [u8; 1usize],
+}
+impl<'a> FmcAliasCertTbsParams<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const TCB_INFO_DEVICE_INFO_HASH_LEN: usize = 48usize;
+    pub const TCB_INFO_FMC_TCI_LEN: usize = 48usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const UEID_LEN: usize = 17usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+    pub const TCB_INFO_FLAGS_LEN: usize = 4usize;
+    pub const TCB_INFO_FMC_SVN_LEN: usize = 1usize;
+    pub const TCB_INFO_FMC_SVN_FUSES_LEN: usize = 1usize;
+}
+pub struct FmcAliasCertTbs {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl FmcAliasCertTbs {
+    const PUBLIC_KEY_OFFSET: usize = 319usize;
+    const SUBJECT_SN_OFFSET: usize = 232usize;
+    const ISSUER_SN_OFFSET: usize = 86usize;
+    const TCB_INFO_DEVICE_INFO_HASH_OFFSET: usize = 551usize;
+    const TCB_INFO_FMC_TCI_OFFSET: usize = 664usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 733usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 766usize;
+    const UEID_OFFSET: usize = 476usize;
+    const NOT_BEFORE_OFFSET: usize = 154usize;
+    const NOT_AFTER_OFFSET: usize = 171usize;
+    const TCB_INFO_FLAGS_OFFSET: usize = 602usize;
+    const TCB_INFO_FMC_SVN_OFFSET: usize = 646usize;
+    const TCB_INFO_FMC_SVN_FUSES_OFFSET: usize = 533usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const TCB_INFO_DEVICE_INFO_HASH_LEN: usize = 48usize;
+    const TCB_INFO_FMC_TCI_LEN: usize = 48usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const UEID_LEN: usize = 17usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    const TCB_INFO_FLAGS_LEN: usize = 4usize;
+    const TCB_INFO_FMC_SVN_LEN: usize = 1usize;
+    const TCB_INFO_FMC_SVN_FUSES_LEN: usize = 1usize;
+    pub const TBS_TEMPLATE_LEN: usize = 786usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 3u8, 14u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 105u8, 49u8,
+        28u8, 48u8, 26u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 19u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+        116u8, 114u8, 97u8, 32u8, 49u8, 46u8, 48u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8,
+        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 108u8, 49u8, 31u8, 48u8, 29u8, 6u8, 3u8, 85u8, 4u8,
+        3u8, 12u8, 22u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8, 46u8,
+        48u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
+        71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8,
+        6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8,
+        3u8, 98u8, 0u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 130u8, 1u8, 110u8, 48u8,
+        130u8, 1u8, 106u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8,
+        6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 3u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+        255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8,
+        4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 129u8, 226u8, 6u8, 6u8, 103u8,
+        129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 129u8, 215u8, 48u8, 129u8, 212u8, 48u8, 114u8, 128u8, 8u8,
+        67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 129u8, 6u8, 68u8, 101u8, 118u8, 105u8,
+        99u8, 101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+        1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 135u8, 5u8, 0u8, 95u8, 95u8,
+        95u8, 95u8, 137u8, 11u8, 68u8, 69u8, 86u8, 73u8, 67u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
+        138u8, 5u8, 0u8, 128u8, 0u8, 0u8, 11u8, 48u8, 94u8, 128u8, 8u8, 67u8, 97u8, 108u8, 105u8,
+        112u8, 116u8, 114u8, 97u8, 129u8, 3u8, 70u8, 77u8, 67u8, 131u8, 2u8, 1u8, 95u8, 166u8,
+        63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 137u8, 8u8, 70u8, 77u8, 67u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8,
+        6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8,
+        6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8,
+    ];
+    pub fn new(params: &FmcAliasCertTbsParams) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &FmcAliasCertTbsParams) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 786usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<
+            { Self::TCB_INFO_DEVICE_INFO_HASH_OFFSET },
+            { Self::TCB_INFO_DEVICE_INFO_HASH_LEN },
+        >(&mut self.tbs, params.tcb_info_device_info_hash);
+        apply_slice::<{ Self::TCB_INFO_FMC_TCI_OFFSET }, { Self::TCB_INFO_FMC_TCI_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_fmc_tci,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+        apply_slice::<{ Self::TCB_INFO_FLAGS_OFFSET }, { Self::TCB_INFO_FLAGS_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_flags,
+        );
+        apply_slice::<{ Self::TCB_INFO_FMC_SVN_OFFSET }, { Self::TCB_INFO_FMC_SVN_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_fmc_svn,
+        );
+        apply_slice::<{ Self::TCB_INFO_FMC_SVN_FUSES_OFFSET }, { Self::TCB_INFO_FMC_SVN_FUSES_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_fmc_svn_fuses,
+        );
+    }
+}

--- a/x509/build/init_dev_id_csr_tbs.rs
+++ b/x509/build/init_dev_id_csr_tbs.rs
@@ -1,0 +1,89 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+pub struct InitDevIdCsrTbsParams<'a> {
+    pub ueid: &'a [u8; 17usize],
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+}
+impl<'a> InitDevIdCsrTbsParams<'a> {
+    pub const UEID_LEN: usize = 17usize;
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+}
+pub struct InitDevIdCsrTbs {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl InitDevIdCsrTbs {
+    const UEID_OFFSET: usize = 305usize;
+    const PUBLIC_KEY_OFFSET: usize = 137usize;
+    const SUBJECT_SN_OFFSET: usize = 50usize;
+    const UEID_LEN: usize = 17usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    pub const TBS_TEMPLATE_LEN: usize = 322usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 1u8, 62u8, 2u8, 1u8, 0u8, 48u8, 105u8, 49u8, 28u8, 48u8, 26u8, 6u8, 3u8, 85u8,
+        4u8, 3u8, 12u8, 19u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8,
+        46u8, 48u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8,
+        85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8,
+        42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8,
+        0u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 160u8, 86u8, 48u8, 84u8, 6u8, 9u8, 42u8,
+        134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 71u8, 48u8, 69u8, 48u8, 18u8, 6u8,
+        3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8,
+        5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8,
+        48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8,
+    ];
+    pub fn new(params: &InitDevIdCsrTbsParams) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &InitDevIdCsrTbsParams) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 322usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+    }
+}

--- a/x509/build/local_dev_id_cert_tbs.rs
+++ b/x509/build/local_dev_id_cert_tbs.rs
@@ -1,0 +1,152 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+pub struct LocalDevIdCertTbsParams<'a> {
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub ueid: &'a [u8; 17usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+}
+impl<'a> LocalDevIdCertTbsParams<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const UEID_LEN: usize = 17usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+}
+pub struct LocalDevIdCertTbs {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl LocalDevIdCertTbs {
+    const PUBLIC_KEY_OFFSET: usize = 316usize;
+    const SUBJECT_SN_OFFSET: usize = 229usize;
+    const ISSUER_SN_OFFSET: usize = 86usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 499usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 532usize;
+    const UEID_OFFSET: usize = 471usize;
+    const NOT_BEFORE_OFFSET: usize = 154usize;
+    const NOT_AFTER_OFFSET: usize = 171usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const UEID_LEN: usize = 17usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    pub const TBS_TEMPLATE_LEN: usize = 552usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 2u8, 36u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 105u8, 49u8,
+        28u8, 48u8, 26u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 19u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+        116u8, 114u8, 97u8, 32u8, 49u8, 46u8, 48u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8,
+        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 105u8, 49u8, 28u8, 48u8, 26u8, 6u8, 3u8, 85u8, 4u8,
+        3u8, 12u8, 19u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8, 46u8,
+        48u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
+        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
+        134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 129u8, 136u8, 48u8, 129u8, 133u8, 48u8,
+        18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8,
+        2u8, 1u8, 4u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8,
+        2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8,
+        4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8,
+        128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &LocalDevIdCertTbsParams) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &LocalDevIdCertTbsParams) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 552usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+    }
+}

--- a/x509/build/rt_alias_cert_tbs.rs
+++ b/x509/build/rt_alias_cert_tbs.rs
@@ -1,0 +1,175 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+pub struct RtAliasCertTbsParams<'a> {
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub tcb_info_rt_tci: &'a [u8; 48usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub ueid: &'a [u8; 17usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+    pub tcb_info_rt_svn: &'a [u8; 1usize],
+}
+impl<'a> RtAliasCertTbsParams<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const TCB_INFO_RT_TCI_LEN: usize = 48usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const UEID_LEN: usize = 17usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+    pub const TCB_INFO_RT_SVN_LEN: usize = 1usize;
+}
+pub struct RtAliasCertTbs {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl RtAliasCertTbs {
+    const PUBLIC_KEY_OFFSET: usize = 321usize;
+    const SUBJECT_SN_OFFSET: usize = 234usize;
+    const ISSUER_SN_OFFSET: usize = 89usize;
+    const TCB_INFO_RT_TCI_OFFSET: usize = 542usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 601usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 634usize;
+    const UEID_OFFSET: usize = 476usize;
+    const NOT_BEFORE_OFFSET: usize = 157usize;
+    const NOT_AFTER_OFFSET: usize = 174usize;
+    const TCB_INFO_RT_SVN_OFFSET: usize = 524usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const TCB_INFO_RT_TCI_LEN: usize = 48usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const UEID_LEN: usize = 17usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    const TCB_INFO_RT_SVN_LEN: usize = 1usize;
+    pub const TBS_TEMPLATE_LEN: usize = 654usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 2u8, 138u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 108u8,
+        49u8, 31u8, 48u8, 29u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 22u8, 67u8, 97u8, 108u8, 105u8,
+        112u8, 116u8, 114u8, 97u8, 32u8, 49u8, 46u8, 48u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8,
+        108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 107u8, 49u8, 30u8, 48u8,
+        28u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 21u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8,
+        97u8, 32u8, 49u8, 46u8, 48u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8,
+        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8,
+        129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8,
+        129u8, 233u8, 48u8, 129u8, 230u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+        4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 2u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+        15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8,
+        5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 95u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 85u8, 48u8, 83u8, 128u8, 8u8, 67u8, 97u8, 108u8,
+        105u8, 112u8, 116u8, 114u8, 97u8, 129u8, 2u8, 82u8, 84u8, 131u8, 2u8, 1u8, 95u8, 166u8,
+        63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8,
+        20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &RtAliasCertTbsParams) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &RtAliasCertTbsParams) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 654usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::TCB_INFO_RT_TCI_OFFSET }, { Self::TCB_INFO_RT_TCI_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_rt_tci,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+        apply_slice::<{ Self::TCB_INFO_RT_SVN_OFFSET }, { Self::TCB_INFO_RT_SVN_LEN }>(
+            &mut self.tbs,
+            params.tcb_info_rt_svn,
+        );
+    }
+}

--- a/x509/src/fmc_alias_cert.rs
+++ b/x509/src/fmc_alias_cert.rs
@@ -13,7 +13,10 @@ Abstract:
 --*/
 
 // Note: All the necessary code is auto generated
+#[cfg(feature = "generate_templates")]
 include!(concat!(env!("OUT_DIR"), "/fmc_alias_cert_tbs.rs"));
+#[cfg(not(feature = "generate_templates"))]
+include! {"../build/fmc_alias_cert_tbs.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -205,5 +208,22 @@ mod tests {
 
         const MULTI_TCB_INFO_OID: Oid = oid!(2.23.133 .5 .4 .5);
         assert!(!ext_map[&MULTI_TCB_INFO_OID].critical);
+    }
+
+    #[test]
+    #[cfg(feature = "generate_templates")]
+    fn test_fmc_alias_template() {
+        let manual_template =
+            std::fs::read(std::path::Path::new("./build/fmc_alias_cert_tbs.rs")).unwrap();
+        let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+            env!("OUT_DIR"),
+            "/fmc_alias_cert_tbs.rs"
+        )))
+        .unwrap();
+        if auto_generated_template != manual_template {
+            panic!(
+                "Auto-generated FMC Alias Certificate template is not equal to the manual template."
+            )
+        }
     }
 }

--- a/x509/src/idevid_csr.rs
+++ b/x509/src/idevid_csr.rs
@@ -13,7 +13,10 @@ Abstract:
 --*/
 
 // Note: All the necessary code is auto generated
+#[cfg(feature = "generate_templates")]
 include!(concat!(env!("OUT_DIR"), "/init_dev_id_csr_tbs.rs"));
+#[cfg(not(feature = "generate_templates"))]
+include! {"../build/init_dev_id_csr_tbs.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -155,5 +158,20 @@ mod tests {
             })
             .unwrap();
         assert!(!ueid_ext.critical);
+    }
+
+    #[test]
+    #[cfg(feature = "generate_templates")]
+    fn test_idevid_template() {
+        let manual_template =
+            std::fs::read(std::path::Path::new("./build/init_dev_id_csr_tbs.rs")).unwrap();
+        let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+            env!("OUT_DIR"),
+            "/init_dev_id_csr_tbs.rs"
+        )))
+        .unwrap();
+        if auto_generated_template != manual_template {
+            panic!("Auto-generated IDevID CSR template is not equal to the manual template.")
+        }
     }
 }

--- a/x509/src/ldevid_cert.rs
+++ b/x509/src/ldevid_cert.rs
@@ -13,7 +13,10 @@ Abstract:
 --*/
 
 // Note: All the necessary code is auto generated
+#[cfg(feature = "generate_templates")]
 include!(concat!(env!("OUT_DIR"), "/local_dev_id_cert_tbs.rs"));
+#[cfg(not(feature = "generate_templates"))]
+include! {"../build/local_dev_id_cert_tbs.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -162,5 +165,22 @@ mod tests {
 
         const UEID_OID: Oid = oid!(2.23.133 .5 .4 .4);
         assert!(!ext_map[&UEID_OID].critical);
+    }
+
+    #[test]
+    #[cfg(feature = "generate_templates")]
+    fn test_ldevid_template() {
+        let manual_template =
+            std::fs::read(std::path::Path::new("./build/local_dev_id_cert_tbs.rs")).unwrap();
+        let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+            env!("OUT_DIR"),
+            "/local_dev_id_cert_tbs.rs"
+        )))
+        .unwrap();
+        if auto_generated_template != manual_template {
+            panic!(
+                "Auto-generated LDevID Certificate template is not equal to the manual template."
+            )
+        }
     }
 }

--- a/x509/src/rt_alias_cert.rs
+++ b/x509/src/rt_alias_cert.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    Rt_alias_cert.rs
+    rt_alias_cert.rs
 
 Abstract:
 
@@ -13,7 +13,10 @@ Abstract:
 --*/
 
 // Note: All the necessary code is auto generated
+#[cfg(feature = "generate_templates")]
 include!(concat!(env!("OUT_DIR"), "/rt_alias_cert_tbs.rs"));
+#[cfg(not(feature = "generate_templates"))]
+include! {"../build/rt_alias_cert_tbs.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -123,5 +126,22 @@ mod tests {
 
         let cert: X509 = X509::from_der(&buf).unwrap();
         assert!(cert.verify(issuer_key.priv_key()).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "generate_templates")]
+    fn test_rt_alias_template() {
+        let manual_template =
+            std::fs::read(std::path::Path::new("./build/rt_alias_cert_tbs.rs")).unwrap();
+        let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+            env!("OUT_DIR"),
+            "/rt_alias_cert_tbs.rs"
+        )))
+        .unwrap();
+        if auto_generated_template != manual_template {
+            panic!(
+                "Auto-generated RT Alias Certificate template is not equal to the manual template."
+            )
+        }
     }
 }


### PR DESCRIPTION
Add static templates in case we don't build with the generate_templates flag. 