### PR TITLE
Enhance PAUSER tests

### DIFF
--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -41,3 +41,9 @@ caliptra-image-types.workspace = true
 caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-test-harness-types.workspace = true
+nix.workspace = true
+
+[[bin]]
+name = "fpga_realtime_mbox_pauser"
+path = "src/bin/fpga_realtime_mbox_pauser.rs"
+required-features = ["fpga_realtime", "itrng"]

--- a/hw-model/src/bin/fpga_realtime_mbox_pauser.rs
+++ b/hw-model/src/bin/fpga_realtime_mbox_pauser.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_hw_model::{mmio::Rv32GenMmio, HwModel, InitParams};
+use nix::sys::signal;
+use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet};
+use std::process::exit;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use caliptra_registers::soc_ifc;
+
+fn gen_image_hi() -> Vec<u8> {
+    let rv32_gen = Rv32GenMmio::new();
+    let soc_ifc =
+        unsafe { soc_ifc::RegisterBlock::new_with_mmio(0x3003_0000 as *mut u32, &rv32_gen) };
+    soc_ifc
+        .cptra_generic_output_wires()
+        .at(0)
+        .write(|_| b'h'.into());
+    soc_ifc
+        .cptra_generic_output_wires()
+        .at(0)
+        .write(|_| b'i'.into());
+    soc_ifc
+        .cptra_generic_output_wires()
+        .at(0)
+        .write(|_| 0x100 | u32::from(b'i'));
+    soc_ifc.cptra_generic_output_wires().at(0).write(|_| 0xff);
+    rv32_gen.into_inner().empty_loop().build()
+}
+
+// Atomic flag to indicate if SIGBUS was received
+static SIGBUS_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+// Signal handler function
+extern "C" fn handle_sigbus(_: i32) {
+    SIGBUS_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+fn main() {
+    println!("Setup signal handler...");
+    // Define the signal action
+    let sig_action = SigAction::new(
+        SigHandler::Handler(handle_sigbus),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+
+    // Set the signal handler for SIGBUS
+    unsafe {
+        signal::sigaction(signal::Signal::SIGBUS, &sig_action)
+            .expect("Failed to set SIGBUS handler");
+    }
+
+    // Spawn a thread that causes a SIGBUS error
+    thread::spawn(|| {
+        // Sleep for a short duration to ensure the main thread is ready
+        thread::sleep(Duration::from_secs(2));
+
+        let mut model = caliptra_hw_model::new_unbooted(InitParams {
+            rom: &gen_image_hi(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        model.soc_ifc().cptra_fuse_wr_done().write(|w| w.done(true));
+        model.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
+
+        // Set up the PAUSER as valid for the mailbox (using index 0)
+        model
+            .soc_ifc()
+            .cptra_mbox_valid_pauser()
+            .at(0)
+            .write(|_| 0x1);
+        model
+            .soc_ifc()
+            .cptra_mbox_pauser_lock()
+            .at(0)
+            .write(|w| w.lock(true));
+
+        // Set the PAUSER to something invalid
+        model.set_apb_pauser(0x2);
+
+        // The accesses below trigger sigbus
+        assert!(!model.soc_mbox().lock().read().lock());
+        // Should continue to read 0 because the reads are being blocked by valid PAUSER
+        assert!(!model.soc_mbox().lock().read().lock());
+
+        // Set the PAUSER back to valid
+        model.set_apb_pauser(0x1);
+
+        // Should read 0 the first time still for lock available
+        assert!(!model.soc_mbox().lock().read().lock());
+        // Should read 1 now for lock taken
+        assert!(model.soc_mbox().lock().read().lock());
+
+        model.soc_mbox().cmd().write(|_| 4242);
+
+        assert_eq!(model.soc_mbox().cmd().read(), 4242);
+        // Continue with the rest of your program
+        println!("Continuing execution...");
+    });
+
+    // Simulate some work in the main thread
+    loop {
+        if SIGBUS_RECEIVED.load(Ordering::SeqCst) {
+            println!("Received SIGBUS signal!");
+            // Handle the SIGBUS signal here
+            exit(42);
+        }
+        println!("Working...");
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/hw-model/src/bin/fpga_realtime_mbox_pauser.rs
+++ b/hw-model/src/bin/fpga_realtime_mbox_pauser.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
+use caliptra_api::soc_mgr::SocManager;
 use caliptra_registers::soc_ifc;
 
 fn gen_image_hi() -> Vec<u8> {

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -81,6 +81,15 @@ pub type DefaultHwModel = ModelVerilated;
 #[cfg(feature = "fpga_realtime")]
 pub type DefaultHwModel = ModelFpgaRealtime;
 
+pub enum ValidPaUsers {
+    Pl0 = 0x01,
+    Pl1 = 0x02,
+    Pl2 = 0x03,
+    Pl3 = 0x04,
+    Pl4 = 0x05,
+}
+pub const DEFAULT_APB_PAUSER: u32 = ValidPaUsers::Pl0 as u32;
+
 /// Constructs an HwModel based on the cargo features and environment
 /// variables. Most test cases that need to construct a HwModel should use this
 /// function over HwModel::new_unbooted().
@@ -252,7 +261,7 @@ pub struct BootParams<'a> {
     pub initial_dbg_manuf_service_reg: u32,
     pub initial_repcnt_thresh_reg: Option<CptraItrngEntropyConfig1WriteVal>,
     pub initial_adaptp_thresh_reg: Option<CptraItrngEntropyConfig0WriteVal>,
-    pub valid_pauser: u32,
+    pub valid_pauser: [u32; 5],
     pub wdt_timeout_cycles: u64,
 }
 
@@ -264,7 +273,13 @@ impl<'a> Default for BootParams<'a> {
             initial_dbg_manuf_service_reg: Default::default(),
             initial_repcnt_thresh_reg: Default::default(),
             initial_adaptp_thresh_reg: Default::default(),
-            valid_pauser: 0x1,
+            valid_pauser: [
+                ValidPaUsers::Pl0 as u32,
+                ValidPaUsers::Pl1 as u32,
+                ValidPaUsers::Pl2 as u32,
+                ValidPaUsers::Pl3 as u32,
+                ValidPaUsers::Pl4 as u32,
+            ],
             wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
         }
     }
@@ -514,15 +529,18 @@ pub trait HwModel: SocManager {
                 .write(|_| reg);
         }
 
-        // Set up the PAUSER as valid for the mailbox (using index 0)
-        self.soc_ifc()
-            .cptra_mbox_valid_pauser()
-            .at(0)
-            .write(|_| boot_params.valid_pauser);
-        self.soc_ifc()
-            .cptra_mbox_pauser_lock()
-            .at(0)
-            .write(|w| w.lock(true));
+        {
+            for idx in 0..5 {
+                self.soc_ifc()
+                    .cptra_mbox_valid_pauser()
+                    .at(idx)
+                    .write(|_| boot_params.valid_pauser[idx]);
+                self.soc_ifc()
+                    .cptra_mbox_pauser_lock()
+                    .at(idx)
+                    .write(|w| w.lock(true));
+            }
+        }
 
         writeln!(self.output().logger(), "writing to cptra_bootfsm_go")?;
         self.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -81,14 +81,7 @@ pub type DefaultHwModel = ModelVerilated;
 #[cfg(feature = "fpga_realtime")]
 pub type DefaultHwModel = ModelFpgaRealtime;
 
-pub enum ValidPaUsers {
-    Pl0 = 0x01,
-    Pl1 = 0x02,
-    Pl2 = 0x03,
-    Pl3 = 0x04,
-    Pl4 = 0x05,
-}
-pub const DEFAULT_APB_PAUSER: u32 = ValidPaUsers::Pl0 as u32;
+pub const DEFAULT_APB_PAUSER: u32 = 0x01;
 
 /// Constructs an HwModel based on the cargo features and environment
 /// variables. Most test cases that need to construct a HwModel should use this
@@ -273,13 +266,7 @@ impl<'a> Default for BootParams<'a> {
             initial_dbg_manuf_service_reg: Default::default(),
             initial_repcnt_thresh_reg: Default::default(),
             initial_adaptp_thresh_reg: Default::default(),
-            valid_pauser: vec![
-                ValidPaUsers::Pl0 as u32,
-                ValidPaUsers::Pl1 as u32,
-                ValidPaUsers::Pl2 as u32,
-                ValidPaUsers::Pl3 as u32,
-                ValidPaUsers::Pl4 as u32,
-            ],
+            valid_pauser: vec![0, 1, 2, 3, 4],
             wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
         }
     }

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -261,7 +261,7 @@ pub struct BootParams<'a> {
     pub initial_dbg_manuf_service_reg: u32,
     pub initial_repcnt_thresh_reg: Option<CptraItrngEntropyConfig1WriteVal>,
     pub initial_adaptp_thresh_reg: Option<CptraItrngEntropyConfig0WriteVal>,
-    pub valid_pauser: [u32; 5],
+    pub valid_pauser: Vec<u32>,
     pub wdt_timeout_cycles: u64,
 }
 
@@ -273,7 +273,7 @@ impl<'a> Default for BootParams<'a> {
             initial_dbg_manuf_service_reg: Default::default(),
             initial_repcnt_thresh_reg: Default::default(),
             initial_adaptp_thresh_reg: Default::default(),
-            valid_pauser: [
+            valid_pauser: vec![
                 ValidPaUsers::Pl0 as u32,
                 ValidPaUsers::Pl1 as u32,
                 ValidPaUsers::Pl2 as u32,
@@ -530,7 +530,7 @@ pub trait HwModel: SocManager {
         }
 
         {
-            for idx in 0..5 {
+            for idx in 0..boot_params.valid_pauser.len() {
                 self.soc_ifc()
                     .cptra_mbox_valid_pauser()
                     .at(idx)


### PR DESCRIPTION
- Modify HwModel  trait so it boots with a set of  five valid pausers for all supported model types.
- Add a negative test to ascertain that , when FpgaRealTime is selected, a  SIGBUS is raised if an invalid
   PAUSER tries to access the mailbox.