### PR TITLE
runtime: Aesthetic enhancement using ok_or when decoding mb input

### DIFF
--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -34,78 +34,76 @@ use crate::{
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = CertifyKeyExtendedReq::read_from(cmd_args) {
-            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-            let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
-            let pdata = drivers.persistent_data.get_mut();
-            let crypto = DpeCrypto::new(
-                &mut drivers.sha384,
-                &mut drivers.trng,
-                &mut drivers.ecc384,
-                &mut drivers.hmac384,
-                &mut drivers.key_vault,
-                &mut pdata.fht.rt_dice_pub_key,
-                key_id_rt_cdi,
-                key_id_rt_priv_key,
-            );
-            let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-            let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
-            // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
-            let dmtf_device_info = if cmd.flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
-                drivers
-                    .dmtf_device_info
-                    .as_ref()
-                    .map(|dmtf_device_info| dmtf_device_info.as_bytes())
-            } else {
-                None
-            };
-            let mut env = DpeEnv::<CptraDpeTypes> {
-                crypto,
-                platform: DpePlatform::new(
-                    pl0_pauser,
-                    &hashed_rt_pub_key,
-                    &drivers.cert_chain,
-                    &nb,
-                    &nf,
-                    dmtf_device_info,
-                ),
-            };
-
-            let locality = drivers.mbox.user();
-            // Cannot call CERTIFY_KEY_EXTENDED from PL1
-            if Drivers::is_caller_pl1(pl0_pauser, pdata.manifest1.header.flags, locality) {
-                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-            }
-
-            let mut dpe = &mut pdata.dpe;
-            let certify_key_cmd = CertifyKeyCmd::read_from(&cmd.certify_key_req[..])
-                .ok_or(CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-            let resp = certify_key_cmd.execute(dpe, &mut env, locality);
-
-            let certify_key_resp = match resp {
-                Ok(Response::CertifyKey(certify_key_resp)) => certify_key_resp,
-                Ok(_) => return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED),
-                Err(e) => {
-                    // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                    if let Some(ext_err) = e.get_error_detail() {
-                        drivers.soc_ifc.set_fw_extended_error(ext_err);
-                    }
-                    return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED);
-                }
-            };
-
-            let certify_key_extended_resp = CertifyKeyExtendedResp {
-                hdr: MailboxRespHeader::default(),
-                certify_key_resp: certify_key_resp
-                    .as_bytes()
-                    .try_into()
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?,
-            };
-
-            Ok(MailboxResp::CertifyKeyExtended(certify_key_extended_resp))
+        let cmd = CertifyKeyExtendedReq::read_from(cmd_args)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+        let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+        let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+        let pdata = drivers.persistent_data.get_mut();
+        let crypto = DpeCrypto::new(
+            &mut drivers.sha384,
+            &mut drivers.trng,
+            &mut drivers.ecc384,
+            &mut drivers.hmac384,
+            &mut drivers.key_vault,
+            &mut pdata.fht.rt_dice_pub_key,
+            key_id_rt_cdi,
+            key_id_rt_priv_key,
+        );
+        let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+        let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
+        // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
+        let dmtf_device_info = if cmd.flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
+            drivers
+                .dmtf_device_info
+                .as_ref()
+                .map(|dmtf_device_info| dmtf_device_info.as_bytes())
         } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
+            None
+        };
+        let mut env = DpeEnv::<CptraDpeTypes> {
+            crypto,
+            platform: DpePlatform::new(
+                pl0_pauser,
+                &hashed_rt_pub_key,
+                &drivers.cert_chain,
+                &nb,
+                &nf,
+                dmtf_device_info,
+            ),
+        };
+
+        let locality = drivers.mbox.user();
+        // Cannot call CERTIFY_KEY_EXTENDED from PL1
+        if Drivers::is_caller_pl1(pl0_pauser, pdata.manifest1.header.flags, locality) {
+            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
         }
