### PR TITLE
Update zerocopy from 0.6.6 to 0.8.8.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,12 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "caliptra-api"
 version = "0.1.0"
 dependencies = [
@@ -2951,19 +2945,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
 wycheproof = "0.5.1"
 x509-parser = "0.15.0"
-zerocopy = "0.6.6"
+zerocopy = { version = "0.8.8", features = ["derive"] }
 serial_test = "2.0.0"
 nix = "0.26.2"
 libc = "0.2"

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-df4a72ee4a88d12d7216f8d23c6567b479694dec959e7332d69094098d312ea2dbf35de1117db156635ad41a78bf3c14  caliptra-rom-no-log.bin
-02db1204eea812bee28904ce877ec7604746169fa7bfa82471cf10af239852466c1a16b2d5b3b9ad26b4ccfe2ca0a1b5  caliptra-rom-with-log.bin
+a0c760bba301d669c7d7ce3f60d9451d2b4ed9f3d9b237a6eaabd6b7d8a7172573d7664c4d1dfc3f519d0babeae702de  caliptra-rom-no-log.bin
+92c38d0f250cb2eee89536ab7b9b81e356c0197b365da2ef04aef946347db46690ea51dad0447cf3acf0a9fc235f7951  caliptra-rom-with-log.bin

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -3,7 +3,7 @@
 use bitflags::bitflags;
 use caliptra_error::{CaliptraError, CaliptraResult};
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref};
 
 use crate::CaliptraApiError;
 use caliptra_registers::mbox;
