### PR TITLE
SignWithExported Command

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -57,6 +57,9 @@ impl CommandId {
 
     // The get FMC Alias CSR command.
     pub const GET_FMC_ALIAS_CSR: Self = Self(0x464D_4352); // "FMCR"
+
+    // The sign with exported ecdsa command.
+    pub const SIGN_WITH_EXPORTED_ECDSA: Self = Self(0x5357_4545); // "SWEE"
 }
 
 impl From<u32> for CommandId {
@@ -157,6 +160,7 @@ pub enum MailboxResp {
     AuthorizeAndStash(AuthorizeAndStashResp),
     GetIdevCsr(GetIdevCsrResp),
     GetFmcAliasCsr(GetFmcAliasCsrResp),
+    SignWithExportedEcdsa(SignWithExportedEcdsaResp),
 }
 
 impl MailboxResp {
@@ -179,6 +183,7 @@ impl MailboxResp {
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_bytes()),
+            MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_bytes()),
         }
     }
 
@@ -201,6 +206,7 @@ impl MailboxResp {
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -259,6 +265,7 @@ pub enum MailboxReq {
     CertifyKeyExtended(CertifyKeyExtendedReq),
     SetAuthManifest(SetAuthManifestReq),
     AuthorizeAndStash(AuthorizeAndStashReq),
+    SignWithExportedEcdsa(SignWithExportedEcdsaReq),
 }
 
 impl MailboxReq {
@@ -284,6 +291,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_bytes()),
             MailboxReq::SetAuthManifest(req) => Ok(req.as_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes()),
+            MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -309,6 +317,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SetAuthManifest(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -334,6 +343,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(_) => CommandId::CERTIFY_KEY_EXTENDED,
             MailboxReq::SetAuthManifest(_) => CommandId::SET_AUTH_MANIFEST,
             MailboxReq::AuthorizeAndStash(_) => CommandId::AUTHORIZE_AND_STASH,
+            MailboxReq::SignWithExportedEcdsa(_) => CommandId::SIGN_WITH_EXPORTED_ECDSA,
         }
     }
 
@@ -1050,6 +1060,66 @@ impl GetFmcAliasCsrResp {
     pub const DATA_MAX_SIZE: usize = 512;
 }
 impl ResponseVarSize for GetFmcAliasCsrResp {}
+
+// SIGN_WITH_EXPORTED_ECDSA
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct SignWithExportedEcdsaReq {
+    pub hdr: MailboxReqHeader,
+    pub exported_cdi_handle: [u8; Self::EXPORTED_CDI_MAX_SIZE],
+    pub tbs: [u8; Self::MAX_DIGEST_SIZE],
+}
+
+impl Default for SignWithExportedEcdsaReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            exported_cdi_handle: [0u8; Self::EXPORTED_CDI_MAX_SIZE],
+            tbs: [0u8; Self::MAX_DIGEST_SIZE],
+        }
+    }
+}
+
+impl SignWithExportedEcdsaReq {
+    pub const EXPORTED_CDI_MAX_SIZE: usize = 32;
+    pub const MAX_DIGEST_SIZE: usize = 48;
+}
+
+impl Request for SignWithExportedEcdsaReq {
+    const ID: CommandId = CommandId::SIGN_WITH_EXPORTED_ECDSA;
+    type Resp = SignWithExportedEcdsaResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct SignWithExportedEcdsaResp {
+    pub hdr: MailboxRespHeader,
+    pub derived_pubkey_x: [u8; Self::X_SIZE],
+    pub derived_pubkey_y: [u8; Self::Y_SIZE],
+    pub signature_r: [u8; Self::R_SIZE],
+    pub signature_s: [u8; Self::S_SIZE],
+}
+
+impl SignWithExportedEcdsaResp {
+    pub const X_SIZE: usize = 48;
+    pub const Y_SIZE: usize = 48;
+    pub const R_SIZE: usize = 48;
+    pub const S_SIZE: usize = 48;
+}
+
+impl ResponseVarSize for SignWithExportedEcdsaResp {}
+
+impl Default for SignWithExportedEcdsaResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            signature_r: [0u8; Self::R_SIZE],
+            signature_s: [0u8; Self::S_SIZE],
+            derived_pubkey_x: [0u8; Self::X_SIZE],
+            derived_pubkey_y: [0u8; Self::Y_SIZE],
+        }
+    }
+}
 
 #[repr(u32)]
 #[derive(Debug, PartialEq, Eq)]

