### PR TITLE
Update DPE submodule

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -630,7 +630,7 @@ pub struct CertifyKeyExtendedResp {
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
 }
 impl CertifyKeyExtendedResp {
-    pub const CERTIFY_KEY_RESP_SIZE: usize = 2176;
+    pub const CERTIFY_KEY_RESP_SIZE: usize = 6272;
 }
 impl Response for CertifyKeyExtendedResp {}
 
@@ -700,7 +700,7 @@ pub struct InvokeDpeResp {
     pub data: [u8; InvokeDpeResp::DATA_MAX_SIZE], // variable length
 }
 impl InvokeDpeResp {
-    pub const DATA_MAX_SIZE: usize = 2200;
+    pub const DATA_MAX_SIZE: usize = 6556;
 }
 impl ResponseVarSize for InvokeDpeResp {}
 

--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -24,9 +24,9 @@ pub const CFI_STATE_ORG: u32 = 0x500003E4; // size = 6 words
 pub const BOOT_STATUS_ORG: u32 = 0x500003FC;
 pub const PERSISTENT_DATA_ORG: u32 = 0x50000400;
 
-pub const DATA_ORG: u32 = 0x5000D800;
+pub const DATA_ORG: u32 = 0x50009C00;
 
-pub const STACK_ORG: u32 = 0x5000f800;
+pub const STACK_ORG: u32 = 0x5000A400;
 pub const ROM_STACK_ORG: u32 = 0x5001C000;
 
 pub const ESTACK_ORG: u32 = 0x5001F800;
@@ -45,7 +45,7 @@ pub const ROM_NSTACK_ORG: u32 = 0x5001FC00;
 // reserved for future use and then allocating the rest of the DCCM.
 //
 // The `DATA_SIZE` variable reflects the leftover space.
-pub const PERSISTENT_DATA_SIZE: u32 = 53 * 1024;
+pub const PERSISTENT_DATA_SIZE: u32 = 38 * 1024;
 
 pub const ROM_RELAXATION_PADDING: u32 = 4 * 1024;
 pub const ROM_SIZE: u32 = 48 * 1024;
@@ -53,8 +53,8 @@ pub const MBOX_SIZE: u32 = 128 * 1024;
 pub const ICCM_SIZE: u32 = 128 * 1024;
 pub const DCCM_SIZE: u32 = 128 * 1024;
 pub const ROM_DATA_SIZE: u32 = 996;
-pub const DATA_SIZE: u32 = 8 * 1024;
-pub const STACK_SIZE: u32 = 64 * 1024;
+pub const DATA_SIZE: u32 = 2 * 1024;
+pub const STACK_SIZE: u32 = 85 * 1024;
 pub const ROM_STACK_SIZE: u32 = 14 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const ROM_ESTACK_SIZE: u32 = 1024;

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -38,7 +38,7 @@ pub const DPE_SIZE: u32 = 5 * 1024;
 pub const PCR_RESET_COUNTER_SIZE: u32 = 1024;
 pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
 pub const IDEVID_CSR_SIZE: u32 = 1024;
-pub const RESERVED_MEMORY_SIZE: u32 = 19 * 1024;
+pub const RESERVED_MEMORY_SIZE: u32 = 4 * 1024;
 
 pub const PCR_LOG_MAX_COUNT: usize = 17;
 pub const FUSE_LOG_MAX_COUNT: usize = 62;

--- a/libcaliptra/inc/caliptra_enums.h
+++ b/libcaliptra/inc/caliptra_enums.h
@@ -103,8 +103,8 @@ enum dpe_error_codes {
     DPE_RAND_ERROR             = 0x1007,
 };
 
-#define DPE_PROFILE_256 1
-#define DPE_PROFILE_384 2
+#define DPE_PROFILE_256 3
+#define DPE_PROFILE_384 4
 
 enum dpe_profile {
     P256Sha256 = DPE_PROFILE_256,

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -204,7 +204,7 @@ struct caliptra_certify_key_extended_req {
 
 struct caliptra_certify_key_extended_resp {
     struct caliptra_resp_header hdr;
-    uint8_t certify_key_resp[2176];
+    uint8_t certify_key_resp[6272];
 };
 
 struct caliptra_fips_version_resp {
@@ -243,7 +243,7 @@ struct dpe_resp_hdr {
 
 
 #define DPE_HANDLE_SIZE 16
-#define DPE_CERT_SIZE   2048
+#define DPE_CERT_SIZE   6144
 
 #ifndef DPE_PROFILE
 #define DPE_PROFILE DPE_PROFILE_384

--- a/test/dpe_verification/transport.go
+++ b/test/dpe_verification/transport.go
@@ -233,7 +233,7 @@ func (s *CptraModel) GetProfileMajorVersion() uint16 {
 }
 
 func (s *CptraModel) GetProfileMinorVersion() uint16 {
-	return 10
+	return 11
 }
 
 func (s *CptraModel) GetProfileVendorID() uint32 {


### PR DESCRIPTION
Adds the following commits:

* 44a2307 - (HEAD, origin/main, origin/HEAD, main) Update fuzzing toolchain (3 weeks ago) <Arthur Heymans>
* 7b6768d - Fix linter and compiler warnings for rust 1.83 (3 weeks ago) <Arthur Heymans>
* d0d0887 - Update the rust toolchain to 1.83 (3 weeks ago) <Arthur Heymans>
* 6cd2ae8 - Increase max cert size to 6KiB (6 weeks ago) <Jordan Hand>

6cd2ae8 increases the stack usage of DPE. This commit addresses the usage by increasing the stack size of Caliptra.