### PR TITLE
Adding owner pub key hash to FW_INFO cmd

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -786,8 +786,7 @@ pub struct FwInfoResp {
     pub rom_sha256_digest: [u32; 8],
     pub fmc_sha384_digest: [u32; 12],
     pub runtime_sha384_digest: [u32; 12],
-    // TODO: Decide what other information to report for general firmware
-    // status.
+    pub owner_pub_key_hash: [u32; 12],
 }
 
 // CAPABILITIES

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -144,6 +144,7 @@ struct caliptra_fw_info_resp {
     uint32_t rom_sha256_digest[8];
     uint32_t fmc_sha384_digest[12];
     uint32_t runtime_sha384_digest[12];
+    uint32_t owner_pub_key_hash[12];
 };
 
 struct caliptra_dpe_tag_tci_req {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -554,6 +554,8 @@ Command Code: `0x4754_4744` ("GTGD")
 
 Retrieves information about the current Runtime Firmware, FMC, and ROM.
 
+NOTE: Additional fields and info may be appended to the response in subsequent FW versions.
+
 Command Code: `0x494E_464F` ("INFO")
 
 *Table: `FW_INFO` input arguments*
@@ -579,6 +581,7 @@ Command Code: `0x494E_464F` ("INFO")
 | rom_sha256_digest      | u32[8]         | Digest of ROM binary.
 | fmc_sha384_digest      | u32[12]        | Digest of FMC binary.
 | runtime_sha384_digest  | u32[12]        | Digest of runtime binary.
+| owner_pub_key_hash     | u32[12]        | Hash of the owner public keys provided in the image bundle manifest.
 
 ### VERSION
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -46,6 +46,7 @@ impl FwInfoCmd {
             rom_sha256_digest: rom_info.sha256_digest,
             fmc_sha384_digest: pdata.manifest1.fmc.digest,
             runtime_sha384_digest: pdata.manifest1.runtime.digest,
+            owner_pub_key_hash: drivers.data_vault.owner_pk_hash().into(),
         }))
     }
 }


### PR DESCRIPTION
A method of obtaining the Owner public key hash from Caliptra is needed to assist the SoC with setting the owner pub key hash fuses. This is to eliminate any dependency by the SoC on the Caliptra image format and guarantee correct hashing of the keys.