### PR TITLE
fix verilator git steps

### DIFF
--- a/hw/verilated/README.md
+++ b/hw/verilated/README.md
@@ -21,7 +21,7 @@ sudo make install
 ## Rust integration tests:
 
 ```shell
-git submodule update --init"  # Needed the first time
+git submodule update --init hw/1.0/rtl/"  # Needed the first time
 (cd hw/verilated && cargo test --features verilator)
 (cd hw-model && cargo test --features verilator)
 ```


### PR DESCRIPTION
If following the git steps in the main README to clone repo, it requires adding submodule path to make the git submodule update command, given in the verilator README, works.

(cherry picked from commit bcc30b1d602bd72f2b857134b3c4021f29394721)