### PR TITLE
Add Zephyr project definitions for Libcaliptra.

### DIFF
--- a/libcaliptra/zephyr/CMakeLists.txt
+++ b/libcaliptra/zephyr/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Licensed under the Apache-2.0 license
+
+if (CONFIG_LIBCALIPTRA)
+
+zephyr_library()
+
+zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/inc)
+zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/src)
+
+# This is for caliptra_top_reg.h which has all of the register definitions for Caliptra.
+zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/../hw/latest/rtl/src/soc_ifc/rtl)
+
+zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/src/caliptra_api.c)
+
+endif() # CONFIG_LIBCALIPTRA

--- a/libcaliptra/zephyr/Kconfig
+++ b/libcaliptra/zephyr/Kconfig
@@ -1,0 +1,14 @@
+# Licensed under the Apache-2.0 license
+
+menuconfig LIBCALIPTRA
+	bool "Enable Libcaliptra"
+	help
+	  This is a library to help interface with Caliptra.
+
+if LIBCALIPTRA
+
+module = LIBCALIPTRA
+module-str = libcaliptra
+source "subsys/logging/Kconfig.template.log_config"
+
+endif # LIBCALIPTRA

--- a/libcaliptra/zephyr/README.md
+++ b/libcaliptra/zephyr/README.md
@@ -1,0 +1,11 @@
+# Zephyr Project Configuration
+
+This directory contains everything needed to include Libcaliptra as a library
+within a Zephyr project.
+
+It leaves the implementation for the functions in `caliptra_if.h` undefined. They
+will need to be defined external to this directory.
+
+The module is labeled `LIBCALIPTRA`. It can be added to your Zephyr project with
+`CONFIG_LIBCALIPTRA=y`. Be sure to add this directory to the list of
+`ZEPHYR_MODULES` in the build rules.

--- a/libcaliptra/zephyr/module.yml
+++ b/libcaliptra/zephyr/module.yml
@@ -1,0 +1,5 @@
+# Licensed under the Apache-2.0 license
+
+build:
+  cmake: zephyr
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
This allows including Libcaliptra in a Zephyr project.