### PR TITLE
[update] Implement IDEVID Subject Key ID for MLDSA

### DIFF
--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -164,33 +164,51 @@ impl FuseBank<'_> {
     /// Get the subject key identifier.
     ///
     /// # Arguments
-    /// * None
+    /// * `ecc_subject_key_id` - Whether to get ECC or MLDSA subject key identifier
     ///
     /// # Returns
     ///     subject key identifier
     ///
-    pub fn subject_key_id(&self) -> [u8; 20] {
+    pub fn subject_key_id(&self, ecc_subject_key_id: bool) -> [u8; 20] {
+        let key_id = if ecc_subject_key_id {
+            [
+                IdevidCertAttr::EccSubjectKeyId1,
+                IdevidCertAttr::EccSubjectKeyId2,
+                IdevidCertAttr::EccSubjectKeyId3,
+                IdevidCertAttr::EccSubjectKeyId4,
+                IdevidCertAttr::EccSubjectKeyId5,
+            ]
+        } else {
+            [
+                IdevidCertAttr::MldsaSubjectKeyId1,
+                IdevidCertAttr::MldsaSubjectKeyId2,
+                IdevidCertAttr::MldsaSubjectKeyId3,
+                IdevidCertAttr::MldsaSubjectKeyId4,
+                IdevidCertAttr::MldsaSubjectKeyId5,
+            ]
+        };
+
         let soc_ifc_regs = self.soc_ifc.regs();
 
         let subkeyid1 = soc_ifc_regs
             .fuse_idevid_cert_attr()
-            .at(IdevidCertAttr::EccSubjectKeyId1.into())
+            .at(key_id[0].into())
             .read();
         let subkeyid2 = soc_ifc_regs
             .fuse_idevid_cert_attr()
-            .at(IdevidCertAttr::EccSubjectKeyId2.into())
+            .at(key_id[1].into())
             .read();
         let subkeyid3 = soc_ifc_regs
             .fuse_idevid_cert_attr()
-            .at(IdevidCertAttr::EccSubjectKeyId3.into())
+            .at(key_id[2].into())
             .read();
         let subkeyid4 = soc_ifc_regs
             .fuse_idevid_cert_attr()
-            .at(IdevidCertAttr::EccSubjectKeyId4.into())
+            .at(key_id[3].into())
             .read();
         let subkeyid5 = soc_ifc_regs
             .fuse_idevid_cert_attr()
-            .at(IdevidCertAttr::EccSubjectKeyId5.into())
+            .at(key_id[4].into())
             .read();
 
         let mut subject_key_id = [0u8; 20];

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -107,7 +107,7 @@ impl FuseBank<'_> {
         if !ecc_key_id_algo {
             // ECC Key Id Algo is in Bits 0-2.
             // MLDSA Key Id Algo is in Bits 3-5.
-            flags >>= 3
+            flags >>= 3;
         }
 
         match flags & 0x7 {

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -64,7 +64,7 @@ Following are the main FUSE & Architectural Registers used by the Caliptra ROM f
 | FUSE_OWNER_PK_HASH              | 384          | Owner ECC and LMS or MLDSA Public Key Hash              |
 | FUSE_RUNTIME_SVN                | 128          | Runtime Security Version Number                         |
 | FUSE_ANTI_ROLLBACK_DISABLE      | 1            | Disable SVN checking for FMC & Runtime when bit is set  |
-| FUSE_IDEVID_CERT_ATTR           | 768          | FUSE containing information for generating IDEVID CSR  <br> **Word 0:bits[0-2]**: ECDSA X509 Key Id Algorithm (3 bits) 0: SHA1, 1: SHA256, 2: SHA384, 3: SHA512, 4: Fuse <br> **Word 0:bits[3-5]**: MLDSA X509 Key Id Algorithm (3 bits) 0: SHA1, 1: SHA256, 2: SHA384, 3: SHA512, 4: Fuse <br> **Word 1,2,3,4,5**: ECDSA Subject Key Id <br> **Word 6,7,8,9,10**: MLDSA Subject Key Id <br> **Words 11,12**: Unique Endpoint ID <br> **Words 13,14,15,16**: Manufacturer Serial Number |
+| FUSE_IDEVID_CERT_ATTR           | 768          | FUSE containing information for generating IDEVID CSR  <br> **Word 0:bits[0-2]**: ECDSA X509 Key Id Algorithm (3 bits) 0: SHA1, 1: SHA256, 2: SHA384, 3: SHA512, 4: Fuse <br> **Word 0:bits[3-5]**: MLDSA X509 Key Id Algorithm (3 bits) 0: SHA1, 1: SHA256, 2: SHA384, 3: SHA512, 4: Fuse <br> **Word 1,2,3,4,5**: ECDSA Subject Key Id <br> **Word 6,7,8,9,10**: MLDSA Subject Key Id <br> **Words 11**: UEID type as defined in [IETF RATS specification](https://www.ietf.org/archive/id/draft-ietf-rats-eat-21.html#section-4.2.1.1) <br> **Words 12,13,14,15**: Manufacturer Serial Number |
 | MANUF_DEBUG_UNLOCK_TOKEN       | 128           | Secret value for manufacturing debug unlock authorization |
 
 ### Architectural Registers

--- a/rom/dev/src/flow/cold_reset/x509.rs
+++ b/rom/dev/src/flow/cold_reset/x509.rs
@@ -101,10 +101,12 @@ impl X509 {
         let pub_key_size = Self::get_pubkey_bytes(pub_key, &mut pub_key_bytes);
         let data: &[u8] = &pub_key_bytes[..pub_key_size];
 
+        let ecc_pub_key = matches!(pub_key, PubKey::Ecc(_));
+
         let digest: [u8; 20] = match env
             .soc_ifc
             .fuse_bank()
-            .idev_id_x509_key_id_algo(matches!(pub_key, PubKey::Ecc(_)))
+            .idev_id_x509_key_id_algo(ecc_pub_key)
         {
             X509KeyIdAlgo::Sha1 => {
                 cprintln!("[idev] Sha1 KeyId Algorithm");
@@ -131,7 +133,7 @@ impl X509 {
             }
             X509KeyIdAlgo::Fuse => {
                 cprintln!("[idev] Fuse KeyId");
-                env.soc_ifc.fuse_bank().subject_key_id()
+                env.soc_ifc.fuse_bank().subject_key_id(ecc_pub_key)
             }
         };
 


### PR DESCRIPTION
This change queries the correct algorithm type for generating the IDEVID subject key id for MLDSA from the fuse_idevid_cert_attr fuse.