--- a/common/src/keyids.rs
+++ b/common/src/keyids.rs
@@ -33,5 +33,7 @@ pub const KEY_ID_RT_PRIV_KEY: KeyId = KeyId::KeyId5;
 pub const KEY_ID_DPE_CDI: KeyId = KeyId::KeyId8;
 #[cfg(feature = "runtime")]
 pub const KEY_ID_DPE_PRIV_KEY: KeyId = KeyId::KeyId9;
+#[cfg(feature = "runtime")]
+pub const KEY_ID_EXPORTED_DPE_CDI: KeyId = KeyId::KeyId10;
 
 pub const KEY_ID_TMP: KeyId = KeyId::KeyId3;

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -449,6 +449,14 @@ impl CaliptraError {
         CaliptraError::new_const(0x000E0052);
     pub const RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_DUPLICATE_FIRMWARE_ID: CaliptraError =
         CaliptraError::new_const(0x000E0053);
+    pub const RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0054);
+    pub const RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED: CaliptraError =
+        CaliptraError::new_const(0x000E0055);
+    pub const RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_DIGEST: CaliptraError =
+        CaliptraError::new_const(0x000E0056);
+    pub const RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE: CaliptraError =
+        CaliptraError::new_const(0x000E0057);
 
     pub const RUNTIME_GET_FMC_CSR_UNPROVISIONED: CaliptraError =
         CaliptraError::new_const(0x000E0054);

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -29,7 +29,7 @@ HWMODEL_DIR = $(OUTPUT_DIR)
 HWMODEL_HEADER_DIR = ../../../hw-model/c-binding/out
 HWMODEL_INCLUDE = -I$(HWMODEL_HEADER_DIR)
 HWMODEL_LIB = -Wl,-L$(HWMODEL_DIR) -lcaliptra_hw_model_c_binding
-HWMODEL_FLAGS = -lpthread -lstdc++ -ldl -lrt -lm 
+HWMODEL_FLAGS = -lpthread -lstdc++ -ldl -lrt -lm -lcrypto
 HWMODEL_HEADER = $(HWMODEL_HEADER_DIR)/caliptra_model.h
 HWMODEL_BINDING_LIB_OBJ = $(HWMODEL_DIR)/libcaliptra_hw_model_c_binding.a
 

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -183,6 +183,9 @@ int caliptra_fips_version(struct caliptra_fips_version_resp *resp, bool async);
 // Get IDev CSR
 int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async);
 
+// Sign with Exported Ecdsa
+int caliptra_sign_with_exported_ecdsa(struct caliptra_sign_with_exported_ecdsa_req *req, struct caliptra_sign_with_exported_ecdsa_resp *resp, bool async);
+
 // Self test start
 int caliptra_self_test_start(bool async);
 

--- a/libcaliptra/inc/caliptra_enums.h
+++ b/libcaliptra/inc/caliptra_enums.h
@@ -103,6 +103,11 @@ enum dpe_error_codes {
     DPE_RAND_ERROR             = 0x1007,
 };
 
+enum dpe_derive_context_cmd_flags {
+    DPE_DERIVE_CONTEXT_FLAG_EXPORT_CDI         = ( 1UL << 23),
+    DPE_DERIVE_CONTEXT_FLAG_CREATE_CERTIFICATE = ( 1UL << 22),
+};
+
 #define DPE_PROFILE_256 3
 #define DPE_PROFILE_384 4
 

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -225,6 +225,20 @@ struct caliptra_get_idev_csr_resp {
     uint8_t data[512];
 };
 
