### PR TITLE
Tweak UART messages to buy some RO memory in ROM.

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-89a3a6cfd9103f902e677a5004e5f600857f33f5931c6a18724447f61808bf39d9604ab7034802e1b2f0e78fdee0e8ef  caliptra-rom-no-log.bin
-418e2f952d29f7a07a8acdff46a8e4f06826c27feacf1409c395262698ceb324aa5aeaea9895a2d0ad9a62ae9c2e4c89  caliptra-rom-with-log.bin
+ad1064cba5b190e4f5258c175b7ec7c697ccb188ba0ed18302c6e924f0ea0b10457dc753d6d2963f415fbaf761eace96  caliptra-rom-no-log.bin
+2aae08cbe6e13559201fee432a7bbf535d27d94df4e8b4d05adab11c4f27b57c6d8392b71a24ee459af7b9663ce9c31f  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-ad1064cba5b190e4f5258c175b7ec7c697ccb188ba0ed18302c6e924f0ea0b10457dc753d6d2963f415fbaf761eace96  caliptra-rom-no-log.bin
-2aae08cbe6e13559201fee432a7bbf535d27d94df4e8b4d05adab11c4f27b57c6d8392b71a24ee459af7b9663ce9c31f  caliptra-rom-with-log.bin
+89a3a6cfd9103f902e677a5004e5f600857f33f5931c6a18724447f61808bf39d9604ab7034802e1b2f0e78fdee0e8ef  caliptra-rom-no-log.bin
+418e2f952d29f7a07a8acdff46a8e4f06826c27feacf1409c395262698ceb324aa5aeaea9895a2d0ad9a62ae9c2e4c89  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
 ad1064cba5b190e4f5258c175b7ec7c697ccb188ba0ed18302c6e924f0ea0b10457dc753d6d2963f415fbaf761eace96  caliptra-rom-no-log.bin
-4d93a6856a0cba636a5d2a9c116393f56dc3b34113f7149ae62325772c1eacb08b1d78424771cc71197252abe603eb92  caliptra-rom-with-log.bin
+2aae08cbe6e13559201fee432a7bbf535d27d94df4e8b4d05adab11c4f27b57c6d8392b71a24ee459af7b9663ce9c31f  caliptra-rom-with-log.bin

