### PR TITLE
Get rid of manual padding in rom tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-cpu",
  "caliptra-drivers",
+ "caliptra-image-types",
  "cfg-if 1.0.0",
  "ufmt",
 ]

--- a/rom/dev/tools/test-fmc/src/fmc.ld
+++ b/rom/dev/tools/test-fmc/src/fmc.ld
@@ -24,8 +24,7 @@ STACK_ORG        = 0x5001C000;
 ESTACK_ORG       = 0x5001F800;
 NSTACK_ORG       = 0x5001FC00;
 
-
-ICCM_SIZE         = 128K;
+ICCM_SIZE         = 16K;
 DCCM_SIZE         = 128K;
 DATA_SIZE         = 93K;
 STACK_SIZE        = 14K;
@@ -80,6 +79,14 @@ SECTIONS
 		. = ALIGN(4);
 	    _edata = .;
 	} > DATA AT> ICCM
+
+    .padding : ALIGN(4)
+    {
+        _padding = .;
+        . += ICCM_SIZE - SIZEOF(.rodata) - SIZEOF(.text) - SIZEOF(.data) - 1;
+        BYTE(0xff);
+        _epadding = .;
+    } > ICCM
 
 	.bss (NOLOAD) : ALIGN(4) 
     {

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -40,27 +40,6 @@ const FW_LOAD_CMD_OPCODE: u32 = mailbox_api::CommandId::FIRMWARE_LOAD.0;
 #[cfg(feature = "std")]
 pub fn main() {}
 
-// Dummy RO data to max out FMC image size to 16K.
-// Note: Adjust this value to account for new changes in this FMC image.
-#[cfg(all(feature = "interactive_test_fmc", not(feature = "fake-fmc")))]
-const PAD_LEN: usize = 4988; // TEST_FMC_INTERACTIVE
-#[cfg(all(feature = "fake-fmc", not(feature = "interactive_test_fmc")))]
-const PAD_LEN: usize = 5224; // FAKE_TEST_FMC_WITH_UART
-#[cfg(all(feature = "interactive_test_fmc", feature = "fake-fmc"))]
-const PAD_LEN: usize = 5452; // FAKE_TEST_FMC_INTERACTIVE
-#[cfg(not(any(feature = "interactive_test_fmc", feature = "fake-fmc")))]
-const PAD_LEN: usize = 0;
-
-static PAD: [u32; PAD_LEN / 4] = {
-    let mut result = [0xdeadbeef_u32; PAD_LEN / 4];
-    let mut i = 0;
-    while i < result.len() {
-        result[i] = result[i].wrapping_add(i as u32);
-        i += 1;
-    }
-    result
-};
-
 const BANNER: &str = r#"
 Running Caliptra FMC ...
 "#;
@@ -299,7 +278,6 @@ fn validate_fmc_rt_load_in_iccm(mbox: &caliptra_registers::mbox::RegisterBlock<R
                 fmc_iccm[idx]
             );
             mismatch = true;
-            cprint!("PAD[{}] = 0x{:08X}", idx, PAD[idx]);
         }
     }
     for (idx, _) in rt_iccm.iter().enumerate().take(rt_size / 4) {

--- a/rom/dev/tools/test-rt/Cargo.toml
+++ b/rom/dev/tools/test-rt/Cargo.toml
@@ -11,6 +11,7 @@ caliptra-drivers.workspace = true
 ufmt.workspace = true
 
 [build-dependencies]
+caliptra-image-types.workspace = true
 cfg-if.workspace = true
 
 [features]

--- a/rom/dev/tools/test-rt/build.rs
+++ b/rom/dev/tools/test-rt/build.rs
@@ -20,7 +20,9 @@ fn main() {
             use std::path::PathBuf;
 
             let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-            fs::write(out_dir.join("rt.ld"), include_bytes!("src/rt.ld")).unwrap();
+            let ld_script = include_str!("src/rt.ld")
+                .replace("#MANIFEST_SIZE#", &caliptra_image_types::IMAGE_MANIFEST_BYTE_SIZE.to_string());
+            fs::write(out_dir.join("rt.ld"), ld_script).unwrap();
 
             println!("cargo:rustc-link-search={}", out_dir.display());
             println!("cargo:rustc-link-arg=-Trt.ld");

--- a/rom/dev/tools/test-rt/src/main.rs
+++ b/rom/dev/tools/test-rt/src/main.rs
@@ -25,17 +25,6 @@ mod print;
 #[cfg(feature = "std")]
 pub fn main() {}
 
-// Dummy RO data to max out FW image size.
-static PAD: [u32; 26778] = {
-    let mut result = [0xba5eba11_u32; 26778];
-    let mut i = 0;
-    while i < result.len() {
-        result[i] = result[i].wrapping_add(i as u32);
-        i += 1;
-    }
-    result
-};
-
 const BANNER: &str = r#"
   ____      _ _       _               ____ _____
  / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
@@ -48,10 +37,6 @@ const BANNER: &str = r#"
 #[no_mangle]
 pub extern "C" fn rt_entry() -> ! {
     cprintln!("{}", BANNER);
-
-    for (x, item) in PAD.iter().enumerate() {
-        cprint!("PAD[{}] = 0x{:08X}", x, *item);
-    }
 
     caliptra_drivers::ExitCtrl::exit(0)
 }

--- a/rom/dev/tools/test-rt/src/rt.ld
+++ b/rom/dev/tools/test-rt/src/rt.ld
@@ -80,6 +80,16 @@ SECTIONS
 	    _edata = .;
 	} > DATA AT> ICCM
 
+    .padding : ALIGN(4)
+    {
+        _padding = .;
+        // The manifest size gets replaced in build.rs
+        . += ICCM_SIZE - SIZEOF(.rodata) - SIZEOF(.text) - SIZEOF(.data) - 1 - #MANIFEST_SIZE#;
+        BYTE(0xff);
+        _epadding = .;
+    } > ICCM
+
+
 	.bss (NOLOAD) : ALIGN(4) 
     {
 		_sbss = .;


### PR DESCRIPTION
Use the linker script to automatically pad test FMC and RT images.