### PR TITLE
Move VPK and OPK hashes to files that are read in.

### DIFF
--- a/libcaliptra/.gitignore
+++ b/libcaliptra/.gitignore
@@ -1,3 +1,4 @@
 inc/caliptra_model.h
 examples/hwmodel/hwmodel
 *.o
+*.bin

--- a/libcaliptra/examples/generic/main.mk
+++ b/libcaliptra/examples/generic/main.mk
@@ -24,11 +24,8 @@ $(TARGET): $(OBJS) $(DEPS)
 	@echo [LINK] $(TARGET)
 	$(Q)$(CC) -o $(TARGET) $(OBJS) $(CFLAGS)
 	@echo [ADD DIGESTS] VENDOR OWNER
-	$(Q)dd status=none if=$(FW_FILE) bs=4 count=480 skip=2   | sha384sum | xxd -r -p > vpk.bin
-	$(Q)dd status=none if=$(FW_FILE) bs=4 count=36  skip=913 | sha384sum | xxd -r -p > opk.bin
-	$(Q)objcopy $(TARGET) --update-section VPK_HASH=vpk.bin
-	$(Q)objcopy $(TARGET) --update-section OPK_HASH=opk.bin
-	$(Q)rm -f vpk.bin opk.bin
+	$(Q)dd status=none if=$(FW_FILE) bs=4 count=480 skip=2   | sha384sum | xxd -r -p > $(VPK_PATH)
+	$(Q)dd status=none if=$(FW_FILE) bs=4 count=36  skip=913 | sha384sum | xxd -r -p > $(OPK_PATH)
 
 
 $(CALIPTRA_API):
@@ -39,5 +36,5 @@ $(CALIPTRA_API):
 	$(Q)$(CC) $(CFLAGS) $(DEFINES) $(INCLUDES) -g -c $< -o $@
 
 clean:
-	@echo [CLEAN] $(OBJS) $(TARGET)
-	$(Q)rm -f $(OBJS) $(TARGET)
+	@echo [CLEAN] $(OBJS) $(TARGET) $(VPK_PATH) $(OPK_PATH)
+	$(Q)rm -f $(OBJS) $(TARGET) $(VPK_PATH) $(OPK_PATH)

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -5,7 +5,7 @@ CROSS_COMPILE ?=
 .DEFAULT_GOAL = $(TARGET)
 
 LIBCALIPTRA_ROOT = ../../
-LIBCALIPTRA_INC  = 
+LIBCALIPTRA_INC  =
 
 OUTPUT_DIR = ../../../target/debug
 
@@ -17,19 +17,24 @@ FW_FILE  = $(ROM_FW_DIR)/image_bundle.bin
 
 BUILDER_PATH = ../../../builder
 
+VPK_PATH=vpk.bin
+OPK_PATH=opk.bin
+
 # ROM AND FW FILES
 #
 # These paths are encoded into the binary so the generic
 # main sources don't need a command line.
 DEFINES  = -DROM_PATH=\"$(ROM_FILE)\"
 DEFINES += -DFW_PATH=\"$(FW_FILE)\"
+DEFINES += -DVPK_PATH=\"$(VPK_PATH)\"
+DEFINES += -DOPK_PATH=\"$(OPK_PATH)\"
 
 # HW MODEL
 HWMODEL_DIR = $(OUTPUT_DIR)
 HWMODEL_HEADER_DIR = ../../../hw-model/c-binding/out
 HWMODEL_INCLUDE = -I$(HWMODEL_HEADER_DIR)
 HWMODEL_LIB = -Wl,-L$(HWMODEL_DIR) -lcaliptra_hw_model_c_binding
-HWMODEL_FLAGS = -lpthread -lstdc++ -ldl -lrt -lm 
+HWMODEL_FLAGS = -lpthread -lstdc++ -ldl -lrt -lm
 HWMODEL_HEADER = $(HWMODEL_HEADER_DIR)/caliptra_model.h
 HWMODEL_BINDING_LIB_OBJ = $(HWMODEL_DIR)/libcaliptra_hw_model_c_binding.a
 

--- a/libcaliptra/examples/hwmodel/interface.c
+++ b/libcaliptra/examples/hwmodel/interface.c
@@ -2,19 +2,16 @@
 
 #define HWMODEL 1
 
-#include <stdint.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <string.h>
 #include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
-#include <caliptra_top_reg.h>
-
 #include "caliptra_model.h"
-#include "caliptra_api.h"
-#include "caliptra_image.h"
 
 #define CALIPTRA_STATUS_OK 0
 
@@ -26,7 +23,7 @@ struct caliptra_model_init_params init_params;
 
 extern struct caliptra_buffer image_bundle;
 
-static struct caliptra_buffer read_file_or_exit(const char* path)
+struct caliptra_buffer read_file_or_exit(const char* path)
 {
     // Open File in Read Only Mode
     FILE *fp = fopen(path, "r");
@@ -125,7 +122,7 @@ int caliptra_write_u32(uint32_t address, uint32_t data)
 
     caliptra_model_step(m);
 
-    return result; 
+    return result;
 }
 
 /**

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -3,13 +3,14 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
+
 #include <caliptra_top_reg.h>
-#include "caliptra_if.h"
+
 #include "caliptra_api.h"
+#include "caliptra_enums.h"
+#include "caliptra_if.h"
 #include "caliptra_fuses.h"
 #include "caliptra_mbox.h"
-#include "caliptra_enums.h"
 
 #define CALIPTRA_STATUS_NOT_READY (0)
 #define CALIPTRA_REG_BASE (CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR)

--- a/libcaliptra/src/caliptra_fuses.h
+++ b/libcaliptra/src/caliptra_fuses.h
@@ -2,7 +2,11 @@
 
 #pragma once
 
-#include "caliptra_api.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#include "caliptra_top_reg.h"
+#include "caliptra_if.h"
 
 #define MBOX_PAUSER_SLOTS (5)
 

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -1,6 +1,12 @@
 // Licensed under the Apache-2.0 license
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include "caliptra_top_reg.h"
+#include "caliptra_if.h"
+
 #define CALIPTRA_MAILBOX_MAX_SIZE (128u * 1024u)
 
 enum caliptra_mailbox_status {


### PR DESCRIPTION
Instead of post processing the binary to add the hashes this has the software read them in as files. This is in an effort to reduce the changes needed to build in a non-`make` environment.