### PR TITLE
Make caliptra-coverage optional for the emulated hw-model.

### DIFF
--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["coverage"]
 verilator = ["dep:caliptra-verilated"]
 fpga_realtime = ["dep:uio"]
 itrng = ["caliptra-verilated?/itrng"]
+coverage = ["dep:caliptra-coverage"]
 
 [dependencies]
 bitfield.workspace = true
@@ -31,7 +32,7 @@ ureg.workspace = true
 zerocopy.workspace = true
 nix.workspace = true
 libc.workspace = true
-caliptra-coverage.workspace = true
+caliptra-coverage = { workspace = true, optional = true }
 caliptra-image-types.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
This adds a new default feature flag for the hw-model. caliptra-coverage depends on caliptra-builder which uses cargo directly. This can make using the hw-model easier for build environments that may not have cargo accessible.