### PR TITLE
Disabling stack overflow check for nightly CI for ROM 1.0.x

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -292,6 +292,8 @@ jobs:
       rom-logging: false
       rom-version: "1.1"
 
+  # The current 1.0.x ROM used in CI will overflow the stack into unused space
+  # We disable the stack overflow check (sw_emu_stack_check_disable) when testing against that ROM
   sw-emulator-hw-1_0-full-suite-etrng-log:
     name: sw-emulator Suite (etrng, log)
     needs: find-latest-release
@@ -299,7 +301,7 @@ jobs:
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-1.0-etrng-log
-      extra-features: hw-1.0,slow_tests
+      extra-features: hw-1.0,slow_tests,sw_emu_stack_check_disable
       rom-logging: true
       rom-version: "1.0"
 
@@ -310,7 +312,7 @@ jobs:
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-1.0-etrng-nolog
-      extra-features: hw-1.0,slow_tests
+      extra-features: hw-1.0,slow_tests,sw_emu_stack_check_disable
       rom-logging: false
       rom-version: "1.0"
 
@@ -321,7 +323,7 @@ jobs:
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-1.0-itrng-log
-      extra-features: hw-1.0,slow_tests,itrng
+      extra-features: hw-1.0,slow_tests,itrng,sw_emu_stack_check_disable
       rom-logging: true
       rom-version: "1.0"
 
@@ -332,7 +334,7 @@ jobs:
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-1.0-itrng-nolog
-      extra-features: hw-1.0,slow_tests,itrng
+      extra-features: hw-1.0,slow_tests,itrng,sw_emu_stack_check_disable
       rom-logging: false
       rom-version: "1.0"
 

--- a/sw-emulator/lib/cpu/Cargo.toml
+++ b/sw-emulator/lib/cpu/Cargo.toml
@@ -15,3 +15,6 @@ caliptra-emu-derive.workspace = true
 caliptra-emu-types.workspace = true
 lazy_static.workspace = true
 tock-registers.workspace = true
+
+[features]
+"sw_emu_stack_check_disable" = []

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -402,6 +402,7 @@ impl<TBus: Bus> Cpu<TBus> {
     /// * `RvException` - Exception with cause `RvExceptionCause::IllegalRegister`
     pub fn write_xreg(&mut self, reg: XReg, val: RvData) -> Result<(), RvException> {
         // XReg::X2 is the sp register.
+        #[cfg(not(feature = "sw_emu_stack_check_disable"))]
         if reg == XReg::X2 {
             self.check_stack(val);
         }


### PR DESCRIPTION
1.0.x ROM is failing in the nightly CI for tripping the stack overflow check.
It was confirmed this is not a security issue as this is overflowing into unused space.
This change disables the stack overflow check for nightly CI when testing against ROM 1.0.x only.