### PR TITLE
Refactor memory_layout and persistent_data

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -42,5 +42,5 @@ pub const FMC_SIZE: u32 = 20 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 97 * 1024;
 
-pub use memory_layout::{DATA_ORG, FHT_ORG, FHT_SIZE, MAN1_ORG};
+pub use memory_layout::{DATA_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/cpu/gen/src/lib.rs
+++ b/cpu/gen/src/lib.rs
@@ -9,15 +9,8 @@ pub fn gen_memory_x(iccm_org: u32, iccm_size: u32) -> String {
         STACK_ORG 		 = 0x{STACK_ORG:08X};
         ESTACK_ORG  	 = 0x{ESTACK_ORG:08X};
         NSTACK_ORG       = 0x{NSTACK_ORG:08X};
-        LDEVID_TBS_ORG   = 0x{LDEVID_TBS_ORG:08X};;
-        FMCALIAS_TBS_ORG = 0x{FMCALIAS_TBS_ORG:08X};;
-        RTALIAS_TBS_ORG  = 0x{RTALIAS_TBS_ORG:08X};
 
         CFI_STATE_ORG = 0x{CFI_STATE_ORG:08X};
-
-        LDEVID_TBS_SIZE   = 0x{LDEVID_TBS_SIZE:08X};
-        FMCALIAS_TBS_SIZE = 0x{FMCALIAS_TBS_SIZE:08X};
-        RTALIAS_TBS_SIZE  = 0x{RTALIAS_TBS_SIZE:08X};
 
         ICCM_SIZE   = 0x{iccm_size:08X};
         DCCM_SIZE   = 0x{DCCM_SIZE:08X};
@@ -30,7 +23,6 @@ pub fn gen_memory_x(iccm_org: u32, iccm_size: u32) -> String {
         MEMORY
         {{
             ICCM 		 (rx) : ORIGIN = ICCM_ORG, 		   LENGTH = ICCM_SIZE
-            RTALIAS_TBS  (rw) : ORIGIN = RTALIAS_TBS_ORG,  LENGTH = RTALIAS_TBS_SIZE
             DATA         (rw) : ORIGIN = DATA_ORG,         LENGTH = DATA_SIZE
             STACK	     (rw) : ORIGIN = STACK_ORG,  	   LENGTH = STACK_SIZE
             ESTACK 		 (rw) : ORIGIN = ESTACK_ORG,       LENGTH = ESTACK_SIZE

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -3,8 +3,8 @@
 use crate::bounded_address::RomAddr;
 use crate::soc_ifc;
 use crate::{
-    memory_layout, ColdResetEntry4, ColdResetEntry48, Ecc384PubKey, Ecc384Signature, KeyId,
-    ResetReason, WarmResetEntry4, WarmResetEntry48,
+    ColdResetEntry4, ColdResetEntry48, Ecc384PubKey, Ecc384Signature, KeyId, ResetReason,
+    WarmResetEntry4, WarmResetEntry48,
 };
 use bitfield::{bitfield_bitrange, bitfield_fields};
 use caliptra_error::CaliptraError;
@@ -177,7 +177,6 @@ impl From<DataStore> for HandOffDataHandle {
 /// location in DCCM. It is initially populated by ROM and modified by FMC as a way
 /// to pass parameters and configuration information from one firmware layer to the next.
 const _: () = assert!(size_of::<FirmwareHandoffTable>() == 2048);
-const _: () = assert!(size_of::<FirmwareHandoffTable>() <= memory_layout::FHT_SIZE as usize);
 #[repr(C)]
 #[derive(Clone, Debug, IntoBytes, TryFromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct FirmwareHandoffTable {

--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -12,12 +12,6 @@ Abstract:
 
 --*/
 
-#[cfg(test)]
-use crate::FirmwareHandoffTable;
-
-#[cfg(test)]
-use caliptra_image_types::ImageManifest;
-
 //
 // Memory Addresses
 //
@@ -28,20 +22,9 @@ pub const DCCM_ORG: u32 = 0x50000000;
 pub const ROM_DATA_ORG: u32 = 0x50000000;
 pub const CFI_STATE_ORG: u32 = 0x500003E4; // size = 6 words
 pub const BOOT_STATUS_ORG: u32 = 0x500003FC;
-pub const MAN1_ORG: u32 = 0x50000400;
-pub const MAN2_ORG: u32 = 0x50001C00;
-pub const FHT_ORG: u32 = 0x50003400;
-pub const LDEVID_TBS_ORG: u32 = 0x50003C00;
-pub const FMCALIAS_TBS_ORG: u32 = 0x50004000;
-pub const RTALIAS_TBS_ORG: u32 = 0x50004400;
-pub const PCR_LOG_ORG: u32 = 0x50004800;
-pub const MEASUREMENT_LOG_ORG: u32 = 0x50004C00;
-pub const FUSE_LOG_ORG: u32 = 0x50005000;
-pub const DPE_ORG: u32 = 0x50005400;
-pub const PCR_RESET_COUNTER_ORG: u32 = 0x50006800;
-pub const AUTH_MAN_IMAGE_METADATA_LIST_ORG: u32 = 0x50006C00;
-pub const IDEVID_CSR_ORG: u32 = 0x50008800;
-pub const DATA_ORG: u32 = 0x50008C00;
+pub const PERSISTENT_DATA_ORG: u32 = 0x50000400;
+
+pub const DATA_ORG: u32 = 0x5000D800;
 
 pub const STACK_ORG: u32 = 0x5000f800;
 pub const ROM_STACK_ORG: u32 = 0x5001C000;
@@ -55,26 +38,22 @@ pub const ROM_NSTACK_ORG: u32 = 0x5001FC00;
 //
 // Memory Sizes In Bytes
 //
+
+// Reserves a large chunk of DCCM for the PersistentData struct.
+//
+// The size was calculated by leaving a portion of the Data section
+// reserved for future use and then allocating the rest of the DCCM.
+//
+// The `DATA_SIZE` variable reflects the leftover space.
+pub const PERSISTENT_DATA_SIZE: u32 = 53 * 1024;
+
 pub const ROM_RELAXATION_PADDING: u32 = 4 * 1024;
 pub const ROM_SIZE: u32 = 48 * 1024;
 pub const MBOX_SIZE: u32 = 128 * 1024;
 pub const ICCM_SIZE: u32 = 128 * 1024;
 pub const DCCM_SIZE: u32 = 128 * 1024;
 pub const ROM_DATA_SIZE: u32 = 996;
-pub const MAN1_SIZE: u32 = 6 * 1024;
-pub const MAN2_SIZE: u32 = 6 * 1024;
-pub const FHT_SIZE: u32 = 2 * 1024;
-pub const LDEVID_TBS_SIZE: u32 = 1024;
-pub const FMCALIAS_TBS_SIZE: u32 = 1024;
-pub const RTALIAS_TBS_SIZE: u32 = 1024;
-pub const PCR_LOG_SIZE: u32 = 1024;
-pub const MEASUREMENT_LOG_SIZE: u32 = 1024;
-pub const FUSE_LOG_SIZE: u32 = 1024;
-pub const DPE_SIZE: u32 = 5 * 1024;
-pub const PCR_RESET_COUNTER_SIZE: u32 = 1024;
-pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
-pub const IDEVID_CSR_SIZE: u32 = 1024;
-pub const DATA_SIZE: u32 = 27 * 1024;
+pub const DATA_SIZE: u32 = 8 * 1024;
 pub const STACK_SIZE: u32 = 64 * 1024;
 pub const ROM_STACK_SIZE: u32 = 14 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
@@ -89,76 +68,8 @@ pub const ICCM_RANGE: core::ops::Range<u32> = core::ops::Range {
 
 #[test]
 #[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_manifest() {
-    assert!(MAN1_SIZE as usize >= core::mem::size_of::<ImageManifest>());
-    assert!(MAN2_SIZE as usize >= core::mem::size_of::<ImageManifest>());
-    assert_eq!(MAN1_SIZE, MAN2_SIZE);
-    assert_eq!((MAN2_ORG - MAN1_ORG), MAN1_SIZE);
-    assert_eq!((FHT_ORG - MAN2_ORG), MAN2_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_fht() {
-    assert!(FHT_SIZE as usize >= core::mem::size_of::<FirmwareHandoffTable>());
-    assert_eq!((LDEVID_TBS_ORG - FHT_ORG), FHT_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_ldevid() {
-    assert_eq!((FMCALIAS_TBS_ORG - LDEVID_TBS_ORG), LDEVID_TBS_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_fmcalias() {
-    assert_eq!((RTALIAS_TBS_ORG - FMCALIAS_TBS_ORG), FMCALIAS_TBS_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_rtalias() {
-    assert_eq!((PCR_LOG_ORG - RTALIAS_TBS_ORG), RTALIAS_TBS_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_pcr_log() {
-    assert_eq!((MEASUREMENT_LOG_ORG - PCR_LOG_ORG), PCR_LOG_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_measurement_log() {
-    assert_eq!((FUSE_LOG_ORG - MEASUREMENT_LOG_ORG), MEASUREMENT_LOG_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_fuselog() {
-    assert_eq!((DPE_ORG - FUSE_LOG_ORG), FUSE_LOG_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_dpe() {
-    assert_eq!((PCR_RESET_COUNTER_ORG - DPE_ORG), DPE_SIZE);
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_pcr_reset_counter() {
-    assert_eq!(
-        (AUTH_MAN_IMAGE_METADATA_LIST_ORG - PCR_RESET_COUNTER_ORG),
-        PCR_RESET_COUNTER_SIZE
-    );
-}
-
-#[test]
-#[allow(clippy::assertions_on_constants)]
-fn mem_layout_test_idevid_csr() {
-    assert_eq!((DATA_ORG - IDEVID_CSR_ORG), IDEVID_CSR_SIZE);
+fn mem_layout_test_persistent_data() {
+    assert_eq!((DATA_ORG - PERSISTENT_DATA_ORG), PERSISTENT_DATA_SIZE);
 }
 
 #[test]

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -329,14 +329,3 @@ impl InitDevIdLayer {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use caliptra_drivers::memory_layout::IDEVID_CSR_SIZE;
-
-    #[test]
-    fn verify_csr_fits_in_dccm() {
-        assert!(MAX_CSR_SIZE <= IDEVID_CSR_SIZE as usize);
-    }
-}

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -24,11 +24,8 @@ use crate::flow::update_reset;
 use crate::flow::warm_reset;
 use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
+use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::RomBootStatus::*;
-use caliptra_common::{
-    memory_layout::{FMCALIAS_TBS_ORG, FMCALIAS_TBS_SIZE, LDEVID_TBS_ORG, LDEVID_TBS_SIZE},
-    FirmwareHandoffTable,
-};
 use caliptra_drivers::cprintln;
 use caliptra_drivers::Lifecycle;
 use caliptra_drivers::LmsResult;

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -14,7 +14,6 @@ use caliptra_common::RomBootStatus::ColdResetComplete;
 use caliptra_common::RomBootStatus::*;
 use caliptra_common::{FirmwareHandoffTable, FuseLogEntry, FuseLogEntryId};
 use caliptra_common::{PcrLogEntry, PcrLogEntryId};
-use caliptra_drivers::memory_layout::*;
 use caliptra_drivers::pcr_log::MeasurementLogEntry;
 use caliptra_drivers::{ColdResetEntry4, PcrId, RomVerifyConfig};
 use caliptra_error::CaliptraError;
@@ -744,11 +743,6 @@ fn test_fht_info() {
     let fht = FirmwareHandoffTable::try_ref_from_bytes(data.as_bytes()).unwrap();
     assert_eq!(fht.ldevid_tbs_size, 552);
     assert_eq!(fht.fmcalias_tbs_size, 753);
-    assert_eq!(fht.ldevid_tbs_addr, LDEVID_TBS_ORG);
-    assert_eq!(fht.fmcalias_tbs_addr, FMCALIAS_TBS_ORG);
-    assert_eq!(fht.pcr_log_addr, PCR_LOG_ORG);
-    assert_eq!(fht.meas_log_addr, MEASUREMENT_LOG_ORG);
-    assert_eq!(fht.fuse_log_addr, FUSE_LOG_ORG);
 }
 
 #[test]


### PR DESCRIPTION
* Reserve a portion of DCCM for future changes to PersistentData.
    * Reserved 19 KiB.
* Remove most hard coded addresses in memory layout.
* Left 8K in the Data section. Currently less than 4KiB is being used.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/1662.
