### PR TITLE
Add script to show code usage by function in runtime

### DIFF
--- a/runtime/bloat.sh
+++ b/runtime/bloat.sh
@@ -1,0 +1,17 @@
+# Licensed under the Apache-2.0 license
+
+#!/bin/bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+cargo bloat \
+  --locked \
+  --target riscv32imc-unknown-none-elf \
+  --profile=firmware \
+  --no-default-features \
+  --features=emu,fips_self_test,riscv \
+  -p caliptra-runtime \
+  -n 200 \
+  # Uncomment this line to see code size by crate
+  #--crates \
+  --bin=caliptra-runtime


### PR DESCRIPTION
This will help optimize code size of runtime firmware by showing which functions are using the most code space.