### PR TITLE
sw-emulator: Add physical memory protection (PMP)

### DIFF
--- a/sw-emulator/lib/bus/src/ram.rs
+++ b/sw-emulator/lib/bus/src/ram.rs
@@ -15,11 +15,11 @@ Abstract:
 use crate::{mem::Mem, Bus, BusError};
 use caliptra_emu_types::{RvAddr, RvData, RvSize};
 
-/// Read Only Memory Device
+/// Random Access Memory Device
 pub struct Ram {
     /// Inject double-bit ECC errors on read
     pub error_injection: u8,
-    /// Read Only Data
+    /// Random Access Data
     data: Mem,
 }
 

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -15,3 +15,7 @@ caliptra-emu-derive.workspace = true
 caliptra-emu-types.workspace = true
 lazy_static.workspace = true
 tock-registers.workspace = true
+
+[features]
+default = ["1.x"]
+"1.x" = []

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -15,7 +15,3 @@ caliptra-emu-derive.workspace = true
 caliptra-emu-types.workspace = true
 lazy_static.workspace = true
 tock-registers.workspace = true
-
-[features]
-default = ["1.x"]
-"1.x" = []

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -14,7 +14,9 @@ Abstract:
 
 use crate::csr_file::{Csr, CsrFile};
 use crate::instr::Instr;
-use crate::types::{RvInstr, RvMEIHAP, RvMStatus, RvMemAccessType, RvMsecCfg, RvPrivMode};
+#[cfg(not(feature = "1.x"))]
+use crate::types::RvMsecCfg;
+use crate::types::{RvInstr, RvMEIHAP, RvMStatus, RvMemAccessType, RvPrivMode};
 use crate::xreg_file::{XReg, XRegFile};
 use bit_vec::BitVec;
 use caliptra_emu_bus::{Bus, BusError, Clock, TimerAction};
