### PR TITLE
Add GetIdevCsr to libcaliptra.

### DIFF
--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -664,6 +664,28 @@ int rom_test_devid_csr(const test_info* info)
         printf("IDEV CSR matches\n");
     }
 
+    caliptra_req_idev_csr_complete();
+    caliptra_ready_for_firmware();
+
+    // Test Get Idev CSR now that a CSR is provisioned.
+    // GET IDEV CSR
+    struct caliptra_get_idev_csr_resp csr_resp = {0};
+
+    status = caliptra_get_idev_csr(&csr_resp, false);
+
+    if (status) {
+        printf("Get IDev CSR failed: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        failure = 1;
+    } else {
+        if (memcmp(csr_resp.data, idev_csr_bytes, csr_resp.data_size) != 0) {
+            printf("IDEV CSR does not match\n");
+            failure = 1;
+        } else {
+            printf("Get IDev CSR: OK\n");
+        }
+    }
+
     free((void*)caliptra_idevid_csr_buf.data);
     return failure;
 }

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -180,6 +180,9 @@ int caliptra_certify_key_extended(struct caliptra_certify_key_extended_req *req,
 // FIPS version
 int caliptra_fips_version(struct caliptra_fips_version_resp *resp, bool async);
 
+// Get IDev CSR
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async);
+
 // Self test start
 int caliptra_self_test_start(bool async);
 

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -218,6 +218,12 @@ struct caliptra_capabilities_resp {
     uint8_t capabilities[16];
 };
 
+struct caliptra_get_idev_csr_resp {
+    struct caliptra_resp_header hdr;
+    uint32_t data_size;
+    uint8_t data[512];
+};
+
 // DPE commands
 
 #define DPE_MAGIC    0x44504543 // "DPEC"

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1170,6 +1170,21 @@ int caliptra_fips_version(struct caliptra_fips_version_resp *resp, bool async)
     return pack_and_execute_command(&p, async);
 }
 
+// Get IDev CSR
+int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async)
+{
+    if (!resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    caliptra_checksum checksum = 0;
+
+    CREATE_PARCEL(p, OP_GET_IDEV_CSR, &checksum, resp);
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Self test start
 int caliptra_self_test_start(bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -51,6 +51,7 @@ enum mailbox_command {
     OP_SELF_TEST_GET_RESULTS       = 0x46504C67, // "FPGR"
     OP_SHUTDOWN                    = 0x46505344, // "FPSD"
     OP_CAPABILITIES                = 0x43415053, // "CAPS"
+    OP_GET_IDEV_CSR                = 0x49444352, // "IDCR"
 };
 
 struct parcel {


### PR DESCRIPTION
Adds libcaliptra support for a new command "GetIdevCsr" added in https://github.com/chipsalliance/caliptra-sw/pull/1732.