+struct caliptra_sign_with_exported_ecdsa_req {
+    struct caliptra_req_header hdr;
+    uint8_t exported_cdi_handle[32];
+    uint8_t tbs[48];
+};
+
+struct caliptra_sign_with_exported_ecdsa_resp {
+    struct caliptra_resp_header hdr;
+    uint8_t derived_public_key_x[48];
+    uint8_t derived_public_key_y[48];
+    uint8_t signature_r[48];
+    uint8_t signature_s[48];
+};
+
 // DPE commands
 
 #define DPE_MAGIC    0x44504543 // "DPEC"
@@ -297,6 +311,15 @@ struct dpe_derive_context_response {
     struct dpe_resp_hdr resp_hdr;
     uint8_t new_context_handle[DPE_HANDLE_SIZE];
     uint8_t parent_context_handle[DPE_HANDLE_SIZE];
+};
+
+struct dpe_derive_context_exported_cdi_response {
+    struct dpe_resp_hdr resp_hdr;
+    uint8_t new_context_handle[DPE_HANDLE_SIZE];
+    uint8_t parent_context_handle[DPE_HANDLE_SIZE];
+    uint8_t exported_cdi_handle[32];
+    uint32_t certificate_size;
+    uint8_t new_certificate[DPE_CERT_SIZE];
 };
 
 // CERTIFY_KEY
@@ -393,15 +416,16 @@ struct caliptra_invoke_dpe_resp {
     struct caliptra_resp_header cpl;
     uint32_t data_size;
     union {
-        struct dpe_resp_hdr                         resp_hdr;
-        struct dpe_get_profile_response             get_profile_resp;
-        struct dpe_initialize_context_response      initialize_context_resp;
-        struct dpe_derive_context_response          derive_context_resp;
-        struct dpe_certify_key_response             certify_key_resp;
-        struct dpe_sign_response                    sign_resp;
-        struct dpe_rotate_context_handle_response   rotate_context_handle_resp;
-        struct dpe_destroy_context_response         destroy_context_resp;
-        struct dpe_get_certificate_chain_response   get_certificate_chain_resp;
-        uint8_t                                     data[0];
+        struct dpe_resp_hdr                                resp_hdr;
+        struct dpe_get_profile_response                    get_profile_resp;
+        struct dpe_initialize_context_response             initialize_context_resp;
+        struct dpe_derive_context_response                 derive_context_resp;
+        struct dpe_derive_context_exported_cdi_response    derive_context_exported_cdi_resp;
+        struct dpe_certify_key_response                    certify_key_resp;
+        struct dpe_sign_response                           sign_resp;
+        struct dpe_rotate_context_handle_response          rotate_context_handle_resp;
+        struct dpe_destroy_context_response                destroy_context_resp;
+        struct dpe_get_certificate_chain_response          get_certificate_chain_resp;
+        uint8_t                                            data[0];
     };
 };

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1215,6 +1215,19 @@ int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async)
     return pack_and_execute_command(&p, async);
 }
 
