### PR TITLE
Properly evaluate PL0 PAUSERs when the fw header bit is unset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-gen-linker-scripts",
  "caliptra-hw-model",
+ "caliptra-image-crypto",
  "caliptra-image-elf",
  "caliptra-image-fake-keys",
  "caliptra-image-gen",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -39,6 +39,7 @@ caliptra-hw-model.workspace = true
 caliptra-image-elf.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
+caliptra-image-crypto.workspace = true
 caliptra-image-serde.workspace = true
 caliptra-cfi-lib-git = { workspace = true, features = ["cfi-test"] }
 openssl.workspace = true

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -590,7 +590,8 @@ impl Drivers {
     /// * `flags` - Flags from manifest header
     /// * `locality` - Caller's locality
     pub fn is_caller_pl1(pl0_pauser: u32, flags: u32, locality: u32) -> bool {
-        flags & PL0_PAUSER_FLAG == 0 && locality != pl0_pauser
+        (flags & PL0_PAUSER_FLAG == 0) // There is no PL0 PAUSER
+            || (locality != pl0_pauser) // There is a PL0 PAUSER, but it's not the current user
     }
 
     /// Get the KeyId for the RT Alias CDI


### PR DESCRIPTION
Previously, if PL0 PAUSER bit was unset, all users were treated as PL0. Align with the spec and treat them all as PL1 in that case.