### PR TITLE
Don't copy manifest2 onto the stack

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-fc4ceed3891771c263c42eb56bdfff3026e1baf75e48b09bad58aaf562aea1a31f5df6636ac90f3aab73d533f03f0e5d  caliptra-rom-no-log.bin
-e6254e3492969108c1340b2f662d82ab72572f38fab970990c72bdb03f0bfbfd18f6a16a5f273df8fd0faf5aefe9c138  caliptra-rom-with-log.bin
+133bf3969893178e041b61001d75bfb504be3b3676cac608a40877f1e4b46b4855f86c1859cfc3e22745327102fba4b0  caliptra-rom-no-log.bin
+44f5bbbc4b71d7f0926f85b7d81ef7e17f721557b38379b650497eb8dd19d0a74ab5a1e2177c7e99653a878d2daed3b3  caliptra-rom-with-log.bin

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -62,7 +62,7 @@ impl UpdateResetFlow {
                 return Err(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND);
             }
 
-            let manifest = Self::load_manifest(env.persistent_data.get_mut(), &mut recv_txn)?;
+            Self::load_manifest(env.persistent_data.get_mut(), &mut recv_txn)?;
             report_boot_status(UpdateResetLoadManifestComplete.into());
 
             let mut venv = FirmwareImageVerificationEnv {
@@ -75,7 +75,10 @@ impl UpdateResetFlow {
                 image: recv_txn.raw_mailbox_contents(),
             };
 
-            let info = Self::verify_image(&mut venv, &manifest, recv_txn.dlen());
+            let info = {
+                let manifest = &env.persistent_data.get().manifest2;
+                Self::verify_image(&mut venv, manifest, recv_txn.dlen())
+            };
             let info = okref(&info)?;
             report_boot_status(UpdateResetImageVerificationComplete.into());
 
@@ -91,7 +94,8 @@ impl UpdateResetFlow {
                 info.vendor_ecc_pub_key_idx
             );
 
-            Self::load_image(&manifest, &mut recv_txn)?;
+            let manifest = &env.persistent_data.get().manifest2;
+            Self::load_image(manifest, &mut recv_txn)?;
             Ok(())
         };
         if let Err(e) = process_txn() {
@@ -197,9 +201,9 @@ impl UpdateResetFlow {
     fn load_manifest(
         persistent_data: &mut PersistentData,
         txn: &mut MailboxRecvTxn,
-    ) -> CaliptraResult<ImageManifest> {
+    ) -> CaliptraResult<()> {
         txn.copy_request(persistent_data.manifest2.as_bytes_mut())?;
-        Ok(persistent_data.manifest2)
+        Ok(())
     }
 
     /// Populate data vault


### PR DESCRIPTION
This save about ~5KiB of stack space. 