+// Sign with Exported
+int caliptra_sign_with_exported_ecdsa(struct caliptra_sign_with_exported_ecdsa_req *req, struct caliptra_sign_with_exported_ecdsa_resp *resp, bool async)
+{
+    if (!req || !resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    CREATE_PARCEL(p, OP_SIGN_WITH_EXPORTED_ECDSA, req, resp);
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Self test start
 int caliptra_self_test_start(bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -52,6 +52,7 @@ enum mailbox_command {
     OP_SHUTDOWN                    = 0x46505344, // "FPSD"
     OP_CAPABILITIES                = 0x43415053, // "CAPS"
     OP_GET_IDEV_CSR                = 0x49444352, // "IDCR"
+    OP_SIGN_WITH_EXPORTED_ECDSA    = 0x53574545, // "SWEE"
 };
 
 struct parcel {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -924,6 +924,28 @@ When called from runtime, if the CSR was not previously provisioned this command
 
 When the `mfg_flag_gen_idev_id_csr` flag has been set, the SoC **MUST** wait for the `flow_status_set_idevid_csr_ready` bit to be set by Caliptra. Once set, the SoC **MUST** clear the `mfg_flag_gen_idev_id_csr` flag for Caliptra to progress.
 
+### SIGN\_WITH\_EXPORTED\_ECDSA
+
+Command Code: `0x5357_4545` ("SWEE")
+
+*Table: `SIGN_WITH_EXPORTED_ECDSA` input arguments*
+
+| **Name**      | **Type** | **Description**
+| --------      | -------- | ---------------
+| chksum        | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
+| exported_cdi  | u8[32]   | The Exported CDI returned by the DPE `DeriveContext` command. Little endian. |
+| digest        | u8[48]   | The digest to be signed. Little endian.                                      |
+
+*Table: `SIGN_WITH_EXPORTED_ECDSA` output arguments*
+| **Name**           | **Type** | **Description**
+| --------           | -------- | ---------------
+| derived_pubkey_x   | u8[48]   | The X BigNum of the ECDSA public key associated with the signing key.      |
+| derived_pubkey_y   | u8[48]   | The Y BigNum of the ECDSA public key associated with the signing key.      |
+| signature_r        | u8[48]   | The R BigNum of an ECDSA signature.                                        |
+| signature_s        | u8[48]   | The S BigNum of an ECDSA signature.                                        |
+
+The `exported_cdi` can be created by calling `DeriveContext` with the `export-cdi` and `create-certificate` flags.
+
 ## Checksum
 
 For every command except for FW_LOAD, the request and response feature a checksum. This

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -57,6 +57,7 @@ impl CertifyKeyExtendedCmd {
             &mut pdata.fht.rt_dice_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
+            &mut drivers.exported_cdi_slots,
         );
         let pl0_pauser = pdata.manifest1.header.pl0_pauser;
         let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
@@ -78,6 +79,7 @@ impl CertifyKeyExtendedCmd {
                 &nb,
                 &nf,
                 dmtf_device_info,
+                None,
             ),
         };
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -23,6 +23,7 @@ use crate::{
     PL1_DPE_ACTIVE_CONTEXT_THRESHOLD,
 };
 
+use crate::dpe_crypto::{ExportedCdiHandles, EXPORTED_HANDLES_NUM};
 use arrayvec::ArrayVec;
 use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder};
@@ -58,7 +59,7 @@ use dpe::{
 };
 
 use core::cmp::Ordering::{Equal, Greater};
-use crypto::{AlgLen, Crypto, CryptoBuf, Hasher};
+use crypto::{AlgLen, Crypto, CryptoBuf, Hasher, MAX_EXPORTED_CDI_SIZE};
 use zerocopy::IntoBytes;
 
 #[derive(PartialEq, Clone)]
@@ -108,6 +109,7 @@ pub struct Drivers {
     pub is_shutdown: bool,
 
     pub dmtf_device_info: Option<ArrayVec<u8, { AddSubjectAltNameReq::MAX_DEVICE_INFO_LEN }>>,
+    pub exported_cdi_slots: ExportedCdiHandles,
 }
 
 impl Drivers {
@@ -146,6 +148,7 @@ impl Drivers {
             cert_chain: ArrayVec::new(),
             is_shutdown: false,
             dmtf_device_info: None,
+            exported_cdi_slots: [None; EXPORTED_HANDLES_NUM],
         })
     }
 
@@ -387,6 +390,7 @@ impl Drivers {
             &mut pdata.fht.rt_dice_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
+            &mut drivers.exported_cdi_slots,
         );
 
         let (nb, nf) = Self::get_cert_validity_info(&pdata.manifest1);
@@ -398,6 +402,7 @@ impl Drivers {
                 &drivers.cert_chain,
                 &nb,
                 &nf,
+                None,
                 None,
             ),
         };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,6 +31,7 @@ mod invoke_dpe;
 mod pcr;
 mod populate_idev;
 mod set_auth_manifest;
+mod sign_with_exported_ecdsa;
 mod stash_measurement;
 mod subject_alt_name;
 mod update;
@@ -47,6 +48,7 @@ use mailbox::Mailbox;
 use crate::capabilities::CapabilitiesCmd;
 pub use crate::certify_key_extended::CertifyKeyExtendedCmd;
 pub use crate::hmac::Hmac;
+use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
 pub use caliptra_common::fips::FipsVersionCmd;
