### PR TITLE
Runtime CFI check of mailbox lock causes race condition

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -120,7 +120,8 @@ fn enter_idle(drivers: &mut Drivers) {
     // Run pending jobs before entering low power mode.
     #[cfg(feature = "fips_self_test")]
     if let SelfTestStatus::InProgress(execute) = drivers.self_test_status {
-        if drivers.mbox.lock() == false {
+        let lock = drivers.mbox.lock();
+        if lock == false {
             let result = execute(drivers);
             drivers.mbox.unlock();
             match result {
@@ -128,7 +129,7 @@ fn enter_idle(drivers: &mut Drivers) {
                 Err(e) => caliptra_common::handle_fatal_error(e.into()),
             }
         } else {
-            cfi_assert!(drivers.mbox.lock());
+            cfi_assert!(lock);
             // Don't enter low power mode when in progress
             return;
         }


### PR DESCRIPTION
The second read of the lock register was inserted to prevent a glitch attack from bypassing the FIPS self test logic and execute a different mailbox command. However, the second read causes a race condition and the SoC can maliciously or accidentally force Caliptra to crash by releasing the lock at the time the CFI check of the lock is performed.

Given an attacker can prevent FIPS self-test from happening by just controlling the acquisition and release of the lock, the CFI check is not protecting much and can potentially be removed altogether.