### PR TITLE
Disable FPGA workflows in main-2.x

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -4,7 +4,8 @@ name: FPGA Build
 on:
   push:
     branches: ["main"]
-  pull_request:
+  # Disabled in main-2.x until FPGA CI works again.
+  # pull_request:
   workflow_call:
     inputs:
       artifact-suffix:


### PR DESCRIPTION
Can re-enable when the FPGA CI works again in that branch.