@@ -544,6 +546,7 @@ impl<TBus: Bus> Cpu<TBus> {
 
         let mut status = RvMStatus(self.read_csr_machine(Csr::MSTATUS)?);
 
+        #[cfg(not(feature = "1.x"))]
         match self.priv_mode {
             RvPrivMode::U => {
                 // All traps are handled in M mode
@@ -635,6 +638,7 @@ impl<TBus: Bus> Cpu<TBus> {
     ///
     /// * `RvException` - Exception with cause `RvException::LoadAccessFault`,
     ///   `RvException::store_access_fault`, or `RvException::instr_access_fault`.
+    #[cfg(not(feature = "1.x"))]
     pub fn check_mem_priv(
         &self,
         addr: RvAddr,
@@ -650,6 +654,15 @@ impl<TBus: Bus> Cpu<TBus> {
         }
         Ok(())
     }
+    #[cfg(feature = "1.x")]
+    pub fn check_mem_priv(
+        &self,
+        _addr: RvAddr,
+        _size: RvSize,
+        _access: RvMemAccessType,
+    ) -> Result<(), RvException> {
+        Ok(())
+    }
 
     /// Check memory privileges of given address
     ///
@@ -662,6 +675,7 @@ impl<TBus: Bus> Cpu<TBus> {
     ///
     /// * `RvException` - Exception with cause `RvException::LoadAccessFault`,
     ///   `RvException::store_access_fault`, or `RvException::instr_access_fault`.
+    #[cfg(not(feature = "1.x"))]
     fn check_mem_priv_addr(
         &self,
         addr: RvAddr,
@@ -745,7 +759,9 @@ impl<TBus: Bus> Cpu<TBus> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caliptra_emu_bus::{testing::FakeBus, DynamicBus, Ram, Rom, Timer};
+    #[cfg(not(feature = "1.x"))]
+    use caliptra_emu_bus::Ram;
+    use caliptra_emu_bus::{testing::FakeBus, DynamicBus, Rom, Timer};
 
     #[test]
     fn test_new() {
@@ -769,6 +785,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "1.x"))]
     fn new_pmp_cpu(fill_val: u32) -> Cpu<DynamicBus> {
         let clock = Clock::new();
         let mut bus = DynamicBus::new();
@@ -785,6 +802,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_napot() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 
@@ -851,6 +869,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_na4() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 
@@ -901,6 +920,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_tor() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 
@@ -1028,6 +1048,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_lock() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 
@@ -1080,6 +1101,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_execute() {
         const RV32_NO_OP: u32 = 0x00000013;
         let mut cpu = new_pmp_cpu(RV32_NO_OP);
@@ -1134,6 +1156,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_smepmp_mmwp() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 
@@ -1191,6 +1214,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_smepmp_mml() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
         let reset_cpu = |cpu: &mut Cpu<DynamicBus>| {
@@ -1563,6 +1587,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "1.x"))]
     fn test_pmp_mprv() {
         let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
 

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::csr_file::{Csr, CsrFile};
 use crate::instr::Instr;
-use crate::types::{RvInstr, RvMEIHAP, RvMStatus};
+use crate::types::{RvInstr, RvMEIHAP, RvMStatus, RvMemAccessType, RvMsecCfg, RvPrivMode};
 use crate::xreg_file::{XReg, XRegFile};
 use bit_vec::BitVec;
 use caliptra_emu_bus::{Bus, BusError, Clock, TimerAction};
@@ -152,6 +152,9 @@ pub struct Cpu<TBus: Bus> {
 
     pub clock: Clock,
 
+    /// Current privilege mode
+    pub priv_mode: RvPrivMode,
+
     // Track if Execution is in progress
     pub(crate) is_execute_instr: bool,
 
@@ -187,6 +190,7 @@ impl<TBus: Bus> Cpu<TBus> {
             next_pc: Self::PC_RESET_VAL,
             bus,
             clock,
+            priv_mode: RvPrivMode::M,
             is_execute_instr: false,
             watch_ptr_cfg: WatchPtrCfg::new(),
             nmivec: 0,
@@ -265,7 +269,7 @@ impl<TBus: Bus> Cpu<TBus> {
         self.xregs.write(reg, val)
     }
 
-    /// Read the specified configuration status register
+    /// Read the specified configuration status register with the current privilege mode
     ///
     /// # Arguments
     ///
@@ -279,10 +283,27 @@ impl<TBus: Bus> Cpu<TBus> {
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
     pub fn read_csr(&self, csr: RvAddr) -> Result<RvData, RvException> {
-        self.csrs.read(csr)
+        self.csrs.read(self.priv_mode, csr)
     }
 
-    /// Write the specified Configuration status register
+    /// Read the specified configuration status register as if we were in M mode
+    ///
+    /// # Arguments
+    ///
+    /// * `csr` - Configuration status register to read
+    ///
+    ///  # Return
+    ///
+    ///  * `RvData` - Register value
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    pub fn read_csr_machine(&self, csr: RvAddr) -> Result<RvData, RvException> {
+        self.csrs.read(RvPrivMode::M, csr)
+    }
+
+    /// Write the specified Configuration status register with the current privilege mode
     ///
     /// # Arguments
     ///
@@ -293,7 +314,21 @@ impl<TBus: Bus> Cpu<TBus> {
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
     pub fn write_csr(&mut self, csr: RvAddr, val: RvData) -> Result<(), RvException> {
-        self.csrs.write(csr, val)
+        self.csrs.write(self.priv_mode, csr, val)
+    }
+
+    /// Write the specified Configuration status register as if we were in M mode
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - Configuration  status register to write
+    /// * `val` - Value to write
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    pub fn write_csr_machine(&mut self, csr: RvAddr, val: RvData) -> Result<(), RvException> {
+        self.csrs.write(RvPrivMode::M, csr, val)
     }
 
     /// Read from bus
@@ -318,6 +353,8 @@ impl<TBus: Bus> Cpu<TBus> {
                 false => None,
             }
         }
+
+        self.check_mem_priv(addr, size, RvMemAccessType::Read)?;
 
         match self.bus.read(size, addr) {
             Ok(val) => Ok(val),
@@ -359,6 +396,9 @@ impl<TBus: Bus> Cpu<TBus> {
                 false => None,
             }
         }
+
+        self.check_mem_priv(addr, size, RvMemAccessType::Write)?;
+
         match self.bus.write(size, addr, val) {
             Ok(val) => Ok(val),
             Err(exception) => match exception {
@@ -383,6 +423,8 @@ impl<TBus: Bus> Cpu<TBus> {
     /// * `RvException` - Exception with cause `RvExceptionCause::LoadAccessFault`
     ///                   or `RvExceptionCause::LoadAddrMisaligned`
     pub fn read_instr(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, RvException> {
+        self.check_mem_priv(addr, size, RvMemAccessType::Execute)?;
+
         match size {
             RvSize::Byte => Err(RvException::instr_access_fault(addr)),
             _ => match self.bus.read(size, addr) {
@@ -396,6 +438,14 @@ impl<TBus: Bus> Cpu<TBus> {
                 },
             },
         }
+    }
+
+    /// Perform a reset of the CPU
+    pub fn do_reset(&mut self) {
+        self.halted = false;
+        self.priv_mode = RvPrivMode::M;
+        self.csrs.reset();
+        self.reset_pc();
     }
 
     pub fn warm_reset(&mut self) {
@@ -488,22 +538,35 @@ impl<TBus: Bus> Cpu<TBus> {
         info: u32,
         next_pc: u32,
     ) -> Result<(), RvException> {
-        self.write_csr(Csr::MEPC, pc)?;
-        self.write_csr(Csr::MCAUSE, cause)?;
-        self.write_csr(Csr::MTVAL, info)?;
+        self.write_csr_machine(Csr::MEPC, pc)?;
+        self.write_csr_machine(Csr::MCAUSE, cause)?;
+        self.write_csr_machine(Csr::MTVAL, info)?;
 
-        let mut status = RvMStatus(self.read_csr(Csr::MSTATUS)?);
+        let mut status = RvMStatus(self.read_csr_machine(Csr::MSTATUS)?);
+
+        match self.priv_mode {
+            RvPrivMode::U => {
+                // All traps are handled in M mode
+                self.priv_mode = RvPrivMode::M;
+                status.set_mpp(RvPrivMode::U);
+            }
+            RvPrivMode::M => {
+                status.set_mpp(RvPrivMode::M);
+            }
+            _ => unreachable!(),
+        }
+
         status.set_mpie(status.mie());
         status.set_mie(0);
-        self.write_csr(Csr::MSTATUS, status.0)?;
+        self.write_csr_machine(Csr::MSTATUS, status.0)?;
         // Don't rely on write_csr to disable global interrupts as the scheduled action could be
         // after a next interrupt
         self.global_int_en = false;
 
         self.write_pc(next_pc);
         println!(
-            "handle_trap: cause={:x}, mtval={:x}, next_pc={:x}",
-            cause, info, next_pc
+            "handle_trap: cause={:x}, mtval={:x}, pc={:x}, next_pc={:x}",
+            cause, info, pc, next_pc
         );
         Ok(())
     }
@@ -524,10 +587,9 @@ impl<TBus: Bus> Cpu<TBus> {
         let next_pc_ptr = vec_table + REDIRECT_ENTRY_SIZE * u32::from(irq);
         let mut meihap = RvMEIHAP(vec_table);
         meihap.set_claimid(irq.into());
-        match self.write_csr(Csr::MEIHAP, meihap.0) {
-            Ok(_) => (),
-            Err(_) => return StepAction::Fatal,
-        };
+        if self.write_csr_machine(Csr::MEIHAP, meihap.0).is_err() {
+            return StepAction::Fatal;
+        }
         let Ok(next_pc) = self.read_bus(RvSize::Word, next_pc_ptr) else { return StepAction::Fatal; };
         const MACHINE_EXTERNAL_INT: u32 = 0x8000_000B;
         let ret = self.handle_trap(self.read_pc(), MACHINE_EXTERNAL_INT, 0, next_pc);
@@ -560,12 +622,130 @@ impl<TBus: Bus> Cpu<TBus> {
     pub fn get_watchptr_hit(&self) -> Option<&WatchPtrHit> {
         self.watch_ptr_cfg.hit.as_ref()
     }
+
+    /// Check memory privileges of given address
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - Address to check
+    /// * `size` - Size of region
+    /// * `access` - Access type to check
+    ///
+    /// # Return
+    ///
+    /// * `RvException` - Exception with cause `RvException::LoadAccessFault`,
+    ///   `RvException::store_access_fault`, or `RvException::instr_access_fault`.
+    pub fn check_mem_priv(
+        &self,
+        addr: RvAddr,
+        size: RvSize,
+        access: RvMemAccessType,
+    ) -> Result<(), RvException> {
+        self.check_mem_priv_addr(addr, access)?;
+        if size == RvSize::Word && addr & 0x3 != 0 {
+            // If unaligned, check permissions of intermediate addresses
+            for i in 1..RvSize::Word.into() {
+                self.check_mem_priv_addr(addr + i as u32, access)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Check memory privileges of given address
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - Address to check
+    /// * `access` - Access type to check
+    ///
+    /// # Return
+    ///
+    /// * `RvException` - Exception with cause `RvException::LoadAccessFault`,
+    ///   `RvException::store_access_fault`, or `RvException::instr_access_fault`.
+    fn check_mem_priv_addr(
+        &self,
+        addr: RvAddr,
+        access: RvMemAccessType,
+    ) -> Result<(), RvException> {
+        let fault = || match access {
+            RvMemAccessType::Read => RvException::load_access_fault(addr),
+            RvMemAccessType::Write => RvException::store_access_fault(addr),
+            RvMemAccessType::Execute => RvException::instr_access_fault(addr),
+            _ => unreachable!(),
+        };
+
+        let mstatus = RvMStatus(self.read_csr_machine(Csr::MSTATUS)?);
+        let priv_mode = if mstatus.mprv() != 0
+            && (access == RvMemAccessType::Read || access == RvMemAccessType::Write)
+        {
+            mstatus.mpp()
+        } else {
+            self.priv_mode
+        };
+
+        let mseccfg = RvMsecCfg(self.read_csr_machine(Csr::MSECCFG)?);
+
+        if let Some(pmpicfg) = self.csrs.pmp_match_addr(addr)? {
+            if mseccfg.mml() != 0 {
+                // Perform enhanced privilege check
+                let check_mask = (pmpicfg.execute() & 0x1)
+                    | ((pmpicfg.write() & 0x1) << 1)
+                    | ((pmpicfg.read() & 0x1) << 2)
+                    | ((pmpicfg.lock() & 0x1) << 3);
+
+                // This matches the spec truth table
+                let allowed_mask = match priv_mode {
+                    RvPrivMode::M => match check_mask {
+                        0 | 1 | 4..=8 => 0,
+                        2 | 3 | 14 => RvMemAccessType::Read as u8 | RvMemAccessType::Write as u8,
+                        9 | 10 => RvMemAccessType::Execute as u8,
+                        11 | 13 => RvMemAccessType::Read as u8 | RvMemAccessType::Execute as u8,
+                        12 | 15 => RvMemAccessType::Read as u8,
+                        _ => unreachable!(),
+                    },
+                    RvPrivMode::U => match check_mask {
+                        0 | 8 | 9 | 12..=14 => 0,
+                        1 | 10 | 11 => RvMemAccessType::Execute as u8,
+                        2 | 4 | 15 => RvMemAccessType::Read as u8,
+                        3 | 6 => RvMemAccessType::Read as u8 | RvMemAccessType::Write as u8,
+                        5 => RvMemAccessType::Read as u8 | RvMemAccessType::Execute as u8,
+                        7 => {
+                            RvMemAccessType::Read as u8
+                                | RvMemAccessType::Write as u8
+                                | RvMemAccessType::Execute as u8
+                        }
+                        _ => unreachable!(),
+                    },
+                    _ => unreachable!(),
+                };
+
+                if (access as u8 & allowed_mask) != access as u8 {
+                    return Err(fault());
+                }
+            } else {
+                let check_bit = match access {
+                    RvMemAccessType::Read => pmpicfg.read(),
+                    RvMemAccessType::Write => pmpicfg.write(),
+                    RvMemAccessType::Execute => pmpicfg.execute(),
+                    _ => unreachable!(),
+                };
+
+                if check_bit == 0 && (priv_mode != RvPrivMode::M || pmpicfg.lock() != 0) {
+                    return Err(fault());
+                }
+            }
+        } else if priv_mode == RvPrivMode::M && mseccfg.mmwp() != 0 {
+            return Err(fault());
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use caliptra_emu_bus::{testing::FakeBus, DynamicBus, Rom, Timer};
+    use caliptra_emu_bus::{testing::FakeBus, DynamicBus, Ram, Rom, Timer};
 
     #[test]
     fn test_new() {
@@ -587,6 +767,846 @@ mod tests {
             assert_eq!(cpu.write_xreg(reg.into(), 0xFF).ok(), Some(()));
             assert_eq!(cpu.read_xreg(reg.into()).ok(), Some(0xFF));
         }
+    }
+
+    fn new_pmp_cpu(fill_val: u32) -> Cpu<DynamicBus> {
+        let clock = Clock::new();
+        let mut bus = DynamicBus::new();
+
+        let ram = Ram::new(
+            std::iter::repeat(fill_val)
+                .take(128)
+                .flat_map(u32::to_le_bytes)
+                .collect(),
+        );
+        bus.attach_dev("RAM", 0..=0x200, Box::new(ram)).unwrap();
+
+        Cpu::new(bus, clock)
+    }
+
+    #[test]
+    fn test_pmp_napot() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0010 >> 2)
+            .unwrap();
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0019)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x1111_1111).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x1111_1111).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0018, 0x1111_1111).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0018).ok(),
+            Some(0x1111_1111),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x2222_2222).err(),
+            Some(RvException::store_access_fault(0x0000_0010)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x2222_2222).err(),
+            Some(RvException::store_access_fault(0x0000_0014)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0018, 0x2222_2222).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0018).ok(),
+            Some(0x2222_2222),
+        );
+    }
+
+    #[test]
+    fn test_pmp_na4() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0010 >> 2)
+            .unwrap();
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0011)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x1111_1111).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x1111_1111).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x1111_1111),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x2222_2222).err(),
+            Some(RvException::store_access_fault(0x0000_0010)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x2222_2222).ok(),
+            Some(())
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x2222_2222),
+        );
+    }
+
+    #[test]
+    fn test_pmp_tor() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0010 >> 2)
+            .unwrap();
+        cpu.write_csr_machine(Csr::PMPADDR_START + 1, 0x0000_0020 >> 2)
+            .unwrap();
+        cpu.write_csr_machine(Csr::PMPADDR_START + 2, 0x0000_0040 >> 2)
+            .unwrap();
+
+        // Test TOR at PMP0CFG and PMP2CFG
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0009_0009)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0x1111_1111).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_000C, 0x1111_1111).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x1111_1111).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_000C).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+
+        // TOR PMP2CFG tests
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0020, 0x2222_2222).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_003C, 0x2222_2222).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0040, 0x2222_2222).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0020).ok(),
+            Some(0x2222_2222),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_003C).ok(),
+            Some(0x2222_2222),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0040).ok(),
+            Some(0x2222_2222),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        // TOR PMP0CFG tests
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0x3333_3333).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_000C, 0x3333_3333).err(),
+            Some(RvException::store_access_fault(0x0000_000C)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x3333_3333).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_000C).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x3333_3333),
+        );
+
+        // TOR PMP2CFG tests
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0020, 0x4444_4444).err(),
+            Some(RvException::store_access_fault(0x0000_0020)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_003C, 0x4444_4444).err(),
+            Some(RvException::store_access_fault(0x0000_003C)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0040, 0x4444_4444).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0020).ok(),
+            Some(0x2222_2222),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_003C).ok(),
+            Some(0x2222_2222),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0040).ok(),
+            Some(0x4444_4444),
+        );
+    }
+
+    #[test]
+    fn test_pmp_lock() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0010 >> 2)
+            .unwrap();
+
+        // NA4 mode, locked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0091)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x1111_1111).err(),
+            Some(RvException::store_access_fault(0x0000_0010)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x1111_1111).ok(),
+            Some(()),
+        );
+
+        assert_ne!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x1111_1111),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x1111_1111),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0010, 0x2222_2222).err(),
+            Some(RvException::store_access_fault(0x0000_0010)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0014, 0x2222_2222).ok(),
+            Some(())
+        );
+
+        assert_ne!(
+            cpu.read_bus(RvSize::Word, 0x0000_0010).ok(),
+            Some(0x2222_2222),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0014).ok(),
+            Some(0x2222_2222),
+        );
+    }
+
+    #[test]
+    fn test_pmp_execute() {
+        const RV32_NO_OP: u32 = 0x00000013;
+        let mut cpu = new_pmp_cpu(RV32_NO_OP);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0000)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        // NA4 mode, execute bit set, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0015)
+            .unwrap();
+
+        cpu.reset_pc();
+        assert_eq!(cpu.exec_instr(None).ok(), Some(StepAction::Continue));
+
+        // NA4 mode, execute bit unset, unlocked (should be ok in M mode)
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0011)
+            .unwrap();
+
+        cpu.reset_pc();
+        assert_eq!(cpu.exec_instr(None).ok(), Some(StepAction::Continue));
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        // NA4 mode, execute bit set, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0015)
+            .unwrap();
+
+        cpu.reset_pc();
+        assert_eq!(cpu.exec_instr(None).ok(), Some(StepAction::Continue));
+
+        // NA4 mode, execute bit unset, unlocked (should fail in U mode)
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0011)
+            .unwrap();
+        cpu.reset_pc();
+        assert_eq!(
+            cpu.exec_instr(None).err(),
+            Some(RvException::instr_access_fault(0x0000_0000))
+        );
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        // NA4 mode, execute bit unset, locked (should be enforced even in M mode)
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0091)
+            .unwrap();
+        cpu.reset_pc();
+        assert_eq!(
+            cpu.exec_instr(None).err(),
+            Some(RvException::instr_access_fault(0x0000_0000))
+        );
+    }
+
+    #[test]
+    fn test_smepmp_mmwp() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        // Set MMWP mode
+        cpu.write_csr_machine(Csr::MSECCFG, 0x0000_0002).unwrap();
+
+        assert_eq!(cpu.read_csr_machine(Csr::MSECCFG).ok(), Some(0x0000_0002));
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0000)
+            .unwrap();
+
+        // NA4 mode, read/write set, execute bit unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0013)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0004, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0004)),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0004).err(),
+            Some(RvException::load_access_fault(0x0000_0004)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0x0000_0000).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0004, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0x0000_0000),
+        );
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0004).ok(),
+            Some(0xFFFF_FFFF),
+        );
+    }
+
+    #[test]
+    fn test_smepmp_mml() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+        let reset_cpu = |cpu: &mut Cpu<DynamicBus>| {
+            cpu.do_reset();
+
+            // Clear memory
+            cpu.priv_mode = RvPrivMode::M;
+            for i in (0..0x200).step_by(4) {
+                cpu.write_bus(RvSize::Word, i, 0xDEAD_BEEF).unwrap();
+            }
+
+            // Set MML mode
+            cpu.write_csr_machine(Csr::MSECCFG, 0x0000_0001).unwrap();
+            cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0000)
+                .unwrap();
+        };
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, r/w/x unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0010)
+            .unwrap();
+
+        cpu.priv_mode = RvPrivMode::M;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        // NA4 mode, r/w/x unset, locked
+        reset_cpu(&mut cpu);
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0090)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, r set, w/x unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0011)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, w set, r/x unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0012)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, w set, r/x unset, locked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0092)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, x set, r/w unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0014)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, x set, r/w unset, locked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0094)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, r/w/x set, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0017)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, r/w/x set, locked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0097)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, w/x set, r unset, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0016)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::instr_access_fault(0x0000_0000)),
+        );
+
+        reset_cpu(&mut cpu);
+        // NA4 mode, w/x set, r unset, locked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0096)
+            .unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+
+        cpu.priv_mode = RvPrivMode::U;
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+    }
+
+    #[test]
+    fn test_pmp_mprv() {
+        let mut cpu = new_pmp_cpu(0xDEAD_BEEF);
+
+        cpu.write_csr_machine(Csr::PMPADDR_START, 0x0000_0000)
+            .unwrap();
+
+        // NA4 mode, execute only, unlocked
+        cpu.write_csr_machine(Csr::PMPCFG_START, 0x0000_0014)
+            .unwrap();
+
+        // Set MPRV bit and MPP to M
+        let mut mstatus = RvMStatus(cpu.read_csr_machine(Csr::MSTATUS).unwrap());
+        mstatus.set_mprv(1);
+        mstatus.set_mpp(RvPrivMode::M);
+        cpu.write_csr_machine(Csr::MSTATUS, mstatus.0).unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xDEAD_BEEF),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).ok(),
+            Some(()),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
+
+        mstatus.set_mpp(RvPrivMode::U);
+        cpu.write_csr_machine(Csr::MSTATUS, mstatus.0).unwrap();
+
+        assert_eq!(
+            cpu.read_bus(RvSize::Word, 0x0000_0000).err(),
+            Some(RvException::load_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.write_bus(RvSize::Word, 0x0000_0000, 0xFFFF_FFFF).err(),
+            Some(RvException::store_access_fault(0x0000_0000)),
+        );
+        assert_eq!(
+            cpu.read_instr(RvSize::Word, 0x0000_0000).ok(),
+            Some(0xFFFF_FFFF),
+        );
     }
 
     #[test]