+
+        let mut dpe = &mut pdata.dpe;
+        let certify_key_cmd = CertifyKeyCmd::read_from(&cmd.certify_key_req[..])
+            .ok_or(CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+        let resp = certify_key_cmd.execute(dpe, &mut env, locality);
+
+        let certify_key_resp = match resp {
+            Ok(Response::CertifyKey(certify_key_resp)) => certify_key_resp,
+            Ok(_) => return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED),
+            Err(e) => {
+                // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+                if let Some(ext_err) = e.get_error_detail() {
+                    drivers.soc_ifc.set_fw_extended_error(ext_err);
+                }
+                return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED);
+            }
+        };
+
+        let certify_key_extended_resp = CertifyKeyExtendedResp {
+            hdr: MailboxRespHeader::default(),
+            certify_key_resp: certify_key_resp
+                .as_bytes()
+                .try_into()
+                .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?,
+        };
+
+        Ok(MailboxResp::CertifyKeyExtended(certify_key_extended_resp))
     }
 }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -32,83 +32,81 @@ impl StashMeasurementCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = StashMeasurementReq::read_from(cmd_args) {
-            let dpe_result = {
-                let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-                let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-                let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
-                let pdata = drivers.persistent_data.get_mut();
-                let mut crypto = DpeCrypto::new(
-                    &mut drivers.sha384,
-                    &mut drivers.trng,
-                    &mut drivers.ecc384,
-                    &mut drivers.hmac384,
-                    &mut drivers.key_vault,
-                    &mut pdata.fht.rt_dice_pub_key,
-                    key_id_rt_cdi,
-                    key_id_rt_priv_key,
-                );
-                let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
-                let mut env = DpeEnv::<CptraDpeTypes> {
-                    crypto,
-                    platform: DpePlatform::new(
-                        pdata.manifest1.header.pl0_pauser,
-                        &hashed_rt_pub_key,
-                        &drivers.cert_chain,
-                        &nb,
-                        &nf,
-                        None,
-                    ),
-                };
-
-                let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-                let flags = pdata.manifest1.header.flags;
-                let locality = drivers.mbox.user();
-                // Check that adding this measurement to DPE doesn't cause
-                // the PL0 context threshold to be exceeded.
-                Drivers::is_dpe_context_threshold_exceeded(
-                    pl0_pauser, flags, locality, &pdata.dpe, false,
-                )?;
-                // let pdata_mut = drivers.persistent_data.get_mut();
-                let derive_context_resp = DeriveContextCmd {
-                    handle: ContextHandle::default(),
-                    data: cmd.measurement,
-                    flags: DeriveContextFlags::MAKE_DEFAULT
-                        | DeriveContextFlags::CHANGE_LOCALITY
-                        | DeriveContextFlags::INPUT_ALLOW_CA
-                        | DeriveContextFlags::INPUT_ALLOW_X509,
-                    tci_type: u32::from_be_bytes(cmd.metadata),
-                    target_locality: locality,
-                }
-                .execute(&mut pdata.dpe, &mut env, locality);
-
-                match derive_context_resp {
-                    Ok(_) => DpeErrorCode::NoError,
-                    Err(e) => {
-                        // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                        if let Some(ext_err) = e.get_error_detail() {
-                            drivers.soc_ifc.set_fw_extended_error(ext_err);
-                        }
-                        e
-                    }
-                }
+        let cmd = StashMeasurementReq::read_from(cmd_args)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let dpe_result = {
+            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+            let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+            let pdata = drivers.persistent_data.get_mut();
+            let mut crypto = DpeCrypto::new(
+                &mut drivers.sha384,
+                &mut drivers.trng,
+                &mut drivers.ecc384,
+                &mut drivers.hmac384,
+                &mut drivers.key_vault,
+                &mut pdata.fht.rt_dice_pub_key,
+                key_id_rt_cdi,
+                key_id_rt_priv_key,
+            );
+            let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
+            let mut env = DpeEnv::<CptraDpeTypes> {
+                crypto,
+                platform: DpePlatform::new(
+                    pdata.manifest1.header.pl0_pauser,
+                    &hashed_rt_pub_key,
+                    &drivers.cert_chain,
+                    &nb,
+                    &nf,
+                    None,
+                ),
             };
 
-            if let DpeErrorCode::NoError = dpe_result {
-                // Extend the measurement into PCR31
-                drivers.pcr_bank.extend_pcr(
-                    PCR_ID_STASH_MEASUREMENT,
-                    &mut drivers.sha384,
-                    cmd.measurement.as_bytes(),
-                )?;
+            let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+            let flags = pdata.manifest1.header.flags;
+            let locality = drivers.mbox.user();
+            // Check that adding this measurement to DPE doesn't cause
+            // the PL0 context threshold to be exceeded.
+            Drivers::is_dpe_context_threshold_exceeded(
+                pl0_pauser, flags, locality, &pdata.dpe, false,
+            )?;
+            // let pdata_mut = drivers.persistent_data.get_mut();
+            let derive_context_resp = DeriveContextCmd {
+                handle: ContextHandle::default(),
+                data: cmd.measurement,
+                flags: DeriveContextFlags::MAKE_DEFAULT
+                    | DeriveContextFlags::CHANGE_LOCALITY
+                    | DeriveContextFlags::INPUT_ALLOW_CA
+                    | DeriveContextFlags::INPUT_ALLOW_X509,
+                tci_type: u32::from_be_bytes(cmd.metadata),
+                target_locality: locality,
             }
+            .execute(&mut pdata.dpe, &mut env, locality);
 
-            Ok(MailboxResp::StashMeasurement(StashMeasurementResp {
-                hdr: MailboxRespHeader::default(),
-                dpe_result: dpe_result.get_error_code(),
-            }))
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
+            match derive_context_resp {
+                Ok(_) => DpeErrorCode::NoError,
+                Err(e) => {
+                    // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+                    if let Some(ext_err) = e.get_error_detail() {
+                        drivers.soc_ifc.set_fw_extended_error(ext_err);
+                    }
+                    e
+                }
+            }
+        };
+
+        if let DpeErrorCode::NoError = dpe_result {
+            // Extend the measurement into PCR31
+            drivers.pcr_bank.extend_pcr(
+                PCR_ID_STASH_MEASUREMENT,
+                &mut drivers.sha384,
+                cmd.measurement.as_bytes(),
+            )?;
         }
+
+        Ok(MailboxResp::StashMeasurement(StashMeasurementResp {
+            hdr: MailboxRespHeader::default(),
+            dpe_result: dpe_result.get_error_code(),
+        }))
     }
 }

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -32,39 +32,37 @@ pub struct TagTciCmd;
 impl TagTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = TagTciReq::read_from(cmd_args) {
-            let pdata_mut = drivers.persistent_data.get_mut();
-            let mut dpe = &mut pdata_mut.dpe;
-            let mut context_has_tag = &mut pdata_mut.context_has_tag;
-            let mut context_tags = &mut pdata_mut.context_tags;
+        let cmd =
+            TagTciReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let pdata_mut = drivers.persistent_data.get_mut();
+        let mut dpe = &mut pdata_mut.dpe;
+        let mut context_has_tag = &mut pdata_mut.context_has_tag;
+        let mut context_tags = &mut pdata_mut.context_tags;
 
-            // Make sure the tag isn't used by any other contexts.
-            if (0..MAX_HANDLES).any(|i| {
-                i < context_has_tag.len()
-                    && i < context_tags.len()
-                    && context_has_tag[i].get()
-                    && context_tags[i] == cmd.tag
-            }) {
-                return Err(CaliptraError::RUNTIME_DUPLICATE_TAG);
-            }
-
-            let locality = drivers.mbox.user();
-            let idx = dpe
-                .get_active_context_pos(&ContextHandle(cmd.handle), locality)
-                .map_err(|_| CaliptraError::RUNTIME_TAGGING_FAILURE)?;
-
-            // Make sure the context doesn't already have a tag
-            if context_has_tag[idx].get() {
-                return Err(CaliptraError::RUNTIME_CONTEXT_ALREADY_TAGGED);
-            }
-
-            context_has_tag[idx] = U8Bool::new(true);
-            context_tags[idx] = cmd.tag;
-
-            Ok(MailboxResp::default())
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
+        // Make sure the tag isn't used by any other contexts.
+        if (0..MAX_HANDLES).any(|i| {
+            i < context_has_tag.len()
+                && i < context_tags.len()
+                && context_has_tag[i].get()
+                && context_tags[i] == cmd.tag
+        }) {
+            return Err(CaliptraError::RUNTIME_DUPLICATE_TAG);
         }
+
+        let locality = drivers.mbox.user();
+        let idx = dpe
+            .get_active_context_pos(&ContextHandle(cmd.handle), locality)
+            .map_err(|_| CaliptraError::RUNTIME_TAGGING_FAILURE)?;
+
+        // Make sure the context doesn't already have a tag
+        if context_has_tag[idx].get() {
+            return Err(CaliptraError::RUNTIME_CONTEXT_ALREADY_TAGGED);
+        }
+
+        context_has_tag[idx] = U8Bool::new(true);
+        context_tags[idx] = cmd.tag;
+
+        Ok(MailboxResp::default())
     }
 }
 
