### PR TITLE
Update builder to use ImageGeneratorCrypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,6 @@ dependencies = [
  "hex",
  "nix 0.26.2",
  "once_cell",
- "sha2",
  "zerocopy",
 ]
 

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -20,7 +20,6 @@ hex.workspace = true
 nix.workspace = true
 once_cell.workspace = true
 zerocopy.workspace = true
-sha2.workspace = true
 
 [features]
 slow_tests = []

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -422,7 +422,7 @@ pub fn elf2rom(elf_bytes: &[u8]) -> io::Result<Vec<u8>> {
         let rom_info_start = rom_info_sym.value as usize;
 
         let rom_info = RomInfo {
-            sha256_digest: sha256::sha256_word_reversed(&result[0..rom_info_start])?,
+            sha256_digest: sha256::sha256_word_reversed(&result[0..rom_info_start]),
             revision: image_revision()?,
             flags: 0,
             version: version::get_rom_version(),

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -422,7 +422,7 @@ pub fn elf2rom(elf_bytes: &[u8]) -> io::Result<Vec<u8>> {
         let rom_info_start = rom_info_sym.value as usize;
 
         let rom_info = RomInfo {
-            sha256_digest: sha256::sha256_word_reversed(&result[0..rom_info_start]),
+            sha256_digest: sha256::sha256_word_reversed(&result[0..rom_info_start])?,
             revision: image_revision()?,
             flags: 0,
             version: version::get_rom_version(),

--- a/builder/src/sha256.rs
+++ b/builder/src/sha256.rs
@@ -1,18 +1,14 @@
 // Licensed under the Apache-2.0 license
 use caliptra_image_gen::ImageGeneratorCrypto;
+use caliptra_image_gen::ImageGeneratorHasher;
 use caliptra_image_openssl::OsslCrypto;
-use std::io::{self, ErrorKind};
 
-pub fn sha256_word_reversed(bytes: &[u8]) -> io::Result<[u32; 8]> {
-    let crypto = OsslCrypto::default();
+pub fn sha256_word_reversed(bytes: &[u8]) -> [u32; 8] {
+    let mut sha = OsslCrypto::default().sha256_start();
 
-    let mut reversed = Vec::<u8>::new();
     for i in 0..bytes.len() / 4 {
         let word = u32::from_le_bytes(bytes[i * 4..][..4].try_into().unwrap());
-        reversed.extend_from_slice(&word.swap_bytes().to_le_bytes());
+        sha.update(&word.swap_bytes().to_le_bytes());
     }
-
-    crypto
-        .sha256_digest(&reversed)
-        .map_err(|e| io::Error::new(ErrorKind::Other, e))
+    sha.finish()
 }

--- a/builder/src/sha256.rs
+++ b/builder/src/sha256.rs
@@ -1,12 +1,18 @@
 // Licensed under the Apache-2.0 license
-use sha2::{Digest, Sha256};
+use caliptra_image_gen::ImageGeneratorCrypto;
+use caliptra_image_openssl::OsslCrypto;
+use std::io::{self, ErrorKind};
 
-pub fn sha256_word_reversed(bytes: &[u8]) -> [u32; 8] {
-    let mut sha = Sha256::new();
+pub fn sha256_word_reversed(bytes: &[u8]) -> io::Result<[u32; 8]> {
+    let crypto = OsslCrypto::default();
+
+    let mut reversed = Vec::<u8>::new();
     for i in 0..bytes.len() / 4 {
         let word = u32::from_le_bytes(bytes[i * 4..][..4].try_into().unwrap());
-        sha.update(word.swap_bytes().to_le_bytes());
+        reversed.extend_from_slice(&word.swap_bytes().to_le_bytes());
     }
-    let result_bytes = sha.finalize();
-    core::array::from_fn(|i| u32::from_be_bytes(result_bytes[i * 4..][..4].try_into().unwrap()))
+
+    crypto
+        .sha256_digest(&reversed)
+        .map_err(|e| io::Error::new(ErrorKind::Other, e))
 }

--- a/image/gen/src/lib.rs
+++ b/image/gen/src/lib.rs
@@ -44,6 +44,9 @@ pub trait ImageGenratorExecutable {
 
 /// Image Gnerator Crypto Trait
 pub trait ImageGeneratorCrypto {
+    /// Calculate SHA-256 digest
+    fn sha256_digest(&self, data: &[u8]) -> anyhow::Result<[u32; SHA256_DIGEST_WORD_SIZE]>;
+
     /// Calculate SHA-384 digest
     fn sha384_digest(&self, data: &[u8]) -> anyhow::Result<ImageDigest>;
 

--- a/image/gen/src/lib.rs
+++ b/image/gen/src/lib.rs
@@ -42,10 +42,26 @@ pub trait ImageGenratorExecutable {
     fn size(&self) -> u32;
 }
 
+pub trait ImageGeneratorHasher {
+    type Output: Copy;
+
+    fn update(&mut self, data: &[u8]);
+
+    fn finish(self) -> Self::Output;
+}
+
 /// Image Gnerator Crypto Trait
 pub trait ImageGeneratorCrypto {
+    type Sha256Hasher: ImageGeneratorHasher<Output = [u32; SHA256_DIGEST_WORD_SIZE]>;
+
+    fn sha256_start(&self) -> Self::Sha256Hasher;
+
     /// Calculate SHA-256 digest
-    fn sha256_digest(&self, data: &[u8]) -> anyhow::Result<[u32; SHA256_DIGEST_WORD_SIZE]>;
+    fn sha256_digest(&self, data: &[u8]) -> anyhow::Result<[u32; SHA256_DIGEST_WORD_SIZE]> {
+        let mut hasher = self.sha256_start();
+        hasher.update(data);
+        Ok(hasher.finish())
+    }
 
     /// Calculate SHA-384 digest
     fn sha384_digest(&self, data: &[u8]) -> anyhow::Result<ImageDigest>;

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -34,6 +34,7 @@ pub const ECC384_SCALAR_WORD_SIZE: usize = 12;
 pub const ECC384_SCALAR_BYTE_SIZE: usize = 48;
 pub const SHA192_DIGEST_BYTE_SIZE: usize = 24;
 pub const SHA192_DIGEST_WORD_SIZE: usize = 6;
+pub const SHA256_DIGEST_WORD_SIZE: usize = 8;
 pub const SHA384_DIGEST_WORD_SIZE: usize = 12;
 pub const SHA384_DIGEST_BYTE_SIZE: usize = 48;
 pub const IMAGE_LMS_OTS_P_PARAM: usize = 51;


### PR DESCRIPTION
Update builder so that all the image generation code uses the ImageGeneratorCrypto trait. This makes it easier to swap out the crypto implementation as needed for different integrations.

This ensures the whole image build can use the same crypto library.