### PR TITLE
inline runtime execute methods

### DIFF
--- a/common/src/fips.rs
+++ b/common/src/fips.rs
@@ -10,6 +10,7 @@ impl FipsVersionCmd {
     pub const NAME: [u8; 12] = *b"Caliptra RTM";
     pub const MODE: u32 = 0x46495053;
 
+    #[cfg_attr(feature = "runtime", inline(never))]
     pub fn execute(soc_ifc: &SocIfc) -> CaliptraResult<FipsVersionResp> {
         cprintln!("[rt] FIPS Version");
 

--- a/runtime/src/capabilities.rs
+++ b/runtime/src/capabilities.rs
@@ -20,6 +20,7 @@ use caliptra_error::CaliptraResult;
 
 pub struct CapabilitiesCmd;
 impl CapabilitiesCmd {
+    #[inline(never)]
     pub(crate) fn execute() -> CaliptraResult<MailboxResp> {
         let mut capabilities = Capabilities::default();
         capabilities |= Capabilities::RT_BASE;

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -34,6 +34,7 @@ use crate::{
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd = CertifyKeyExtendedReq::read_from(cmd_args)
             .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -28,6 +28,7 @@ use zerocopy::AsBytes;
 
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
+    #[inline(never)]
     pub(crate) fn execute(cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<GetIdevCertReq>() {
             let mut cmd = GetIdevCertReq::default();
@@ -65,6 +66,7 @@ impl IDevIdCertCmd {
 
 pub struct GetLdevCertCmd;
 impl GetLdevCertCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut resp = GetLdevCertResp::default();
 
@@ -80,6 +82,7 @@ impl GetLdevCertCmd {
 
 pub struct GetFmcAliasCertCmd;
 impl GetFmcAliasCertCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut resp = GetFmcAliasCertResp::default();
 
@@ -95,6 +98,7 @@ impl GetFmcAliasCertCmd {
 
 pub struct GetRtAliasCertCmd;
 impl GetRtAliasCertCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut resp = GetRtAliasCertResp::default();
 

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -212,6 +212,7 @@ pub mod fips_self_test_cmd {
 pub struct FipsShutdownCmd;
 impl FipsShutdownCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<MailboxResp> {
         FipsModule::zeroize(env);
         env.is_shutdown = true;

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -19,6 +19,7 @@ use caliptra_image_types::RomInfo;
 
 pub struct FwInfoCmd;
 impl FwInfoCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &Drivers) -> CaliptraResult<MailboxResp> {
         let pdata = drivers.persistent_data.get();
 
@@ -51,6 +52,7 @@ impl FwInfoCmd {
 
 pub struct IDevIdInfoCmd;
 impl IDevIdInfoCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &Drivers) -> CaliptraResult<MailboxResp> {
         let pdata = drivers.persistent_data.get();
         let pub_key = pdata.fht.idev_dice_pub_key;

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -32,6 +32,7 @@ use zerocopy::{AsBytes, FromBytes};
 pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<InvokeDpeReq>() {
             let mut cmd = InvokeDpeReq::default();

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -24,6 +24,7 @@ use zerocopy::FromBytes;
 pub struct IncrementPcrResetCounterCmd;
 impl IncrementPcrResetCounterCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd = IncrementPcrResetCounterReq::read_from(cmd_args)
             .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
@@ -45,6 +46,7 @@ impl IncrementPcrResetCounterCmd {
 pub struct GetPcrQuoteCmd;
 impl GetPcrQuoteCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
         let args: QuotePcrsReq = QuotePcrsReq::read_from(cmd_bytes)
             .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
@@ -73,6 +75,7 @@ impl GetPcrQuoteCmd {
 pub struct ExtendPcrCmd;
 impl ExtendPcrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd =
             ExtendPcrReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -21,6 +21,7 @@ use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
 
 pub struct PopulateIDevIdCertCmd;
 impl PopulateIDevIdCertCmd {
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<PopulateIdevCertReq>() {
             let mut cmd = PopulateIdevCertReq::default();

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -27,6 +27,7 @@ impl AddSubjectAltNameCmd {
     pub const DMTF_OID: &'static [u8] =
         &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0x1C, 0x82, 0x12, 0x01];
 
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<AddSubjectAltNameReq>() {
             let mut cmd = AddSubjectAltNameReq::default();

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -31,6 +31,7 @@ use crate::{dpe_crypto::DpeCrypto, CptraDpeTypes, DpePlatform, Drivers};
 pub struct TagTciCmd;
 impl TagTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd =
             TagTciReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -28,6 +28,7 @@ use zerocopy::{BigEndian, FromBytes, LittleEndian, U32};
 pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd = EcdsaVerifyReq::read_from(cmd_args)
             .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
@@ -60,6 +61,7 @@ impl EcdsaVerifyCmd {
 pub struct LmsVerifyCmd;
 impl LmsVerifyCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         // Re-run LMS KAT once (since LMS is more SW-based than other crypto)
         if let Err(e) =


### PR DESCRIPTION
This reduces the stack frame and saves a bit of code space.