@@ -73,30 +71,28 @@ impl GetTaggedTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = GetTaggedTciReq::read_from(cmd_args) {
-            let persistent_data = drivers.persistent_data.get();
-            let context_has_tag = &persistent_data.context_has_tag;
-            let context_tags = &persistent_data.context_tags;
-            let idx = (0..MAX_HANDLES)
-                .find(|i| {
-                    *i < context_has_tag.len()
-                        && *i < context_tags.len()
-                        && context_has_tag[*i].get()
-                        && context_tags[*i] == cmd.tag
-                })
-                .ok_or(CaliptraError::RUNTIME_TAGGING_FAILURE)?;
-            if idx >= persistent_data.dpe.contexts.len() {
-                return Err(CaliptraError::RUNTIME_TAGGING_FAILURE);
-            }
-            let context = persistent_data.dpe.contexts[idx];
-
-            Ok(MailboxResp::GetTaggedTci(GetTaggedTciResp {
-                hdr: MailboxRespHeader::default(),
-                tci_cumulative: context.tci.tci_cumulative.0,
-                tci_current: context.tci.tci_current.0,
-            }))
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
+        let cmd = GetTaggedTciReq::read_from(cmd_args)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let persistent_data = drivers.persistent_data.get();
+        let context_has_tag = &persistent_data.context_has_tag;
+        let context_tags = &persistent_data.context_tags;
+        let idx = (0..MAX_HANDLES)
+            .find(|i| {
+                *i < context_has_tag.len()
+                    && *i < context_tags.len()
+                    && context_has_tag[*i].get()
+                    && context_tags[*i] == cmd.tag
+            })
+            .ok_or(CaliptraError::RUNTIME_TAGGING_FAILURE)?;
+        if idx >= persistent_data.dpe.contexts.len() {
+            return Err(CaliptraError::RUNTIME_TAGGING_FAILURE);
         }
+        let context = persistent_data.dpe.contexts[idx];
+
+        Ok(MailboxResp::GetTaggedTci(GetTaggedTciResp {
+            hdr: MailboxRespHeader::default(),
+            tci_cumulative: context.tci.tci_cumulative.0,
+            tci_current: context.tci.tci_current.0,
+        }))
     }
 }

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -29,31 +29,29 @@ pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = EcdsaVerifyReq::read_from(cmd_args) {
-            // Won't panic, full_digest is always larger than digest
-            let full_digest = drivers.sha_acc.regs().digest().read();
-            let mut digest = Array4x12::default();
-            for (i, target_word) in digest.0.iter_mut().enumerate() {
-                *target_word = full_digest[i];
-            }
+        let cmd = EcdsaVerifyReq::read_from(cmd_args)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        // Won't panic, full_digest is always larger than digest
+        let full_digest = drivers.sha_acc.regs().digest().read();
+        let mut digest = Array4x12::default();
+        for (i, target_word) in digest.0.iter_mut().enumerate() {
+            *target_word = full_digest[i];
+        }
 
-            let pubkey = Ecc384PubKey {
-                x: Ecc384Scalar::from(cmd.pub_key_x),
-                y: Ecc384Scalar::from(cmd.pub_key_y),
-            };
-
-            let sig = Ecc384Signature {
-                r: Ecc384Scalar::from(cmd.signature_r),
-                s: Ecc384Scalar::from(cmd.signature_s),
-            };
-
-            let success = drivers.ecc384.verify(&pubkey, &digest, &sig)?;
-            if success != Ecc384Result::Success {
-                return Err(CaliptraError::RUNTIME_ECDSA_VERIFY_FAILED);
-            }
-        } else {
-            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        let pubkey = Ecc384PubKey {
+            x: Ecc384Scalar::from(cmd.pub_key_x),
+            y: Ecc384Scalar::from(cmd.pub_key_y),
         };
+
+        let sig = Ecc384Signature {
+            r: Ecc384Scalar::from(cmd.signature_r),
+            s: Ecc384Scalar::from(cmd.signature_s),
+        };
+
+        let success = drivers.ecc384.verify(&pubkey, &digest, &sig)?;
+        if success != Ecc384Result::Success {
+            return Err(CaliptraError::RUNTIME_ECDSA_VERIFY_FAILED);
+        }
 
         Ok(MailboxResp::default())
     }
