### PR TITLE
Add alignment check to PersistentData structure.

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -133,6 +133,7 @@ impl PersistentData {
                 memory_layout::AUTH_MAN_IMAGE_METADATA_LIST_ORG
                     + memory_layout::AUTH_MAN_IMAGE_METADATA_LIST_MAX_SIZE
             );
+            assert_eq!(P.add(1) as u32, memory_layout::DATA_ORG);
         }
     }
 }


### PR DESCRIPTION
We should also check that the address after the `PersistentData` struct is `DATA_ORG`. Currently we are mostly checking that the struct sizes add up.