### PR TITLE
drivers/persistent: Ensure no rom changes with AuthManifest

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -86,9 +86,10 @@ pub use okref::okmutref;
 pub use okref::okref;
 pub use pcr_bank::{PcrBank, PcrId};
 pub use pcr_reset::PcrResetCounter;
+#[cfg(feature = "runtime")]
+pub use persistent::{AuthManifestImageMetadataArray, AUTH_MANIFEST_IMAGE_METADATA_LIST_MAX_COUNT};
 pub use persistent::{
-    AuthManifestImageMetadataArray, FuseLogArray, PcrLogArray, PersistentData,
-    PersistentDataAccessor, StashMeasurementArray, AUTH_MANIFEST_IMAGE_METADATA_LIST_MAX_COUNT,
+    FuseLogArray, PcrLogArray, PersistentData, PersistentDataAccessor, StashMeasurementArray,
     FUSE_LOG_MAX_COUNT, MEASUREMENT_MAX_COUNT, PCR_LOG_MAX_COUNT,
 };
 pub use pic::{IntSource, Pic};

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -2,6 +2,7 @@
 
 use core::{marker::PhantomData, mem::size_of, ptr::addr_of};
 
+#[cfg(feature = "runtime")]
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 #[cfg(feature = "runtime")]
 use caliptra_auth_man_types::AuthManifestImageMetadataCollection;
@@ -24,6 +25,7 @@ use crate::pcr_reset::PcrResetCounter;
 pub const PCR_LOG_MAX_COUNT: usize = 17;
 pub const FUSE_LOG_MAX_COUNT: usize = 62;
 pub const MEASUREMENT_MAX_COUNT: usize = 8;
+#[cfg(feature = "runtime")]
 pub const AUTH_MANIFEST_IMAGE_METADATA_LIST_MAX_COUNT: usize = 8;
 
 #[cfg(feature = "runtime")]
@@ -38,6 +40,7 @@ const _: () = assert!(DPE_DCCM_STORAGE < memory_layout::DPE_SIZE as usize);
 pub type PcrLogArray = [PcrLogEntry; PCR_LOG_MAX_COUNT];
 pub type FuseLogArray = [FuseLogEntry; FUSE_LOG_MAX_COUNT];
 pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
+#[cfg(feature = "runtime")]
 pub type AuthManifestImageMetadataArray =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_LIST_MAX_COUNT];
 

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -81,7 +81,11 @@ impl AuthorizeAndStashCmd {
 
             let mut auth_result = DENY_IMAGE_AUTHORIZATION;
             for metadata_entry in auth_manifest_image_metadata_col.image_metadata_array.iter() {
-                if metadata_entry.digest == cmd.measurement {
+                if cfi_launder(metadata_entry.digest) == cmd.measurement {
+                    caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+                        &Array4x12::from(metadata_entry.digest).0,
+                        &Array4x12::from(cmd.measurement).0,
+                    );
                     auth_result = AUTHORIZE_IMAGE;
                     break;
                 }


### PR DESCRIPTION
Adding the data structures to the code somehow changes the ROM so guard those as those structs as those are only used in runtime anyway. A similar thing is done for the PCR reset counter.