@@ -78,57 +76,55 @@ impl LmsVerifyCmd {
         const LMS_ALGORITHM_TYPE: LmsAlgorithmType = LmsAlgorithmType::new(12);
         const LMOTS_ALGORITHM_TYPE: LmotsAlgorithmType = LmotsAlgorithmType::new(7);
 
-        if let Some(cmd) = LmsVerifyReq::read_from(cmd_args) {
-            // Get the digest from the SHA accelerator
-            let msg_digest_be = drivers.sha_acc.regs().digest().truncate::<12>().read();
-            // Flip the endianness since LMS treats this as raw message bytes
-            let mut msg_digest = [0u8; 48];
-            for (i, src_word) in msg_digest_be.iter().enumerate() {
-                msg_digest[i * 4..][..4].copy_from_slice(&src_word.to_be_bytes());
-            }
+        let cmd =
+            LmsVerifyReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        // Get the digest from the SHA accelerator
+        let msg_digest_be = drivers.sha_acc.regs().digest().truncate::<12>().read();
+        // Flip the endianness since LMS treats this as raw message bytes
+        let mut msg_digest = [0u8; 48];
+        for (i, src_word) in msg_digest_be.iter().enumerate() {
+            msg_digest[i * 4..][..4].copy_from_slice(&src_word.to_be_bytes());
+        }
 
-            let lms_pub_key: LmsPublicKey<LMS_N> = LmsPublicKey {
-                id: cmd.pub_key_id,
-                digest: <[U32<LittleEndian>; LMS_N]>::read_from(&cmd.pub_key_digest[..])
-                    .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
-                tree_type: LmsAlgorithmType::new(cmd.pub_key_tree_type),
-                otstype: LmotsAlgorithmType::new(cmd.pub_key_ots_type),
-            };
-
-            let lms_sig: LmsSignature<LMS_N, LMS_P, LMS_H> = LmsSignature {
-                q: <U32<BigEndian>>::from(cmd.signature_q),
-                ots: <LmotsSignature<LMS_N, LMS_P>>::read_from(&cmd.signature_ots[..])
-                    .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
-                tree_type: LmsAlgorithmType::new(cmd.signature_tree_type),
-                tree_path: <[[U32<LittleEndian>; LMS_N]; LMS_H]>::read_from(
-                    &cmd.signature_tree_path[..],
-                )
+        let lms_pub_key: LmsPublicKey<LMS_N> = LmsPublicKey {
+            id: cmd.pub_key_id,
+            digest: <[U32<LittleEndian>; LMS_N]>::read_from(&cmd.pub_key_digest[..])
                 .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
-            };
-
-            // Check that fixed params are correct
-            if lms_pub_key.tree_type != LMS_ALGORITHM_TYPE {
-                return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM);
-            }
-            if lms_pub_key.otstype != LMOTS_ALGORITHM_TYPE {
-                return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMOTS_ALGORITHM);
-            }
-            if lms_sig.tree_type != LMS_ALGORITHM_TYPE {
-                return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM);
-            }
-
-            let success = drivers.lms.verify_lms_signature(
-                &mut drivers.sha256,
-                &msg_digest,
-                &lms_pub_key,
-                &lms_sig,
-            )?;
-            if success != LmsResult::Success {
-                return Err(CaliptraError::RUNTIME_LMS_VERIFY_FAILED);
-            }
-        } else {
-            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+            tree_type: LmsAlgorithmType::new(cmd.pub_key_tree_type),
+            otstype: LmotsAlgorithmType::new(cmd.pub_key_ots_type),
         };