--- a/sw-emulator/lib/cpu/src/csr_file.rs
+++ b/sw-emulator/lib/cpu/src/csr_file.rs
@@ -13,7 +13,6 @@ Abstract:
 --*/
 
 use crate::types::{RvMIE, RvMPMC, RvMStatus, RvPrivMode};
-#[cfg(not(feature = "1.x"))]
 use crate::types::{RvPmpAddrMode, RvPmpCfgi, RvPmpiCfg};
 use caliptra_emu_bus::{Clock, Timer, TimerAction};
 use caliptra_emu_types::{RvAddr, RvData, RvException};
@@ -73,19 +72,14 @@ impl Csr {
     pub const MEIHAP: RvAddr = 0xFC8;
 
     /// PMP configuration register range start, inclusive
-    #[cfg(not(feature = "1.x"))]
     pub const PMPCFG_START: RvAddr = 0x3A0;
     /// PMP configuration register range end, inclusive
-    #[cfg(not(feature = "1.x"))]
     pub const PMPCFG_END: RvAddr = 0x3A3;
     /// PMP address register range start, inclusive
-    #[cfg(not(feature = "1.x"))]
     pub const PMPADDR_START: RvAddr = 0x3B0;
     /// PMP address register range end, inclusive
-    #[cfg(not(feature = "1.x"))]
     pub const PMPADDR_END: RvAddr = 0x3C0;
     /// Number of PMP address/cfg registers
-    #[cfg(not(feature = "1.x"))]
     pub const PMPCOUNT: usize = 16;
 
     /// Create a new Configurations and Status register
@@ -179,8 +173,9 @@ pub struct CsrFile {
     /// Timer
     timer: Timer,
     /// Maximum set PMPCFGi register
-    #[cfg(not(feature = "1.x"))]
     max_pmpcfgi: Option<usize>,
+    /// True if Physical Memory Protection is enabled.
+    pmp_enabled: bool,
 }
 
 /// Initalise a CSR read/write function in the CSR table
@@ -213,7 +208,7 @@ macro_rules! csr_fn_block {
 
 /// Initalise the default value and mask of a CSR
 macro_rules! csr_val {
-    ($csrs:ident, $index:expr, $default_val:literal, $mask:literal) => {
+    ($csrs:ident, $index:expr, $default_val:expr, $mask:expr) => {
         $csrs[($index) as usize] = Csr::new($default_val, $mask);
     };
 }
@@ -260,7 +255,6 @@ impl CsrFile {
             CsrFile::system_read,
             CsrFile::meivt_write
         );
-        #[cfg(not(feature = "1.x"))]
         csr_fn_block!(
             table,
             Csr::PMPCFG_START,
@@ -268,7 +262,6 @@ impl CsrFile {
             CsrFile::system_read,
             CsrFile::pmpcfg_write
         );
-        #[cfg(not(feature = "1.x"))]
         csr_fn_block!(
             table,
             Csr::PMPADDR_START,
@@ -280,20 +273,21 @@ impl CsrFile {
     };
 
     /// Create a new Configuration and status register file
-    pub fn new(clock: &Clock) -> Self {
+    pub fn new(clock: &Clock, pmp_enabled: bool) -> Self {
         let mut csrs = Box::new([Csr::default(); CsrFile::CSR_COUNT]);
-        #[cfg(not(feature = "1.x"))]
-        csr_val!(csrs, Csr::MISA, 0x4010_1104, 0x0000_0000);
-        #[cfg(feature = "1.x")]
-        csr_val!(csrs, Csr::MISA, 0x4000_1104, 0x0000_0000);
+        let isa = 0x4000_1104;
+        let isa = if pmp_enabled { isa | 0x0010_0000 } else { isa };
+        csr_val!(csrs, Csr::MISA, isa, 0x0000_0000);
         csr_val!(csrs, Csr::MVENDORID, 0x0000_0045, 0x0000_0000);
         csr_val!(csrs, Csr::MARCHID, 0x0000_0010, 0x0000_0000);
         csr_val!(csrs, Csr::MIMPIID, 0x0000_0004, 0x0000_0000);
         csr_val!(csrs, Csr::MHARTID, 0x0000_0000, 0x0000_0000);
-        #[cfg(not(feature = "1.x"))]
-        csr_val!(csrs, Csr::MSTATUS, 0x1800_1800, 0x0002_1888);
-        #[cfg(feature = "1.x")]
-        csr_val!(csrs, Csr::MSTATUS, 0x1800_0000, 0x0000_0088);
+        let (mstatus, mstatus_mask) = if pmp_enabled {
+            (0x1800_1800, 0x0002_1888)
+        } else {
+            (0x1800_0000, 0x0000_0088)
+        };
+        csr_val!(csrs, Csr::MSTATUS, mstatus, mstatus_mask);
         csr_val!(csrs, Csr::MIE, 0x0000_0000, 0x7000_0888);
         csr_val!(csrs, Csr::MTVEC, 0x0000_0000, 0xFFFF_FFFF);
         csr_val!(csrs, Csr::MCOUNTINHIBIT, 0x0000_0000, 0x0000_007D);
@@ -311,28 +305,28 @@ impl CsrFile {
         csr_val!(csrs, Csr::MEIVT, 0x0000_0000, 0xFFFF_FC00);
         csr_val!(csrs, Csr::MEIHAP, 0x0000_0000, 0xFFFF_FFFC);
 
-        #[cfg(not(feature = "1.x"))]
-        csr_val_block!(
-            csrs,
-            Csr::PMPCFG_START,
-            Csr::PMPCFG_END,
-            0x0000_0000,
-            0x9F9F_9F9F
-        );
-        #[cfg(not(feature = "1.x"))]
-        csr_val_block!(
-            csrs,
-            Csr::PMPADDR_START,
-            Csr::PMPADDR_END,
-            0x0000_0000,
-            0x3FFF_FFFF
-        );
+        if pmp_enabled {
+            csr_val_block!(
+                csrs,
+                Csr::PMPCFG_START,
+                Csr::PMPCFG_END,
+                0x0000_0000,
+                0x9F9F_9F9F
+            );
+            csr_val_block!(
+                csrs,
+                Csr::PMPADDR_START,
+                Csr::PMPADDR_END,
+                0x0000_0000,
+                0x3FFF_FFFF
+            );
+        }
 
         Self {
             csrs,
             timer: Timer::new(clock),
-            #[cfg(not(feature = "1.x"))]
             max_pmpcfgi: None,
+            pmp_enabled,
         }
     }
 
@@ -341,10 +335,7 @@ impl CsrFile {
         for csr in self.csrs.iter_mut() {
             csr.reset();
         }
-        #[cfg(not(feature = "1.x"))]
-        {
-            self.max_pmpcfgi = None;
-        }
+        self.max_pmpcfgi = None;
     }
 
     /// Read the specified configuration status register
@@ -410,7 +401,17 @@ impl CsrFile {
         if priv_mode == RvPrivMode::U {
             return Err(RvException::illegal_register());
         }
-
+        if !self.pmp_enabled {
+            match addr {
+                Csr::PMPCFG_START..=Csr::PMPCFG_END => {
+                    return Err(RvException::illegal_register());
+                }
+                Csr::PMPADDR_START..=Csr::PMPADDR_END => {
+                    return Err(RvException::illegal_register());
+                }
+                _ => {}
+            }
+        }
         self.any_read(priv_mode, addr)
     }
 
@@ -450,8 +451,7 @@ impl CsrFile {
         val: RvData,
     ) -> Result<(), RvException> {
         // Write new mstatus value
-        #[cfg(not(feature = "1.x"))]
-        {
+        if self.pmp_enabled {
             let csr = self.csrs[addr as usize];
             let mstatus_old = RvMStatus(csr.val);
             let mut mstatus_new = RvMStatus(val);
@@ -460,9 +460,7 @@ impl CsrFile {
                 mstatus_new.set_mpp(mstatus_old.mpp());
             }
             self.system_write(priv_mode, addr, mstatus_new.0)?;
-        }
-        #[cfg(feature = "1.x")]
-        {
+        } else {
             let mstatus_new = RvMStatus(val);
             self.system_write(priv_mode, addr, mstatus_new.0)?;
         }
@@ -543,13 +541,15 @@ impl CsrFile {
     }
 
     /// Perform a write to a PMPCFG CSR
-    #[cfg(not(feature = "1.x"))]
     fn pmpcfg_write(
         &mut self,
         priv_mode: RvPrivMode,
         addr: RvAddr,
         val: RvData,
     ) -> Result<(), RvException> {
+        if !self.pmp_enabled {
+            return Err(RvException::illegal_register());
+        }
         if priv_mode != RvPrivMode::M {
             return Err(RvException::illegal_register());
         }
@@ -618,13 +618,15 @@ impl CsrFile {
     }
 
     /// Perform a write to a PMPADDR register
-    #[cfg(not(feature = "1.x"))]
     fn pmpaddr_write(
         &mut self,
         priv_mode: RvPrivMode,
         addr: RvAddr,
         val: RvData,
     ) -> Result<(), RvException> {
+        if !self.pmp_enabled {
+            return Err(RvException::illegal_register());
+        }
         if priv_mode != RvPrivMode::M {
             return Err(RvException::illegal_register());
         }
@@ -659,8 +661,10 @@ impl CsrFile {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
-    #[cfg(not(feature = "1.x"))]
     fn read_pmpicfg(&self, reg: usize) -> Result<RvPmpiCfg, RvException> {
+        if !self.pmp_enabled {
+            return Err(RvException::illegal_register());
+        }
         // Find corresponding pmpcfg register
         let pmpcfgi_index = (reg / 4) as RvAddr + Csr::PMPCFG_START;
         let pmpcfg_offset = reg % 4;
@@ -693,13 +697,15 @@ impl CsrFile {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
-    #[cfg(not(feature = "1.x"))]
     fn pmp_match_one_addr(
         &self,
         pmpicfg: RvPmpiCfg,
         index: usize,
         addr: RvAddr,
     ) -> Result<bool, RvException> {
+        if !self.pmp_enabled {
+            return Err(RvException::illegal_register());
+        }
         let addr_mode = pmpicfg.addr_mode();
         if addr_mode == RvPmpAddrMode::Off {
             // No need for additional checks
@@ -754,8 +760,10 @@ impl CsrFile {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
-    #[cfg(not(feature = "1.x"))]
     pub fn pmp_match_addr(&self, addr: RvAddr) -> Result<Option<RvPmpiCfg>, RvException> {
+        if !self.pmp_enabled {
+            return Err(RvException::illegal_register());
+        }
         let max_pmpcfgi = match self.max_pmpcfgi {
             // Optimisation: ignore PMP if no registers are set
             None => return Ok(None),
@@ -794,7 +802,7 @@ mod tests {
     #[test]
     fn test_u_mode_read_m_mode_csr() {
         let clock = Clock::new();
-        let csrs = CsrFile::new(&clock);
+        let csrs = CsrFile::new(&clock, true);
 
         assert_eq!(
             csrs.read(RvPrivMode::U, Csr::MSTATUS).err(),
@@ -809,7 +817,7 @@ mod tests {
     #[test]
     fn test_u_mode_write_m_mode_csr() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
         assert_eq!(
             csrs.write(RvPrivMode::U, Csr::MSTATUS, 0xFFFF_FFFF).err(),
@@ -822,10 +830,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "1.x"))]
     fn test_u_mode_read_write_pmp() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
         assert_eq!(
             csrs.write(RvPrivMode::U, Csr::PMPCFG_START, 0xFFFF_FFFF)
@@ -885,10 +892,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "1.x"))]
     fn test_m_mode_read_write_pmp() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x1717_1717)
@@ -934,7 +940,7 @@ mod tests {
     #[cfg(not(feature = "1.x"))]
     fn test_lock_pmp() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
         // Lock PMPADDR1, but not PMPADDR0, 2, or 3.
         assert_eq!(
@@ -1034,7 +1040,7 @@ mod tests {
     #[cfg(not(feature = "1.x"))]
     fn test_pmp_tor_lock() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
         // Set PMP2CFG to TOR and lock
         assert_eq!(
@@ -1087,25 +1093,21 @@ mod tests {
 
     #[test]
     fn test_read_only_csr() {
-        #[cfg(feature = "1.x")]
-        const KNOWN_VALUE: u32 = 0x4000_1104;
-        #[cfg(not(feature = "1.x"))]
-        const KNOWN_VALUE: u32 = 0x4010_1104;
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
 
-        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(KNOWN_VALUE));
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(0x4010_1104));
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MISA, u32::MAX).ok(),
             Some(())
         );
-        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(KNOWN_VALUE));
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(0x4010_1104));
     }
 
     #[test]
     fn test_read_write_csr() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
         assert_eq!(csrs.read(RvPrivMode::M, Csr::MEPC).ok(), Some(0));
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MEPC, u32::MAX).ok(),
@@ -1117,7 +1119,7 @@ mod tests {
     #[test]
     fn test_mseccfg_csr_sticky() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MSECCFG, 0xFFFF_FFFF).ok(),
             Some(())
@@ -1137,10 +1139,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "1.x"))]
     fn test_mstatus_invalid_mpp() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
+        let mut csrs = CsrFile::new(&clock, true);
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MSTATUS, 0x0000_1800).ok(),
             Some(())
@@ -1170,20 +1171,11 @@ mod tests {
     #[test]
     fn test_read_write_masked_csr() {
         let clock = Clock::new();
-        let mut csrs = CsrFile::new(&clock);
-
-        #[cfg(feature = "1.x")]
-        const MSTATUS_START: u32 = 0x1800_0000;
-        #[cfg(feature = "1.x")]
-        const MSTATUS_MASK: u32 = 0x1800_0088;
-        #[cfg(not(feature = "1.x"))]
-        const MSTATUS_START: u32 = 0x1800_1800;
-        #[cfg(not(feature = "1.x"))]
-        const MSTATUS_MASK: u32 = 0x1802_1888;
+        let mut csrs = CsrFile::new(&clock, true);
 
         assert_eq!(
             csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
-            Some(MSTATUS_START)
+            Some(0x1800_1800)
         );
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MSTATUS, u32::MAX).ok(),
@@ -1191,7 +1183,7 @@ mod tests {
         );
         assert_eq!(
             csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
-            Some(MSTATUS_MASK)
+            Some(0x1802_1888)
         );
 
         assert_eq!(

--- a/sw-emulator/lib/cpu/src/csr_file.rs
+++ b/sw-emulator/lib/cpu/src/csr_file.rs
@@ -12,80 +12,74 @@ Abstract:
 
 --*/
 
-use crate::types::{RvMIE, RvMPMC, RvMStatus};
+use crate::types::{RvMIE, RvMPMC, RvMStatus, RvPmpAddrMode, RvPmpCfgi, RvPmpiCfg, RvPrivMode};
 use caliptra_emu_bus::{Clock, Timer, TimerAction};
 use caliptra_emu_types::{RvAddr, RvData, RvException};
 
 /// Configuration & Status Register
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Csr {
     val: RvData,
+    default_val: RvData,
     mask: u32,
 }
 
 impl Csr {
     /// ISA CSR
     pub const MISA: RvAddr = 0x301;
-
-    /// Vendor ID CSR
-    pub const MVENDORID: RvAddr = 0xF11;
-
-    /// Architecture ID CSR
-    pub const MARCHID: RvAddr = 0xF12;
-
-    /// Implementation ID CSR
-    pub const MIMPIID: RvAddr = 0xF13;
-
-    /// HART ID CSR
-    pub const MHARTID: RvAddr = 0xF14;
-
     /// HART Status CSR
     pub const MSTATUS: RvAddr = 0x300;
-
     /// Interrupt Enable CSR
     pub const MIE: RvAddr = 0x304;
-
     /// Interrupt Vector Table Address CSR
     pub const MTVEC: RvAddr = 0x305;
-
     /// Performance Counter Inhibit register CSR
     pub const MCOUNTINHIBIT: RvAddr = 0x320;
-
     /// Scratch Register CSR
     pub const MSCRATCH: RvAddr = 0x340;
-
     /// Exception Program Counter CSR
     pub const MEPC: RvAddr = 0x341;
-
     /// Exception Cause CSR
     pub const MCAUSE: RvAddr = 0x342;
-
     /// Exception Value CSR
     pub const MTVAL: RvAddr = 0x343;
-
     /// Interrupt Pending CSR
     pub const MIP: RvAddr = 0x344;
-
+    /// Machine security configuration CSR
+    pub const MSECCFG: RvAddr = 0x747;
     /// Power management const CSR
     pub const MPMC: RvAddr = 0x7C6;
-
     /// Cycle Low Counter CSR
     pub const MCYCLE: RvAddr = 0xB00;
-
     /// Instruction Retired Low Counter CSR
     pub const MINSTRET: RvAddr = 0xB02;
-
     /// Cycle High Counter CSR
     pub const MCYCLEH: RvAddr = 0xB80;
-
     /// Instruction Retired High Counter CSR
     pub const MINSTRETH: RvAddr = 0xB82;
-
     /// External Interrupt Vector Table CSR
     pub const MEIVT: RvAddr = 0xBC8;
-
+    /// Vendor ID CSR
+    pub const MVENDORID: RvAddr = 0xF11;
+    /// Architecture ID CSR
+    pub const MARCHID: RvAddr = 0xF12;
+    /// Implementation ID CSR
+    pub const MIMPIID: RvAddr = 0xF13;
+    /// HART ID CSR
+    pub const MHARTID: RvAddr = 0xF14;
     /// External Interrupt Handler Address Pointer CSR
     pub const MEIHAP: RvAddr = 0xFC8;
+
+    /// PMP configuration register range start, inclusive
+    pub const PMPCFG_START: RvAddr = 0x3A0;
+    /// PMP configuration register range end, inclusive
+    pub const PMPCFG_END: RvAddr = 0x3A3;
+    /// PMP address register range start, inclusive
+    pub const PMPADDR_START: RvAddr = 0x3B0;
+    /// PMP address register range end, inclusive
+    pub const PMPADDR_END: RvAddr = 0x3C0;
+    /// Number of PMP address/cfg registers
+    pub const PMPCOUNT: usize = 16;
 
     /// Create a new Configurations and Status register
     ///
@@ -94,63 +88,245 @@ impl Csr {
     /// * `val` - Reset value
     /// * `mask` - Write Mask
     ///'
-    pub fn new(val: RvData, mask: RvData) -> Self {
-        Self { val, mask }
+    pub fn new(default_val: RvData, mask: RvData) -> Self {
+        Self {
+            val: default_val,
+            default_val,
+            mask,
+        }
+    }
+
+    pub fn reset(&mut self) -> &Self {
+        self.val = self.default_val;
+        self
+    }
+}
+
+type CsrReadFn = fn(&CsrFile, RvPrivMode, RvAddr) -> Result<RvData, RvException>;
+type CsrWriteFn = fn(&mut CsrFile, RvPrivMode, RvAddr, RvData) -> Result<(), RvException>;
+
+/// CSR read/write functions
+#[derive(Copy, Clone)]
+struct CsrFn {
+    /// CSR read function
+    read_fn: CsrReadFn,
+
+    /// CSR write function
+    write_fn: CsrWriteFn,
+}
+
+impl CsrFn {
+    /// Perform a CSR read
+    ///
+    /// # Arguments
+    /// * `csr_file` - CSR file
+    /// * `priv_mode` - Effective privilege mode
+    /// * `addr` - CSR address to read from
+    ///
+    /// # Return
+    ///
+    /// * `RvData` - Register value
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    pub fn read(
+        &self,
+        csr_file: &CsrFile,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+    ) -> Result<RvData, RvException> {
+        (self.read_fn)(csr_file, priv_mode, addr)
+    }
+
+    /// Perform a CSR write
+    ///
+    /// # Arguments
+    /// * `csr_file` - CSR file
+    /// * `priv_mode` - Effective privilege mode
+    /// * `addr` - CSR address to write to
+    /// * `val` - Data to write
+    ///
+    /// # Return
+    ///
+    /// * `RvData` - Register value
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    pub fn write(
+        &self,
+        csr_file: &mut CsrFile,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        (self.write_fn)(csr_file, priv_mode, addr, val)
     }
 }
 
 /// Configuration and status register file
 pub struct CsrFile {
     /// CSRS
-    csrs: [Csr; CsrFile::CSR_COUNT],
+    csrs: Box<[Csr; CsrFile::CSR_COUNT]>,
     /// Timer
     timer: Timer,
+    /// Maximum set PMPCFGi register
+    max_pmpcfgi: Option<usize>,
+}
+
+/// Initalise a CSR read/write function in the CSR table
+macro_rules! csr_fn {
+    ($csrs:ident, $index:expr, $read_fn:path, $write_fn:path) => {
+        // Because this is used in a constant expression, and write_fn is considered mutable,
+        // a constructor can't be const. Therefore, we do it manually.
+        $csrs[($index) as usize] = CsrFn {
+            read_fn: $read_fn,
+            write_fn: $write_fn,
+        };
+    };
+}
+
+/// Initialise the read/write functions of a block of CSRs in the CSR table
+macro_rules! csr_fn_block {
+    ($csrs:ident, $start:path, $end:path, $read_fn:path, $write_fn:path) => {
+        let mut i = $start;
+        // For loops aren't allowed in constant expressions; but loops are.
+        loop {
+            if i > $end {
+                break;
+            }
+            csr_fn!($csrs, i, $read_fn, $write_fn);
+            i += 1;
+        }
+    };
+}
+
+/// Initalise the default value and mask of a CSR
+macro_rules! csr_val {
+    ($csrs:ident, $index:expr, $default_val:literal, $mask:literal) => {
+        $csrs[($index) as usize] = Csr::new($default_val, $mask);
+    };
+}
+
+/// Initalise the default value and mask of a block of CSRs
+macro_rules! csr_val_block {
+    ($csrs:ident, $start:path, $end:path, $default_val:literal, $mask:literal) => {
+        for i in ($start..=$end) {
+            csr_val!($csrs, i, $default_val, $mask);
+        }
+    };
 }
 
 impl CsrFile {
     /// Supported CSR Count
     const CSR_COUNT: usize = 4096;
 
+    /// CSR function table
+    const CSR_FN: [CsrFn; CsrFile::CSR_COUNT] = {
+        let default = CsrFn {
+            read_fn: CsrFile::system_read,
+            write_fn: CsrFile::system_write,
+        };
+        let mut table = [default; CsrFile::CSR_COUNT];
+
+        csr_fn!(
+            table,
+            Csr::MSTATUS,
+            CsrFile::system_read,
+            CsrFile::mstatus_write
+        );
+        csr_fn!(table, Csr::MIE, CsrFile::system_read, CsrFile::mie_write);
+        csr_fn!(table, Csr::MPMC, CsrFile::system_read, CsrFile::mpmc_write);
+        csr_fn!(
+            table,
+            Csr::MSECCFG,
+            CsrFile::system_read,
+            CsrFile::mseccfg_write
+        );
+        csr_fn!(
+            table,
+            Csr::MEIVT,
+            CsrFile::system_read,
+            CsrFile::meivt_write
+        );
+        csr_fn_block!(
+            table,
+            Csr::PMPCFG_START,
+            Csr::PMPCFG_END,
+            CsrFile::system_read,
+            CsrFile::pmpcfg_write
+        );
+        csr_fn_block!(
+            table,
+            Csr::PMPADDR_START,
+            Csr::PMPADDR_END,
+            CsrFile::system_read,
+            CsrFile::pmpaddr_write
+        );
+        table
+    };
+
     /// Create a new Configuration and status register file
     pub fn new(clock: &Clock) -> Self {
-        let mut csrs = Self {
-            csrs: [Csr::new(0, 0); CsrFile::CSR_COUNT],
-            timer: Timer::new(clock),
-        };
+        let mut csrs = Box::new([Csr::default(); CsrFile::CSR_COUNT]);
+        csr_val!(csrs, Csr::MISA, 0x4010_1104, 0x0000_0000);
+        csr_val!(csrs, Csr::MVENDORID, 0x0000_0045, 0x0000_0000);
+        csr_val!(csrs, Csr::MARCHID, 0x0000_0010, 0x0000_0000);
+        csr_val!(csrs, Csr::MIMPIID, 0x0000_0004, 0x0000_0000);
+        csr_val!(csrs, Csr::MHARTID, 0x0000_0000, 0x0000_0000);
+        csr_val!(csrs, Csr::MSTATUS, 0x1800_1800, 0x0002_1888);
+        csr_val!(csrs, Csr::MIE, 0x0000_0000, 0x7000_0888);
+        csr_val!(csrs, Csr::MTVEC, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MCOUNTINHIBIT, 0x0000_0000, 0x0000_007D);
+        csr_val!(csrs, Csr::MSCRATCH, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MEPC, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MCAUSE, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MTVAL, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MIP, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MPMC, 0x0000_0002, 0x0000_0002);
+        csr_val!(csrs, Csr::MSECCFG, 0x0000_0000, 0x0000_0003);
+        csr_val!(csrs, Csr::MCYCLE, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MCYCLEH, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MINSTRET, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MINSTRETH, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MEIVT, 0x0000_0000, 0xFFFF_FC00);
+        csr_val!(csrs, Csr::MEIHAP, 0x0000_0000, 0xFFFF_FFFC);
+        csr_val_block!(
+            csrs,
+            Csr::PMPCFG_START,
+            Csr::PMPCFG_END,
+            0x0000_0000,
+            0x9F9F_9F9F
+        );
+        csr_val_block!(
+            csrs,
+            Csr::PMPADDR_START,
+            Csr::PMPADDR_END,
+            0x0000_0000,
+            0x3FFF_FFFF
+        );
 
-        csrs.reset();
-        csrs
+        Self {
+            csrs,
+            timer: Timer::new(clock),
+            max_pmpcfgi: None,
+        }
     }
 
     /// Reset the CSR file
-    fn reset(&mut self) {
-        self.csrs[Csr::MISA as usize] = Csr::new(0x4000_1104, 0);
-        self.csrs[Csr::MVENDORID as usize] = Csr::new(0x0000_0045, 0);
-        self.csrs[Csr::MARCHID as usize] = Csr::new(0x0000_0010, 0);
-        self.csrs[Csr::MIMPIID as usize] = Csr::new(0x0000_0004, 0);
-        self.csrs[Csr::MHARTID as usize] = Csr::new(0x0000_0000, 0);
-        self.csrs[Csr::MSTATUS as usize] = Csr::new(0x1800_0000, 0x0000_0088);
-        self.csrs[Csr::MIE as usize] = Csr::new(0x0000_0000, 0x7000_0888);
-        self.csrs[Csr::MTVEC as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MCOUNTINHIBIT as usize] = Csr::new(0x0000_0000, 0x0000_007D);
-        self.csrs[Csr::MSCRATCH as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MEPC as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MCAUSE as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MTVAL as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MIP as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MPMC as usize] = Csr::new(0x0000_0002, 0x0000_0002);
-        self.csrs[Csr::MCYCLE as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MCYCLEH as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MINSTRET as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MINSTRETH as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFF);
-        self.csrs[Csr::MEIVT as usize] = Csr::new(0x0000_0000, 0xFFFF_FC00);
-        self.csrs[Csr::MEIHAP as usize] = Csr::new(0x0000_0000, 0xFFFF_FFFC);
+    pub fn reset(&mut self) {
+        for csr in self.csrs.iter_mut() {
+            csr.reset();
+        }
+        self.max_pmpcfgi = None;
     }
 
     /// Read the specified configuration status register
     ///
     /// # Arguments
     ///
+    /// * `priv_mode` - Privilege mode
     /// * `csr` - Configuration status register to read
     ///
     ///  # Return
@@ -160,75 +336,415 @@ impl CsrFile {
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister``
-    pub fn read(&self, addr: RvAddr) -> Result<RvData, RvException> {
-        let addr = addr as usize;
+    pub fn read(&self, priv_mode: RvPrivMode, addr: RvAddr) -> Result<RvData, RvException> {
         const CSR_MAX: usize = CsrFile::CSR_COUNT - 1;
-        match addr {
-            0..=CSR_MAX => Ok(self.csrs[addr].val),
-            _ => Err(RvException::illegal_register()),
+        if addr as usize > CSR_MAX {
+            return Err(RvException::illegal_register());
         }
+        Self::CSR_FN[addr as usize].read(self, priv_mode, addr)
     }
 
     /// Write the specified Configuration status register
     ///
     /// # Arguments
     ///
+    /// * `priv_mode` - Privilege mode
     /// * `reg` - Configuration  status register to write
     /// * `val` - Value to write
     ///
     /// # Error
     ///
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
-    pub fn write(&mut self, addr: RvAddr, val: RvData) -> Result<(), RvException> {
-        let addr = addr as usize;
+    pub fn write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
         const CSR_MAX: usize = CsrFile::CSR_COUNT - 1;
-        match addr {
-            0..=CSR_MAX => {
-                let csr = &mut self.csrs[addr];
-                csr.val = (csr.val & !csr.mask) | (val & csr.mask);
+        if addr as usize > CSR_MAX {
+            return Err(RvException::illegal_register());
+        }
+        Self::CSR_FN[addr as usize].write(self, priv_mode, addr, val)
+    }
 
-                if addr == Csr::MEIVT as usize {
-                    self.timer
-                        .schedule_action_in(0, TimerAction::SetExtIntVec { addr: csr.val });
+    /// Allow all reads from the given CSR
+    fn any_read(&self, _: RvPrivMode, addr: RvAddr) -> Result<RvData, RvException> {
+        Ok(self.csrs[addr as usize].val)
+    }
+
+    /// Allow all writes to the given CSR, taking into account the mask
+    fn any_write(&mut self, _: RvPrivMode, addr: RvAddr, val: RvData) -> Result<(), RvException> {
+        let csr = &mut self.csrs[addr as usize];
+        csr.val = (csr.val & !csr.mask) | (val & csr.mask);
+        Ok(())
+    }
+
+    /// Allow only system reads from the given CSR
+    fn system_read(&self, priv_mode: RvPrivMode, addr: RvAddr) -> Result<RvData, RvException> {
+        if priv_mode == RvPrivMode::U {
+            return Err(RvException::illegal_register());
+        }
+
+        self.any_read(priv_mode, addr)
+    }
+
+    /// Allow only system writes to the given CSR
+    fn system_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        if priv_mode == RvPrivMode::U {
+            return Err(RvException::illegal_register());
+        }
+
+        self.any_write(priv_mode, addr, val)
+    }
+
+    /// Perform a write to the MEIVT CSR
+    fn meivt_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        self.system_write(priv_mode, addr, val)?;
+        let csr = self.csrs[addr as usize];
+        self.timer
+            .schedule_action_in(0, TimerAction::SetExtIntVec { addr: csr.val });
+        Ok(())
+    }
+
+    /// Perform a write to the MSTATUS CSR
+    fn mstatus_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        // Write new mstatus value
+        let csr = self.csrs[addr as usize];
+        let mstatus_old = RvMStatus(csr.val);
+        let mut mstatus_new = RvMStatus(val);
+        if mstatus_new.mpp() == RvPrivMode::Invalid {
+            // Ignore invalid write
+            mstatus_new.set_mpp(mstatus_old.mpp());
+        }
+        self.system_write(priv_mode, addr, mstatus_new.0)?;
+
+        // Read back mstatus register after masking
+        let csr = self.csrs[addr as usize];
+        let mstatus_new = RvMStatus(csr.val);
+        self.timer.schedule_action_in(
+            0,
+            TimerAction::SetGlobalIntEn {
+                en: mstatus_new.mie() == 1,
+            },
+        );
+        // Let's see if the soc wants to interrupt
+        self.timer.schedule_poll_in(2);
+        Ok(())
+    }
+
+    /// Perform a write to the MIE CSR
+    fn mie_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        self.system_write(priv_mode, addr, val)?;
+        let csr = self.csrs[addr as usize];
+        let mie = RvMIE(csr.val);
+        self.timer.schedule_action_in(
+            0,
+            TimerAction::SetExtIntEn {
+                en: mie.meie() == 1,
+            },
+        );
+        // Let's see if the soc wants to interrupt
+        self.timer.schedule_poll_in(2);
+        Ok(())
+    }
+
+    /// Perform a write to the MPMC CSR
+    fn mpmc_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        self.system_write(priv_mode, addr, val)?;
+        let csr = self.csrs[addr as usize];
+        let mpmc_write = RvMPMC(val);
+        if mpmc_write.halt() == 1 {
+            let mpcm = RvMPMC(csr.val);
+            if mpcm.haltie() == 1 {
+                let mut mstatus = RvMStatus(self.read(priv_mode, Csr::MSTATUS)?);
+                mstatus.set_mie(1);
+                self.write(priv_mode, Csr::MSTATUS, mstatus.0)?;
+            }
+            self.timer.schedule_action_in(0, TimerAction::Halt);
+        }
+        Ok(())
+    }
+
+    /// Perform a write to the MSECCFG register
+    fn mseccfg_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        if priv_mode != RvPrivMode::M {
+            return Err(RvException::illegal_register());
+        }
+
+        let csr = self.csrs[addr as usize];
+
+        // All current bits are sticky
+        let val = val | csr.val;
+        self.any_write(priv_mode, addr, val)
+    }
+
+    /// Perform a write to a PMPCFG CSR
+    fn pmpcfg_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        if priv_mode != RvPrivMode::M {
+            return Err(RvException::illegal_register());
+        }
+
+        // Locate the specific packed PMP config register
+        let mut pmpcfgi = RvPmpCfgi(self.read(priv_mode, addr)?);
+
+        // None: no change
+        // Some(true): is set
+        // Some(false): is unset
+        let mut is_set: Option<bool> = None;
+
+        // Do not write if the entry is locked
+        if pmpcfgi.r1().lock() == 0 {
+            let val = (val & 0xFF) as u8;
+            is_set = Some(val > 0);
+            pmpcfgi.set_r1(RvPmpiCfg(val));
+        }
+        if pmpcfgi.r2().lock() == 0 {
+            let val = ((val >> 8) & 0xFF) as u8;
+            if is_set.is_none() || is_set == Some(false) {
+                is_set = Some(val > 0);
+            }
+            pmpcfgi.set_r2(RvPmpiCfg(val));
+        }
+        if pmpcfgi.r3().lock() == 0 {
+            let val = ((val >> 16) & 0xFF) as u8;
+            if is_set.is_none() || is_set == Some(false) {
+                is_set = Some(val > 0);
+            }
+            pmpcfgi.set_r3(RvPmpiCfg(val));
+        }
+        if pmpcfgi.r4().lock() == 0 {
+            let val = ((val >> 24) & 0xFF) as u8;
+            if is_set.is_none() || is_set == Some(false) {
+                is_set = Some(val > 0);
+            }
+            pmpcfgi.set_r4(RvPmpiCfg(val));
+        }
+
+        let index = (addr - Csr::PMPCFG_START) as usize;
+        match is_set {
+            Some(true) => {
+                // New highest index?
+                if self.max_pmpcfgi.is_none() || self.max_pmpcfgi < Some(index) {
+                    self.max_pmpcfgi = Some(index);
                 }
-                if addr == Csr::MSTATUS as usize {
-                    let mstatus = RvMStatus(csr.val);
-                    self.timer.schedule_action_in(
-                        0,
-                        TimerAction::SetGlobalIntEn {
-                            en: mstatus.mie() == 1,
-                        },
-                    );
-                    // Let's see if the soc wants to interrupt
-                    self.timer.schedule_poll_in(2);
-                }
-                if addr == Csr::MIE as usize {
-                    let mie = RvMIE(csr.val);
-                    self.timer.schedule_action_in(
-                        0,
-                        TimerAction::SetExtIntEn {
-                            en: mie.meie() == 1,
-                        },
-                    );
-                    // Let's see if the soc wants to interrupt
-                    self.timer.schedule_poll_in(2);
-                }
-                if addr == Csr::MPMC as usize {
-                    let mpmc_write = RvMPMC(val);
-                    if mpmc_write.halt() == 1 {
-                        let mpcm = RvMPMC(csr.val);
-                        if mpcm.haltie() == 1 {
-                            let mut mstatus = RvMStatus(self.read(Csr::MSTATUS)?);
-                            mstatus.set_mie(1);
-                            self.write(Csr::MSTATUS, mstatus.0)?;
+            }
+            Some(false) => {
+                // Was this the highest index?
+                if self.max_pmpcfgi == Some(index) {
+                    // Find new highest index, or fall back to None
+                    self.max_pmpcfgi = None;
+                    for i in (0..index).rev() {
+                        if self.any_read(RvPrivMode::M, Csr::PMPCFG_START + i as RvAddr)? > 0 {
+                            self.max_pmpcfgi = Some(i);
+                            break;
                         }
-                        self.timer.schedule_action_in(0, TimerAction::Halt);
                     }
                 }
-                Ok(())
             }
-            _ => Err(RvException::illegal_register()),
+            _ => return Ok(()),
         }
+
+        self.any_write(priv_mode, addr, pmpcfgi.0)
+    }
+
+    /// Perform a write to a PMPADDR register
+    fn pmpaddr_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        if priv_mode != RvPrivMode::M {
+            return Err(RvException::illegal_register());
+        }
+
+        // Find corresponding pmpcfg register
+        let index: usize = (addr - Csr::PMPADDR_START) as usize;
+        let mut pmpicfg = self.read_pmpicfg(index)?;
+        if pmpicfg.lock() != 0 {
+            // Ignore the write
+            return Ok(());
+        }
+
+        // If pmpicfg is TOR, writes to pmpaddri-1 are ignored
+        // Therefore, check pmpi+1cfg, which corresponds to pmpaddri
+        if index < (Csr::PMPCOUNT - 1) {
+            pmpicfg = self.read_pmpicfg(index + 1)?;
+            if pmpicfg.addr_mode() == RvPmpAddrMode::Tor && pmpicfg.lock() != 0 {
+                // Ignore the write
+                return Ok(());
+            }
+        }
+
+        self.any_write(priv_mode, addr, val)
+    }
+
+    /// Read the specified PMPiCFG status register
+    ///
+    /// # Arguments
+    ///
+    /// * `reg` - PMP configuration register to read
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    fn read_pmpicfg(&self, reg: usize) -> Result<RvPmpiCfg, RvException> {
+        // Find corresponding pmpcfg register
+        let pmpcfgi_index = (reg / 4) as RvAddr + Csr::PMPCFG_START;
+        let pmpcfg_offset = reg % 4;
+        let pmpcfgi = RvPmpCfgi(self.any_read(RvPrivMode::M, pmpcfgi_index)?);
+        let result = match pmpcfg_offset {
+            0 => pmpcfgi.r1(),
+            1 => pmpcfgi.r2(),
+            2 => pmpcfgi.r3(),
+            3 => pmpcfgi.r4(),
+            _ => unreachable!(),
+        };
+        Ok(result)
+    }
+
+    /// Check if an address matches against one PMP register.
+    /// Return the first configuration register that does, or None.
+    ///
+    /// This function performs no other checks.
+    ///
+    /// # Arguments
+    ///
+    /// * `pmpicfg` - PMPiCFG register to check
+    /// * `index` - index of PMPADDR register to check
+    /// * `addr` - Address to check
+    ///
+    /// # Return
+    ///
+    /// * `true` if PMP entry matches, otherwise `false`
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    fn pmp_match_one_addr(
+        &self,
+        pmpicfg: RvPmpiCfg,
+        index: usize,
+        addr: RvAddr,
+    ) -> Result<bool, RvException> {
+        let addr_mode = pmpicfg.addr_mode();
+        if addr_mode == RvPmpAddrMode::Off {
+            // No need for additional checks
+            return Ok(false);
+        }
+
+        let pmpaddr = self.any_read(RvPrivMode::M, Csr::PMPADDR_START + index as RvAddr)?;
+        let pmpaddr_shift = pmpaddr << 2;
+        let addr_top;
+        let addr_bottom;
+
+        match addr_mode {
+            RvPmpAddrMode::Tor => {
+                // Bottom address is 0 if this register is 0
+                // otherwise it's the previous one
+                addr_top = pmpaddr_shift;
+                addr_bottom = if index > 0 {
+                    self.any_read(RvPrivMode::M, Csr::PMPADDR_START + (index - 1) as RvAddr)? << 2
+                } else {
+                    0
+                };
+            }
+            RvPmpAddrMode::Na4 => {
+                // Four-byte range
+                addr_top = pmpaddr_shift + 4;
+                addr_bottom = pmpaddr_shift;
+            }
+            RvPmpAddrMode::Napot => {
+                // Range from 8..32
+                addr_top = pmpaddr_shift + (1 << (pmpaddr.trailing_ones() + 3));
+                addr_bottom = pmpaddr_shift;
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(addr >= addr_bottom && addr < addr_top)
+    }
+
+    /// Check if an address matches against the PMP registers.
+    /// Return the first configuration register that does, or None.
+    ///
+    /// This function performs no other checks.
+    ///
+    /// # Arguments
+    ///
+    /// * `addr` - Address to check
+    ///
+    /// # Return
+    ///
+    /// * `RvPmpCfg` - Configuration value
+    ///
+    /// # Error
+    ///
+    /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
+    pub fn pmp_match_addr(&self, addr: RvAddr) -> Result<Option<RvPmpiCfg>, RvException> {
+        let max_pmpcfgi = match self.max_pmpcfgi {
+            // Optimisation: ignore PMP if no registers are set
+            None => return Ok(None),
+            Some(val) => val,
+        };
+
+        for i in 0..=max_pmpcfgi {
+            let pmpcfgi = RvPmpCfgi(self.any_read(RvPrivMode::M, Csr::PMPCFG_START + i as RvAddr)?);
+
+            let pmpicfg_1 = pmpcfgi.r1();
+            let pmpicfg_2 = pmpcfgi.r2();
+            let pmpicfg_3 = pmpcfgi.r3();
+            let pmpicfg_4 = pmpcfgi.r4();
+
+            // Check packed registers
+            if self.pmp_match_one_addr(pmpicfg_1, i * 4, addr)? {
+                return Ok(Some(pmpicfg_1));
+            } else if self.pmp_match_one_addr(pmpicfg_2, (i * 4) + 1, addr)? {
+                return Ok(Some(pmpicfg_2));
+            } else if self.pmp_match_one_addr(pmpicfg_3, (i * 4) + 2, addr)? {
+                return Ok(Some(pmpicfg_3));
+            } else if self.pmp_match_one_addr(pmpicfg_4, (i * 4) + 3, addr)? {
+                return Ok(Some(pmpicfg_4));
+            }
+        }
+
+        Ok(None)
     }
 }
 
@@ -238,22 +754,370 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_u_mode_read_m_mode_csr() {
+        let clock = Clock::new();
+        let csrs = CsrFile::new(&clock);
+
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::MSTATUS).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::MISA).err(),
+            Some(RvException::illegal_register())
+        );
+    }
+
+    #[test]
+    fn test_u_mode_write_m_mode_csr() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::MSTATUS, 0xFFFF_FFFF).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::MISA, 0xFFFF_FFFF).err(),
+            Some(RvException::illegal_register())
+        );
+    }
+
+    #[test]
+    fn test_u_mode_read_write_pmp() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::PMPCFG_START, 0xFFFF_FFFF)
+                .err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::PMPCFG_START).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::PMPADDR_START, 0xFFFF_FFFF)
+                .err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::PMPADDR_START).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::PMPCFG_END, 0xFFFF_FFFF)
+                .err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::PMPCFG_END).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_END).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::U, Csr::PMPADDR_END, 0xFFFF_FFFF)
+                .err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::U, Csr::PMPADDR_END).err(),
+            Some(RvException::illegal_register())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_END).ok(),
+            Some(0x0000_0000)
+        );
+    }
+
+    #[test]
+    fn test_m_mode_read_write_pmp() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x1717_1717)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x1717_1717)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START).ok(),
+            Some(0x3FFF_FFFF)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_END, 0x1717_1717).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_END).ok(),
+            Some(0x1717_1717)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_END, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_END).ok(),
+            Some(0x3FFF_FFFF)
+        );
+    }
+
+    #[test]
+    fn test_lock_pmp() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+
+        // Lock PMPADDR1, but not PMPADDR0, 2, or 3.
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0000_8000)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0000_8000)
+        );
+
+        // PMP0CFG, PMP2CFG, and PMP3CFG should be writable, but not PMP1CFG
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0000_8001)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0000_8001)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0000_8101)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0000_8001)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0001_8101)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0001_8001)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0101_8101)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPCFG_START).ok(),
+            Some(0x0101_8001)
+        );
+
+        // PMPADDR0, 2, and 3 should be writable, but not PMPADDR1
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START).ok(),
+            Some(0x3FFF_FFFF)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 1, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 1).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 2, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 2).ok(),
+            Some(0x3FFF_FFFF)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 3, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 3).ok(),
+            Some(0x3FFF_FFFF)
+        );
+    }
+
+    #[test]
+    fn test_pmp_tor_lock() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+
+        // Set PMP2CFG to TOR and lock
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x0000_8800)
+                .ok(),
+            Some(())
+        );
+
+        // Writes to PMPADDR1 and 2 should be ignored, but not PMPADDR3 or PMPADDR4
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 1, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 1).ok(),
+            Some(0x0000_0000)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 2, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 2).ok(),
+            Some(0x3FFF_FFFF)
+        );
+
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::PMPADDR_START + 3, 0xFFFF_FFFF)
+                .ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::PMPADDR_START + 3).ok(),
+            Some(0x3FFF_FFFF)
+        );
+    }
+
+    #[test]
     fn test_read_only_csr() {
         let clock = Clock::new();
         let mut csrs = CsrFile::new(&clock);
 
-        assert_eq!(csrs.read(Csr::MISA).ok(), Some(0x4000_1104));
-        assert_eq!(csrs.write(Csr::MISA, u32::MAX).ok(), Some(()));
-        assert_eq!(csrs.read(Csr::MISA).ok(), Some(0x4000_1104));
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(0x4010_1104));
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MISA, u32::MAX).ok(),
+            Some(())
+        );
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(0x4010_1104));
     }
 
     #[test]
     fn test_read_write_csr() {
         let clock = Clock::new();
         let mut csrs = CsrFile::new(&clock);
-        assert_eq!(csrs.read(Csr::MEPC).ok(), Some(0));
-        assert_eq!(csrs.write(Csr::MEPC, u32::MAX).ok(), Some(()));
-        assert_eq!(csrs.read(Csr::MEPC).ok(), Some(u32::MAX));
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MEPC).ok(), Some(0));
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MEPC, u32::MAX).ok(),
+            Some(())
+        );
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MEPC).ok(), Some(u32::MAX));
+    }
+
+    #[test]
+    fn test_mseccfg_csr_sticky() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSECCFG, 0xFFFF_FFFF).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSECCFG).ok(),
+            Some(0x0000_0003)
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSECCFG, 0x0000_0000).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSECCFG).ok(),
+            Some(0x0000_0003)
+        );
+    }
+
+    #[test]
+    fn test_mstatus_invalid_mpp() {
+        let clock = Clock::new();
+        let mut csrs = CsrFile::new(&clock);
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSTATUS, 0x0000_1800).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
+            Some(0x1800_1800)
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSTATUS, 0x0000_0800).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
+            Some(0x1800_1800)
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSTATUS, 0x0000_0000).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
+            Some(0x1800_0000)
+        );
     }
 
     #[test]
