### PR TITLE
[fix] Fixing ROM integration tests for running on the FPGA

### DIFF
--- a/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
+++ b/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
@@ -76,8 +76,15 @@ fn test_cold_reset_status_reporting() {
     hw.step_until_boot_status(FwProcessorImageVerificationComplete.into(), false);
     hw.step_until_boot_status(FwProcessorPopulateDataVaultComplete.into(), false);
     hw.step_until_boot_status(FwProcessorExtendPcrComplete.into(), false);
-    hw.step_until_boot_status(FwProcessorLoadImageComplete.into(), false);
-    hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), false);
+
+    if cfg!(feature = "fpga_realtime") {
+        // Skip check for FwProcessorLoadImageComplete because it is set for too short of a time in nolog mode
+        hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), true);
+    } else {
+        hw.step_until_boot_status(FwProcessorLoadImageComplete.into(), false);
+        hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), false);
+    }
+
     hw.step_until_boot_status(FwProcessorComplete.into(), false);
     hw.step_until_boot_status(FmcAliasDeriveCdiComplete.into(), false);
     hw.step_until_boot_status(FmcAliasKeyPairDerivationComplete.into(), false);

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -147,7 +147,7 @@ fn test_update_reset_non_fw_load_cmd() {
         .unwrap();
     hw.step_until_boot_status(KatStarted.into(), true);
     hw.step_until_boot_status(KatComplete.into(), true);
-    hw.step_until_boot_status(UpdateResetStarted.into(), false);
+    hw.step_until_boot_status(UpdateResetStarted.into(), true);
 
     let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
     hw.step_until_exit_success().unwrap();


### PR DESCRIPTION
This change updates the ROM test_update_reset_non_fw_load_cmd and test_cold_reset_status_reporting integration tests. These tests were failing due to timing changes caused by disabling CFI protections in the ROM.