### PR TITLE
Update image-builder to output a hashes file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,8 +283,11 @@ dependencies = [
  "clap",
  "elf",
  "hex",
+ "memoffset 0.8.0",
  "nix 0.26.2",
  "once_cell",
+ "serde_json",
+ "sha2",
  "zerocopy",
 ]
 

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -17,8 +17,11 @@ caliptra-image-types.workspace = true
 clap.workspace = true
 elf.workspace = true
 hex.workspace = true
+memoffset.workspace = true
 nix.workspace = true
 once_cell.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 zerocopy.workspace = true
 
 [features]


### PR DESCRIPTION
This can be useful for offline/external signing to extract the digests for an image bundle to be passed to the signing interface.

The output is a JSON file with the vendor and owner hashes tagged with their respective names.

This was tested by printing the hash from the ROM in the smoke tests to ensure the calculated hash is the same for both the firmware and tool.