### PR TITLE
Make `GetIdevCsr` enums / naming consistent with `GetIdevCert` naming.

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -154,7 +154,7 @@ pub enum MailboxResp {
     QuotePcrs(QuotePcrsResp),
     CertifyKeyExtended(CertifyKeyExtendedResp),
     AuthorizeAndStash(AuthorizeAndStashResp),
-    GetIdevIdCsr(GetIdevIdCsrResp),
+    GetIdevCsr(GetIdevCsrResp),
 }
 
 impl MailboxResp {
@@ -175,7 +175,7 @@ impl MailboxResp {
             MailboxResp::QuotePcrs(resp) => Ok(resp.as_bytes()),
             MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_bytes()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes()),
-            MailboxResp::GetIdevIdCsr(resp) => Ok(resp.as_bytes()),
+            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes()),
         }
     }
 
@@ -196,7 +196,7 @@ impl MailboxResp {
             MailboxResp::QuotePcrs(resp) => Ok(resp.as_bytes_mut()),
             MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_bytes_mut()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::GetIdevIdCsr(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes_mut()),
         }
     }
 
@@ -986,28 +986,28 @@ impl Default for SetAuthManifestReq {
 // GET_IDEVID_CSR
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
-pub struct GetIdevIdCsrReq {
+pub struct GetIdevCsrReq {
     pub hdr: MailboxReqHeader,
 }
 
-impl Request for GetIdevIdCsrReq {
+impl Request for GetIdevCsrReq {
     const ID: CommandId = CommandId::GET_IDEV_CSR;
-    type Resp = GetIdevIdCsrResp;
+    type Resp = GetIdevCsrResp;
 }
 
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
-pub struct GetIdevIdCsrResp {
+pub struct GetIdevCsrResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
     pub data: [u8; Self::DATA_MAX_SIZE],
 }
-impl GetIdevIdCsrResp {
+impl GetIdevCsrResp {
     pub const DATA_MAX_SIZE: usize = 512;
 }
-impl ResponseVarSize for GetIdevIdCsrResp {}
+impl ResponseVarSize for GetIdevCsrResp {}
 
-impl Default for GetIdevIdCsrResp {
+impl Default for GetIdevCsrResp {
     fn default() -> Self {
         Self {
             hdr: MailboxRespHeader::default(),

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -22,7 +22,7 @@ use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::capabilities::Capabilities;
 use caliptra_common::fips::FipsVersionCmd;
 use caliptra_common::mailbox_api::{
-    CapabilitiesResp, CommandId, GetIdevIdCsrResp, MailboxReqHeader, MailboxRespHeader, Response,
+    CapabilitiesResp, CommandId, GetIdevCsrResp, MailboxReqHeader, MailboxRespHeader, Response,
     StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_common::pcr::PCR_ID_STASH_MEASUREMENT;
@@ -309,7 +309,7 @@ impl FirmwareProcessor {
                         Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
 
                         let csr_persistent_mem = &persistent_data.idevid_csr;
-                        let mut resp = GetIdevIdCsrResp::default();
+                        let mut resp = GetIdevCsrResp::default();
 
                         if csr_persistent_mem.is_unprovisioned() {
                             // CSR was never written to DCCM. This means the gen_idev_id_csr

--- a/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
+++ b/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
@@ -2,7 +2,7 @@
 
 use caliptra_api::SocManager;
 use caliptra_builder::ImageOptions;
-use caliptra_common::mailbox_api::{CommandId, GetIdevIdCsrResp, MailboxReqHeader};
+use caliptra_common::mailbox_api::{CommandId, GetIdevCsrResp, MailboxReqHeader};
 use caliptra_drivers::MfgFlags;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
@@ -36,7 +36,7 @@ fn test_get_csr() {
         .unwrap()
         .unwrap();
 
-    let get_idv_csr_resp = GetIdevIdCsrResp::read_from(response.as_bytes()).unwrap();
+    let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
 
     assert!(caliptra_common::checksum::verify_checksum(
         get_idv_csr_resp.hdr.chksum,

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -7,7 +7,7 @@ use caliptra_cfi_lib_git::cfi_launder;
 
 use caliptra_common::{
     cprintln,
-    mailbox_api::{GetIdevIdCsrReq, GetIdevIdCsrResp, MailboxResp, MailboxRespHeader},
+    mailbox_api::{GetIdevCsrReq, GetIdevCsrResp, MailboxResp, MailboxRespHeader},
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 
@@ -15,12 +15,12 @@ use caliptra_drivers::IdevIdCsr;
 
 use zerocopy::{AsBytes, FromBytes};
 
-pub struct GetIdevIdCsrCmd;
-impl GetIdevIdCsrCmd {
+pub struct GetIdevCsrCmd;
+impl GetIdevCsrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = GetIdevIdCsrReq::read_from(cmd_args) {
+        if let Some(cmd) = GetIdevCsrReq::read_from(cmd_args) {
             let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
 
             match csr_persistent_mem.get_csr_len() {
@@ -33,7 +33,7 @@ impl GetIdevIdCsrCmd {
                         .get()
                         .ok_or(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)?;
 
-                    let mut resp = GetIdevIdCsrResp {
+                    let mut resp = GetIdevCsrResp {
                         data_size: len,
                         ..Default::default()
                     };
@@ -43,10 +43,10 @@ impl GetIdevIdCsrCmd {
                     // `resp.data_size` by the `IDevIDCsr::get` API.
                     //
                     // A valid `IDevIDCsr` cannot be larger than `MAX_CSR_SIZE`, which is the max
-                    // size of the buffer in `GetIdevIdCsrResp`
+                    // size of the buffer in `GetIdevCsrResp`
                     resp.data[..resp.data_size as usize].copy_from_slice(csr);
 
-                    Ok(MailboxResp::GetIdevIdCsr(resp))
+                    Ok(MailboxResp::GetIdevCsr(resp))
                 }
             }
         } else {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub use fips::FipsShutdownCmd;
 pub use fips::{fips_self_test_cmd, fips_self_test_cmd::SelfTestStatus};
 pub use populate_idev::PopulateIDevIdCertCmd;
 
-pub use get_idev_csr::GetIdevIdCsrCmd;
+pub use get_idev_csr::GetIdevCsrCmd;
 pub use info::{FwInfoCmd, IDevIdInfoCmd};
 pub use invoke_dpe::InvokeDpeCmd;
 pub use pcr::IncrementPcrResetCounterCmd;
@@ -228,7 +228,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::SHUTDOWN => FipsShutdownCmd::execute(drivers),
         CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers, cmd_bytes),
         CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers, cmd_bytes),
-        CommandId::GET_IDEV_CSR => GetIdevIdCsrCmd::execute(drivers, cmd_bytes),
+        CommandId::GET_IDEV_CSR => GetIdevCsrCmd::execute(drivers, cmd_bytes),
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     }?;
 

--- a/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::SocManager;
-use caliptra_common::mailbox_api::{CommandId, GetIdevIdCsrResp, MailboxReqHeader};
+use caliptra_common::mailbox_api::{CommandId, GetIdevCsrResp, MailboxReqHeader};
 use caliptra_drivers::{IdevIdCsr, MfgFlags};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError};
@@ -30,7 +30,7 @@ fn test_get_csr() {
         .unwrap()
         .unwrap();
 
-    let get_idv_csr_resp = GetIdevIdCsrResp::read_from(response.as_bytes()).unwrap();
+    let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
 
     assert_ne!(IdevIdCsr::UNPROVISIONED_CSR, get_idv_csr_resp.data_size);
     assert_ne!(0, get_idv_csr_resp.data_size);


### PR DESCRIPTION
`%s/GetIdevIdCsr/GetIdevCsr/g`
