### PR TITLE
Some nits to the smoke test.

### DIFF
--- a/hw-model/c-binding/build.rs
+++ b/hw-model/c-binding/build.rs
@@ -13,6 +13,8 @@ fn main() {
     let config = cbindgen::Config {
         header: Some(String::from_str("// Licensed under the Apache-2.0 license").unwrap()),
         language: cbindgen::Language::C,
+        include_guard: Some("HW_MODEL_C_BINDING_OUT_CALIPTRA_MODEL_H".to_string()),
+        cpp_compat: true,
         ..Default::default()
     };
 

--- a/hw-model/c-binding/examples/api/caliptra_api.c
+++ b/hw-model/c-binding/examples/api/caliptra_api.c
@@ -146,9 +146,6 @@ int caliptra_mailbox_execute(struct caliptra_model *model, uint32_t cmd, struct 
         return -EIO;
     }
 
-    // Read Mbox out Data Len
-    uint32_t dlen = caliptra_mbox_read_dlen(model);
-
     // Read Buffer
     caliptra_mailbox_read_buffer(model, mbox_rx_buffer);
 

--- a/hw-model/c-binding/examples/api/caliptra_api.h
+++ b/hw-model/c-binding/examples/api/caliptra_api.h
@@ -27,6 +27,10 @@ struct caliptra_fuses {
     enum DeviceLifecycle life_cycle;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Initialize Caliptra fuses prior to boot
 int caliptra_init_fuses(struct caliptra_model *model, struct caliptra_fuses *fuses);
 
@@ -38,5 +42,9 @@ int caliptra_upload_fw(struct caliptra_model *model, struct caliptra_buffer *fw_
 
 // Execute Mailbox Command
 int caliptra_mailbox_execute(struct caliptra_model *model, uint32_t cmd, struct caliptra_buffer *mbox_tx_buffer, struct caliptra_buffer *mbox_rx_buffer);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CALIPTRA_API_H

--- a/hw-model/c-binding/examples/api/caliptra_fuses.h
+++ b/hw-model/c-binding/examples/api/caliptra_fuses.h
@@ -11,6 +11,10 @@
 //          SOC FW MUST HAVE NO ACCESS TO THOSE APIS.
 //          A HW STATE MACHINE SHOULD BE USED TO SEND FUSE VALUES TO CALIPTRA OVER APB BUS
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void caliptra_fuse_write(caliptra_model *model, uint32_t offset, uint32_t data)
 {
     caliptra_model_apb_write_u32(model, (offset + CALIPTRA_TOP_REG_GENERIC_AND_FUSE_REG_BASE_ADDR), data);
@@ -22,5 +26,8 @@ static inline void caliptra_fuse_array_write(caliptra_model *model, uint32_t off
         caliptra_fuse_write(model, (offset + (idx * sizeof(uint32_t))), data[idx]);
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/hw-model/c-binding/examples/api/caliptra_mbox.h
+++ b/hw-model/c-binding/examples/api/caliptra_mbox.h
@@ -5,6 +5,10 @@
 #include <caliptra_top_reg.h>
 #include "caliptra_api.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline void caliptra_mbox_write(caliptra_model *model, uint32_t offset, uint32_t data)
 {
     caliptra_model_apb_write_u32(model, (offset + CALIPTRA_TOP_REG_MBOX_CSR_BASE_ADDR), data);
@@ -52,6 +56,9 @@ static inline void caliptra_mbox_write_dlen(caliptra_model *model, uint32_t dlen
     caliptra_mbox_write(model, MBOX_CSR_MBOX_DLEN, dlen);
 }
 
+#ifdef __cplusplus
+}
+#endif
 
 #define CALIPTRA_MBOX_STATUS_BUSY               0
 #define CALIPTRA_MBOX_STATUS_DATA_READY         1


### PR DESCRIPTION
* Adds `extern C` to the header files in case of C++
* Removes an unused variable