@@ -70,12 +70,12 @@ impl From<CommandId> for u32 {
 
 /// A trait implemented by request types. Describes the associated command ID
 /// and response type.
-pub trait Request: AsBytes + FromBytes {
+pub trait Request: IntoBytes + FromBytes + Immutable + KnownLayout {
     const ID: CommandId;
     type Resp: Response;
 }
 
-pub trait Response: AsBytes + FromBytes
+pub trait Response: IntoBytes + FromBytes
 where
     Self: Sized,
 {
@@ -86,31 +86,29 @@ where
 
     fn populate_chksum(&mut self) {
         // Note: This will panic if sizeof::<Self>() < 4
-        populate_checksum(self.as_bytes_mut());
+        populate_checksum(self.as_mut_bytes());
     }
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, Default, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, Default, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct MailboxRespHeaderVarSize {
     pub hdr: MailboxRespHeader,
     pub data_len: u32,
 }
-pub trait ResponseVarSize: AsBytes + FromBytes {
+pub trait ResponseVarSize: IntoBytes + FromBytes + Immutable + KnownLayout {
     fn data(&self) -> CaliptraResult<&[u8]> {
         // Will panic if sizeof<Self>() is smaller than MailboxRespHeaderVarSize
         // or Self doesn't have compatible alignment with
-        // MailboxRespHeaderVarSize (should be impossible if MailboxRespHeaderVarSize is the first field)
-        let (hdr, data) =
-            LayoutVerified::<_, MailboxRespHeaderVarSize>::new_from_prefix(self.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+        // MailboxRespHeaderVarSize (should be impossible if MailboxRespHeaderVarSiz is the first field)                                                                 ..
+        let (hdr, data) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
         data.get(..hdr.data_len as usize)
             .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)
     }
     fn partial_len(&self) -> CaliptraResult<usize> {
-        let (hdr, _) =
-            LayoutVerified::<_, MailboxRespHeaderVarSize>::new_from_prefix(self.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+        let (hdr, _) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
         Ok(size_of::<MailboxRespHeaderVarSize>() + hdr.data_len as usize)
     }
     fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
@@ -120,7 +118,7 @@ pub trait ResponseVarSize: AsBytes + FromBytes {
     }
     fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
         let partial_len = self.partial_len()?;
-        self.as_bytes_mut()
+        self.as_mut_bytes()
             .get_mut(..partial_len)
             .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)
     }
@@ -179,24 +177,24 @@ impl MailboxResp {
         }
     }
 
-    pub fn as_bytes_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+    pub fn as_mut_bytes(&mut self) -> CaliptraResult<&mut [u8]> {
         match self {
-            MailboxResp::Header(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::Header(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetIdevCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::GetIdevInfo(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::GetIdevInfo(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetLdevCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::StashMeasurement(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::StashMeasurement(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::InvokeDpeCommand(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::FipsVersion(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::FwInfo(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::Capabilities(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::GetTaggedTci(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::FipsVersion(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::FwInfo(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::Capabilities(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::GetTaggedTci(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetFmcAliasCert(resp) => resp.as_bytes_partial_mut(),
             MailboxResp::GetRtAliasCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::QuotePcrs(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::QuotePcrs(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -210,16 +208,14 @@ impl MailboxResp {
         }
         let checksum = crate::checksum::calc_checksum(0, &resp_bytes[size_of::<u32>()..]);
 
-        let mut_resp_bytes = self.as_bytes_mut()?;
+        let mut_resp_bytes = self.as_mut_bytes()?;
         if size_of::<MailboxRespHeader>() > mut_resp_bytes.len() {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE);
         }
-        // cast as header struct
-        let hdr: &mut MailboxRespHeader = LayoutVerified::<&mut [u8], MailboxRespHeader>::new(
+        let hdr: &mut MailboxRespHeader = MailboxRespHeader::mut_from_bytes(
             &mut mut_resp_bytes[..size_of::<MailboxRespHeader>()],
         )
-        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
-        .into_mut();
+        .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         // Set the chksum field
         hdr.chksum = checksum;
@@ -285,28 +281,28 @@ impl MailboxReq {
         }
     }
 
-    pub fn as_bytes_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+    pub fn as_mut_bytes(&mut self) -> CaliptraResult<&mut [u8]> {
         match self {
-            MailboxReq::EcdsaVerify(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::LmsVerify(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetLdevCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::StashMeasurement(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::EcdsaVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::LmsVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetLdevCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::StashMeasurement(req) => Ok(req.as_mut_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial_mut(),
-            MailboxReq::FipsVersion(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::FwInfo(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::FipsVersion(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::FwInfo(req) => Ok(req.as_mut_bytes()),
             MailboxReq::PopulateIdevCert(req) => req.as_bytes_partial_mut(),
             MailboxReq::GetIdevCert(req) => req.as_bytes_partial_mut(),
-            MailboxReq::TagTci(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetTaggedTci(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetFmcAliasCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetRtAliasCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::IncrementPcrResetCounter(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::QuotePcrs(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::ExtendPcr(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::TagTci(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetTaggedTci(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetFmcAliasCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetRtAliasCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::IncrementPcrResetCounter(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::QuotePcrs(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::ExtendPcr(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AddSubjectAltName(req) => req.as_bytes_partial_mut(),
-            MailboxReq::CertifyKeyExtended(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::SetAuthManifest(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::CertifyKeyExtended(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::SetAuthManifest(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -343,12 +339,10 @@ impl MailboxReq {
             &self.as_bytes()?[size_of::<i32>()..],
         );
 
-        // cast as header struct
-        let hdr: &mut MailboxReqHeader = LayoutVerified::<&mut [u8], MailboxReqHeader>::new(
-            &mut self.as_bytes_mut()?[..size_of::<MailboxReqHeader>()],
+        let hdr: &mut MailboxReqHeader = MailboxReqHeader::mut_from_bytes(
+            &mut self.as_mut_bytes()?[..size_of::<MailboxReqHeader>()],
         )
-        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
-        .into_mut();
+        .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         // Set the chksum field
         hdr.chksum = checksum;
@@ -359,13 +353,13 @@ impl MailboxReq {
 
 // HEADER
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct MailboxReqHeader {
     pub chksum: u32,
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct MailboxRespHeader {
     pub chksum: u32,
     pub fips_status: u32,
@@ -387,7 +381,7 @@ impl Default for MailboxRespHeader {
 
 // GET_IDEV_CERT
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevCertReq {
     pub hdr: MailboxReqHeader,
     pub tbs_size: u32,
@@ -411,7 +405,7 @@ impl GetIdevCertReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::DATA_MAX_SIZE - self.tbs_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for GetIdevCertReq {
@@ -427,7 +421,7 @@ impl Default for GetIdevCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevCertResp {
     pub hdr: MailboxRespHeader,
     pub cert_size: u32,
@@ -451,7 +445,7 @@ impl Default for GetIdevCertResp {
 // GET_IDEV_INFO
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevInfoResp {
     pub hdr: MailboxRespHeader,
     pub idev_pub_x: [u8; 48],
@@ -460,7 +454,7 @@ pub struct GetIdevInfoResp {
 
 // GET_LDEV_CERT
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetLdevCertReq {
     header: MailboxReqHeader,
 }
@@ -471,7 +465,7 @@ impl Request for GetLdevCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetLdevCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -494,7 +488,7 @@ impl Default for GetLdevCertResp {
 
 // GET_RT_ALIAS_CERT
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetRtAliasCertReq {
     header: MailboxReqHeader,
 }
@@ -504,7 +498,7 @@ impl Request for GetRtAliasCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetRtAliasCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -531,7 +525,7 @@ impl Default for GetRtAliasCertResp {
 
 // ECDSA384_SIGNATURE_VERIFY
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct EcdsaVerifyReq {
     pub hdr: MailboxReqHeader,
     pub pub_key_x: [u8; 48],
@@ -547,7 +541,7 @@ impl Request for EcdsaVerifyReq {
 
 // LMS_SIGNATURE_VERIFY
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct LmsVerifyReq {
     pub hdr: MailboxReqHeader,
     pub pub_key_tree_type: u32,
@@ -567,7 +561,7 @@ impl Request for LmsVerifyReq {
 
 // STASH_MEASUREMENT
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct StashMeasurementReq {
     pub hdr: MailboxReqHeader,
     pub metadata: [u8; 4],
@@ -592,7 +586,7 @@ impl Request for StashMeasurementReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct StashMeasurementResp {
     pub hdr: MailboxRespHeader,
     pub dpe_result: u32,
@@ -605,7 +599,7 @@ impl Response for StashMeasurementResp {}
 
 // CERTIFY_KEY_EXTENDED
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CertifyKeyExtendedReq {
     pub hdr: MailboxReqHeader,
     pub flags: CertifyKeyExtendedFlags,
@@ -620,7 +614,7 @@ impl Request for CertifyKeyExtendedReq {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, FromBytes, AsBytes)]
+#[derive(Debug, PartialEq, Eq, FromBytes, Immutable, KnownLayout, IntoBytes)]
 pub struct CertifyKeyExtendedFlags(pub u32);
 
 bitflags! {
@@ -630,7 +624,7 @@ bitflags! {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CertifyKeyExtendedResp {
     pub hdr: MailboxRespHeader,
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
@@ -642,7 +636,7 @@ impl Response for CertifyKeyExtendedResp {}
 
 // INVOKE_DPE_COMMAND
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct InvokeDpeReq {
     pub hdr: MailboxReqHeader,
     pub data_size: u32,
@@ -665,7 +659,7 @@ impl InvokeDpeReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for InvokeDpeReq {
@@ -684,7 +678,7 @@ impl Request for InvokeDpeReq {
 
 // EXTEND_PCR
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct ExtendPcrReq {
     pub hdr: MailboxReqHeader,
     pub pcr_idx: u32,
@@ -699,7 +693,7 @@ impl Request for ExtendPcrReq {
 // No command-specific output args
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct InvokeDpeResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -722,7 +716,7 @@ impl Default for InvokeDpeResp {
 
 // GET_FMC_ALIAS_CERT
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetFmcAliasCertReq {
     header: MailboxReqHeader,
 }
@@ -732,7 +726,7 @@ impl Request for GetFmcAliasCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetFmcAliasCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -760,7 +754,7 @@ impl Default for GetFmcAliasCertResp {
 // FIPS_GET_VERSION
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct FipsVersionResp {
     pub hdr: MailboxRespHeader,
     pub mode: u32,
@@ -772,7 +766,7 @@ impl Response for FipsVersionResp {}
 // FW_INFO
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct FwInfoResp {
     pub hdr: MailboxRespHeader,
     pub pl0_pauser: u32,
@@ -792,7 +786,7 @@ pub struct FwInfoResp {
 // CAPABILITIES
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CapabilitiesResp {
     pub hdr: MailboxRespHeader,
     pub capabilities: [u8; crate::capabilities::Capabilities::SIZE_IN_BYTES],
@@ -802,7 +796,7 @@ impl Response for CapabilitiesResp {}
 // ADD_SUBJECT_ALT_NAME
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AddSubjectAltNameReq {
     pub hdr: MailboxReqHeader,
     pub dmtf_device_info_size: u32,
@@ -824,7 +818,7 @@ impl AddSubjectAltNameReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_DEVICE_INFO_LEN - self.dmtf_device_info_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for AddSubjectAltNameReq {
@@ -840,7 +834,7 @@ impl Default for AddSubjectAltNameReq {
 // POPULATE_IDEV_CERT
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct PopulateIdevCertReq {
     pub hdr: MailboxReqHeader,
     pub cert_size: u32,
@@ -862,7 +856,7 @@ impl PopulateIdevCertReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_CERT_SIZE - self.cert_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for PopulateIdevCertReq {
@@ -878,7 +872,7 @@ impl Default for PopulateIdevCertReq {
 // DPE_TAG_TCI
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct TagTciReq {
     pub hdr: MailboxReqHeader,
     pub handle: [u8; 16],
@@ -887,13 +881,13 @@ pub struct TagTciReq {
 
 // DPE_GET_TAGGED_TCI
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetTaggedTciReq {
     pub hdr: MailboxReqHeader,
     pub tag: u32,
 }
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetTaggedTciResp {
     pub hdr: MailboxRespHeader,
     pub tci_cumulative: [u8; 48],
@@ -903,7 +897,7 @@ pub struct GetTaggedTciResp {
 // INCREMENT_PCR_RESET_COUNTER request
 // No command specific output
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct IncrementPcrResetCounterReq {
     pub hdr: MailboxReqHeader,
     pub index: u32,
@@ -916,7 +910,7 @@ impl Request for IncrementPcrResetCounterReq {
 
 /// QUOTE_PCRS input arguments
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct QuotePcrsReq {
     pub hdr: MailboxReqHeader,
     pub nonce: [u8; 32],
@@ -926,7 +920,7 @@ pub type PcrValue = [u8; 48];
 
 /// QUOTE_PCRS output
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct QuotePcrsResp {
     pub hdr: MailboxRespHeader,
     /// The PCR values
@@ -947,7 +941,7 @@ impl Request for QuotePcrsReq {
 
 // SET_AUTH_MANIFEST
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct SetAuthManifestReq {
     pub hdr: MailboxReqHeader,
     pub manifest_size: u32,
@@ -969,7 +963,7 @@ impl SetAuthManifestReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_MAN_SIZE - self.manifest_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for SetAuthManifestReq {
@@ -984,7 +978,7 @@ impl Default for SetAuthManifestReq {
 
 // GET_IDEVID_CSR
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct GetIdevCsrReq {
     pub hdr: MailboxReqHeader,
 }
@@ -995,7 +989,7 @@ impl Request for GetIdevCsrReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct GetIdevCsrResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -1055,7 +1049,7 @@ impl AuthAndStashFlags {
 
 // AUTHORIZE_AND_STASH
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AuthorizeAndStashReq {
     pub hdr: MailboxReqHeader,
     pub fw_id: [u8; 4],
@@ -1084,7 +1078,7 @@ impl Request for AuthorizeAndStashReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AuthorizeAndStashResp {
     pub hdr: MailboxRespHeader,
     pub auth_req_result: u32,
@@ -1127,15 +1121,15 @@ pub fn mbox_read_fifo(
         .ok_or(CaliptraApiError::UnableToReadMailbox)?;
 
     let len_words = buf.len() / size_of::<u32>();
-    let (mut buf_words, suffix) = LayoutVerified::new_slice_unaligned_from_prefix(buf, len_words)
-        .ok_or(CaliptraApiError::ReadBuffTooSmall)?;
+    let (mut buf_words, suffix) = Ref::from_prefix_with_elems(buf, len_words)
+        .map_err(|_| CaliptraApiError::ReadBuffTooSmall)?;
 
     dequeue_words(&mbox, &mut buf_words);
     if !suffix.is_empty() {
         let last_word = mbox.dataout().read();
         let suffix_len = suffix.len();
         suffix
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&last_word.as_bytes()[..suffix_len]);
     }
 

--- a/auth-manifest/app/src/main.rs
+++ b/auth-manifest/app/src/main.rs
@@ -23,7 +23,7 @@ use clap::ArgMatches;
 use clap::{arg, value_parser, Command};
 use std::io::Write;
 use std::path::PathBuf;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 mod config;
 

--- a/auth-manifest/gen/src/generator.rs
+++ b/auth-manifest/gen/src/generator.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_image_gen::ImageGeneratorCrypto;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::*;
 use core::mem::size_of;

--- a/auth-manifest/types/src/lib.rs
+++ b/auth-manifest/types/src/lib.rs
@@ -19,7 +19,7 @@ use caliptra_image_types::*;
 use core::default::Default;
 use core::ops::Range;
 use memoffset::span_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const AUTH_MANIFEST_MARKER: u32 = 0x4154_4D4E;
@@ -40,7 +40,7 @@ impl From<u32> for AuthManifestFlags {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestPubKeys {
     pub ecc_pub_key: ImageEccPubKey,
@@ -49,7 +49,7 @@ pub struct AuthManifestPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Default, Debug, Clone, Copy, Zeroize)]
 pub struct AuthManifestPrivKeys {
     pub ecc_priv_key: ImageEccPrivKey,
     #[zeroize(skip)]
@@ -57,7 +57,7 @@ pub struct AuthManifestPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestSignatures {
     pub ecc_sig: ImageEccSignature,
@@ -67,7 +67,7 @@ pub struct AuthManifestSignatures {
 
 /// Caliptra Authorization Image Manifest Preamble
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize, Default)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestPreamble {
     pub marker: u32,
@@ -138,7 +138,7 @@ bitfield! {
 
 /// Caliptra Authorization Manifest Image Metadata
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestImageMetadata {
     pub fw_id: u32,
@@ -160,7 +160,7 @@ impl Default for AuthManifestImageMetadata {
 
 /// Caliptra Authorization Manifest Image Metadata Collection
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestImageMetadataCollection {
     pub entry_count: u32,
@@ -180,7 +180,7 @@ impl Default for AuthManifestImageMetadataCollection {
 
 /// Caliptra Image Authorization Manifest
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize, Default)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthorizationManifest {
     pub preamble: AuthManifestPreamble,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -23,7 +23,7 @@ use caliptra_image_gen::{
 use caliptra_image_types::{ImageBundle, ImageRevision, RomInfo};
 use elf::endian::LittleEndian;
 use nix::fcntl::FlockArg;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 mod elf_symbols;
 pub mod firmware;

--- a/drivers/src/array.rs
+++ b/drivers/src/array.rs
@@ -15,7 +15,7 @@ Abstract:
 
 use caliptra_cfi_derive::Launder;
 use core::mem::MaybeUninit;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 macro_rules! static_assert {
@@ -27,7 +27,19 @@ macro_rules! static_assert {
 /// The `Array4xN` type represents large arrays in the native format of the Caliptra
 /// cryptographic hardware, and provides From traits for converting to/from byte arrays.
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Launder, Zeroize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    PartialEq,
+    Eq,
+    Launder,
+    Zeroize,
+)]
 pub struct Array4xN<const W: usize, const B: usize>(pub [u32; W]);
 impl<const W: usize, const B: usize> Array4xN<W, B> {
     pub const fn new(val: [u32; W]) -> Self {
@@ -43,15 +55,9 @@ impl<const W: usize, const B: usize> Default for Array4xN<W, B> {
 
 //// Ensure there is no padding in the struct
 static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
-unsafe impl<const W: usize, const B: usize> AsBytes for Array4xN<W, B> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 //// Ensure there is no padding in the struct
 static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
-unsafe impl<const W: usize, const B: usize> FromBytes for Array4xN<W, B> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 impl<const W: usize, const B: usize> Array4xN<W, B> {
     #[inline(always)]

--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -21,7 +21,7 @@ use crate::{
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_registers::ecc::{EccReg, RegisterBlock};
 use core::cmp::Ordering;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 /// ECC-384 Coordinate
@@ -116,7 +116,19 @@ impl<'a> From<Ecc384PrivKeyOut<'a>> for Ecc384PrivKeyIn<'a> {
 
 /// ECC-384 Public Key
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 pub struct Ecc384PubKey {
     /// X coordinate
     pub x: Ecc384Scalar,
@@ -135,7 +147,19 @@ impl Ecc384PubKey {
 
 /// ECC-384 Signature
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Debug,
+    Default,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 pub struct Ecc384Signature {
     /// Random point
     pub r: Ecc384Scalar,

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::Array4x12;
 use caliptra_cfi_derive::Launder;
 use caliptra_registers::soc_ifc::SocIfcReg;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct FuseBank<'a> {
     pub(crate) soc_ifc: &'a SocIfcReg,

--- a/drivers/src/fuse_log.rs
+++ b/drivers/src/fuse_log.rs
@@ -11,7 +11,7 @@ Abstract:
 
 --*/
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[repr(u32)]
@@ -51,7 +51,7 @@ impl From<u32> for FuseLogEntryId {
 
 /// Fuse log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, KnownLayout, Immutable, Zeroize)]
 pub struct FuseLogEntry {
     /// Entry identifier
     pub entry_id: u32,

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -10,14 +10,14 @@ use bitfield::{bitfield_bitrange, bitfield_fields};
 use caliptra_error::CaliptraError;
 use caliptra_image_types::RomInfo;
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 pub const FHT_MARKER: u32 = 0x54484643;
 pub const FHT_INVALID_ADDRESS: u32 = u32::MAX;
 
 #[repr(C)]
-#[derive(AsBytes, Copy, Clone, Debug, FromBytes, PartialEq, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, Copy, Clone, Debug, FromBytes, PartialEq, Zeroize)]
 pub struct HandOffDataHandle(pub u32);
 pub const FHT_INVALID_HANDLE: HandOffDataHandle = HandOffDataHandle(u32::MAX);
 
@@ -179,7 +179,7 @@ impl From<DataStore> for HandOffDataHandle {
 const _: () = assert!(size_of::<FirmwareHandoffTable>() == 2048);
 const _: () = assert!(size_of::<FirmwareHandoffTable>() <= memory_layout::FHT_SIZE as usize);
 #[repr(C)]
-#[derive(Clone, Debug, AsBytes, FromBytes, Zeroize)]
+#[derive(Clone, Debug, IntoBytes, TryFromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct FirmwareHandoffTable {
     /// Magic Number marking start of table. Value must be 0x54484643
     /// (‘CFHT’ when viewed as little-endian ASCII).

--- a/drivers/src/lms.rs
+++ b/drivers/src/lms.rs
@@ -21,7 +21,7 @@ use caliptra_error::CaliptraError;
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmsAlgorithmType, LmsIdentifier, LmsPublicKey, LmsSignature,
 };
-use zerocopy::{AsBytes, LittleEndian, U32};
+use zerocopy::{IntoBytes, LittleEndian, U32};
 use zeroize::Zeroize;
 
 pub const D_PBLC: u16 = 0x8080;

--- a/drivers/src/pcr_log.rs
+++ b/drivers/src/pcr_log.rs
@@ -12,7 +12,7 @@ Abstract:
 --*/
 
 use crate::PcrId;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const PCR_ID_FMC_CURRENT: PcrId = PcrId::PcrId0;
@@ -52,7 +52,7 @@ impl From<u16> for PcrLogEntryId {
 
 /// PCR log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct PcrLogEntry {
     /// Entry identifier
     pub id: u16,
@@ -85,7 +85,7 @@ impl PcrLogEntry {
 
 /// Measurement log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct MeasurementLogEntry {
     pub pcr_entry: PcrLogEntry,
     pub metadata: [u8; 4],

--- a/drivers/src/pcr_reset.rs
+++ b/drivers/src/pcr_reset.rs
@@ -13,11 +13,11 @@ Abstract:
 
 use crate::pcr_bank::{PcrBank, PcrId};
 use core::ops::{Index, IndexMut};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[repr(C, align(4))]
-#[derive(AsBytes, FromBytes, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct PcrResetCounter {
     counter: [u32; PcrBank::ALL_PCR_IDS.len()],
 }

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -11,7 +11,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
 #[cfg(feature = "runtime")]
 use dpe::{DpeInstance, U8Bool, MAX_HANDLES};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 use crate::{
@@ -45,7 +45,7 @@ pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
 pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
-#[derive(Clone, FromBytes, AsBytes, Zeroize)]
+#[derive(Clone, TryFromBytes, IntoBytes, Zeroize)]
 #[repr(C)]
 pub struct IdevIdCsr {
     csr_len: u32,
@@ -104,7 +104,7 @@ impl IdevIdCsr {
 
 const _: () = assert!(size_of::<IdevIdCsr>() < memory_layout::IDEVID_CSR_SIZE as usize);
 
-#[derive(FromBytes, AsBytes, Zeroize)]
+#[derive(TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct PersistentData {
     pub manifest1: ImageManifest,
@@ -244,7 +244,7 @@ impl PersistentDataAccessor {
 }
 
 #[inline(always)]
-unsafe fn ref_from_addr<'a, T: FromBytes>(addr: u32) -> &'a T {
+unsafe fn ref_from_addr<'a, T: TryFromBytes>(addr: u32) -> &'a T {
     // LTO should be able to optimize out the assertions to maintain panic_is_missing
 
     // dereferencing zero is undefined behavior
@@ -255,7 +255,7 @@ unsafe fn ref_from_addr<'a, T: FromBytes>(addr: u32) -> &'a T {
 }
 
 #[inline(always)]
-unsafe fn ref_mut_from_addr<'a, T: FromBytes>(addr: u32) -> &'a mut T {
+unsafe fn ref_mut_from_addr<'a, T: TryFromBytes>(addr: u32) -> &'a mut T {
     // LTO should be able to optimize out the assertions to maintain panic_is_missing
 
     // dereferencing zero is undefined behavior

--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -29,7 +29,7 @@ use caliptra_registers::{
     csrng::CsrngReg, doe::DoeReg, entropy_src::EntropySrcReg, hmac::HmacReg, mbox::MboxCsr,
 };
 use caliptra_test_harness::test_suite;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn export_result_from_kv(ecc: &mut Ecc384, trng: &mut Trng, key_id: KeyId) -> Ecc384PubKey {
     ecc.key_pair(

--- a/drivers/test-fw/src/bin/mailbox_driver_responder.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_responder.rs
@@ -11,7 +11,7 @@ use caliptra_test_harness::{self, println};
 
 use caliptra_drivers::{self, Mailbox};
 use caliptra_registers::mbox::MboxCsr;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[panic_handler]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {
@@ -32,7 +32,7 @@ extern "C" fn main() {
                 let mut buf = [0u32; 4];
                 let dlen = txn.dlen();
                 println!("dlen: {dlen}");
-                txn.recv_request(buf.as_bytes_mut()).unwrap();
+                txn.recv_request(buf.as_mut_bytes()).unwrap();
                 println!("buf: {:08x?}", buf);
             }
             // Test recv_request with non-multiple-of-4 result buffer
@@ -50,7 +50,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -72,7 +72,7 @@ extern "C" fn main() {
                 let rem_words = dlen_words / 2;
                 let mut buf = [0u32; 1];
                 for _ in 0..rem_words {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -88,7 +88,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.send_response(&[0x98, 0x76]).unwrap();

--- a/drivers/test-fw/src/bin/trng_driver_responder.rs
+++ b/drivers/test-fw/src/bin/trng_driver_responder.rs
@@ -14,7 +14,7 @@ use caliptra_registers::{
     csrng::CsrngReg, entropy_src::EntropySrcReg, mbox::MboxCsr, soc_ifc::SocIfcReg,
     soc_ifc_trng::SocIfcTrngReg,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[panic_handler]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/drivers/test-fw/src/lib.rs
+++ b/drivers/test-fw/src/lib.rs
@@ -7,7 +7,7 @@ use caliptra_drivers::Ecc384PubKey;
 /// Code shared between the caliptra-drivers integration_test.rs (running on the
 /// host) and the test binaries (running inside the hw-model).
 use core::fmt::Debug;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const DOE_TEST_IV: [u32; 4] = [0xc6b407a2, 0xd119a37d, 0xb7a5bdeb, 0x26214aed];
 
@@ -16,7 +16,7 @@ pub const DOE_TEST_HMAC_KEY: [u32; 12] = [
     0xc6879874, 0x0aa49a0f, 0x4e740e9c, 0x2c9f9aad,
 ];
 
-#[derive(AsBytes, Clone, Copy, Default, Eq, PartialEq, FromBytes)]
+#[derive(IntoBytes, KnownLayout, Immutable, Clone, Copy, Default, Eq, PartialEq, FromBytes)]
 #[repr(C)]
 pub struct DoeTestResults {
     /// HMAC result of the UDS as key, and b"Hello world!" as data.

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -23,7 +23,7 @@ use caliptra_test::{
 };
 use openssl::{hash::MessageDigest, pkey::PKey};
 use ureg::ResettableReg;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 fn default_init_params() -> InitParams<'static> {
     InitParams {
@@ -221,7 +221,7 @@ fn test_doe_when_debug_not_locked() {
     .unwrap();
 
     let txn = model.wait_for_mailbox_receive().unwrap();
-    let test_results = DoeTestResults::read_from(txn.req.data.as_slice()).unwrap();
+    let test_results = DoeTestResults::read_from_bytes(txn.req.data.as_slice()).unwrap();
     assert_eq!(
         test_results,
         DOE_TEST_VECTORS_DEBUG_MODE.expected_test_results
@@ -315,7 +315,7 @@ fn test_doe_when_debug_locked() {
     .unwrap();
 
     let txn = model.wait_for_mailbox_receive().unwrap();
-    let test_results = DoeTestResults::read_from(txn.req.data.as_slice()).unwrap();
+    let test_results = DoeTestResults::read_from_bytes(txn.req.data.as_slice()).unwrap();
     assert_eq!(test_results, DOE_TEST_VECTORS.expected_test_results);
     txn.respond_success();
     model.step_until_exit_success().unwrap();

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -31,7 +31,7 @@ use caliptra_drivers::{
     CaliptraResult, PersistentData,
 };
 use caliptra_error::CaliptraError;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Extend common data into the RT current and journey PCRs
 ///
@@ -92,7 +92,7 @@ fn log_pcr(
         pcr_ids,
         ..Default::default()
     };
-    dst.pcr_data.as_bytes_mut()[..data.len()].copy_from_slice(data);
+    dst.pcr_data.as_mut_bytes()[..data.len()].copy_from_slice(data);
     fht.pcr_log_index += 1;
 
     Ok(())

--- a/fmc/src/flow/tci.rs
+++ b/fmc/src/flow/tci.rs
@@ -19,7 +19,7 @@ Environment:
 use crate::flow::crypto::Crypto;
 use crate::fmc_env::FmcEnv;
 use caliptra_drivers::{Array4x12, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct Tci {}
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -18,7 +18,7 @@ use caliptra_hw_model_types::{
     ErrorInjectionMode, EtrngResponse, HexBytes, HexSlice, RandomEtrngResponses, RandomNibbles,
     DEFAULT_CPTRA_OBF_KEY,
 };
-use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unalign};
+use zerocopy::{FromBytes, FromZeros, IntoBytes, Ref, Unalign};
 
 use caliptra_registers::mbox;
 use caliptra_registers::mbox::enums::{MboxFsmE, MboxStatusE};
@@ -837,7 +837,7 @@ pub trait HwModel: SocManager {
     ) -> std::result::Result<R::Resp, ModelError> {
         let mut response = R::Resp::new_zeroed();
 
-        self.mailbox_exec_req(req, response.as_bytes_mut())
+        self.mailbox_exec_req(req, response.as_mut_bytes())
             .map_err(ModelError::from)
     }
 
@@ -974,13 +974,9 @@ pub trait HwModel: SocManager {
 
         // Unwrap cannot fail, count * sizeof(u32) is always smaller than data.len()
         let (prefix_words, suffix_bytes) =
-            LayoutVerified::<_, [Unalign<u32>]>::new_slice_unaligned_from_prefix(
-                data,
-                data.len() / 4,
-            )
-            .unwrap();
+            Ref::<_, [Unalign<u32>]>::from_prefix_with_elems(data, data.len() / 4).unwrap();
 
-        for word in prefix_words.into_slice() {
+        for word in Ref::into_ref(prefix_words) {
             self.soc_sha512_acc()
                 .datain()
                 .write(|_| word.get().swap_bytes());
@@ -1054,8 +1050,8 @@ pub trait HwModel: SocManager {
         let response = response.ok_or(ModelError::UploadMeasurementResponseError)?;
 
         // Get response as a response header struct
-        let response = api::mailbox::StashMeasurementResp::read_from(response.as_slice())
-            .ok_or(ModelError::UploadMeasurementResponseError)?;
+        let response = api::mailbox::StashMeasurementResp::ref_from_bytes(response.as_slice())
+            .map_err(|_| ModelError::UploadMeasurementResponseError)?;
 
         // Verify checksum and FIPS status
         if !api::verify_checksum(
@@ -1085,7 +1081,7 @@ mod tests {
     use caliptra_emu_bus::Bus;
     use caliptra_emu_types::RvSize;
     use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc};
-    use zerocopy::{AsBytes, FromBytes};
+    use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
     use crate as caliptra_hw_model;
 
@@ -1432,7 +1428,7 @@ mod tests {
         // Send command that echoes the command and input message
         let mut resp_data = [0u8; 128];
         assert_eq!(
-            model.mailbox_exec(0x1000_0000, &message[..8], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x1000_0000, &message[..8], resp_data.as_mut_bytes()),
             Ok(Some(
                 [0x00, 0x00, 0x00, 0x10, 0x90, 0x5e, 0x1f, 0xad, 0x8b, 0x60, 0xb0, 0xbf].as_slice()
             )),
@@ -1443,19 +1439,19 @@ mod tests {
         let mut resp_data = [0u8; 128];
 
         assert_eq!(
-            model.mailbox_exec(0x1000_1000, &[42], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x1000_1000, &[42], resp_data.as_mut_bytes()),
             Ok(Some([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd].as_slice())),
         );
 
         // Send command that returns success with no output
         assert_eq!(
-            model.mailbox_exec(0x2000_0000, &[], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x2000_0000, &[], resp_data.as_mut_bytes()),
             Ok(None)
         );
 
         // Send command that returns failure
         assert_eq!(
-            model.mailbox_exec(0x4000_0000, &message, resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x4000_0000, &message, resp_data.as_mut_bytes()),
             Err(CaliptraApiError::MailboxCmdFailed(0))
         );
     }
@@ -1596,7 +1592,7 @@ mod tests {
         const GET_RESPONSE_CMD: u32 = 0x3000_0001;
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Default, Immutable, KnownLayout)]
         struct TestReq {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1606,7 +1602,7 @@ mod tests {
             type Resp = TestResp;
         }
         #[repr(C)]
-        #[derive(AsBytes, Debug, FromBytes, PartialEq, Eq)]
+        #[derive(IntoBytes, Immutable, KnownLayout, Debug, FromBytes, PartialEq, Eq)]
         struct TestResp {
             hdr: MailboxRespHeader,
             data: [u8; 4],
@@ -1614,7 +1610,7 @@ mod tests {
         impl mailbox::Response for TestResp {}
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReqNoData {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1710,7 +1706,7 @@ mod tests {
                     data: *b"Hi!!",
                     ..Default::default()
                 },
-                packet.as_bytes_mut(),
+                packet.as_mut_bytes(),
             )
             .map_err(ModelError::from);
         assert_eq!(
@@ -1760,7 +1756,7 @@ mod tests {
         const GET_RESPONSE_CMD: u32 = 0x3000_0001;
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReq {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1770,7 +1766,7 @@ mod tests {
             type Resp = TestResp;
         }
         #[repr(C)]
-        #[derive(AsBytes, Debug, FromBytes, PartialEq, Eq)]
+        #[derive(IntoBytes, Debug, FromBytes, PartialEq, Eq)]
         struct TestResp {
             hdr: MailboxRespHeader,
             data: [u8; 4],
@@ -1778,7 +1774,7 @@ mod tests {
         impl mailbox::Response for TestResp {}
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReqNoData {
             hdr: MailboxReqHeader,
             data: [u8; 4],

--- a/image/fake-keys/src/lib.rs
+++ b/image/fake-keys/src/lib.rs
@@ -13,7 +13,7 @@ use std::fs;
 #[cfg(test)]
 use std::io::Write; // bring trait into scope
 #[cfg(test)]
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Generated with
 ///

--- a/image/gen/src/generator.rs
+++ b/image/gen/src/generator.rs
@@ -14,7 +14,7 @@ Abstract:
 use anyhow::bail;
 use caliptra_image_types::*;
 use memoffset::offset_of;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::*;
 

--- a/image/serde/src/lib.rs
+++ b/image/serde/src/lib.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 use caliptra_image_types::*;
 use std::io::Write;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Image Bundle Writer
 pub struct ImageBundleWriter<W: Write> {

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -23,7 +23,7 @@ use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPrivateKey, LmsPublicKey, LmsSignature,
 };
 use memoffset::{offset_of, span_of};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const MANIFEST_MARKER: u32 = 0x4E414D43;
 pub const VENDOR_ECC_KEY_COUNT: u32 = 4;
@@ -52,7 +52,19 @@ pub type ImageRevision = [u8; IMAGE_REVISION_BYTE_SIZE];
 pub type ImageEccPrivKey = ImageScalar;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Default,
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccPubKey {
     /// X Coordinate
@@ -66,7 +78,19 @@ pub type ImageLmsPublicKey = LmsPublicKey<SHA192_DIGEST_WORD_SIZE>;
 pub type ImageLmsPrivKey = LmsPrivateKey<SHA192_DIGEST_WORD_SIZE>;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Default,
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccSignature {
     /// Random point
@@ -132,7 +156,7 @@ impl ImageBundle {
 
 /// Calipatra Image Manifest
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageManifest {
     /// Marker
@@ -141,7 +165,7 @@ pub struct ImageManifest {
     /// Size of `Manifest` structure
     pub size: u32,
 
-    /// Preabmle
+    /// Preamble
     pub preamble: ImagePreamble,
 
     /// Header
@@ -195,7 +219,7 @@ impl ImageManifest {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageVendorPubKeys {
     pub ecc_pub_keys: [ImageEccPubKey; VENDOR_ECC_KEY_COUNT as usize],
@@ -204,7 +228,7 @@ pub struct ImageVendorPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 pub struct ImageVendorPrivKeys {
     pub ecc_priv_keys: [ImageEccPrivKey; VENDOR_ECC_KEY_COUNT as usize],
     #[zeroize(skip)]
@@ -212,7 +236,7 @@ pub struct ImageVendorPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageOwnerPubKeys {
     pub ecc_pub_key: ImageEccPubKey,
@@ -221,7 +245,7 @@ pub struct ImageOwnerPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 pub struct ImageOwnerPrivKeys {
     pub ecc_priv_key: ImageEccPrivKey,
     #[zeroize(skip)]
@@ -229,7 +253,7 @@ pub struct ImageOwnerPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageSignatures {
     pub ecc_sig: ImageEccSignature,
@@ -239,7 +263,7 @@ pub struct ImageSignatures {
 
 /// Calipatra Image Bundle Preamble
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePreamble {
     /// Vendor  Public Keys
@@ -264,7 +288,7 @@ pub struct ImagePreamble {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct VendorSignedData {
     /// Vendor Start Date [ASN1 Time Format] For FMC alias certificate.
@@ -277,7 +301,7 @@ pub struct VendorSignedData {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OwnerSignedData {
     /// Owner Start Date [ASN1 Time Format] For FMC alias certificate: Takes Preference over vendor start date
@@ -294,7 +318,7 @@ pub struct OwnerSignedData {
 
 /// Caliptra Image header
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageHeader {
     /// Revision
@@ -358,7 +382,7 @@ impl From<ImageTocEntryId> for u32 {
 
 /// Caliptra Table of contents entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageTocEntry {
     /// ID
@@ -414,7 +438,7 @@ impl ImageTocEntry {
 
 /// Information about the ROM image.
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default, Debug)]
 pub struct RomInfo {
     // sha256 digest with big-endian words, where each 4-byte segment of the
     // digested data has the bytes reversed.

--- a/lms-types/src/lib.rs
+++ b/lms-types/src/lib.rs
@@ -5,7 +5,9 @@
 use core::mem::size_of;
 
 use caliptra_cfi_derive::Launder;
-use zerocopy::{AsBytes, BigEndian, FromBytes, LittleEndian, U32};
+use zerocopy::{
+    BigEndian, FromBytes, Immutable, IntoBytes, KnownLayout, LittleEndian, Unaligned, U32,
+};
 use zeroize::Zeroize;
 
 pub type LmsIdentifier = [u8; 16];
@@ -17,7 +19,19 @@ macro_rules! static_assert {
 }
 
 #[repr(transparent)]
-#[derive(AsBytes, FromBytes, Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Copy,
+    Clone,
+    Debug,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Default,
+    PartialEq,
+    Eq,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LmsAlgorithmType(pub U32<BigEndian>);
 impl LmsAlgorithmType {
@@ -40,7 +54,19 @@ impl LmsAlgorithmType {
 }
 
 #[repr(transparent)]
-#[derive(AsBytes, FromBytes, Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Debug,
+    Immutable,
+    KnownLayout,
+    Unaligned,
+    Default,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LmotsAlgorithmType(pub U32<BigEndian>);
 
@@ -61,7 +87,9 @@ impl LmotsAlgorithmType {
     pub const LmotsSha256N24W8: Self = Self::new(8);
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Launder)]
+#[derive(
+    Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Launder,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(C)]
 pub struct LmsPublicKey<const N: usize> {
@@ -81,7 +109,7 @@ impl<const N: usize> Default for LmsPublicKey<N> {
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmsPublicKey<1>>()
         == (size_of::<LmsAlgorithmType>()
@@ -89,16 +117,21 @@ static_assert!(
             + size_of::<[u8; 16]>()
             + size_of::<[U32<LittleEndian>; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize> AsBytes for LmsPublicKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize> FromBytes for LmsPublicKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Zeroize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    IntoBytes,
+    Immutable,
+    KnownLayout,
+    Unaligned,
+    FromBytes,
+    PartialEq,
+    Eq,
+    Zeroize,
+)]
 #[repr(C)]
 pub struct LmotsSignature<const N: usize, const P: usize> {
     #[zeroize(skip)]
@@ -119,23 +152,18 @@ impl<const N: usize, const P: usize> Default for LmotsSignature<N, P> {
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmotsSignature<1, 1>>()
         == (size_of::<LmotsAlgorithmType>()
             + size_of::<[U32<LittleEndian>; 1]>()
             + size_of::<[[U32<LittleEndian>; 1]; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize, const P: usize> AsBytes for LmotsSignature<N, P> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize, const P: usize> FromBytes for LmotsSignature<N, P> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Launder)]
+#[derive(
+    Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq, Launder,
+)]
 #[repr(C)]
 pub struct LmsSignature<const N: usize, const P: usize, const H: usize> {
     pub q: U32<BigEndian>,
@@ -156,7 +184,7 @@ impl<const N: usize, const P: usize, const H: usize> Default for LmsSignature<N,
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmsSignature<1, 1, 1>>()
         == (size_of::<U32<BigEndian>>()
@@ -164,15 +192,8 @@ static_assert!(
             + size_of::<LmsAlgorithmType>()
             + size_of::<[[U32<LittleEndian>; 1]; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize, const P: usize, const H: usize> AsBytes for LmsSignature<N, P, H> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize, const P: usize, const H: usize> FromBytes for LmsSignature<N, P, H> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Eq, PartialEq)]
 #[repr(C)]
 pub struct LmsPrivateKey<const N: usize> {
     pub tree_type: LmsAlgorithmType,
@@ -200,13 +221,6 @@ static_assert!(
             + size_of::<LmsIdentifier>()
             + size_of::<[U32<LittleEndian>; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize> AsBytes for LmsPrivateKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize> FromBytes for LmsPrivateKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 /// Converts a byte array to word arrays as used in the LMS types. Intended for
 /// use at compile-time or in tests / host utilities; not optimized for use in

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -159,7 +159,7 @@ impl FakeRomFlow {
                 // In real ROM, this is done as part of executing the SHA-ACC KAT.
                 let sha_op = env
                     .sha2_512_384_acc
-                    .try_start_operation(ShaAccLockState::AssumedLocked)?
+                    .try_start_operation(ShaAccLockState::AssumedLocked)
                     .unwrap();
                 drop(sha_op);
 

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -27,7 +27,7 @@ use caliptra_drivers::{DataVault, PersistentData};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
 use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[derive(Default)]
 pub struct UpdateResetFlow {}
@@ -184,7 +184,7 @@ impl UpdateResetFlow {
             core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
         };
 
-        txn.copy_request(runtime_dest.as_bytes_mut())?;
+        txn.copy_request(runtime_dest.as_mut_bytes())?;
 
         //Call the complete here to reset the execute bit
         txn.complete(true)?;
@@ -202,7 +202,7 @@ impl UpdateResetFlow {
         persistent_data: &mut PersistentData,
         txn: &mut MailboxRecvTxn,
     ) -> CaliptraResult<()> {
-        txn.copy_request(persistent_data.manifest2.as_bytes_mut())?;
+        txn.copy_request(persistent_data.manifest2.as_mut_bytes())?;
         Ok(())
     }
 

--- a/rom/dev/src/fuse.rs
+++ b/rom/dev/src/fuse.rs
@@ -13,7 +13,7 @@ Abstract:
 use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_common::{FuseLogEntry, FuseLogEntryId};
 use caliptra_drivers::{CaliptraError, CaliptraResult, FuseLogArray};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Log Fuse data
 ///
@@ -42,7 +42,7 @@ pub fn log_fuse_data(
         entry_id: entry_id as u32,
         ..Default::default()
     };
-    let Some(data_dest) = log_entry.log_data.as_bytes_mut().get_mut(..data.len()) else {
+    let Some(data_dest) = log_entry.log_data.as_mut_bytes().get_mut(..data.len()) else {
         return Err(CaliptraError::ROM_GLOBAL_FUSE_LOG_UNSUPPORTED_DATA_LENGTH);
     };
     data_dest.copy_from_slice(data);

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -32,7 +32,7 @@ use caliptra_drivers::{
 };
 use caliptra_image_verify::ImageVerificationInfo;
 
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 struct PcrExtender<'a> {
     persistent_data: &'a mut PersistentData,
@@ -144,7 +144,7 @@ pub fn log_pcr(
         pcr_ids,
         ..Default::default()
     };
-    let Some(dest_data) = pcr_log_entry.pcr_data.as_bytes_mut().get_mut(..data.len()) else {
+    let Some(dest_data) = pcr_log_entry.pcr_data.as_mut_bytes().get_mut(..data.len()) else {
         return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH);
     };
     dest_data.copy_from_slice(data);

--- a/rom/dev/tests/rom_integration_tests/test_capabilities.rs
+++ b/rom/dev/tests/rom_integration_tests/test_capabilities.rs
@@ -6,7 +6,7 @@ use caliptra_common::mailbox_api::{
     CapabilitiesResp, CommandId, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::{Fuses, HwModel};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -24,7 +24,7 @@ fn test_capabilities() {
         .unwrap()
         .unwrap();
 
-    let capabilities_resp = CapabilitiesResp::read_from(response.as_bytes()).unwrap();
+    let capabilities_resp = CapabilitiesResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     // Verify response checksum
     assert!(caliptra_common::checksum::verify_checksum(

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -9,7 +9,7 @@ use caliptra_image_types::ImageBundle;
 use openssl::pkey::{PKey, Public};
 use openssl::x509::X509;
 use openssl::{rand::rand_bytes, x509::X509Req};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 
@@ -146,7 +146,7 @@ fn verify_key(
 
     assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
     let mut cert_resp = GetLdevCertResp::default();
-    cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Extract the certificate from the response
     let cert_der = &cert_resp.data[..(cert_resp.data_size as usize)];

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -35,7 +35,7 @@ use openssl::rsa::Rsa;
 use openssl::x509::X509Req;
 use openssl::x509::X509;
 use std::str;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 

--- a/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
@@ -4,7 +4,7 @@ use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, StashMeasurementReq};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -19,7 +19,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
 use caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0;
 use caliptra_image_gen::ImageGeneratorVendorConfig;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const TEST_FMC_CMD_RESET_FOR_UPDATE: u32 = 0x1000_0004;
 const TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD: u32 = 0x1000_000B;
@@ -456,16 +456,16 @@ fn test_check_rom_update_reset_status_reg() {
     let mut warmresetentry4_offset = core::mem::size_of::<u32>() * 8; // Skip first four entries
 
     // Check RomUpdateResetStatus datavault value.
-    let warmresetentry4_id =
-        u32::read_from_prefix(warmresetentry4_array[warmresetentry4_offset..].as_bytes()).unwrap();
+    let (warmresetentry4_id, _) =
+        u32::ref_from_prefix(warmresetentry4_array[warmresetentry4_offset..].as_bytes()).unwrap();
     assert_eq!(
-        warmresetentry4_id,
+        *warmresetentry4_id,
         WarmResetEntry4::RomUpdateResetStatus as u32
     );
     warmresetentry4_offset += core::mem::size_of::<u32>();
-    let warmresetentry4_value =
-        u32::read_from_prefix(warmresetentry4_array[warmresetentry4_offset..].as_bytes()).unwrap();
-    assert_eq!(warmresetentry4_value, u32::from(UpdateResetComplete));
+    let (warmresetentry4_value, _) =
+        u32::ref_from_prefix(warmresetentry4_array[warmresetentry4_offset..].as_bytes()).unwrap();
+    assert_eq!(*warmresetentry4_value, u32::from(UpdateResetComplete));
 }
 
 #[test]

--- a/rom/dev/tests/rom_integration_tests/test_version.rs
+++ b/rom/dev/tests/rom_integration_tests/test_version.rs
@@ -6,7 +6,7 @@ use caliptra_common::mailbox_api::{
     CommandId, FipsVersionResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::{Fuses, HwModel};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -28,7 +28,7 @@ fn test_version() {
         .unwrap()
         .unwrap();
 
-    let version_resp = FipsVersionResp::read_from(response.as_bytes()).unwrap();
+    let version_resp = FipsVersionResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     // Verify response checksum
     assert!(caliptra_common::checksum::verify_checksum(

--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -11,7 +11,7 @@ use caliptra_hw_model::DeviceLifecycle;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_test::swap_word_bytes_inplace;
 use openssl::sha::sha384;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 

--- a/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
+++ b/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
@@ -6,7 +6,7 @@ use caliptra_common::mailbox_api::{CommandId, GetIdevCsrResp, MailboxReqHeader};
 use caliptra_drivers::MfgFlags;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -36,7 +36,7 @@ fn test_get_csr() {
         .unwrap()
         .unwrap();
 
-    let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
+    let get_idv_csr_resp = GetIdevCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     assert!(caliptra_common::checksum::verify_checksum(
         get_idv_csr_resp.hdr.chksum,

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -27,7 +27,7 @@ use caliptra_registers::pv::PvReg;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, LocalDevIdCertTbs};
 use ureg::RealMmioMut;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[cfg(not(feature = "std"))]
 core::arch::global_asm!(include_str!("start.S"));

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -43,7 +43,7 @@ use dpe::{
     response::DpeErrorCode,
 };
 use memoffset::offset_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
 pub const IMAGE_NOT_AUTHORIZED: u32 = 0x21523F21; // FW ID not found in the image metadata entry collection.
@@ -54,7 +54,7 @@ impl AuthorizeAndStashCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = AuthorizeAndStashReq::read_from(cmd_args) {
+        if let Ok(cmd) = AuthorizeAndStashReq::ref_from_bytes(cmd_args) {
             if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
                 Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
             }

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -25,7 +25,7 @@ use dpe::{
     commands::{CertifyKeyCmd, Command, CommandExecution},
     response::Response,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::{
     CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges, MAX_CERT_CHAIN_SIZE,
@@ -36,8 +36,8 @@ pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = CertifyKeyExtendedReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = CertifyKeyExtendedReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         match drivers.caller_privilege_level() {
             // CERTIFY_KEY_EXTENDED MUST only be called from PL0
@@ -85,8 +85,8 @@ impl CertifyKeyExtendedCmd {
         };
 
         let mut dpe = &mut pdata.dpe;
-        let certify_key_cmd = CertifyKeyCmd::read_from(&cmd.certify_key_req[..])
-            .ok_or(CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+        let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..])
+            .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let locality = drivers.mbox.user();
         let resp = certify_key_cmd.execute(dpe, &mut env, locality);
 

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -24,7 +24,7 @@ use caliptra_drivers::{
     PersistentData,
 };
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
@@ -32,7 +32,7 @@ impl IDevIdCertCmd {
     pub(crate) fn execute(cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<GetIdevCertReq>() {
             let mut cmd = GetIdevCertReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             // Validate tbs
             if cmd.tbs_size as usize > cmd.tbs.len() {

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -23,7 +23,7 @@ use caliptra_drivers::{
     KeyVault, KeyWriteArgs, Sha384, Sha384DigestOp, Trng,
 };
 use crypto::{AlgLen, Crypto, CryptoBuf, CryptoError, Digest, EcdsaPub, EcdsaSig, Hasher, HmacSig};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 pub struct DpeCrypto<'a> {

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -28,7 +28,7 @@ use platform::{
     MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
     MAX_SN_SIZE,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{subject_alt_name::AddSubjectAltNameCmd, MAX_CERT_CHAIN_SIZE};
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -59,7 +59,7 @@ use dpe::{
 
 use core::cmp::Ordering::{Equal, Greater};
 use crypto::{AlgLen, Crypto, CryptoBuf, Hasher};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[derive(PartialEq, Clone)]
 pub enum PauserPrivileges {

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -71,7 +71,7 @@ pub mod fips_self_test_cmd {
     use caliptra_drivers::{ResetReason, ShaAccLockState};
     use caliptra_image_types::{ImageTocEntry, RomInfo};
     use caliptra_image_verify::ImageVerifier;
-    use zerocopy::AsBytes;
+    use zerocopy::IntoBytes;
 
     // Helper function to create a slice from a memory region
     unsafe fn create_slice(toc: &ImageTocEntry) -> &'static [u8] {

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -13,44 +13,40 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use caliptra_drivers::IdevIdCsr;
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct GetIdevCsrCmd;
 impl GetIdevCsrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = GetIdevCsrReq::read_from(cmd_args) {
-            let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
+        let cmd = GetIdevCsrReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
 
-            match csr_persistent_mem.get_csr_len() {
-                IdevIdCsr::UNPROVISIONED_CSR => {
-                    Err(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)
-                }
-                0 => Err(CaliptraError::RUNTIME_GET_IDEV_ID_UNSUPPORTED_ROM),
-                len => {
-                    let csr = csr_persistent_mem
-                        .get()
-                        .ok_or(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)?;
+        match csr_persistent_mem.get_csr_len() {
+            IdevIdCsr::UNPROVISIONED_CSR => Err(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED),
+            0 => Err(CaliptraError::RUNTIME_GET_IDEV_ID_UNSUPPORTED_ROM),
+            len => {
+                let csr = csr_persistent_mem
+                    .get()
+                    .ok_or(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)?;
 
-                    let mut resp = GetIdevCsrResp {
-                        data_size: len,
-                        ..Default::default()
-                    };
-                    // NOTE: This code will not panic.
-                    //
-                    // csr is guranteed to be the same size as `len`, and therefore
-                    // `resp.data_size` by the `IDevIDCsr::get` API.
-                    //
-                    // A valid `IDevIDCsr` cannot be larger than `MAX_CSR_SIZE`, which is the max
-                    // size of the buffer in `GetIdevCsrResp`
-                    resp.data[..resp.data_size as usize].copy_from_slice(csr);
+                let mut resp = GetIdevCsrResp {
+                    data_size: len,
+                    ..Default::default()
+                };
+                // NOTE: This code will not panic.
+                //
+                // csr is guranteed to be the same size as `len`, and therefore
+                // `resp.data_size` by the `IDevIDCsr::get` API.
+                //
+                // A valid `IDevIDCsr` cannot be larger than `MAX_CSR_SIZE`, which is the max
+                // size of the buffer in `GetIdevIdCsrResp`
+                resp.data[..resp.data_size as usize].copy_from_slice(csr);
 
-                    Ok(MailboxResp::GetIdevCsr(resp))
-                }
+                Ok(MailboxResp::GetIdevCsr(resp))
             }
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 }

--- a/runtime/src/hmac.rs
+++ b/runtime/src/hmac.rs
@@ -20,7 +20,7 @@ use caliptra_drivers::{
     KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 use caliptra_error::CaliptraResult;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 use crate::Drivers;

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use core::mem::size_of;
 use core::slice;
 
 use caliptra_drivers::{memory_layout, CaliptraResult};
@@ -20,7 +21,7 @@ use caliptra_registers::mbox::{
     enums::{MboxFsmE, MboxStatusE},
     MboxCsr,
 };
-use zerocopy::{AsBytes, LayoutVerified, Unalign};
+use zerocopy::{FromBytes, IntoBytes, Unalign};
 
 use crate::CommandId;
 
@@ -133,12 +134,12 @@ impl Mailbox {
 
     /// Copies word-aligned `buf` to the mailbox
     pub fn copy_bytes_to_mbox(&mut self, buf: &[u8]) -> CaliptraResult<()> {
-        let (buf_words, suffix) =
-            LayoutVerified::new_slice_unaligned_from_prefix(buf, buf.len() / 4).unwrap();
-        self.copy_words_to_mbox(&buf_words);
-        if !suffix.is_empty() {
+        let count = buf.len() / size_of::<u32>();
+        let (buf_words, suffix) = <[Unalign<u32>]>::ref_from_prefix_with_elems(buf, count).unwrap();
+        self.copy_words_to_mbox(buf_words);
+        if !suffix.is_empty() && suffix.len() <= size_of::<u32>() {
             let mut last_word = 0_u32;
-            last_word.as_bytes_mut()[..suffix.len()].copy_from_slice(suffix);
+            last_word.as_mut_bytes()[..suffix.len()].copy_from_slice(suffix);
             self.copy_words_to_mbox(&[Unalign::new(last_word)]);
         }
         Ok(())

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -26,8 +26,8 @@ impl IncrementPcrResetCounterCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = IncrementPcrResetCounterReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = IncrementPcrResetCounterReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let index =
             u8::try_from(cmd.index).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
@@ -48,8 +48,8 @@ impl GetPcrQuoteCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
-        let args: QuotePcrsReq = QuotePcrsReq::read_from(cmd_bytes)
-            .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let args: &QuotePcrsReq = QuotePcrsReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
         let pcr_hash = drivers.sha384.gen_pcr_hash(args.nonce.into())?;
         let signature = drivers.ecc384.pcr_sign_flow(&mut drivers.trng)?;
@@ -77,8 +77,8 @@ impl ExtendPcrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd =
-            ExtendPcrReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = ExtendPcrReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let idx =
             u8::try_from(cmd.pcr_idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -15,7 +15,7 @@ Abstract:
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{MailboxResp, PopulateIdevCertReq};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
 
@@ -25,7 +25,7 @@ impl PopulateIDevIdCertCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<PopulateIdevCertReq>() {
             let mut cmd = PopulateIdevCertReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             let cert_size = cmd.cert_size as usize;
             if cert_size > cmd.cert.len() {

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -43,7 +43,7 @@ use dpe::{
     response::DpeErrorCode,
 };
 use memoffset::offset_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 use zeroize::Zeroize;
 
 pub struct SetAuthManifestCmd;
@@ -425,7 +425,7 @@ impl SetAuthManifestCmd {
         metadata_persistent.zeroize();
 
         // Copy the image metadata collection to the persistent data.
-        metadata_persistent.as_bytes_mut()[..buf.len()].copy_from_slice(buf);
+        metadata_persistent.as_mut_bytes()[..buf.len()].copy_from_slice(buf);
 
         Ok(())
     }
@@ -489,8 +489,8 @@ impl SetAuthManifestCmd {
         let preamble_size = size_of::<AuthManifestPreamble>();
         let auth_manifest_preamble = {
             let err = CaliptraError::RUNTIME_AUTH_MANIFEST_PREAMBLE_SIZE_LT_MIN;
-            AuthManifestPreamble::read_from(manifest_buf.get(..preamble_size).ok_or(err)?)
-                .ok_or(err)?
+            let bytes = manifest_buf.get(..preamble_size).ok_or(err)?;
+            AuthManifestPreamble::ref_from_bytes(bytes).map_err(|_| err)?
         };
 
         // Check if the preamble has the required marker.
@@ -506,7 +506,7 @@ impl SetAuthManifestCmd {
         let persistent_data = drivers.persistent_data.get_mut();
         // Verify the vendor signed data (vendor public keys + flags).
         Self::verify_vendor_signed_data(
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha384,
             &mut drivers.ecc384,
@@ -516,7 +516,7 @@ impl SetAuthManifestCmd {
 
         // Verify the owner public keys.
         Self::verify_owner_pub_keys(
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha384,
             &mut drivers.ecc384,
@@ -528,7 +528,7 @@ impl SetAuthManifestCmd {
             manifest_buf
                 .get(preamble_size..)
                 .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &mut persistent_data.auth_manifest_image_metadata_col,
             &mut drivers.sha384,
             &mut drivers.ecc384,

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -25,7 +25,7 @@ use dpe::{
     dpe_instance::DpeEnv,
     response::DpeErrorCode,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
@@ -115,8 +115,8 @@ impl StashMeasurementCmd {
     }
 
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = StashMeasurementReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = StashMeasurementReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let dpe_result = Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement)?;
 

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -17,7 +17,7 @@ use core::str::from_utf8;
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
 
@@ -31,7 +31,7 @@ impl AddSubjectAltNameCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<AddSubjectAltNameReq>() {
             let mut cmd = AddSubjectAltNameReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             let dmtf_device_info_size = cmd.dmtf_device_info_size as usize;
             if dmtf_device_info_size > cmd.dmtf_device_info.len() {

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -33,8 +33,8 @@ impl TagTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd =
-            TagTciReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = TagTciReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let pdata_mut = drivers.persistent_data.get_mut();
         let mut dpe = &mut pdata_mut.dpe;
         let mut context_has_tag = &mut pdata_mut.context_has_tag;
@@ -72,8 +72,8 @@ impl GetTaggedTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = GetTaggedTciReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = GetTaggedTciReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let persistent_data = drivers.persistent_data.get();
         let context_has_tag = &persistent_data.context_has_tag;
         let context_tags = &persistent_data.context_tags;

--- a/runtime/test-fw/src/mock_rt_test_interactive.rs
+++ b/runtime/test-fw/src/mock_rt_test_interactive.rs
@@ -12,7 +12,7 @@ use caliptra_registers::pv::PvReg;
 use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc::SocIfcReg};
 use caliptra_runtime::{mailbox::Mailbox, Drivers, RtBootStatus};
 use caliptra_test_harness::{runtime_handlers, test_suite};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 const OPCODE_FW_LOAD: u32 = CommandId::FIRMWARE_LOAD.0;
 

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -18,8 +18,7 @@ use caliptra_hw_model::{DefaultHwModel, HwModel};
 use caliptra_runtime::RtBootStatus;
 use caliptra_runtime::{IMAGE_AUTHORIZED, IMAGE_NOT_AUTHORIZED};
 use sha2::{Digest, Sha384};
-use zerocopy::AsBytes;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 const IMAGE_HASH_MISMATCH: u32 = 0x8BFB95CB; // FW ID matched, but image digest mismatched.
 
@@ -100,7 +99,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::ref_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -159,7 +158,7 @@ fn test_authorize_and_stash_cmd_success() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 
     // create a new fw image with the runtime replaced by the mbox responder
@@ -214,7 +213,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -242,7 +241,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -271,7 +270,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_HASH_MISMATCH
@@ -300,7 +299,7 @@ fn test_authorize_and_stash_cmd_success_skip_auth() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -338,7 +337,7 @@ fn test_authorize_and_stash_fwid_0() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -376,7 +375,7 @@ fn test_authorize_and_stash_fwid_127() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -403,7 +402,8 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
             .unwrap()
             .expect("We should have received a response");
 
-        let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+        let authorize_and_stash_resp =
+            AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
         assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
     }
 
@@ -438,7 +438,8 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
             .unwrap()
             .expect("We should have received a response");
 
-        let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+        let authorize_and_stash_resp =
+            AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
         assert_eq!(
             authorize_and_stash_resp.auth_req_result,
             IMAGE_HASH_MISMATCH

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -11,7 +11,7 @@ use caliptra_common::{
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{run_rt_test, RuntimeTestArgs, DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION};
 

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -15,7 +15,7 @@ use dpe::{
 use x509_parser::{
     certificate::X509Certificate, extensions::GeneralName, oid_registry::asn1_rs::FromDer,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs, TEST_LABEL};
 
@@ -99,9 +99,10 @@ fn test_dmtf_other_name_extension_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
 
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
@@ -151,9 +152,10 @@ fn test_dmtf_other_name_extension_not_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();
@@ -194,9 +196,10 @@ fn test_dmtf_other_name_extension_not_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -18,7 +18,7 @@ use openssl::{
     nid::Nid,
     x509::X509,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
     execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST,
@@ -36,7 +36,11 @@ fn test_disable_attestation_cmd() {
         flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -54,7 +58,7 @@ fn test_disable_attestation_cmd() {
         )
         .unwrap()
         .unwrap();
-    let resp_hdr = MailboxRespHeader::read_from(resp.as_bytes()).unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
     assert_eq!(
         resp_hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -69,7 +73,7 @@ fn test_disable_attestation_cmd() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -109,7 +113,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
         )
         .unwrap()
         .unwrap();
-    let resp_hdr = MailboxRespHeader::read_from(resp.as_bytes()).unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
     assert_eq!(
         resp_hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -136,7 +140,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 
     // test that attestation is really disabled by checking that
@@ -152,7 +156,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -7,7 +7,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_hw_model::{HwModel, ShaAccMode};
 use caliptra_runtime::RtBootStatus;
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+use zerocopy::{FromBytes, IntoBytes};
 
 // This file includes some tests from Wycheproof to testing specific common
 // ECDSA problems.
@@ -117,7 +117,7 @@ fn ecdsa_cmd_run_wycheproof() {
                     }
                     Ok(Some(resp)) => {
                         // Verify the checksum and FIPS status
-                        let resp_hdr = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
+                        let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
                         assert_eq!(
                             resp_hdr.fips_status,
                             MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -211,10 +211,7 @@ fn test_ecdsa_verify_cmd() {
         .unwrap()
         .expect("We should have received a response");
 
-    let resp_hdr: &MailboxRespHeader =
-        LayoutVerified::<&[u8], MailboxRespHeader>::new(resp.as_bytes())
-            .unwrap()
-            .into_ref();
+    let resp_hdr: &MailboxRespHeader = MailboxRespHeader::ref_from_bytes(resp.as_bytes()).unwrap();
 
     assert_eq!(
         resp_hdr.fips_status,

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -8,7 +8,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::FipsVersionCmd;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const HW_REV_ID: u32 = if cfg!(feature = "hw-1.0") { 0x1 } else { 0x11 };
 
@@ -40,7 +40,7 @@ fn test_fips_version() {
     let fips_version_bytes: &[u8] = fips_version_resp.as_bytes();
 
     // Check values against expected.
-    let fips_version = FipsVersionResp::read_from(fips_version_bytes).unwrap();
+    let fips_version = FipsVersionResp::read_from_bytes(fips_version_bytes).unwrap();
     assert!(caliptra_common::checksum::verify_checksum(
         fips_version.hdr.chksum,
         0x0,
@@ -86,7 +86,7 @@ fn test_fips_shutdown() {
         .unwrap()
         .unwrap();
 
-    let resp = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
+    let resp = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
     // Verify checksum and FIPS status
     assert!(caliptra_common::checksum::verify_checksum(
         resp.chksum,

--- a/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
@@ -8,7 +8,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError};
 use caliptra_runtime::RtBootStatus;
 use openssl::x509::X509Req;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -37,7 +37,7 @@ fn test_get_csr() {
         _ => {
             let response = result.unwrap().unwrap();
 
-            let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
+            let get_idv_csr_resp = GetIdevCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
 
             assert_ne!(IdevIdCsr::UNPROVISIONED_CSR, get_idv_csr_resp.data_size);
             assert_ne!(0, get_idv_csr_resp.data_size);

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -18,7 +18,7 @@ use caliptra_image_gen::ImageGenerator;
 use caliptra_image_types::RomInfo;
 
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
@@ -31,8 +31,9 @@ fn find_rom_info(rom: &[u8]) -> Option<RomInfo> {
         // Check if the chunk contains non-zero data
         if chunk.iter().any(|&byte| byte != 0) {
             // Found non-zero data, return RomInfo constructed from the data
-            let rom_info = RomInfo::read_from(&rom[i..i + size_of::<RomInfo>()])?;
-            return Some(rom_info);
+            if let Ok(rom_info) = RomInfo::read_from_bytes(&rom[i..i + size_of::<RomInfo>()]) {
+                return Some(rom_info);
+            }
         }
     }
 
@@ -94,7 +95,7 @@ fn test_fw_info() {
             .unwrap()
             .unwrap();
 
-        let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+        let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
 
         // Verify checksum and FIPS status
         assert!(caliptra_common::checksum::verify_checksum(
@@ -183,7 +184,7 @@ fn test_idev_id_info() {
         .mailbox_execute(u32::from(CommandId::GET_IDEV_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    GetIdevInfoResp::read_from(resp.as_slice()).unwrap();
+    GetIdevInfoResp::read_from_bytes(resp.as_slice()).unwrap();
 }
 
 #[test]
@@ -196,7 +197,7 @@ fn test_capabilities() {
         .mailbox_execute(u32::from(CommandId::CAPABILITIES), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let capabilities_resp = CapabilitiesResp::read_from(resp.as_slice()).unwrap();
+    let capabilities_resp = CapabilitiesResp::read_from_bytes(resp.as_slice()).unwrap();
     let capabilities = Capabilities::try_from(capabilities_resp.capabilities.as_bytes()).unwrap();
     assert!(capabilities.contains(Capabilities::RT_BASE));
 }

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -78,7 +78,7 @@ fn test_invoke_dpe_get_certificate_chain_cmd() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chain)) = resp else {
@@ -99,7 +99,11 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
         flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -112,7 +116,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -148,7 +152,11 @@ fn test_invoke_dpe_symmetric_sign() {
         flags: SignFlags::IS_SYMMETRIC,
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -171,7 +179,7 @@ fn test_dpe_header_error_code() {
     let init_ctx_cmd = InitCtxCmd::new_use_default();
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::InitCtx(init_ctx_cmd),
+        &mut Command::InitCtx(&init_ctx_cmd),
         DpeResult::DpeCmdFailure,
     );
     let Some(Response::Error(hdr)) = resp else {
@@ -199,7 +207,7 @@ fn test_invoke_dpe_certify_key_csr() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -266,7 +274,7 @@ fn test_invoke_dpe_rotate_context() {
 
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {
@@ -282,7 +290,7 @@ fn test_invoke_dpe_rotate_context() {
 
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_mailbox.rs
@@ -3,7 +3,7 @@
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
 use caliptra_hw_model::HwModel;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -28,7 +28,7 @@ use dpe::{
     response::Response,
     DPE_PROFILE,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{
     assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_LABEL,
@@ -52,7 +52,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {
@@ -78,7 +78,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(derive_context_cmd),
+                &mut Command::DeriveContext(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -89,7 +89,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(derive_context_cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -121,7 +121,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
     let init_ctx_cmd = InitCtxCmd::new_simulation();
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::InitCtx(init_ctx_cmd),
+        &mut Command::InitCtx(&init_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::InitCtx(init_ctx_resp)) = resp else {
@@ -148,7 +148,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(derive_context_cmd),
+                &mut Command::DeriveContext(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -159,7 +159,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(derive_context_cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -185,7 +185,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::InitCtx(init_ctx_cmd),
+                &mut Command::InitCtx(&init_ctx_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -196,7 +196,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::InitCtx(init_ctx_cmd),
+            &mut Command::InitCtx(&init_ctx_cmd),
             DpeResult::Success,
         );
         let Some(Response::InitCtx(_)) = resp else {
@@ -231,7 +231,7 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::InitCtx(init_ctx_cmd),
+                &mut Command::InitCtx(&init_ctx_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -242,7 +242,7 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::InitCtx(init_ctx_cmd),
+            &mut Command::InitCtx(&init_ctx_cmd),
             DpeResult::Success,
         );
         let Some(Response::InitCtx(_)) = resp else {
@@ -337,7 +337,7 @@ fn test_certify_key_x509_cannot_be_called_from_pl1() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
     assert!(resp.is_none());
@@ -399,7 +399,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
     let init_ctx_cmd = InitCtxCmd::new_simulation();
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::InitCtx(init_ctx_cmd),
+        &mut Command::InitCtx(&init_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::InitCtx(init_ctx_resp)) = resp else {
@@ -415,7 +415,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(derive_context_cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::MboxCmdFailure(
             caliptra_drivers::CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
         ),
@@ -595,7 +595,7 @@ fn test_pl0_unset_in_header() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
     assert!(resp.is_none());
@@ -640,7 +640,7 @@ fn test_user_not_pl0() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
     assert!(resp.is_none());

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -16,7 +16,7 @@ use openssl::{
     hash::{Hasher, MessageDigest},
     x509::X509,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 #[test]
 fn test_pcr_quote() {
@@ -51,7 +51,7 @@ fn test_pcr_quote() {
         .unwrap()
         .unwrap();
 
-    let resp = QuotePcrsResp::read_from(resp.as_slice()).unwrap();
+    let resp = QuotePcrsResp::read_from_bytes(resp.as_slice()).unwrap();
 
     // Compute the digest and compare to mailbox result
     let mut h = Hasher::new(MessageDigest::sha384()).unwrap();
@@ -100,7 +100,9 @@ pub fn get_model_pcrs(model: &mut DefaultHwModel) -> [[u8; 48]; 32] {
         .unwrap()
         .unwrap();
 
-    return QuotePcrsResp::read_from(resp.as_slice()).unwrap().pcrs;
+    return QuotePcrsResp::read_from_bytes(resp.as_slice())
+        .unwrap()
+        .pcrs;
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_populate_idev.rs
+++ b/runtime/tests/runtime_integration_tests/test_populate_idev.rs
@@ -27,7 +27,7 @@ fn get_full_cert_chain(model: &mut DefaultHwModel, out: &mut [u8; 4096]) -> usiz
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chunk_1)) = resp else {
@@ -43,7 +43,7 @@ fn get_full_cert_chain(model: &mut DefaultHwModel, out: &mut [u8; 4096]) -> usiz
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chunk_2)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -18,7 +18,7 @@ use caliptra_hw_model::HwModel;
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_fake_keys::*;
 use caliptra_runtime::RtBootStatus;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub fn create_auth_manifest(manifest_flags: AuthManifestFlags) -> AuthorizationManifest {
     let vendor_fw_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -11,7 +11,7 @@ use caliptra_common::mailbox_api::{
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
-use zerocopy::{AsBytes, LayoutVerified};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -42,9 +42,7 @@ fn test_stash_measurement() {
         .expect("We should have received a response");
 
     let resp_hdr: &StashMeasurementResp =
-        LayoutVerified::<&[u8], StashMeasurementResp>::new(resp.as_bytes())
-            .unwrap()
-            .into_ref();
+        StashMeasurementResp::ref_from_bytes(resp.as_bytes()).unwrap();
 
     assert_eq!(resp_hdr.dpe_result, 0);
 

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -47,7 +47,7 @@ fn test_tagging_default_context() {
         )
         .unwrap()
         .expect("We expected a response");
-    let _ = GetTaggedTciResp::read_from(resp.as_slice()).unwrap();
+    let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn test_tagging_destroyed_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DestroyCtx(destroy_ctx_cmd),
+        &mut Command::DestroyCtx(&destroy_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::DestroyCtx(_)) = resp else {
@@ -222,7 +222,7 @@ fn test_tagging_retired_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(derive_context_cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -268,7 +268,7 @@ fn test_tagging_retired_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(derive_context_cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(_)) = resp else {
@@ -288,5 +288,5 @@ fn test_tagging_retired_context() {
         )
         .unwrap()
         .expect("We expected a response");
-    let _ = GetTaggedTciResp::read_from(resp.as_slice()).unwrap();
+    let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
 }

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -21,7 +21,7 @@ use dpe::{
     validation::ValidationError,
     DpeInstance, U8Bool, DPE_PROFILE, MAX_HANDLES,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -157,7 +157,7 @@ fn test_dpe_validation_deformed_structure() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating multiple normal connected components
     dpe.contexts[0].children = 0;
@@ -193,7 +193,7 @@ fn test_dpe_validation_deformed_structure() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 
@@ -207,7 +207,7 @@ fn test_dpe_validation_illegal_state() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE state by messing up parent-child links
     dpe.contexts[1].children = 0b1;
@@ -241,7 +241,7 @@ fn test_dpe_validation_illegal_state() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 
@@ -255,7 +255,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating PL0_DPE_ACTIVE_CONTEXT_THRESHOLD contexts
     let pl0_pauser = ImageOptions::default().vendor_config.pl0_pauser.unwrap();
@@ -295,7 +295,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -10,7 +10,7 @@ use caliptra_hw_model::{BootParams, DeviceLifecycle, Fuses, HwModel, InitParams,
 use caliptra_registers::mbox::enums::MboxStatusE;
 use dpe::DPE_PROFILE;
 use openssl::sha::sha384;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn swap_word_bytes_inplace(words: &mut [u32]) {
     for word in words.iter_mut() {

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::registers::InMemoryRegister;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 register_bitfields! [
     u32,
@@ -669,7 +669,7 @@ impl HashSha512Regs {
         self.sha512.update_bytes(self.pcr_gen_hash_nonce.as_bytes());
         self.sha512
             .finalize((PCR_COUNT * PCR_SIZE + NONCE_SIZE).try_into().unwrap());
-        self.sha512.copy_hash(self.pcr_hash_digest.as_bytes_mut());
+        self.sha512.copy_hash(self.pcr_hash_digest.as_mut_bytes());
 
         self.pcr_hash_status
             .reg

--- a/sw-emulator/lib/periph/src/hmac_sha384.rs
+++ b/sw-emulator/lib/periph/src/hmac_sha384.rs
@@ -22,7 +22,7 @@ use caliptra_emu_types::{RvData, RvSize};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::registers::InMemoryRegister;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 register_bitfields! [
     u32,
@@ -484,7 +484,7 @@ impl HmacSha384 {
 
     fn op_complete(&mut self) {
         // Retrieve the tag
-        self.hmac.tag(self.tag.as_bytes_mut());
+        self.hmac.tag(self.tag.as_mut_bytes());
         // Don't reveal the tag to the CPU if the inputs came from the
         // key-vault.
         self.hide_tag_from_cpu = self.block_from_kv || self.key_from_kv;
@@ -533,7 +533,7 @@ impl HmacSha384 {
         if let Some(key) = &key {
             self.key_from_kv = true;
             self.key
-                .as_bytes_mut()
+                .as_mut_bytes()
                 .copy_from_slice(&key[..HMAC_KEY_SIZE]);
         }
 
@@ -598,7 +598,7 @@ impl HmacSha384 {
         block_arr[HMAC_BLOCK_SIZE - 16..].copy_from_slice(&len.to_be_bytes());
 
         block_arr.to_big_endian();
-        self.block.as_bytes_mut().copy_from_slice(&block_arr);
+        self.block.as_mut_bytes().copy_from_slice(&block_arr);
     }
 
     fn tag_write_complete(&mut self) {

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -10,7 +10,7 @@ use openssl::{
     pkey::{PKey, Public},
     sha::{sha256, sha384},
 };
-use zerocopy::{transmute, AsBytes};
+use zerocopy::{transmute, IntoBytes};
 
 #[cfg(test)]
 use caliptra_api_types::DeviceLifecycle;
@@ -98,7 +98,7 @@ impl DoeOutput {
 
         result
             .uds
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&aes256_decrypt_blocks(
                 swap_word_bytes(&input.doe_obf_key).as_bytes(),
                 swap_word_bytes(&input.doe_iv).as_bytes(),
@@ -107,7 +107,7 @@ impl DoeOutput {
         swap_word_bytes_inplace(&mut result.uds);
 
         result.field_entropy[0..8]
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&aes256_decrypt_blocks(
                 swap_word_bytes(&input.doe_obf_key).as_bytes(),
                 swap_word_bytes(&input.doe_iv).as_bytes(),
@@ -464,7 +464,7 @@ impl RtAliasKey {
         let mut tci: [u8; 96] = [0; 96];
         tci[0..48].copy_from_slice(swap_word_bytes(&tci_input.runtime_digest).as_bytes());
         tci[48..96]
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&sha384(tci_input.manifest.as_bytes()));
 
         let mut cdi: [u32; 12] = transmute!(hmac384_kdf(

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -16,7 +16,7 @@ use caliptra_test::{
 };
 use openssl::sha::sha384;
 use std::io::Write;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
@@ -114,7 +114,7 @@ fn fake_boot_test() {
 
     assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
     let mut ldev_cert_resp = GetLdevCertResp::default();
-    ldev_cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    ldev_cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Verify checksum and FIPS approval
     assert!(caliptra_common::checksum::verify_checksum(
@@ -180,7 +180,7 @@ fn fake_boot_test() {
 
     assert!(resp.len() <= std::mem::size_of::<GetFmcAliasCertResp>());
     let mut fmc_alias_cert_resp = GetFmcAliasCertResp::default();
-    fmc_alias_cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    fmc_alias_cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Verify checksum and FIPS approval
     assert!(caliptra_common::checksum::verify_checksum(

--- a/test/tests/caliptra_integration_tests/jtag_test.rs
+++ b/test/tests/caliptra_integration_tests/jtag_test.rs
@@ -8,7 +8,7 @@ use caliptra_test::swap_word_bytes_inplace;
 use openssl::sha::sha384;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{ChildStdin, Command, Stdio};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn bytes_to_be_words_48(buf: &[u8; 48]) -> [u32; 12] {
     let mut result: [u32; 12] = zerocopy::transmute!(*buf);

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -23,7 +23,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use regex::Regex;
 use std::mem;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 // Support testing against older versions of ROM in CI
 // More constants may need to be added here as the ROMs further diverge

--- a/test/tests/caliptra_integration_tests/warm_reset.rs
+++ b/test/tests/caliptra_integration_tests/warm_reset.rs
@@ -10,7 +10,7 @@ use caliptra_common::mailbox_api::CommandId;
 use caliptra_hw_model::{mbox_write_fifo, BootParams, HwModel, InitParams, SecurityState};
 use caliptra_test::swap_word_bytes_inplace;
 use openssl::sha::sha384;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn bytes_to_be_words_48(buf: &[u8; 48]) -> [u32; 12] {
     let mut result: [u32; 12] = zerocopy::transmute!(*buf);

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -14,7 +14,7 @@ use dpe::{
         Response, ResponseHdr, SignResp,
     },
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const HOOK_CODE_MASK: u32 = 0x00FF0000;
 pub const HOOK_CODE_OFFSET: u32 = 16;
@@ -253,7 +253,7 @@ pub fn fips_test_init_to_rt(
     // HW model will complete FW upload cmd, nothing to wait for
 }
 
-pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
+pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + IntoBytes>(
     hw: &mut T,
     cmd: u32,
     req_payload: &[u8],
@@ -261,9 +261,10 @@ pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
     let resp_bytes = hw.mailbox_execute(cmd, req_payload)?.unwrap();
 
     // Check values against expected.
-    let resp_hdr =
-        MailboxRespHeader::read_from(&resp_bytes[..core::mem::size_of::<MailboxRespHeader>()])
-            .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(
+        &resp_bytes[..core::mem::size_of::<MailboxRespHeader>()],
+    )
+    .unwrap();
     assert!(caliptra_common::checksum::verify_checksum(
         resp_hdr.chksum,
         0x0,
@@ -277,11 +278,11 @@ pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
     // Handle variable-sized responses
     assert!(resp_bytes.len() <= std::mem::size_of::<U>());
     let mut typed_resp = U::new_zeroed();
-    typed_resp.as_bytes_mut()[..resp_bytes.len()].copy_from_slice(&resp_bytes);
+    typed_resp.as_mut_bytes()[..resp_bytes.len()].copy_from_slice(&resp_bytes);
     Ok(typed_resp)
 
     // TODO: Add option for fixed-length enforcement
-    //Ok(U::read_from(resp_bytes.as_bytes()).unwrap())
+    //Ok(U::read_from_bytes(resp_bytes.as_bytes()).unwrap())
 }
 
 fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
@@ -296,7 +297,7 @@ fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
         Command::GetCertificateChain(_) => Command::GET_CERTIFICATE_CHAIN,
     }
 }
-pub fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
+pub fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
     match dpe_cmd {
         Command::CertifyKey(cmd) => cmd.as_bytes(),
         Command::DeriveContext(cmd) => cmd.as_bytes(),
@@ -312,19 +313,27 @@ pub fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
 pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
         Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::read_from(resp_bytes).unwrap())
+            Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
         }
         Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::read_from(resp_bytes).unwrap())
+            Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::GetCertificateChain(_) => {
-            Response::GetCertificateChain(GetCertificateChainResp::read_from(resp_bytes).unwrap())
+        Command::GetCertificateChain(_) => Response::GetCertificateChain(
+            GetCertificateChainResp::read_from_bytes(resp_bytes).unwrap(),
+        ),
+        Command::DestroyCtx(_) => {
+            Response::DestroyCtx(ResponseHdr::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::DestroyCtx(_) => Response::DestroyCtx(ResponseHdr::read_from(resp_bytes).unwrap()),
-        Command::GetProfile => Response::GetProfile(GetProfileResp::read_from(resp_bytes).unwrap()),
-        Command::InitCtx(_) => Response::InitCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::RotateCtx(_) => Response::RotateCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::Sign(_) => Response::Sign(SignResp::read_from(resp_bytes).unwrap()),
+        Command::GetProfile => {
+            Response::GetProfile(GetProfileResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::InitCtx(_) => {
+            Response::InitCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::RotateCtx(_) => {
+            Response::RotateCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::Sign(_) => Response::Sign(SignResp::read_from_bytes(resp_bytes).unwrap()),
     }
 }
 

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -19,7 +19,7 @@ use caliptra_image_types::{ImageBundle, VENDOR_ECC_KEY_COUNT, VENDOR_LMS_KEY_COU
 use openssl::sha::sha384;
 
 use common::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[allow(dead_code)]
 #[derive(PartialEq, Eq)]

--- a/test/tests/fips_test_suite/security_parameters.rs
+++ b/test/tests/fips_test_suite/security_parameters.rs
@@ -157,7 +157,7 @@ pub fn attempt_ssp_access_fw_load() {
     let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_FIPS_TEST_HOOKS).unwrap();
 
     let fw_image = fips_fw_image();
-    let manifest = ImageManifest::read_from_prefix(&*fw_image).unwrap();
+    let (manifest, _) = ImageManifest::read_from_prefix(&fw_image).unwrap();
 
     let gen = ImageGenerator::new(Crypto::default());
     let vendor_pubkey_digest = gen.vendor_pubkey_digest(&manifest.preamble).unwrap();
@@ -208,7 +208,7 @@ pub fn attempt_ssp_access_fw_load() {
 #[test]
 pub fn attempt_ssp_access_rt() {
     let fw_image = fips_fw_image();
-    let manifest = ImageManifest::read_from_prefix(&*fw_image).unwrap();
+    let (manifest, _) = ImageManifest::read_from_prefix(&fw_image).unwrap();
 
     let gen = ImageGenerator::new(Crypto::default());
     let vendor_pubkey_digest = gen.vendor_pubkey_digest(&manifest.preamble).unwrap();

--- a/test/tests/fips_test_suite/self_tests.rs
+++ b/test/tests/fips_test_suite/self_tests.rs
@@ -12,7 +12,7 @@ use caliptra_drivers::CaliptraError;
 use caliptra_drivers::FipsTestHook;
 use caliptra_hw_model::{BootParams, HwModel, InitParams, ModelError, ShaAccMode};
 use common::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[test]
 #[cfg(not(feature = "test_env_immutable_rom"))]


### PR DESCRIPTION
This PR does not optimize out a large portion of copies. Ideally it will be done in follow up PRs.

There are slight changes made to optimize panics out of the final binary.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/1721