### PR TITLE
Fix driver/dma: Operate on 64bit addresses

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -60,7 +60,9 @@ pub use bounded_address::{BoundedAddr, MemBounds, RomAddr};
 pub use caliptra_error::{CaliptraError, CaliptraResult};
 pub use csrng::{Csrng, HealthFailCounts as CsrngHealthFailCounts, Seed as CsrngSeed};
 pub use data_vault::{ColdResetEntries, DataVault, WarmResetEntries};
-pub use dma::{Dma, DmaReadTarget, DmaReadTransaction, DmaWriteOrigin, DmaWriteTransaction};
+pub use dma::{
+    AxiAddr, Dma, DmaReadTarget, DmaReadTransaction, DmaWriteOrigin, DmaWriteTransaction,
+};
 pub use doe::DeobfuscationEngine;
 pub use ecc384::{
     Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Scalar,


### PR DESCRIPTION
This fixes the driver side to operate on 64bit AXI addresses.

Currently the sw-emulator DMA engine operates on the root_bus which is 32bit.
Is that 32bit root bus that caliptra has access to a subset of the 64bit AXI bus which only the DMA engine has full access to?