### PR TITLE
rdl: Mount external memory as a register array

### DIFF
--- a/hw/latest/registers/src/i3ccsr.rs
+++ b/hw/latest/registers/src/i3ccsr.rs
@@ -73,6 +73,26 @@ impl<TMmio: ureg::Mmio> RegisterBlock<TMmio> {
     pub unsafe fn new_with_mmio(ptr: *mut u32, mmio: TMmio) -> Self {
         Self { ptr, mmio }
     }
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn dat(&self) -> ureg::Array<256, ureg::RegRef<crate::i3ccsr::meta::Dat, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x400 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn dct(&self) -> ureg::Array<512, ureg::RegRef<crate::i3ccsr::meta::Dct, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x800 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
     #[inline(always)]
     pub fn i3c_base(&self) -> I3cbaseBlock<&TMmio> {
         I3cbaseBlock {
@@ -6246,6 +6266,8 @@ pub mod enums {
 }
 pub mod meta {
     //! Additional metadata needed by ureg.
+    pub type Dat = ureg::ReadWriteReg32<0, u32, u32>;
+    pub type Dct = ureg::ReadWriteReg32<0, u32, u32>;
     pub type I3cbaseHciVersion = ureg::ReadOnlyReg32<u32>;
     pub type I3cbaseHcControl = ureg::ReadWriteReg32<
         0,

--- a/hw/latest/registers/src/mldsa.rs
+++ b/hw/latest/registers/src/mldsa.rs
@@ -205,6 +205,66 @@ impl<TMmio: ureg::Mmio> RegisterBlock<TMmio> {
             )
         }
     }
+    /// 648 32-bit registers storing the public key in big-endian representation.
+    /// These registers are read by MLDSA user after keygen operation,
+    /// or set before verifying operation.
+    ///
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn pubkey(&self) -> ureg::Array<648, ureg::RegRef<crate::mldsa::meta::Pubkey, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x1000 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
+    /// 1157 32-bit registers storing the signature of the message in big-endian representation.
+    /// These registers are read by MLDSA user after signing operation,
+    /// or set before verifying operation.
+    ///
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn signature(
+        &self,
+    ) -> ureg::Array<1157, ureg::RegRef<crate::mldsa::meta::Signature, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x2000 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
+    /// 1224 32-bit registers storing the private key for keygen in big-endian representation.
+    /// These registers are read by MLDSA user after keygen operation.
+    ///
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn privkey_out(
+        &self,
+    ) -> ureg::Array<1224, ureg::RegRef<crate::mldsa::meta::PrivkeyOut, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x4000 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
+    /// 1224 32-bit entries storing the private key for signing in big-endian representation.
+    /// These entries must be set before signing operation.
+    ///
+    /// Read value: [`u32`]; Write value: [`u32`]
+    #[inline(always)]
+    pub fn privkey_in(
+        &self,
+    ) -> ureg::Array<1224, ureg::RegRef<crate::mldsa::meta::PrivkeyIn, &TMmio>> {
+        unsafe {
+            ureg::Array::new_with_mmio(
+                self.ptr.wrapping_add(0x6000 / core::mem::size_of::<u32>()),
+                core::borrow::Borrow::borrow(&self.mmio),
+            )
+        }
+    }
     /// Controls the Key Vault read access for this engine
     ///
     /// Read value: [`regs::KvReadCtrlRegReadVal`]; Write value: [`regs::KvReadCtrlRegWriteVal`]
@@ -1167,6 +1227,10 @@ pub mod meta {
     pub type SignRnd = ureg::WriteOnlyReg32<0, u32>;
     pub type Msg = ureg::WriteOnlyReg32<0, u32>;
     pub type VerifyRes = ureg::ReadOnlyReg32<u32>;
+    pub type Pubkey = ureg::ReadWriteReg32<0, u32, u32>;
+    pub type Signature = ureg::ReadWriteReg32<0, u32, u32>;
+    pub type PrivkeyOut = ureg::ReadOnlyReg32<u32>;
+    pub type PrivkeyIn = ureg::WriteOnlyReg32<0, u32>;
     pub type KvRdSeedCtrl = ureg::ReadWriteReg32<
         0,
         crate::regs::KvReadCtrlRegReadVal,

--- a/ureg/lib/codegen/src/lib.rs
+++ b/ureg/lib/codegen/src/lib.rs
@@ -373,7 +373,11 @@ fn generate_register(reg: &RegisterType) -> TokenStream {
     for field in reg.fields.iter() {
         let field_ident = snake_ident(&field.name);
         let position = Literal::u64_unsuffixed(field.position.into());
-        let mask = hex_literal((1u64 << field.width) - 1);
+        let mask = if field.width == 64 {
+            hex_literal(u64::MAX)
+        } else {
+            hex_literal((1u64 << field.width) - 1)
+        };
         let access_expr = quote! {
             (self.0 >> #position) & #mask
         };

--- a/ureg/lib/systemrdl/src/lib.rs
+++ b/ureg/lib/systemrdl/src/lib.rs
@@ -222,19 +222,16 @@ fn translate_mem(iref: systemrdl::InstanceRef, start_offset: u64) -> Result<ureg
         width: RegisterWidth::_32,
     };
 
-    match iref.instance.scope.properties.get("memwidth") {
-        Some(Value::U64(memwidth)) => {
-            ty.width = match *memwidth {
-                8 => RegisterWidth::_8,
-                16 => RegisterWidth::_16,
-                32 => RegisterWidth::_32,
-                64 => RegisterWidth::_64,
-                128 => RegisterWidth::_128,
-                _ => return Err(wrap_err(Error::UnsupportedRegWidth(*memwidth))),
-            }
+    if let Some(Value::U64(memwidth)) = iref.instance.scope.properties.get("memwidth") {
+        ty.width = match *memwidth {
+            8 => RegisterWidth::_8,
+            16 => RegisterWidth::_16,
+            32 => RegisterWidth::_32,
+            64 => RegisterWidth::_64,
+            128 => RegisterWidth::_128,
+            _ => return Err(wrap_err(Error::UnsupportedRegWidth(*memwidth))),
         }
-        _ => {}
-    }
+    };
     let mut double = 1;
     if ty.width == RegisterWidth::_128 {
         // hack: convert to four u32s

--- a/ureg/lib/systemrdl/src/lib.rs
+++ b/ureg/lib/systemrdl/src/lib.rs
@@ -8,10 +8,10 @@ use ureg::{RegisterSubBlock, RegisterType};
 
 use std::rc::Rc;
 
-use caliptra_systemrdl as systemrdl;
+use caliptra_systemrdl::{self as systemrdl, Value};
 use caliptra_systemrdl::{ComponentType, ScopeType};
 use systemrdl::{AccessType, InstanceRef, ParentScope, RdlError};
-use ureg_schema as ureg;
+use ureg_schema::{self as ureg, FieldType, RegisterField, RegisterWidth};
 use ureg_schema::{RegisterBlock, RegisterBlockInstance};
 
 fn unpad_description(desc: &str) -> String {
@@ -195,6 +195,91 @@ fn translate_register(iref: systemrdl::InstanceRef) -> Result<ureg::Register, Er
 
     Ok(result)
 }
+
+// Translates a memory into a register array
+fn translate_mem(iref: systemrdl::InstanceRef, start_offset: u64) -> Result<ureg::Register, Error> {
+    let wrap_err = |err: Error| Error::RegisterError {
+        register_name: iref.instance.name.clone(),
+        err: Box::new(err),
+    };
+
+    expect_instance_type(iref.scope, ComponentType::Mem.into()).map_err(wrap_err)?;
+    let inst = iref.instance;
+
+    let description: String = inst
+        .scope
+        .property_val_opt("desc")
+        .unwrap()
+        .unwrap_or_default();
+
+    if inst.reset.is_some() {
+        return Err(wrap_err(Error::ResetValueOnRegisterUnsupported));
+    }
+
+    let mut ty = RegisterType {
+        name: inst.type_name.clone(),
+        fields: vec![],
+        width: RegisterWidth::_32,
+    };
+
+    match iref.instance.scope.properties.get("memwidth") {
+        Some(Value::U64(memwidth)) => {
+            ty.width = match *memwidth {
+                8 => RegisterWidth::_8,
+                16 => RegisterWidth::_16,
+                32 => RegisterWidth::_32,
+                64 => RegisterWidth::_64,
+                128 => RegisterWidth::_128,
+                _ => return Err(wrap_err(Error::UnsupportedRegWidth(*memwidth))),
+            }
+        }
+        _ => {}
+    }
+    let mut double = 1;
+    if ty.width == RegisterWidth::_128 {
+        // hack: convert to four u32s
+        ty.width = RegisterWidth::_32;
+        double = 4;
+    } else if ty.width == RegisterWidth::_64 {
+        // hack: convert to two u32s
+        ty.width = RegisterWidth::_32;
+        double = 2;
+    }
+    let entries = match iref.instance.scope.properties.get("mementries") {
+        Some(Value::U64(mementries)) => *mementries * double,
+        _ => return Err(wrap_err(Error::ValueNotDefined)),
+    };
+    let access_type = match iref.instance.scope.properties.get("sw") {
+        Some(Value::AccessType(AccessType::Rw)) => FieldType::RW,
+        Some(Value::AccessType(AccessType::Rw1)) => FieldType::RW,
+        Some(Value::AccessType(AccessType::R)) => FieldType::RO,
+        Some(Value::AccessType(AccessType::W)) => FieldType::WO,
+        Some(Value::AccessType(AccessType::W1)) => FieldType::WO,
+        _ => FieldType::RW,
+    };
+
+    ty.fields.push(RegisterField {
+        name: "single".to_string(),
+        ty: access_type,
+        default_val: 0,
+        comment: "".to_string(),
+        enum_type: None,
+        position: 0,
+        width: (ty.width.in_bytes() * 8) as u8,
+    });
+
+    let result = ureg_schema::Register {
+        name: inst.name.clone(),
+        offset: inst.offset.unwrap_or(start_offset),
+        default_val: 0,
+        comment: unpad_description(&description),
+        array_dimensions: vec![entries],
+        ty: Rc::new(ty),
+    };
+
+    Ok(result)
+}
+
 fn translate_register_ty(
     type_name: Option<String>,
     scope: ParentScope,
@@ -259,6 +344,18 @@ fn calculate_reg_size(block: &RegisterBlock) -> Option<u64> {
         .max()
 }
 
+fn calculate_mem_size(iref: systemrdl::InstanceRef) -> u64 {
+    let bits = match iref.instance.scope.properties.get("memwidth") {
+        Some(Value::U64(memwidth)) => *memwidth,
+        _ => 32,
+    };
+    let entries = match iref.instance.scope.properties.get("mementries") {
+        Some(Value::U64(mementries)) => *mementries,
+        _ => panic!("No mementries found for memory"),
+    };
+    bits / 8 * entries
+}
+
 fn next_multiple_of(x: u64, mult: u64) -> u64 {
     assert!(mult > 0);
     if x % mult == 0 {
@@ -310,16 +407,34 @@ fn translate_block(iref: InstanceRef, top: bool) -> Result<RegisterBlock, Error>
     }
     let mut next_offset = Some(0u64);
     for child in iref.scope.instance_iter() {
+        let parent_offset = if top {
+            0
+        } else {
+            iref.instance.offset.unwrap_or_default()
+        };
+
         if child.instance.scope.ty == ComponentType::Reg.into() {
-            block
-                .registers
-                .push(Rc::new(translate_register(child).map_err(wrap_err)?));
+            let r = Rc::new(translate_register(child).map_err(wrap_err)?);
+            block.registers.push(r.clone());
+            next_offset =
+                Some(r.offset + r.ty.width.in_bytes() * r.array_dimensions.iter().product::<u64>());
+        } else if child.instance.scope.ty == ComponentType::Mem.into() {
+            let mem_size = calculate_mem_size(child);
+            let start_offset = child
+                .instance
+                .offset
+                .map(|o| parent_offset + o)
+                .or(next_offset.map(|o| {
+                    // align according to RDL spec
+                    // TODO: when we upgrade Rust we can use o.next_multple_of()
+                    next_multiple_of(o, mem_size.next_power_of_two())
+                }))
+                .expect("Offset not defined for memory and could not calculate automatically");
+            next_offset = Some(start_offset + calculate_mem_size(child));
+            block.registers.push(Rc::new(
+                translate_mem(child, start_offset).map_err(wrap_err)?,
+            ));
         } else if child.instance.scope.ty == ComponentType::RegFile.into() {
-            let parent_offset = if top {
-                0
-            } else {
-                iref.instance.offset.unwrap_or_default()
-            };
             let next_block = translate_block(child, false)?;
             let next_block_size = calculate_reg_size(&next_block);
             let start_offset = child
@@ -343,9 +458,7 @@ fn translate_block(iref: InstanceRef, top: bool) -> Result<RegisterBlock, Error>
                 block: next_block,
                 start_offset,
             });
-        } else if child.instance.scope.ty == ComponentType::Signal.into()
-            || child.instance.scope.ty == ComponentType::Mem.into()
-        {
+        } else if child.instance.scope.ty == ComponentType::Signal.into() {
             // ignore
             next_offset = None;
         } else {


### PR DESCRIPTION
This makes external memory look like an array of registers. 64-bit and 128-bit memory arrays are converted to 32-bit, since we don't have a great story for accessing more than 32 bits at a time anyway from RISC-V.
    
This only affects MLDSA and I3C (which uses 128-bit memory access).
