### PR TITLE
[fix] MLDSA driver fixes

### DIFF
--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -117,6 +117,9 @@ impl Mldsa87 {
         // Clear the hardware before start
         mldsa.ctrl().write(|w| w.zeroize(true));
 
+        // Wait for hardware ready
+        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
+
         // Copy seed from keyvault
         KvAccess::copy_from_kv(*seed, mldsa.kv_rd_seed_status(), mldsa.kv_rd_seed_ctrl())
             .map_err(|err| err.into_read_seed_err())?;
@@ -172,6 +175,9 @@ impl Mldsa87 {
         // Clear the hardware before start
         mldsa.ctrl().write(|w| w.zeroize(true));
 
+        // Wait for hardware ready
+        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
+
         // Copy seed from keyvault
         KvAccess::copy_from_kv(*seed, mldsa.kv_rd_seed_status(), mldsa.kv_rd_seed_ctrl())
             .map_err(|err| err.into_read_seed_err())?;
@@ -195,8 +201,7 @@ impl Mldsa87 {
         // Copy signature
         let signature = Mldsa87Signature::read_from_reg(mldsa.signature());
 
-        // Clear the hardware when done
-        mldsa.ctrl().write(|w| w.zeroize(true));
+        // No need to zeroize here, as the hardware will be zeroized by verify_res.
 
         let verify_res = self.verify_res(pub_key, msg, &signature)?;
 
@@ -242,6 +247,9 @@ impl Mldsa87 {
 
         // Clear the hardware before start
         mldsa.ctrl().write(|w| w.zeroize(true));
+
+        // Wait for hardware ready
+        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
 
         // Copy digest
         msg.write_to_reg(mldsa.msg());

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -21,6 +21,7 @@ use crate::{
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_derive::Launder;
+use caliptra_cfi_lib::{cfi_assert_eq, cfi_assert_eq_12_words, cfi_assert_eq_8_words, cfi_launder};
 use caliptra_registers::mldsa::{MldsaReg, RegisterBlock};
 
 #[must_use]
@@ -201,22 +202,10 @@ impl Mldsa87 {
         // Copy signature
         let signature = Mldsa87Signature::read_from_reg(mldsa.signature());
 
-        // No need to zeroize here, as the hardware will be zeroized by verify_res.
-
-        let verify_res = self.verify_res(pub_key, msg, &signature)?;
-
-        let truncated_signature = &signature.0[..16];
-
-        if verify_res.0 == truncated_signature {
-            // We only have a 6, 8 and 12 dword cfi assert
-            caliptra_cfi_lib::cfi_assert_eq_12_words(
-                &verify_res.0[..12].try_into().unwrap(),
-                &truncated_signature[..12].try_into().unwrap(),
-            );
-            caliptra_cfi_lib::cfi_assert_eq_8_words(
-                &verify_res.0[8..].try_into().unwrap(),
-                &truncated_signature[8..].try_into().unwrap(),
-            );
+        // No need to zeroize here, as the hardware will be zeroized by verify.
+        let result = self.verify(pub_key, msg, &signature)?;
+        if result == Mldsa87Result::Success {
+            cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
         } else {
             Err(CaliptraError::DRIVER_MLDSA87_SIGN_VALIDATION_FAILED)
@@ -284,15 +273,15 @@ impl Mldsa87 {
     ) -> CaliptraResult<Mldsa87Result> {
         let verify_res = self.verify_res(pub_key, msg, signature)?;
 
-        let truncated_signature = &signature.0[..16];
+        let truncated_signature = &signature.0[signature.0.len() - verify_res.0.len()..];
 
         let result = if verify_res.0 == truncated_signature {
             // We only have a 6, 8 and 12 dword cfi assert
-            caliptra_cfi_lib::cfi_assert_eq_12_words(
+            cfi_assert_eq_12_words(
                 &verify_res.0[..12].try_into().unwrap(),
                 &truncated_signature[..12].try_into().unwrap(),
             );
-            caliptra_cfi_lib::cfi_assert_eq_8_words(
+            cfi_assert_eq_8_words(
                 &verify_res.0[8..].try_into().unwrap(),
                 &truncated_signature[8..].try_into().unwrap(),
             );

--- a/sw-emulator/lib/periph/src/ml_dsa87.rs
+++ b/sw-emulator/lib/periph/src/ml_dsa87.rs
@@ -399,8 +399,9 @@ impl Mldsa87 {
         let success = public_key.verify(message, &signature[..SIG_LEN].try_into().unwrap(), &[]);
 
         if success {
-            self.verify_res
-                .copy_from_slice(&self.signature[..ML_DSA87_VERIFICATION_SIZE / 4]);
+            self.verify_res.copy_from_slice(
+                &self.signature[self.signature.len() - ML_DSA87_VERIFICATION_SIZE / 4..],
+            );
         } else {
             self.verify_res = rand::thread_rng().gen::<[u32; 16]>();
         }
@@ -755,8 +756,17 @@ mod tests {
             clock.increment_and_process_timer_actions(1, &mut ml_dsa87);
         }
 
+        let signature = {
+            let mut sig = [0; SIG_LEN + 1];
+            sig[..SIG_LEN].copy_from_slice(&test_signature);
+            sig
+        };
+
         let result = bytes_from_words_be(&ml_dsa87.verify_res);
-        assert_eq!(result, &test_signature[..ML_DSA87_VERIFICATION_SIZE]);
+        assert_eq!(
+            result,
+            &signature[signature.len() - ML_DSA87_VERIFICATION_SIZE..]
+        );
 
         // Bad signature
         let mut rng = rand::thread_rng();
@@ -796,8 +806,17 @@ mod tests {
             clock.increment_and_process_timer_actions(1, &mut ml_dsa87);
         }
 
+        let signature = {
+            let mut sig = [0; SIG_LEN + 1];
+            sig[..SIG_LEN].copy_from_slice(&test_signature);
+            sig
+        };
+
         let result = bytes_from_words_be(&ml_dsa87.verify_res);
-        assert_ne!(result, &test_signature[..ML_DSA87_VERIFICATION_SIZE]);
+        assert_ne!(
+            result,
+            &signature[signature.len() - ML_DSA87_VERIFICATION_SIZE..]
+        );
     }
 
     #[test]


### PR DESCRIPTION
This change contains the following fixes:

1. Updates the MLDSA driver to wait for the zeroize operation to be complete before further interacting with the MLDSA hardware peripheral.
2. Updates the MLDSA driver to use the last 64 bytes of the signature for comparison against the 'verify result' value from the MLDSA peripheral.