### PR TITLE
registers/systemrdl/ureg: update RDL parser and register generator with more features

### DIFF
--- a/hw/1.0/registers/src/doe.rs
+++ b/hw/1.0/registers/src/doe.rs
@@ -460,6 +460,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/ecc.rs
+++ b/hw/1.0/registers/src/ecc.rs
@@ -642,6 +642,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/hmac.rs
+++ b/hw/1.0/registers/src/hmac.rs
@@ -617,6 +617,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/sha256.rs
+++ b/hw/1.0/registers/src/sha256.rs
@@ -520,6 +520,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/sha512.rs
+++ b/hw/1.0/registers/src/sha512.rs
@@ -624,6 +624,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/sha512_acc.rs
+++ b/hw/1.0/registers/src/sha512_acc.rs
@@ -573,6 +573,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/1.0/registers/src/soc_ifc.rs
+++ b/hw/1.0/registers/src/soc_ifc.rs
@@ -1932,6 +1932,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/doe.rs
+++ b/hw/latest/registers/src/doe.rs
@@ -460,6 +460,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/ecc.rs
+++ b/hw/latest/registers/src/ecc.rs
@@ -616,6 +616,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/hmac.rs
+++ b/hw/latest/registers/src/hmac.rs
@@ -598,6 +598,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/sha256.rs
+++ b/hw/latest/registers/src/sha256.rs
@@ -501,6 +501,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/sha512.rs
+++ b/hw/latest/registers/src/sha512.rs
@@ -602,6 +602,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/sha512_acc.rs
+++ b/hw/latest/registers/src/sha512_acc.rs
@@ -573,6 +573,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/hw/latest/registers/src/soc_ifc.rs
+++ b/hw/latest/registers/src/soc_ifc.rs
@@ -1941,6 +1941,45 @@ impl<TMmio: ureg::Mmio> IntrBlockRfBlock<TMmio> {
         }
     }
 }
