### PR TITLE
Export Libcaliptra zephyr project include directories.

### DIFF
--- a/libcaliptra/zephyr/CMakeLists.txt
+++ b/libcaliptra/zephyr/CMakeLists.txt
@@ -4,11 +4,11 @@ if (CONFIG_LIBCALIPTRA)
 
 zephyr_library()
 
-zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/inc)
-zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/src)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/inc)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/src)
 
 # This is for caliptra_top_reg.h which has all of the register definitions for Caliptra.
-zephyr_library_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/../hw/latest/rtl/src/soc_ifc/rtl)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/../hw/latest/rtl/src/soc_ifc/rtl)
 
 zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/src/caliptra_api.c)
 


### PR DESCRIPTION
This makes it so projects including this library have the directories added to their include paths.