### PR TITLE
Remove reference to main branch in nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-          ref: 'main'
           fetch-depth: 0
 
       - name: Find latest release


### PR DESCRIPTION
Removing a reference to main in the nightly release that would force some aspects of the release to reference the main branch instead of the branch the action was run against.