+/// A zero-sized type that represents ownership of this
+/// peripheral, used to get access to a Register lock. Most
+/// programs create one of these in unsafe code near the top of
+/// main(), and pass it to the driver responsible for managing
+/// all access to the hardware.
+pub struct IntrBlockRf {
+    _priv: (),
+}
+impl IntrBlockRf {
+    pub const PTR: *mut u32 = 0x800 as *mut u32;
+    /// # Safety
+    ///
+    /// Caller must ensure that all concurrent use of this
+    /// peripheral in the firmware is done so in a compatible
+    /// way. The simplest way to enforce this is to only call
+    /// this function once.
+    #[inline(always)]
+    pub unsafe fn new() -> Self {
+        Self { _priv: () }
+    }
+    /// Returns a register block that can be used to read
+    /// registers from this peripheral, but cannot write.
+    #[inline(always)]
+    pub fn regs(&self) -> RegisterBlock<ureg::RealMmio> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+    /// Return a register block that can be used to read and
+    /// write this peripheral's registers.
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> RegisterBlock<ureg::RealMmioMut> {
+        RegisterBlock {
+            ptr: Self::PTR,
+            mmio: core::default::Default::default(),
+        }
+    }
+}
 pub mod regs {
     //! Types that represent the values held by registers.
     #[derive(Clone, Copy)]

--- a/registers/bin/generator/src/main.rs
+++ b/registers/bin/generator/src/main.rs
@@ -169,7 +169,6 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
     let addrmap = scope.lookup_typedef("clp").unwrap();
     let addrmap2 = scope.lookup_typedef("clp2").unwrap();
-    let addrmap3 = scope.lookup_typedef("clp3").unwrap();
 
     // These are types like kv_read_ctrl_reg that are used by multiple crates
     let root_block = RegisterBlock {
@@ -183,9 +182,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
     let mut blocks = ureg_systemrdl::translate_addrmap(addrmap)?;
     let mut blocks2 = ureg_systemrdl::translate_addrmap(addrmap2)?;
-    let mut blocks3 = ureg_systemrdl::translate_addrmap(addrmap3)?;
     blocks.append(&mut blocks2);
-    blocks.append(&mut blocks3);
 
     let mut validated_blocks = vec![];
     for mut block in blocks {

--- a/registers/bin/generator/src/main.rs
+++ b/registers/bin/generator/src/main.rs
@@ -169,6 +169,7 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
     let addrmap = scope.lookup_typedef("clp").unwrap();
     let addrmap2 = scope.lookup_typedef("clp2").unwrap();
+    let addrmap3 = scope.lookup_typedef("clp3").unwrap();
 
     // These are types like kv_read_ctrl_reg that are used by multiple crates
     let root_block = RegisterBlock {
@@ -182,7 +183,9 @@ fn real_main() -> Result<(), Box<dyn Error>> {
 
     let mut blocks = ureg_systemrdl::translate_addrmap(addrmap)?;
     let mut blocks2 = ureg_systemrdl::translate_addrmap(addrmap2)?;
+    let mut blocks3 = ureg_systemrdl::translate_addrmap(addrmap3)?;
     blocks.append(&mut blocks2);
+    blocks.append(&mut blocks3);
 
     let mut validated_blocks = vec![];
     for mut block in blocks {

--- a/registers/update.sh
+++ b/registers/update.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed under the Apache-2.0 license
 
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/systemrdl/src/error.rs
+++ b/systemrdl/src/error.rs
@@ -31,6 +31,7 @@ pub enum RdlError<'a> {
     DefaultPropertiesMustBeDefinedBeforeComponents,
     StrideIsLessThanElementSize,
     MultidimensionalFieldsNotSupported,
+    BadTernaryExpression(String),
 }
 
 impl Error for RdlError<'_> {}
@@ -38,6 +39,10 @@ impl Error for RdlError<'_> {}
 impl Display for RdlError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::BadTernaryExpression(v) => write!(
+                f,
+                "Ternary expression takes boolean value for first argument but bot {v:?}"
+            ),
             Self::UnexpectedToken(t) => write!(f, "Unexpected token {t:?}"),
             Self::UnknownIdentifier(s) => write!(f, "Unexpected identifier {s:?}"),
             Self::DuplicateInstanceName(s) => write!(f, "Dupicate instance name {s:?}"),

--- a/systemrdl/src/token.rs
+++ b/systemrdl/src/token.rs
@@ -7,6 +7,7 @@ use crate::Bits;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Token<'a> {
     Field,
+    External,
     Reg,
     RegFile,
     AddrMap,
@@ -25,6 +26,7 @@ pub enum Token<'a> {
     Comma,
     Period,
     Equals,
+    NotEquals,
     At,
     Colon,
     Hash,
@@ -32,6 +34,8 @@ pub enum Token<'a> {
     Pointer,
     PlusEqual,
     PercentEqual,
+    QuestionMark,
+    And,
 
     Identifier(&'a str),
     StringLiteral(&'a str),

--- a/systemrdl/src/token_iter.rs
+++ b/systemrdl/src/token_iter.rs
@@ -92,6 +92,7 @@ impl<'a> TokenIter<'a> {
                         file_path: old_file_path,
                         file_contents: old_file_contents,
                     });
+                    self.current_file_path = file_path;
                     // Retry with new lexer
                     continue;
                 }

--- a/ureg/lib/schema/src/lib.rs
+++ b/ureg/lib/schema/src/lib.rs
@@ -340,6 +340,7 @@ pub enum RegisterWidth {
     _32 = 32,
 
     _64 = 64,
+    _128 = 128,
 }
 impl RegisterWidth {
     pub fn in_bytes(self) -> u64 {
@@ -348,6 +349,7 @@ impl RegisterWidth {
             RegisterWidth::_16 => 2,
             RegisterWidth::_32 => 4,
             RegisterWidth::_64 => 8,
+            RegisterWidth::_128 => 16,
         }
     }
 
@@ -357,6 +359,7 @@ impl RegisterWidth {
             RegisterWidth::_16 => "u16",
             RegisterWidth::_32 => "u32",
             RegisterWidth::_64 => "u64",
+            RegisterWidth::_128 => "u128",
         }
     }
 }


### PR DESCRIPTION
These support the upcoming I3C and recovery register SystemRDL blocks.

Replaces https://github.com/chipsalliance/caliptra-sw/pull/1684