@@ -261,12 +1125,30 @@ mod tests {
         let clock = Clock::new();
         let mut csrs = CsrFile::new(&clock);
 
-        assert_eq!(csrs.read(Csr::MSTATUS).ok(), Some(0x1800_0000));
-        assert_eq!(csrs.write(Csr::MSTATUS, u32::MAX).ok(), Some(()));
-        assert_eq!(csrs.read(Csr::MSTATUS).ok(), Some(0x1800_0088));
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
+            Some(0x1800_1800)
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MSTATUS, u32::MAX).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
+            Some(0x1802_1888)
+        );
 
-        assert_eq!(csrs.read(Csr::MCOUNTINHIBIT).ok(), Some(0x0000_0000));
-        assert_eq!(csrs.write(Csr::MCOUNTINHIBIT, u32::MAX).ok(), Some(()));
-        assert_eq!(csrs.read(Csr::MCOUNTINHIBIT).ok(), Some(0x0000_007D));
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MCOUNTINHIBIT).ok(),
+            Some(0x0000_0000)
+        );
+        assert_eq!(
+            csrs.write(RvPrivMode::M, Csr::MCOUNTINHIBIT, u32::MAX).ok(),
+            Some(())
+        );
+        assert_eq!(
+            csrs.read(RvPrivMode::M, Csr::MCOUNTINHIBIT).ok(),
+            Some(0x0000_007D)
+        );
     }
 }

