### PR TITLE
[experiment] Hack the smoke_test to only include the first HMAC block in the expected rt-alias-key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "elf",
  "openssl",
  "rand",
+ "sha2",
  "zerocopy",
 ]
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -14,6 +14,7 @@ caliptra-builder.workspace = true
 caliptra_common = { workspace = true, default-features = false }
 caliptra-coverage.workspace = true
 caliptra-drivers.workspace = true
+sha2.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-image-types.workspace = true
 caliptra-runtime = { workspace = true, default-features = false }

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -16,7 +16,9 @@ use zerocopy::{transmute, AsBytes};
 use caliptra_hw_model_types::DeviceLifecycle;
 
 use crate::{
-    crypto::{self, derive_ecdsa_key, hmac384, hmac384_drbg_keygen, hmac384_kdf},
+    crypto::{
+        self, derive_ecdsa_key, hmac384, hmac384_drbg_keygen, hmac384_kdf, hmac384_kdf_truncated,
+    },
     swap_word_bytes, swap_word_bytes_inplace,
 };
 
@@ -467,7 +469,8 @@ impl RtAliasKey {
             .as_bytes_mut()
             .copy_from_slice(&sha384(tci_input.manifest.as_bytes()));
 
-        let mut cdi: [u32; 12] = transmute!(hmac384_kdf(
+        // DO NOT SUBMIT: Using hmac384_kdf_truncated(), which only includes the first block
+        let mut cdi: [u32; 12] = transmute!(hmac384_kdf_truncated(
             swap_word_bytes(&fmc_key.cdi).as_bytes(),
             b"rt_alias_cdi",
             Some(&tci),

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -9,6 +9,7 @@ use caliptra_common::RomBootStatus;
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{BootParams, HwModel, InitParams, SecurityState};
 use caliptra_hw_model_types::{DeviceLifecycle, Fuses, RandomEtrngResponses, RandomNibbles};
+use caliptra_test::derive::{PcrRtCurrentInput, RtAliasKey};
 use caliptra_test::{derive, redact_cert, run_test, RedactOpts, UnwrapSingle};
 use caliptra_test::{
     derive::{DoeInput, DoeOutput, FmcAliasKey, IDevId, LDevId, Pcr0, Pcr0Input},
@@ -409,6 +410,26 @@ fn smoke_test() {
     let rt_alias_cert_der = rt_alias_cert_resp.data().unwrap();
     let rt_alias_cert = openssl::x509::X509::from_der(rt_alias_cert_der).unwrap();
     let rt_alias_cert_txt = String::from_utf8(rt_alias_cert.to_text().unwrap()).unwrap();
+
+    println!(
+        "Manifest digest is {:02x?}",
+        image.manifest.runtime.digest.as_bytes()
+    );
+    let expected_rt_alias_key = RtAliasKey::derive(
+        &PcrRtCurrentInput {
+            runtime_digest: image.manifest.runtime.digest,
+            manifest: image.manifest,
+        },
+        &expected_fmc_alias_key,
+    );
+
+    // Check that the rt-alias key has the rt measurements input above mixed into it
+    // If a firmware change causes this assertion to fail, it is likely that the
+    // logic in the FMC that derives the CDI. Ensure this is intentional, and
+    // then make the same change to caliptra_test::RtAliasKey::derive().
+    assert!(expected_rt_alias_key
+        .derive_public_key()
+        .public_eq(&rt_alias_cert.public_key().unwrap()));
 
     println!("rt-alias cert: {rt_alias_cert_txt}");
 


### PR DESCRIPTION
Hack the smoke_test to only include the first HMAC block in the expected rt-alias-key derivation

If the smoke_test() passes on the FPGA with this change, that confirms
that the first block is being fully mixed in by today's FMC.

This is the (already padded) data intended to be hmac'd:

```
# block 0 (this block included in rt-alias)
00000000  00 00 00 01 72 74 5f 61  6c 69 61 73 5f 63 64 69  |....rt_alias_cdi|
00000010  00 03 91 03 63 1e f7 9d  36 a1 5c 5a 38 07 ca 6a  |....c...6.\Z8..j|
00000020  71 42 de c4 7e 3c 90 8c  aa 9c 41 2b be 83 71 92  |qB..~<....A+..q.|
00000030  0a fe a7 2b ed 4d 52 a4  f0 7b c3 bb 7d b6 50 3f  |...+.MR..{..}.P?|
00000040  7e cb 5a c2 23 45 70 96  84 6a 6c da 09 3a 03 f2  |~.Z.#Ep..jl..:..|
00000050  78 c5 52 19 5f bb e4 76  26 2b 4d 05 90 60 b5 18  |x.R._..v&+M..`..|
00000060  28 54 df 20 81 0f a8 fe  59 2a 3c 3c e9 a5 27 bc  |(T. ....Y*<<..'.|
00000070  27 80 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |'...............|
# block 1 (this block was skipped)
00000080  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000090  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000000f0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 07 88  |................|
```