+
+        let lms_sig: LmsSignature<LMS_N, LMS_P, LMS_H> = LmsSignature {
+            q: <U32<BigEndian>>::from(cmd.signature_q),
+            ots: <LmotsSignature<LMS_N, LMS_P>>::read_from(&cmd.signature_ots[..])
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
+            tree_type: LmsAlgorithmType::new(cmd.signature_tree_type),
+            tree_path: <[[U32<LittleEndian>; LMS_N]; LMS_H]>::read_from(
+                &cmd.signature_tree_path[..],
+            )
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
+        };
+
+        // Check that fixed params are correct
+        if lms_pub_key.tree_type != LMS_ALGORITHM_TYPE {
+            return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM);
+        }
+        if lms_pub_key.otstype != LMOTS_ALGORITHM_TYPE {
+            return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMOTS_ALGORITHM);
+        }
+        if lms_sig.tree_type != LMS_ALGORITHM_TYPE {
+            return Err(CaliptraError::RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM);
+        }
+
+        let success = drivers.lms.verify_lms_signature(
+            &mut drivers.sha256,
+            &msg_digest,
+            &lms_pub_key,
+            &lms_sig,
+        )?;
+        if success != LmsResult::Success {
+            return Err(CaliptraError::RUNTIME_LMS_VERIFY_FAILED);
+        }
 
         Ok(MailboxResp::default())
     }


### PR DESCRIPTION
Instead of having the bulk of the mailbox execution code indented below a if let Some(...) else Err(CaliptraError::...) statement use .ok_or(CaliptraError:...)? to reduce indentation.