--- a/rom/dev/src/fht.rs
+++ b/rom/dev/src/fht.rs
@@ -151,10 +151,7 @@ impl FhtDataStore {
 pub fn initialize_fht(env: &mut RomEnv) {
     let pdata = &env.persistent_data.get();
 
-    cprintln!(
-        "[fht] Storing FHT @ 0x{:08X}",
-        &pdata.fht as *const _ as usize
-    );
+    cprintln!("[fht] FHT @ 0x{:08X}", &pdata.fht as *const _ as usize);
 
     env.persistent_data.get_mut().fht = FirmwareHandoffTable {
         fht_marker: FHT_MARKER,

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -196,14 +196,14 @@ impl FmcAliasLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[afmc] Signing Cert with AUTHORITY.KEYID = {}",
+            "[afmc] Signing Cert w/ AUTHORITY.KEYID = {}",
             auth_priv_key as u8
         );
         let mut sig = Crypto::ecdsa384_sign_and_verify(env, auth_priv_key, auth_pub_key, tbs.tbs());
         let sig = okmutref(&mut sig)?;
 
         // Clear the authority private key
-        cprintln!("[afmc] Erasing AUTHORITY.KEYID = {}", auth_priv_key as u8);
+        cprintln!("[afmc] Erase AUTHORITY.KEYID = {}", auth_priv_key as u8);
         env.key_vault.erase_key(auth_priv_key).map_err(|err| {
             sig.zeroize();
             err

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -180,7 +180,7 @@ impl FirmwareProcessor {
     ) -> CaliptraResult<ManuallyDrop<MailboxRecvTxn<'a>>> {
         let mut self_test_in_progress = false;
 
-        cprintln!("[fwproc] Waiting for Commands...");
+        cprintln!("[fwproc] Wait for Commands...");
         loop {
             // Random delay for CFI glitch protection.
             CfiCounter::delay();
@@ -193,7 +193,7 @@ impl FirmwareProcessor {
                     return Err(CaliptraError::FW_PROC_MAILBOX_RESERVED_PAUSER);
                 }
 
-                cprintln!("[fwproc] Received command 0x{:08x}", txn.cmd());
+                cprintln!("[fwproc] Recv command 0x{:08x}", txn.cmd());
 
                 // Handle FW load as a separate case due to the re-borrow explained below
                 if txn.cmd() == CommandId::FIRMWARE_LOAD.into() {
@@ -207,11 +207,11 @@ impl FirmwareProcessor {
                     // failure) or by a manual complete call upon success.
                     let txn = ManuallyDrop::new(txn.start_txn());
                     if txn.dlen() == 0 || txn.dlen() > IMAGE_BYTE_SIZE as u32 {
-                        cprintln!("Invalid Image of size {} bytes" txn.dlen());
+                        cprintln!("Invalid Img size: {} bytes" txn.dlen());
                         return Err(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE);
                     }
 
-                    cprintln!("[fwproc] Received Image of size {} bytes" txn.dlen());
+                    cprintln!("[fwproc] Recv'd Img size: {} bytes" txn.dlen());
                     report_boot_status(FwProcessorDownloadImageComplete.into());
                     return Ok(txn);
                 }
@@ -285,9 +285,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::STASH_MEASUREMENT => {
                         if persistent_data.fht.meas_log_index == MEASUREMENT_MAX_COUNT as u32 {
-                            cprintln!(
-                                "[fwproc] Maximum supported number of measurements already received."
-                            );
+                            cprintln!("[fwproc] Max # of measurements received.");
                             txn.complete(false)?;
 
                             // Raise a fatal error on hitting the max. limit.
@@ -365,7 +363,7 @@ impl FirmwareProcessor {
         let info = verifier.verify(manifest, img_bundle_sz, ResetReason::ColdReset)?;
 
         cprintln!(
-            "[fwproc] Image verified using Vendor ECC Key Index {}",
+            "[fwproc] Img verified w/ Vendor ECC Key Idx {}",
             info.vendor_ecc_pub_key_idx,
         );
         report_boot_status(FwProcessorImageVerificationComplete.into());
@@ -478,7 +476,7 @@ impl FirmwareProcessor {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
         cprintln!(
-            "[fwproc] Loading FMC at address 0x{:08x} len {}",
+            "[fwproc] Load FMC at address 0x{:08x} len {}",
             manifest.fmc.load_addr,
             manifest.fmc.size
         );
@@ -491,7 +489,7 @@ impl FirmwareProcessor {
         txn.copy_request(fmc_dest.as_bytes_mut())?;
 
         cprintln!(
-            "[fwproc] Loading Runtime at address 0x{:08x} len {}",
+            "[fwproc] Load Runtime at address 0x{:08x} len {}",
             manifest.runtime.load_addr,
             manifest.runtime.size
         );

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -213,7 +213,7 @@ impl InitDevIdLayer {
             return Ok(());
         }
 
-        cprintln!("[idev] CSR upload requested");
+        cprintln!("[idev] CSR upload begun");
 
         // Generate the CSR
         Self::make_csr(env, output)
@@ -244,7 +244,7 @@ impl InitDevIdLayer {
         let tbs = InitDevIdCsrTbs::new(&params);
 
         cprintln!(
-            "[idev] Signing CSR with SUBJECT.KEYID = {}",
+            "[idev] Sign CSR w/ SUBJECT.KEYID = {}",
             key_pair.priv_key as u8
         );
 

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -171,7 +171,7 @@ impl LocalDevIdLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[ldev] Signing Cert with AUTHORITY.KEYID = {}",
+            "[ldev] Signing Cert w/ AUTHORITY.KEYID = {}",
             auth_priv_key as u8
         );
         let mut sig = Crypto::ecdsa384_sign_and_verify(env, auth_priv_key, auth_pub_key, tbs.tbs());

--- a/rom/dev/src/flow/cold_reset/x509.rs
+++ b/rom/dev/src/flow/cold_reset/x509.rs
@@ -89,24 +89,24 @@ impl X509 {
 
         let digest: [u8; 20] = match env.soc_ifc.fuse_bank().idev_id_x509_key_id_algo() {
             X509KeyIdAlgo::Sha1 => {
-                cprintln!("[idev] Using Sha1 for KeyId Algorithm");
+                cprintln!("[idev] Sha1 KeyId Algorithm");
                 let digest = Crypto::sha1_digest(env, &data);
                 okref(&digest)?.into()
             }
             X509KeyIdAlgo::Sha256 => {
-                cprintln!("[idev] Using Sha256 for KeyId Algorithm");
+                cprintln!("[idev] Sha256 KeyId Algorithm");
                 let digest = Crypto::sha256_digest(env, &data);
                 let digest: [u8; 32] = okref(&digest)?.into();
                 digest[..20].try_into().unwrap()
             }
             X509KeyIdAlgo::Sha384 => {
-                cprintln!("[idev] Using Sha384 for KeyId Algorithm");
+                cprintln!("[idev] Sha384 KeyId Algorithm");
                 let digest = Crypto::sha384_digest(env, &data);
                 let digest: [u8; 48] = okref(&digest)?.into();
                 digest[..20].try_into().unwrap()
             }
             X509KeyIdAlgo::Fuse => {
-                cprintln!("[idev] Using Fuse for KeyId");
+                cprintln!("[idev] Fuse KeyId");
                 env.soc_ifc.fuse_bank().subject_key_id()
             }
         };

--- a/rom/dev/src/flow/mod.rs
+++ b/rom/dev/src/flow/mod.rs
@@ -66,7 +66,7 @@ pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         if (env.soc_ifc.lifecycle() == caliptra_drivers::Lifecycle::Production)
             && !(env.soc_ifc.prod_en_in_fake_mode())
         {
-            cprintln!("Fake ROM in Production lifecycle not enabled");
+            cprintln!("Fake ROM in Prod disabled");
             handle_fatal_error(CaliptraError::ROM_GLOBAL_FAKE_ROM_IN_PRODUCTION.into());
         }
 

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -52,13 +52,13 @@ impl UpdateResetFlow {
         );
 
         let Some(mut recv_txn) = env.mbox.try_start_recv_txn() else {
-            cprintln!("Failed To Get Mailbox Transaction");
+            cprintln!("Failed To Get Mailbox Txn");
             return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE);
         };
 
         let mut process_txn = || -> CaliptraResult<()> {
             if recv_txn.cmd() != CommandId::FIRMWARE_LOAD.into() {
-                cprintln!("Invalid command 0x{:08x} received", recv_txn.cmd());
+                cprintln!("Invalid command 0x{:08x} recv", recv_txn.cmd());
                 return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND);
             }
 
@@ -87,7 +87,7 @@ impl UpdateResetFlow {
             report_boot_status(UpdateResetExtendPcrComplete.into());
 
             cprintln!(
-                "[update-reset] Image verified using Vendor ECC Key Index {}",
+                "[update-reset] Img verified w/ Vendor ECC Key Index {}",
                 info.vendor_ecc_pub_key_idx
             );
 
@@ -167,7 +167,7 @@ impl UpdateResetFlow {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn load_image(manifest: &ImageManifest, txn: &mut MailboxRecvTxn) -> CaliptraResult<()> {
         cprintln!(
-            "[update-reset] Loading Runtime at address 0x{:08x} len {}",
+            "[update-reset] Loading Runtime at addr 0x{:08x} len {}",
             manifest.runtime.load_addr,
             manifest.runtime.size
         );

--- a/rom/dev/src/flow/warm_reset.rs
+++ b/rom/dev/src/flow/warm_reset.rs
@@ -33,7 +33,7 @@ impl WarmResetFlow {
 
         // Check if previous Cold-Reset was successful.
         if cfi_launder(env.data_vault.rom_cold_boot_status()) != ColdResetComplete.into() {
-            cprintln!("[warm-reset] Previous Cold-Reset was not successful.");
+            cprintln!("[warm-reset] Prev Cold-Reset failed");
             return Err(CaliptraError::ROM_WARM_RESET_UNSUCCESSFUL_PREVIOUS_COLD_RESET);
         } else {
             cfi_assert_eq(
@@ -44,7 +44,7 @@ impl WarmResetFlow {
 
         // Check if previous Update-Reset, if any,  was successful.
         if cfi_launder(env.data_vault.rom_update_reset_status()) == UpdateResetStarted.into() {
-            cprintln!("[warm-reset] Previous Update Reset was not successful.");
+            cprintln!("[warm-reset] Prev Update Reset failed");
             return Err(CaliptraError::ROM_WARM_RESET_UNSUCCESSFUL_PREVIOUS_UPDATE_RESET);
         } else {
             cfi_assert_ne(

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -99,7 +99,7 @@ pub extern "C" fn rom_entry() -> ! {
         && (env.soc_ifc.lifecycle() == caliptra_drivers::Lifecycle::Production)
         && !(env.soc_ifc.prod_en_in_fake_mode())
     {
-        cprintln!("Fake ROM in Production lifecycle not enabled");
+        cprintln!("Fake ROM in Prod lifecycle disabled");
         handle_fatal_error(CaliptraError::ROM_GLOBAL_FAKE_ROM_IN_PRODUCTION.into());
     }
 

--- a/rom/dev/src/wdt.rs
+++ b/rom/dev/src/wdt.rs
@@ -36,7 +36,7 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
             wdt_timeout_cycles = 1;
         }
         cprintln!(
-            "[state] Starting the Watchdog Timer {} cycles",
+            "[state] Starting the WD Timer {} cycles",
             wdt_timeout_cycles
         );
         caliptra_common::wdt::start_wdt(
@@ -44,8 +44,6 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
             WdtTimeout::from(core::num::NonZeroU64::new(wdt_timeout_cycles).unwrap()),
         );
     } else {
-        cprintln!(
-            "[state] Watchdog Timer is not started because the device is not locked for debugging"
-        );
+        cprintln!("[state] WD Timer not started. Device not locked for debugging");
     }
 }

--- a/rom/dev/src/wdt.rs
+++ b/rom/dev/src/wdt.rs
@@ -20,6 +20,8 @@ use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_common::WdtTimeout;
 use caliptra_drivers::SocIfc;
 
+use crate::cprintln;
+
 /// Start the Watchdog Timer
 /// Note: WDT is configured only if the device is in non-debug mode (i.e debug_locked = 1)
 ///
@@ -33,9 +35,15 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
         if wdt_timeout_cycles == 0 {
             wdt_timeout_cycles = 1;
         }
+        cprintln!(
+            "[state] Starting the WD Timer {} cycles",
+            wdt_timeout_cycles
+        );
         caliptra_common::wdt::start_wdt(
             soc_ifc,
             WdtTimeout::from(core::num::NonZeroU64::new(wdt_timeout_cycles).unwrap()),
         );
+    } else {
+        cprintln!("[state] WD Timer not started. Device not locked for debugging");
     }
 }

--- a/rom/dev/src/wdt.rs
+++ b/rom/dev/src/wdt.rs
@@ -20,8 +20,6 @@ use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_common::WdtTimeout;
 use caliptra_drivers::SocIfc;
 
-use crate::cprintln;
-
 /// Start the Watchdog Timer
 /// Note: WDT is configured only if the device is in non-debug mode (i.e debug_locked = 1)
 ///
@@ -35,15 +33,9 @@ pub fn start_wdt(soc_ifc: &mut SocIfc) {
         if wdt_timeout_cycles == 0 {
             wdt_timeout_cycles = 1;
         }
-        cprintln!(
-            "[state] Starting the WD Timer {} cycles",
-            wdt_timeout_cycles
-        );
         caliptra_common::wdt::start_wdt(
             soc_ifc,
             WdtTimeout::from(core::num::NonZeroU64::new(wdt_timeout_cycles).unwrap()),
         );
-    } else {
-        cprintln!("[state] WD Timer not started. Device not locked for debugging");
     }
 }


### PR DESCRIPTION
https://github.com/chipsalliance/caliptra-sw/pull/1732 pushes the code size too far. Re-coup some of the code-size for the UART image by compressing some of the existing messages.