--- a/sw-emulator/lib/cpu/src/instr/test_macros.rs
+++ b/sw-emulator/lib/cpu/src/instr/test_macros.rs
@@ -447,7 +447,7 @@ mod test {
             {$($init_reg:path = $init_val:expr;)*},
             {$($result_reg:path = $result_val:expr;)*}
         ) => {
-            let mut cpu = $crate::isa_test_cpu!( $text_addr => $text, $data_addr => $data);
+            let mut cpu = $crate::isa_test_cpu!( $text_addr => $text, $data_addr => $data );
             $(assert_eq!(cpu.write_xreg($init_reg, $init_val).ok(), Some(()));)*
 
             while (cpu.read_pc() < $text_addr + $text.len() as u32) {
@@ -470,7 +470,7 @@ mod test {
             let text_range = $text_addr..=u32::try_from($text_addr + $text.len() - 1).unwrap();
             let data_range = $data_addr..=u32::try_from($data_addr + $data.len() - 1).unwrap();
 
-            let mut cpu = Cpu::new(DynamicBus::new(), Clock::new());
+            let mut cpu = Cpu::new(DynamicBus::new(), Clock::new(), true);
             let rom = Rom::new($text.clone());
             cpu.bus
                 .attach_dev("ROM", text_range, Box::new(rom))

--- a/sw-emulator/lib/cpu/src/types.rs
+++ b/sw-emulator/lib/cpu/src/types.rs
@@ -389,6 +389,9 @@ emu_enum! {
 
         /// Mret
         Mret = 0b0011_0000_0010,
+
+        /// Wfi
+        Wfi = 0b0001_0000_0101,
     };
     Invalid
 }
@@ -618,6 +621,39 @@ pub enum RvInstr {
     Instr16(u16),
 }
 
+emu_enum! {
+    /// Privilege modes
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
+    pub RvPrivMode;
+    u32;
+    {
+        /// User mode
+        U = 0b00,
+
+        /// Machine mode
+        M = 0b11,
+    };
+    Invalid
+}
+
+emu_enum! {
+    /// Memory access types
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
+    pub RvMemAccessType;
+    u8;
+    {
+        /// Read access
+        Read = 0b001,
+
+        /// Write access
+        Write = 0b010,
+
+        /// Execute access
+        Execute = 0b100,
+    };
+    Invalid
+}
+
 bitfield! {
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     /// RISCV Machine Mode Status Register
@@ -628,6 +664,12 @@ bitfield! {
 
     /// Machine Mode Previous Interrupt Enable
     pub u32, mpie, set_mpie: 7, 7;
+
+    /// Machine Prior Privilege mode
+    pub from into RvPrivMode, mpp, set_mpp: 12, 11;
+
+    /// Modify Privilege level
+    pub u32, mprv, set_mprv: 17, 17;
 }
 
 bitfield! {
@@ -661,4 +703,92 @@ bitfield! {
 
     /// Control interrupt enable
     pub u32, haltie, _: 1, 1;
+}
+
+emu_enum! {
+    /// PMP address modes
+    #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
+    pub RvPmpAddrMode;
+    u8;
+    {
+        /// PMP entry disabled
+        Off = 0b00,
+
+        /// Top of range
+        Tor = 0b01,
+
+        /// Naturally aligned 4-byte region
+        Na4 = 0b10,
+
+        /// Naturally-aligned power of 2
+        Napot = 0b11,
+    };
+    Invalid
+}
+
+bitfield! {
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    /// PMP control register
+    pub struct RvPmpiCfg(u8);
+
+    u8;
+
+    /// Read bit
+    pub read, set_read: 0, 0;
+
+    /// Write bit
+    pub write, set_write: 1, 1;
+
+    /// Execute bit
+    pub execute, set_execute: 2, 2;
+
+    /// Address mode
+    pub from into RvPmpAddrMode, addr_mode, set_addr_mode: 4, 3;
+
+    /// Lock bit
+    pub lock, set_lock: 7, 7;
+}
+
+impl From<u8> for RvPmpiCfg {
+    fn from(i: u8) -> RvPmpiCfg {
+        RvPmpiCfg(i)
+    }
+}
+
+impl From<RvPmpiCfg> for u8 {
+    fn from(i: RvPmpiCfg) -> u8 {
+        i.0
+    }
+}
+
+bitfield! {
+    /// PMP packed control register
+    pub struct RvPmpCfgi(u32);
+
+    u8;
+
+    /// Packed register 1
+    pub from into RvPmpiCfg, r1, set_r1: 7, 0;
+
+    /// Packed register 2
+    pub from into RvPmpiCfg, r2, set_r2: 15, 8;
+
+    /// Packed register 3
+    pub from into RvPmpiCfg, r3, set_r3: 23, 16;
+
+    /// Packed register 4
+    pub from into RvPmpiCfg, r4, set_r4: 31, 24;
+}
+
+bitfield! {
+    /// Machine security configuration register (low)
+    pub struct RvMsecCfg(u32);
+
+    u8;
+
+    /// Machine mode lockdown
+    pub mml, set_mml: 0, 0;
+
+    /// Machine Mode Whitelist Policy
+    pub mmwp, set_mmwp: 1, 1;
 }

--- a/sw-emulator/lib/types/src/exception.rs
+++ b/sw-emulator/lib/types/src/exception.rs
@@ -43,8 +43,11 @@ emu_enum! {
         /// Store access fault exception
         StoreAccessFault = 7,
 
-        /// Environment Call
-        EnvironmentCall = 11,
+        /// Environment Call (User)
+        EnvironmentCallUser = 8,
+
+        /// Environment Call (Machine)
+        EnvironmentCallMachine = 11,
 
         /// Illegal Register exception
         IllegalRegister = 24,
@@ -108,9 +111,14 @@ impl RvException {
         RvException::new(RvExceptionCause::IllegalRegister, 0)
     }
 
-    /// Create a new illegal register exception
-    pub fn environment_call() -> Self {
-        RvException::new(RvExceptionCause::EnvironmentCall, 0)
+    /// Create a new environment call from U mode exception
+    pub fn environment_call_user() -> Self {
+        RvException::new(RvExceptionCause::EnvironmentCallUser, 0)
+    }
+
+    /// Create a new environment call from M mode exception
+    pub fn environment_call_machine() -> Self {
+        RvException::new(RvExceptionCause::EnvironmentCallMachine, 0)
     }
 
     /// Returns the exception cause
@@ -200,9 +208,16 @@ mod tests {
     }
 
     #[test]
-    fn test_environment_call() {
-        let e = RvException::environment_call();
-        assert_eq!(e.cause(), RvExceptionCause::EnvironmentCall);
+    fn test_environment_call_user() {
+        let e = RvException::environment_call_user();
+        assert_eq!(e.cause(), RvExceptionCause::EnvironmentCallUser);
+        assert_eq!(e.info(), 0);
+    }
+
+    #[test]
+    fn test_environment_call_machine() {
+        let e = RvException::environment_call_machine();
+        assert_eq!(e.cause(), RvExceptionCause::EnvironmentCallMachine);
         assert_eq!(e.info(), 0);
     }
 }

--- a/sw-emulator/lib/types/src/lib.rs
+++ b/sw-emulator/lib/types/src/lib.rs
@@ -38,3 +38,19 @@ emu_enum!(
     };
     Invalid
 );
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum CaliptraVersion {
+    V1_0,
+    V1_1,
+    V2_0,
+}
+
+impl CaliptraVersion {
+    pub fn is_1x(&self) -> bool {
+        match self {
+            CaliptraVersion::V1_0 | CaliptraVersion::V1_1 => true,
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
This will allow us to be able to move some values out of the data vault and into DCCM, which we can lock for access as appropriate.

Originally written by @Elizafox for the 2.0 MCU emulator.