@@ -228,6 +230,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers, cmd_bytes),
         CommandId::GET_IDEV_CSR => GetIdevCsrCmd::execute(drivers, cmd_bytes),
         CommandId::GET_FMC_ALIAS_CSR => GetFmcAliasCsrCmd::execute(drivers, cmd_bytes),
+        CommandId::SIGN_WITH_EXPORTED_ECDSA => {
+            SignWithExportedEcdsaCmd::execute(drivers, cmd_bytes)
+        }
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     };
     let resp = okmutref(&mut resp)?;

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -1,0 +1,124 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
+
+use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+
+use caliptra_common::mailbox_api::{
+    MailboxResp, MailboxRespHeader, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
+};
+use caliptra_error::{CaliptraError, CaliptraResult};
+
+use crypto::{Crypto, Digest, EcdsaPub, EcdsaSig};
+use dpe::{DPE_PROFILE, MAX_EXPORTED_CDI_SIZE};
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct SignWithExportedEcdsaCmd;
+impl SignWithExportedEcdsaCmd {
+    /// SignWithExported signs a `digest` using an ECDSA keypair derived from a exported_cdi
+    /// handle and the CDI stored in DPE.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - DPE environment containing Crypto and Platform implementations
+    /// * `digest` - The data to be signed
+    /// * `exported_cdi_handle` - A handle from DPE that is exchanged for a CDI.
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn ecdsa_sign(
+        env: &mut DpeCrypto,
+        digest: &Digest,
+        exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
+    ) -> CaliptraResult<(EcdsaSig, EcdsaPub)> {
+        let algs = DPE_PROFILE.alg_len();
+        let key_pair = env.derive_key_pair_exported(
+            algs,
+            exported_cdi_handle,
+            b"Exported ECC",
+            b"Exported ECC",
+        );
+
+        if cfi_launder(key_pair.is_ok()) {
+            #[cfg(not(feature = "no-cfi"))]
+            cfi_assert!(key_pair.is_ok());
+        } else {
+            #[cfg(not(feature = "no-cfi"))]
+            cfi_assert!(key_pair.is_err());
+        }
+        let (priv_key, pub_key) = key_pair
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
+
+        let sig = env
+            .ecdsa_sign_with_derived(algs, digest, &priv_key, &pub_key)
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED)?;
+
+        Ok((sig, pub_key))
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        let cmd = SignWithExportedEcdsaReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        match drivers.caller_privilege_level() {
+            // SIGN_WITH_EXPORTED_ECDSA MUST only be called from PL0
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+
+        let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+        let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+
+        let mut crypto = DpeCrypto::new(
+            &mut drivers.sha384,
+            &mut drivers.trng,
+            &mut drivers.ecc384,
+            &mut drivers.hmac384,
+            &mut drivers.key_vault,
+            &mut drivers.persistent_data.get_mut().fht.rt_dice_pub_key,
+            key_id_rt_cdi,
+            key_id_rt_priv_key,
+            &mut drivers.exported_cdi_slots,
+        );
+
+        let digest = Digest::new(&cmd.tbs)
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_DIGEST)?;
+        let (EcdsaSig { ref r, ref s }, EcdsaPub { ref x, ref y }) =
+            Self::ecdsa_sign(&mut crypto, &digest, &cmd.exported_cdi_handle)?;
+
+        let mut resp = SignWithExportedEcdsaResp::default();
+        let mut bytes_written = 0;
+
+        if r.len() <= resp.signature_r.len() {
+            resp.signature_r[..r.len()].copy_from_slice(r.bytes());
+            bytes_written += r.len()
+        } else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
+        }
+
+        if s.len() <= resp.signature_s.len() {
+            resp.signature_s[..s.len()].copy_from_slice(s.bytes());
+            bytes_written += s.len()
+        } else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
+        }
+
+        if x.len() <= resp.derived_pubkey_x.len() {
+            resp.derived_pubkey_x[..x.len()].copy_from_slice(x.bytes());
+            bytes_written += x.len()
+        } else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
+        }
+
+        if y.len() <= resp.derived_pubkey_y.len() {
+            resp.derived_pubkey_y[..y.len()].copy_from_slice(y.bytes());
+            bytes_written += y.len()
+        } else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
+        }
+        Ok(MailboxResp::SignWithExportedEcdsa(resp))
+    }
+}

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -62,6 +62,7 @@ impl StashMeasurementCmd {
                 &mut pdata.fht.rt_dice_pub_key,
                 key_id_rt_cdi,
                 key_id_rt_priv_key,
+                &mut drivers.exported_cdi_slots,
             );
             let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
             let mut env = DpeEnv::<CptraDpeTypes> {
@@ -72,6 +73,7 @@ impl StashMeasurementCmd {
                     &drivers.cert_chain,
                     &nb,
                     &nf,
+                    None,
                     None,
                 ),
             };

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -21,10 +21,10 @@ use caliptra_hw_model::{
     StackInfo, StackRange,
 };
 use dpe::{
-    commands::{Command, CommandHdr},
+    commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags},
     response::{
-        CertifyKeyResp, DeriveContextResp, GetCertificateChainResp, GetProfileResp, NewHandleResp,
-        Response, ResponseHdr, SignResp,
+        CertifyKeyResp, DeriveContextExportedCdiResp, DeriveContextResp, GetCertificateChainResp,
+        GetProfileResp, NewHandleResp, Response, ResponseHdr, SignResp,
     },
 };
 use openssl::{
@@ -185,6 +185,13 @@ fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
         Command::CertifyKey(_) => {
             Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::DeriveContext(DeriveContextCmd { flags, .. })
+            if flags.contains(DeriveContextFlags::EXPORT_CDI) =>
+        {
+            Response::DeriveContextExportedCdi(
+                DeriveContextExportedCdiResp::read_from_bytes(resp_bytes).unwrap(),
+            )
         }
         Command::DeriveContext(_) => {
             Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -19,6 +19,7 @@ mod test_pauser_privilege_levels;
 mod test_pcr;
 mod test_populate_idev;
 mod test_set_auth_manifest;
+mod test_sign_with_export_ecdsa;
 mod test_stash_measurement;
 mod test_tagging;
 mod test_update_reset;

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -81,7 +81,7 @@ fn test_disable_attestation_cmd() {
     };
 
     let sig = EcdsaSig::from_private_components(
-        BigNum::from_slice(&sign_resp.sig_r_or_hmac).unwrap(),
+        BigNum::from_slice(&sign_resp.sig_r).unwrap(),
         BigNum::from_slice(&sign_resp.sig_s).unwrap(),
     )
     .unwrap();

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -124,7 +124,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
     };
 
     let sig = EcdsaSig::from_private_components(
-        BigNum::from_slice(&sign_resp.sig_r_or_hmac).unwrap(),
+        BigNum::from_slice(&sign_resp.sig_r).unwrap(),
         BigNum::from_slice(&sign_resp.sig_s).unwrap(),
     )
     .unwrap();
@@ -139,7 +139,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
 }
 
 #[test]
-fn test_invoke_dpe_symmetric_sign() {
+fn test_invoke_dpe_asymmetric_sign() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
@@ -149,7 +149,7 @@ fn test_invoke_dpe_symmetric_sign() {
     let sign_cmd = SignCmd {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
-        flags: SignFlags::IS_SYMMETRIC,
+        flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
     let resp = execute_dpe_cmd(
@@ -162,9 +162,9 @@ fn test_invoke_dpe_symmetric_sign() {
     };
 
     // r contains the hmac so it should not be all 0s
-    assert_ne!(sign_resp.sig_r_or_hmac, [0u8; 48]);
+    assert_ne!(sign_resp.sig_r, [0u8; 48]);
     // s must be all 0s for hmac sign
-    assert_eq!(sign_resp.sig_s, [0u8; 48]);
+    assert_ne!(sign_resp.sig_s, [0u8; 48]);
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::SocManager;
+use caliptra_api::{mailbox::SignWithExportedEcdsaReq, SocManager};
 use caliptra_builder::{
     build_firmware_elf,
     firmware::{APP_WITH_UART, FMC_WITH_UART},
@@ -310,6 +310,66 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
         &mut model,
         CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
         resp,
+    );
+}
+
+#[test]
+fn test_sign_with_exported_ecdsa_cannot_be_called_from_pl1() {
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq::default());
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::SIGN_WITH_EXPORTED_ECDSA),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        resp,
+    );
+}
+
+#[test]
+fn test_export_cdi_cannot_be_called_from_pl1() {
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let get_cert_chain_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+    let _ = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&get_cert_chain_cmd),
+        DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
 }
 

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -1,0 +1,159 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::SocManager;
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::{HwModel, ModelError};
+use caliptra_runtime::RtBootStatus;
+use crypto::MAX_EXPORTED_CDI_SIZE;
+use dpe::{
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
+    context::ContextHandle,
+    response::Response,
+    DPE_PROFILE,
+};
+use openssl::{
+    bn::BigNum,
+    ec::{EcGroup, EcKey},
+    ecdsa::EcdsaSig,
+    nid::Nid,
+    x509::X509,
+};
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::common::{execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST};
+
+#[test]
+fn test_sign_with_exported_cdi() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let resp = match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: resp.exported_cdi,
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let response = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    let sig = EcdsaSig::from_private_components(
+        BigNum::from_slice(&response.signature_r).unwrap(),
+        BigNum::from_slice(&response.signature_s).unwrap(),
+    )
+    .unwrap();
+
+    // Verify that the certificate from DeriveContext can verify the signature.
+    let x509 =
+        X509::from_der(&resp.new_certificate[..resp.certificate_size.try_into().unwrap()]).unwrap();
+    let ec_pub_key = x509.public_key().unwrap().ec_key().unwrap();
+    assert!(sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap());
+
+    // Let's also check that the returned public key can verify the signature.
+    let x = BigNum::from_slice(&response.derived_pubkey_x).unwrap();
+    let y = BigNum::from_slice(&response.derived_pubkey_y).unwrap();
+    let ec_pub_key = EcKey::from_public_key_affine_coordinates(
+        &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
+        &x,
+        &y,
+    )
+    .unwrap();
+    assert!(sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap());
+}
+
+#[test]
+fn test_sign_with_exported_incorrect_cdi_handle() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let get_cert_chain_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&get_cert_chain_cmd),
+        DpeResult::Success,
+    );
+
+    match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFF; MAX_EXPORTED_CDI_SIZE],
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_eq!(
+        result.unwrap_err(),
+        ModelError::MailboxCmdFailed(
+            CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED.into(),
+        )
+    );
+}
+
+#[test]
+fn test_sign_with_exported_never_derived() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFF; MAX_EXPORTED_CDI_SIZE],
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_eq!(
+        result.unwrap_err(),
+        ModelError::MailboxCmdFailed(
+            CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED.into(),
+        )
+    );
+}

