### PR TITLE
Fix a memory leak in the HW model.

### DIFF
--- a/hw-model/c-binding/examples/api/caliptra_fuses.h
+++ b/hw-model/c-binding/examples/api/caliptra_fuses.h
@@ -2,6 +2,7 @@
 #ifndef CALIPTRA_FUSES_H
 #define CALIPTRA_FUSES_H
 
+#include <caliptra_top_reg.h>
 #include "caliptra_api.h"
 
 #define CALIPTRA_ARRAY_SIZE(array) ((size_t)(sizeof(array) / sizeof(array[0])))

--- a/hw-model/c-binding/examples/api/caliptra_mbox.h
+++ b/hw-model/c-binding/examples/api/caliptra_mbox.h
@@ -2,7 +2,9 @@
 #ifndef CALIPTRA_MBOX_H
 #define CALIPTRA_MBOX_H
 
+#include <caliptra_top_reg.h>
 #include "caliptra_api.h"
+
 static inline void caliptra_mbox_write(caliptra_model *model, uint32_t offset, uint32_t data)
 {
     caliptra_model_apb_write_u32(model, (offset + CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR), data);

--- a/hw-model/c-binding/examples/smoke_test.c
+++ b/hw-model/c-binding/examples/smoke_test.c
@@ -76,11 +76,14 @@ int main(int argc, char *argv[])
         return -EINVAL;
     }
 
+    // slice::from_raw_parts can panic when the pointer is NULL
+    uint8_t empty[0];
+
     // Initialize Params
     struct caliptra_model_init_params init_params = {
       .rom = read_file_or_die(rom_path),
-      .dccm = {.data = NULL, .len = 0},
-      .iccm = {.data = NULL, .len = 0},
+      .dccm = {.data = empty, .len = 0},
+      .iccm = {.data = empty, .len = 0},
       .security_state = CALIPTRA_SEC_STATE_DBG_UNLOCKED_UNPROVISIONED,
     };
 
@@ -107,6 +110,9 @@ int main(int argc, char *argv[])
 
     // Run Until RT is ready to receive commands
     caliptra_model_step_until_boot_status(model, RT_READY_FOR_COMMANDS);
+
+    // Free the model
+    caliptra_model_destroy(model);
 
     printf("Caliptra C Smoke Test Passed \n");
     return 0;

--- a/hw-model/c-binding/src/caliptra_model.rs
+++ b/hw-model/c-binding/src/caliptra_model.rs
@@ -65,8 +65,8 @@ pub unsafe extern "C" fn caliptra_model_destroy(model: *mut caliptra_model) {
     // Parameter check
     assert!(!model.is_null());
 
-    // This will force model to be freed
-    drop(Box::from_raw(model));
+    // This will force model to be freed. Needs the cast to know how much memory to be freed.
+    drop(Box::from_raw(model as *mut DefaultHwModel));
 }
 
 /// # Safety


### PR DESCRIPTION
Previously, the `drop` didn't free anything because the compiler thought it was a zero-sized struct. This tells the compiler how much memory needs to be freed.