### PR TITLE
Adds support for running Caliptra on Versal FPGAs

### DIFF
--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -149,7 +149,7 @@ impl ModelFpgaRealtime {
                 };
                 if trngfifosts.trng_fifo_full() == 0 {
                     let mut itrng_dw = 0;
-                    for i in (0..8).rev() {
+                    for i in 0..8 {
                         match itrng_nibbles.next() {
                             Some(nibble) => itrng_dw += u32::from(nibble) << (4 * i),
                             None => return,

--- a/hw/fpga/fpga_configuration.tcl
+++ b/hw/fpga/fpga_configuration.tcl
@@ -60,62 +60,6 @@ if {$GUI} {
 # Packaging Caliptra allows Vivado to recognize the APB bus as an endpoint for the memory map.
 create_project caliptra_package_project $outputDir -part xczu7ev-ffvc1156-2-e
 
-# Generate ROM
-create_ip -name blk_mem_gen -vendor xilinx.com -library ip -version 8.4 -module_name fpga_imem -dir $outputDir
-set_property -dict [list \
-  CONFIG.Memory_Type {True_Dual_Port_RAM} \
-  CONFIG.Write_Depth_A {6144} \
-  CONFIG.Write_Width_A {64} \
-  CONFIG.Write_Width_B {32} \
-  CONFIG.Use_RSTB_Pin {true} \
-  CONFIG.Byte_Size {8} \
-  CONFIG.Use_Byte_Write_Enable {true} \
-  CONFIG.Register_PortA_Output_of_Memory_Primitives {false} \
-  CONFIG.Register_PortB_Output_of_Memory_Primitives {false} \
-] [get_ips fpga_imem]
-
-# Generate Mailbox RAM. 128K
-create_ip -name blk_mem_gen -vendor xilinx.com -library ip -version 8.4 -module_name fpga_mbox_ram -dir $outputDir
-set_property -dict [list \
-  CONFIG.Memory_Type {Single_Port_RAM} \
-  CONFIG.Write_Depth_A {32768} \
-  CONFIG.Write_Width_A {39} \
-  CONFIG.Register_PortA_Output_of_Memory_Primitives {false} \
-] [get_ips fpga_mbox_ram]
-
-# Generate ECC TDP File
-create_ip -name blk_mem_gen -vendor xilinx.com -library ip -version 8.4 -module_name fpga_ecc_ram_tdp_file -dir $outputDir
-set_property -dict [list \
-  CONFIG.Memory_Type {True_Dual_Port_RAM} \
-  CONFIG.Write_Depth_A {64} \
-  CONFIG.Write_Width_A {384} \
-  CONFIG.Write_Width_B {384} \
-  CONFIG.Use_RSTA_Pin {true} \
-  CONFIG.Register_PortA_Output_of_Memory_Primitives {false} \
-  CONFIG.Register_PortB_Output_of_Memory_Primitives {false} \
-] [get_ips fpga_ecc_ram_tdp_file]
-
-# Create FIFO for fake UART communication
-create_ip -name fifo_generator -vendor xilinx.com -library ip -version 13.2 -module_name log_fifo -dir $outputDir
-set_property -dict [list \
-  CONFIG.Input_Data_Width {8} \
-  CONFIG.Input_Depth {8192} \
-  CONFIG.Performance_Options {First_Word_Fall_Through} \
-  CONFIG.Full_Threshold_Assert_Value {7168} \
-  CONFIG.Programmable_Full_Type {Single_Programmable_Full_Threshold_Constant} \
-] [get_ips log_fifo]
-
-# Create FIFO for ITRNG data
-create_ip -name fifo_generator -vendor xilinx.com -library ip -version 13.2 -module_name itrng_fifo -dir $outputDir
-set_property -dict [list \
-  CONFIG.Input_Data_Width {32} \
-  CONFIG.Input_Depth {1024} \
-  CONFIG.Output_Data_Width {4} \
-  CONFIG.Overflow_Flag {false} \
-  CONFIG.Valid_Flag {true} \
-  CONFIG.asymmetric_port_width {true} \
-] [get_ips itrng_fifo]
-
 set_property verilog_define $VERILOG_OPTIONS [current_fileset]
 
 # Add VEER Headers

--- a/hw/fpga/src/caliptra_wrapper_top.sv
+++ b/hw/fpga/src/caliptra_wrapper_top.sv
@@ -346,23 +346,23 @@ caliptra_veer_sram_export veer_sram_export_inst (
     assign fifo_char[7:0] = caliptra_top_dut.soc_ifc_top1.i_soc_ifc_reg.field_combo.CPTRA_GENERIC_OUTPUT_WIRES[0].generic_wires.next[7:0];
 
    xpm_fifo_sync #(
-      .CASCADE_HEIGHT(0),        // DECIMAL
-      .DOUT_RESET_VALUE("0"),    // String
-      .ECC_MODE("no_ecc"),       // String
-      .FIFO_MEMORY_TYPE("auto"), // String
-      .FIFO_READ_LATENCY(0),     // DECIMAL
-      .FIFO_WRITE_DEPTH(8192),   // DECIMAL
-      .FULL_RESET_VALUE(0),      // DECIMAL
-      .PROG_EMPTY_THRESH(10),    // DECIMAL
-      .PROG_FULL_THRESH(4096),   // DECIMAL
-      .RD_DATA_COUNT_WIDTH(14),  // DECIMAL
-      .READ_DATA_WIDTH(8),       // DECIMAL
-      .READ_MODE("fwft"),        // String
-      .SIM_ASSERT_CHK(0),        // DECIMAL; 0=disable simulation messages, 1=enable simulation messages
-      .USE_ADV_FEATURES("0707"), // String
-      .WAKEUP_TIME(0),           // DECIMAL
-      .WRITE_DATA_WIDTH(8),      // DECIMAL
-      .WR_DATA_COUNT_WIDTH(14)   // DECIMAL
+      .CASCADE_HEIGHT(0),         // DECIMAL
+      .DOUT_RESET_VALUE("0"),     // String
+      .ECC_MODE("no_ecc"),        // String
+      .FIFO_MEMORY_TYPE("block"), // String
+      .FIFO_READ_LATENCY(0),      // DECIMAL
+      .FIFO_WRITE_DEPTH(8192),    // DECIMAL
+      .FULL_RESET_VALUE(0),       // DECIMAL
+      .PROG_EMPTY_THRESH(10),     // DECIMAL
+      .PROG_FULL_THRESH(7168),    // DECIMAL Currently unused
+      .RD_DATA_COUNT_WIDTH(14),   // DECIMAL
+      .READ_DATA_WIDTH(8),        // DECIMAL
+      .READ_MODE("fwft"),         // String
+      .SIM_ASSERT_CHK(0),         // DECIMAL; 0=disable simulation messages, 1=enable simulation messages
+      .USE_ADV_FEATURES("0000"),  // String
+      .WAKEUP_TIME(0),            // DECIMAL
+      .WRITE_DATA_WIDTH(8),       // DECIMAL
+      .WR_DATA_COUNT_WIDTH(14)    // DECIMAL
    )
    log_fifo_inst (
       .almost_empty(),
@@ -403,23 +403,23 @@ caliptra_veer_sram_export veer_sram_export_inst (
     end
 
    xpm_fifo_sync #(
-      .CASCADE_HEIGHT(0),        // DECIMAL
-      .DOUT_RESET_VALUE("0"),    // String
-      .ECC_MODE("no_ecc"),       // String
-      .FIFO_MEMORY_TYPE("auto"), // String
-      .FIFO_READ_LATENCY(1),     // DECIMAL
-      .FIFO_WRITE_DEPTH(1024),   // DECIMAL
-      .FULL_RESET_VALUE(0),      // DECIMAL
-      .PROG_EMPTY_THRESH(10),    // DECIMAL
-      .PROG_FULL_THRESH(10),     // DECIMAL
-      .RD_DATA_COUNT_WIDTH(13),  // DECIMAL
-      .READ_DATA_WIDTH(4),       // DECIMAL
-      .READ_MODE("std"),         // String
-      .SIM_ASSERT_CHK(0),        // DECIMAL; 0=disable simulation messages, 1=enable simulation messages
-      .USE_ADV_FEATURES("1000"), // String
-      .WAKEUP_TIME(0),           // DECIMAL
-      .WRITE_DATA_WIDTH(32),     // DECIMAL
-      .WR_DATA_COUNT_WIDTH(11)   // DECIMAL
+      .CASCADE_HEIGHT(0),         // DECIMAL
+      .DOUT_RESET_VALUE("0"),     // String
+      .ECC_MODE("no_ecc"),        // String
+      .FIFO_MEMORY_TYPE("block"), // String
+      .FIFO_READ_LATENCY(1),      // DECIMAL
+      .FIFO_WRITE_DEPTH(1024),    // DECIMAL
+      .FULL_RESET_VALUE(0),       // DECIMAL
+      .PROG_EMPTY_THRESH(10),     // DECIMAL
+      .PROG_FULL_THRESH(10),      // DECIMAL
+      .RD_DATA_COUNT_WIDTH(13),   // DECIMAL
+      .READ_DATA_WIDTH(4),        // DECIMAL
+      .READ_MODE("std"),          // String
+      .SIM_ASSERT_CHK(0),         // DECIMAL; 0=disable simulation messages, 1=enable simulation messages
+      .USE_ADV_FEATURES("1000"),  // String
+      .WAKEUP_TIME(0),            // DECIMAL
+      .WRITE_DATA_WIDTH(32),      // DECIMAL
+      .WR_DATA_COUNT_WIDTH(11)    // DECIMAL
    )
    trng_fifo_inst (
       .almost_empty(),

--- a/hw/fpga/src/jtag_constraints.xdc
+++ b/hw/fpga/src/jtag_constraints.xdc
@@ -1,2 +1,0 @@
-create_clock -period 5000.000 -name {caliptra_fpga_project_bd_i/zynq_ultra_ps_e_0/inst/emio_gpio_o[0]} -waveform {0.000 2500.000} [get_pins {caliptra_fpga_project_bd_i/zynq_ultra_ps_e_0/inst/PS8_i/EMIOGPIOO[0]}]
-set_clock_groups -asynchronous -group [get_clocks {caliptra_fpga_project_bd_i/zynq_ultra_ps_e_0/inst/emio_gpio_o[0]}]


### PR DESCRIPTION
Migrate FPGA memories and fifos to XPM macros: Old Memory and FIFOs were not portable to Versal. Changed to XPM macros that can work on Zynq and Versal.