--- a/test/dpe_verification/transport.go
+++ b/test/dpe_verification/transport.go
@@ -197,11 +197,10 @@ func (s *CptraModel) GetSupport() *client.Support {
 		RotateContext:       true,
 		X509:                true,
 		Csr:                 true,
-		IsSymmetric:         true,
 		InternalInfo:        true,
 		InternalDice:        true,
-		IsCA:                true,
 		RetainParentContext: true,
+		CdiExport: true,
 	}
 }
 
@@ -233,7 +232,7 @@ func (s *CptraModel) GetProfileMajorVersion() uint16 {
 }
 
 func (s *CptraModel) GetProfileMinorVersion() uint16 {
-	return 11
+	return 12
 }
 
 func (s *CptraModel) GetProfileVendorID() uint32 {

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -528,7 +528,7 @@ pub fn exec_dpe_sign<T: HwModel>(hw: &mut T) {
         panic!("Wrong response type!");
     };
 
-    assert!(contains_some_data(&sign_resp.sig_r_or_hmac));
+    assert!(contains_some_data(&sign_resp.sig_r));
     assert!(contains_some_data(&sign_resp.sig_s));
 }
 


### PR DESCRIPTION
Add support for export cdi crypto api and sign with exported.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/1807.

`SignWithExported` is a new runtime command that allows signing a digest with a CDI exported from DPE.