### PR TITLE
Refactor common runtime tests so new parameters to run_rt_test do not require updating every test using it

### DIFF
--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -40,20 +40,22 @@ pub const TEST_DIGEST: [u8; 48] = [
 pub const DEFAULT_FMC_VERSION: u16 = 0xaaaa;
 pub const DEFAULT_APP_VERSION: u32 = 0xbbbbbbbb;
 
-pub fn run_rt_test_lms(
-    test_fwid: Option<&'static FwId>,
-    test_image_options: Option<ImageOptions>,
-    init_params: Option<InitParams>,
-    lms_verify: bool,
-) -> DefaultHwModel {
+#[derive(Default)]
+pub struct RuntimeTestArgs<'a> {
+    pub test_fwid: Option<&'static FwId<'static>>,
+    pub test_image_options: Option<ImageOptions>,
+    pub init_params: Option<InitParams<'a>>,
+}
+
+pub fn run_rt_test_lms(args: RuntimeTestArgs, lms_verify: bool) -> DefaultHwModel {
     let default_rt_fwid = if cfg!(feature = "fpga_realtime") {
         &APP_WITH_UART_FPGA
     } else {
         &APP_WITH_UART
     };
-    let runtime_fwid = test_fwid.unwrap_or(default_rt_fwid);
+    let runtime_fwid = args.test_fwid.unwrap_or(default_rt_fwid);
 
-    let image_options = test_image_options.unwrap_or_else(|| {
+    let image_options = args.test_image_options.unwrap_or_else(|| {
         let mut opts = ImageOptions::default();
         opts.vendor_config.pl0_pauser = Some(0x1);
         opts.fmc_version = DEFAULT_FMC_VERSION;
@@ -62,7 +64,7 @@ pub fn run_rt_test_lms(
     });
 
     let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
-    let init_params = match init_params {
+    let init_params = match args.init_params {
         Some(init_params) => init_params,
         None => InitParams {
             rom: &rom,
@@ -93,12 +95,8 @@ pub fn run_rt_test_lms(
 
 // Run a test which boots ROM -> FMC -> test_bin. If test_bin_name is None,
 // run the production runtime image.
-pub fn run_rt_test(
-    test_fwid: Option<&'static FwId>,
-    test_image_options: Option<ImageOptions>,
-    init_params: Option<InitParams>,
-) -> DefaultHwModel {
-    run_rt_test_lms(test_fwid, test_image_options, init_params, false)
+pub fn run_rt_test(args: RuntimeTestArgs) -> DefaultHwModel {
+    run_rt_test_lms(args, false)
 }
 
 pub fn generate_test_x509_cert(ec_key: PKey<Private>) -> X509 {

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::run_rt_test;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
@@ -13,7 +13,7 @@ use zerocopy::FromBytes;
 
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -17,11 +17,11 @@ use x509_parser::{
 };
 use zerocopy::{AsBytes, FromBytes};
 
-use crate::common::{assert_error, run_rt_test, TEST_LABEL};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs, TEST_LABEL};
 
 #[test]
 fn test_dmtf_other_name_validation_fail() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -54,7 +54,7 @@ fn test_dmtf_other_name_validation_fail() {
 
 #[test]
 fn test_dmtf_other_name_extension_present() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -123,7 +123,7 @@ fn test_dmtf_other_name_extension_present() {
 
 #[test]
 fn test_dmtf_other_name_extension_not_present() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{
     execute_dpe_cmd, generate_test_x509_cert, get_fmc_alias_cert, get_rt_alias_cert, run_rt_test,
-    DpeResult, TEST_LABEL,
+    DpeResult, RuntimeTestArgs, TEST_LABEL,
 };
 use caliptra_builder::firmware::{APP_WITH_UART, FMC_WITH_UART};
 use caliptra_builder::ImageOptions;
@@ -58,7 +58,11 @@ fn test_rt_cert_with_custom_dates() {
 
     opts.owner_config = Some(own_config);
 
-    let mut model = run_rt_test(None, Some(opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(
@@ -85,7 +89,7 @@ fn test_rt_cert_with_custom_dates() {
 
 #[test]
 fn test_idev_id_cert() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // generate 48 byte ECDSA key pair
     let ec_group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
@@ -172,7 +176,7 @@ fn get_ldev_cert(model: &mut DefaultHwModel) -> GetLdevCertResp {
 
 #[test]
 fn test_ldev_cert() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let ldev_resp = get_ldev_cert(&mut model);
     let ldev_cert: X509 = X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
@@ -200,7 +204,7 @@ fn test_ldev_cert() {
 
 #[test]
 fn test_fmc_alias_cert() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let ldev_resp = get_ldev_cert(&mut model);
     let ldev_cert: X509 = X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
@@ -221,7 +225,7 @@ fn test_fmc_alias_cert() {
 
 #[test]
 fn test_rt_alias_cert() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let fmc_resp = get_fmc_alias_cert(&mut model);
     let fmc_cert: X509 = X509::from_der(&fmc_resp.data[..fmc_resp.data_size as usize]).unwrap();
@@ -242,7 +246,7 @@ fn test_rt_alias_cert() {
 
 #[test]
 fn test_dpe_leaf_cert() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let rt_resp = get_rt_alias_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
@@ -279,7 +283,7 @@ fn test_dpe_leaf_cert() {
 
 #[test]
 fn test_full_cert_chain() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let ldev_resp = get_ldev_cert(&mut model);
     let ldev_cert: X509 = X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -21,12 +21,13 @@ use openssl::{
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, TEST_DIGEST, TEST_LABEL,
+    execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST,
+    TEST_LABEL,
 };
 
 #[test]
 fn test_disable_attestation_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // sign the digest
     let sign_cmd = SignCmd {
@@ -92,7 +93,7 @@ fn test_disable_attestation_cmd() {
 
 #[test]
 fn test_attestation_disabled_flag_after_update_reset() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // disable attestation
     let payload = MailboxReqHeader {

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license.
 
-use crate::common::{assert_error, run_rt_test};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{
     CommandId, EcdsaVerifyReq, MailboxReq, MailboxReqHeader, MailboxRespHeader,
@@ -19,7 +19,7 @@ fn ecdsa_cmd_run_wycheproof() {
     // This test is too slow to run as part of the verilator nightly.
     #![cfg_attr(all(not(feature = "slow_tests"), feature = "verilator"), ignore)]
 
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read()
@@ -149,7 +149,7 @@ fn ecdsa_cmd_run_wycheproof() {
 
 #[test]
 fn test_ecdsa_verify_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -227,7 +227,7 @@ fn test_ecdsa_verify_cmd() {
 
 #[test]
 fn test_ecdsa_verify_bad_chksum() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let cmd = MailboxReq::EcdsaVerify(EcdsaVerifyReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -254,7 +254,7 @@ fn test_ecdsa_verify_bad_chksum() {
 #[cfg(any(feature = "verilator", feature = "fpga_realtime"))]
 #[test]
 fn test_ecdsa_hw_failure() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let mut cmd = MailboxReq::EcdsaVerify(EcdsaVerifyReq {
         hdr: MailboxReqHeader { chksum: 0 },

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license.
 
-use crate::common::{assert_error, run_rt_test};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use caliptra_api::SocManager;
 use caliptra_builder::{version, ImageOptions};
 use caliptra_common::mailbox_api::{
@@ -14,15 +14,15 @@ const HW_REV_ID: u32 = if cfg!(feature = "hw-1.0") { 0x1 } else { 0x11 };
 
 #[test]
 fn test_fips_version() {
-    let mut model = run_rt_test(
-        None,
-        Some(ImageOptions {
+    let args = RuntimeTestArgs {
+        test_image_options: Some(ImageOptions {
             fmc_version: version::get_fmc_version(),
             app_version: version::get_runtime_version(),
             ..Default::default()
         }),
-        None,
-    );
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 
@@ -72,7 +72,7 @@ fn test_fips_version() {
 
 #[test]
 fn test_fips_shutdown() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license.
 
-use crate::common::run_rt_test;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 use caliptra_builder::{
     firmware::{APP_WITH_UART, FMC_WITH_UART},
     ImageOptions,
@@ -159,7 +159,7 @@ fn test_fw_info() {
 
 #[test]
 fn test_idev_id_info() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_IDEV_INFO), &[]),
     };
@@ -172,7 +172,7 @@ fn test_idev_id_info() {
 
 #[test]
 fn test_capabilities() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::CAPABILITIES), &[]),
     };

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -1,7 +1,8 @@
 // Licensed under the Apache-2.0 license.
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, TEST_DIGEST, TEST_LABEL,
+    execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST,
+    TEST_LABEL,
 };
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{InvokeDpeReq, MailboxReq, MailboxReqHeader};
@@ -33,7 +34,7 @@ use sha2::{Digest, Sha384};
 
 #[test]
 fn test_invoke_dpe_get_profile_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -65,7 +66,7 @@ fn test_invoke_dpe_size_too_big() {
 
 #[test]
 fn test_invoke_dpe_get_certificate_chain_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -90,7 +91,7 @@ fn test_invoke_dpe_get_certificate_chain_cmd() {
 
 #[test]
 fn test_invoke_dpe_sign_and_certify_key_cmds() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let sign_cmd = SignCmd {
         handle: ContextHandle::default(),
@@ -135,7 +136,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
 
 #[test]
 fn test_invoke_dpe_symmetric_sign() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -160,7 +161,7 @@ fn test_invoke_dpe_symmetric_sign() {
 
 #[test]
 fn test_dpe_header_error_code() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -184,7 +185,7 @@ fn test_dpe_header_error_code() {
 
 #[test]
 fn test_invoke_dpe_certify_key_csr() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -252,7 +253,7 @@ fn test_invoke_dpe_certify_key_csr() {
 
 #[test]
 fn test_invoke_dpe_rotate_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_lms.rs
+++ b/runtime/tests/runtime_integration_tests/test_lms.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license.
 
-use crate::common::{assert_error, run_rt_test};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{
     CommandId, LmsVerifyReq, MailboxReq, MailboxReqHeader, MailboxRespHeader,
@@ -813,7 +813,7 @@ fn execute_lms_cmd<T: HwModel>(
 
 #[test]
 fn test_lms_verify_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -838,7 +838,7 @@ fn test_lms_verify_cmd() {
 
 #[test]
 fn test_lms_verify_failure() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -856,7 +856,7 @@ fn test_lms_verify_failure() {
 
 #[test]
 fn test_lms_verify_invalid_sig_lms_type() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -879,7 +879,7 @@ fn test_lms_verify_invalid_sig_lms_type() {
 
 #[test]
 fn test_lms_verify_invalid_key_lms_type() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -901,7 +901,7 @@ fn test_lms_verify_invalid_key_lms_type() {
 
 #[test]
 fn test_lms_verify_invalid_lmots_type() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_mailbox.rs
@@ -5,13 +5,13 @@ use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
 use caliptra_hw_model::HwModel;
 use zerocopy::AsBytes;
 
-use crate::common::{assert_error, run_rt_test};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 
 /// When a successful command runs after a failed command, ensure the error
 /// register is cleared.
 #[test]
 fn test_error_cleared() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 
@@ -37,7 +37,7 @@ fn test_error_cleared() {
 
 #[test]
 fn test_unimplemented_cmds() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 
@@ -61,7 +61,7 @@ fn test_unimplemented_cmds() {
 // Changing PAUSER not supported on sw emulator
 #[cfg(any(feature = "verilator", feature = "fpga_realtime"))]
 fn test_reserved_pauser() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -30,13 +30,15 @@ use dpe::{
 };
 use zerocopy::AsBytes;
 
-use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult, TEST_LABEL};
+use crate::common::{
+    assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_LABEL,
+};
 
 const DATA: [u8; DPE_PROFILE.get_hash_size()] = [0u8; 48];
 
 #[test]
 fn test_pl0_derive_context_dpe_context_thresholds() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -102,7 +104,12 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -164,7 +171,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
 
 #[test]
 fn test_pl0_init_ctx_dpe_context_thresholds() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -203,7 +210,12 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -244,7 +256,11 @@ fn test_populate_idev_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -271,7 +287,11 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -298,7 +318,12 @@ fn test_certify_key_x509_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -323,7 +348,12 @@ fn test_certify_key_extended_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -354,7 +384,12 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
 
-    let mut model = run_rt_test(None, Some(image_opts), None);
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -390,7 +425,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
 
 #[test]
 fn test_stash_measurement_pl_context_thresholds() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -435,7 +470,7 @@ fn test_stash_measurement_pl_context_thresholds() {
 
 #[test]
 fn test_measurement_log_pl_context_threshold() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{get_fmc_alias_cert, run_rt_test};
+use crate::common::{get_fmc_alias_cert, run_rt_test, RuntimeTestArgs};
 use caliptra_api::SocManager;
 
 use caliptra_common::mailbox_api::{
@@ -20,7 +20,7 @@ use zerocopy::{AsBytes, FromBytes};
 
 #[test]
 fn test_pcr_quote() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     const RESET_PCR: u32 = 7;
 
@@ -114,7 +114,7 @@ fn test_extend_pcr_cmd_multiple_extensions() {
     }
 
     // 0. Get fresh pcr state and verify
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
     assert_eq!(get_model_pcrs(&mut model)[4], [0u8; 48]);
 
     // 1.0 Testing for extension_data [0,...,0]
@@ -159,7 +159,7 @@ fn test_extend_pcr_cmd_multiple_extensions() {
 
 #[test]
 fn test_extend_pcr_cmd_invalid_pcr_index() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
     let extension_data: [u8; 48] = [0u8; 48];
 
     // 3. Invalid PCR index
@@ -175,7 +175,7 @@ fn test_extend_pcr_cmd_invalid_pcr_index() {
 
 #[test]
 fn test_extend_pcr_cmd_reserved_range() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
     let extension_data: [u8; 48] = [0u8; 48];
 
     // 4. Ensure reserved PCR range

--- a/runtime/tests/runtime_integration_tests/test_populate_idev.rs
+++ b/runtime/tests/runtime_integration_tests/test_populate_idev.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{execute_dpe_cmd, generate_test_x509_cert, run_rt_test, DpeResult};
+use crate::common::{
+    execute_dpe_cmd, generate_test_x509_cert, run_rt_test, DpeResult, RuntimeTestArgs,
+};
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxReqHeader, PopulateIdevCertReq};
 use caliptra_error::CaliptraError;
@@ -68,7 +70,7 @@ fn parse_cert_chain(cert_chain: &[u8], cert_chain_size: usize, expected_num_cert
 
 #[test]
 fn test_populate_idev_cert_cmd() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{assert_error, run_rt_test_lms};
+use crate::common::{assert_error, run_rt_test_lms, RuntimeTestArgs};
 use caliptra_api::SocManager;
 use caliptra_auth_man_gen::{
     AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
@@ -106,7 +106,7 @@ fn test_auth_manifest() -> AuthorizationManifest {
 
 #[test]
 fn test_set_auth_manifest_cmd() {
-    let mut model = run_rt_test_lms(None, None, None, true);
+    let mut model = run_rt_test_lms(RuntimeTestArgs::default(), true);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -135,7 +135,7 @@ fn test_set_auth_manifest_cmd() {
 
 #[test]
 fn test_set_auth_manifest_cmd_invalid_len() {
-    let mut model = run_rt_test_lms(None, None, None, true);
+    let mut model = run_rt_test_lms(RuntimeTestArgs::default(), true);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -183,7 +183,7 @@ fn test_set_auth_manifest_cmd_invalid_len() {
 }
 
 fn test_manifest_expect_err(manifest: AuthorizationManifest, expected_err: CaliptraError) {
-    let mut model = run_rt_test_lms(None, None, None, true);
+    let mut model = run_rt_test_lms(RuntimeTestArgs::default(), true);
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -13,11 +13,11 @@ use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
 use zerocopy::{AsBytes, LayoutVerified};
 
-use crate::common::run_rt_test;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 
 #[test]
 fn test_stash_measurement() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -82,7 +82,11 @@ fn test_stash_measurement() {
 
 #[test]
 fn test_pcr31_extended_upon_stash_measurement() {
-    let mut model = run_rt_test(Some(&firmware::runtime_tests::MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&firmware::runtime_tests::MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // Read PCR_ID_STASH_MEASUREMENT
     let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult};
+use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs};
 use caliptra_common::mailbox_api::{
     CommandId, GetTaggedTciReq, GetTaggedTciResp, MailboxReq, MailboxReqHeader, TagTciReq,
 };
@@ -20,7 +20,7 @@ const BAD_HANDLE: [u8; 16] = [1u8; 16];
 
 #[test]
 fn test_tagging_default_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // Tag default context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
@@ -52,7 +52,7 @@ fn test_tagging_default_context() {
 
 #[test]
 fn test_tagging_a_tagged_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // Tag default context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
@@ -85,7 +85,7 @@ fn test_tagging_a_tagged_context() {
 
 #[test]
 fn test_duplicate_tag() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // Tag default context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
@@ -118,7 +118,7 @@ fn test_duplicate_tag() {
 
 #[test]
 fn test_get_tagged_tci_on_non_existent_tag() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // Check that DPE_GET_TAGGED_TCI fails if the tag does not exist
     let mut cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
@@ -141,7 +141,7 @@ fn test_get_tagged_tci_on_non_existent_tag() {
 
 #[test]
 fn test_tagging_inactive_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // check that we cannot tag an inactive context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
@@ -162,7 +162,7 @@ fn test_tagging_inactive_context() {
 
 #[test]
 fn test_tagging_destroyed_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // Tag default context
     let mut cmd = MailboxReq::TagTci(TagTciReq {
@@ -210,7 +210,7 @@ fn test_tagging_destroyed_context() {
 
 #[test]
 fn test_tagging_retired_context() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // retire context via DeriveContext
     let derive_context_cmd = DeriveContextCmd {

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -23,7 +23,7 @@ use dpe::{
 };
 use zerocopy::{AsBytes, FromBytes};
 
-use crate::common::run_rt_test;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 
 fn update_fw(model: &mut DefaultHwModel, rt_fw: &FwId<'static>, image_opts: ImageOptions) {
     let image = caliptra_builder::build_and_sign_image(&FMC_WITH_UART, rt_fw, image_opts)
@@ -37,7 +37,7 @@ fn update_fw(model: &mut DefaultHwModel, rt_fw: &FwId<'static>, image_opts: Imag
 
 #[test]
 fn test_rt_journey_pcr_updated_in_dpe() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -57,7 +57,7 @@ fn test_rt_journey_pcr_updated_in_dpe() {
 
 #[test]
 fn test_tags_persistence() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -97,7 +97,11 @@ fn test_tags_persistence() {
 
 #[test]
 fn test_context_tags_validation() {
-    let mut model = run_rt_test(Some(&MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // make context_tags validation fail by "tagging" an inactive context
     let mut context_tags = [0u32; MAX_HANDLES];
@@ -119,7 +123,11 @@ fn test_context_tags_validation() {
 
 #[test]
 fn test_context_has_tag_validation() {
-    let mut model = run_rt_test(Some(&MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // make context_has_tag validation fail by "tagging" an inactive context
     let mut context_has_tag = [U8Bool::new(false); MAX_HANDLES];
@@ -141,7 +149,11 @@ fn test_context_has_tag_validation() {
 
 #[test]
 fn test_dpe_validation_deformed_structure() {
-    let mut model = run_rt_test(Some(&MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
@@ -187,7 +199,11 @@ fn test_dpe_validation_deformed_structure() {
 
 #[test]
 fn test_dpe_validation_illegal_state() {
-    let mut model = run_rt_test(Some(&MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
@@ -231,7 +247,11 @@ fn test_dpe_validation_illegal_state() {
 
 #[test]
 fn test_dpe_validation_used_context_threshold_exceeded() {
-    let mut model = run_rt_test(Some(&MBOX), None, None);
+    let args = RuntimeTestArgs {
+        test_fwid: Some(&MBOX),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
@@ -281,7 +301,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
 
 #[test]
 fn test_pcr_reset_counter_persistence() {
-    let mut model = run_rt_test(None, None, None);
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)


### PR DESCRIPTION
This helps reduce the size of https://github.com/chipsalliance/caliptra-sw/pull/1732.

Wrapping the arguments to `run_rt_test` reduces how many locations need to be updated if a new argument is introduced.
