### PR TITLE
[feat] Implement PQC Key type validation in FW Image Verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,9 @@ dependencies = [
 [[package]]
 name = "caliptra-api-types"
 version = "0.1.0"
+dependencies = [
+ "caliptra-image-types",
+]
 
 [[package]]
 name = "caliptra-auth-man-gen"

--- a/api/src/soc_mgr.rs
+++ b/api/src/soc_mgr.rs
@@ -155,6 +155,10 @@ pub trait SocManager {
             .fuse_soc_stepping_id()
             .write(|w| w.soc_stepping_id(fuses.soc_stepping_id.into()));
 
+        self.soc_ifc()
+            .fuse_pqc_key_type()
+            .write(|w| w.key_type(fuses.fuse_pqc_key_type));
+
         self.soc_ifc().cptra_fuse_wr_done().write(|w| w.done(true));
 
         if !self.soc_ifc().cptra_fuse_wr_done().read().done() {

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+caliptra-image-types = { workspace = true, default-features = false }

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_CPTRA_OBF_KEY: [u32; 8] = [
     0xa0a1a2a3, 0xb0b1b2b3, 0xc0c1c2c3, 0xd0d1d2d3, 0xe0e1e2e3, 0xf0f1f2f3, 0xa4a5a6a7, 0xb4b5b6b7,
 ];
 
+pub const DEFAULT_PQC_KEY_TYPE: u32 = 0x1; // MLDLSA = 1, LMS = 3.
+
 // Based on device_lifecycle_e from RTL
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum DeviceLifecycle {
@@ -168,6 +170,7 @@ pub struct Fuses {
     pub fuse_lms_revocation: u32,
     pub fuse_mldsa_revocation: u32,
     pub soc_stepping_id: u16,
+    pub fuse_pqc_key_type: u32,
 }
 impl Default for Fuses {
     fn default() -> Self {
@@ -186,6 +189,7 @@ impl Default for Fuses {
             fuse_lms_revocation: Default::default(),
             fuse_mldsa_revocation: Default::default(),
             soc_stepping_id: Default::default(),
+            fuse_pqc_key_type: DEFAULT_PQC_KEY_TYPE,
         }
     }
 }

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 #![cfg_attr(not(test), no_std)]
 
+use caliptra_image_types::FwVerificationPqcKeyType;
+
 // Rationale behind this choice
 //
 // * The constant should be easily recognizable in waveforms and debug logs
@@ -19,7 +21,7 @@ pub const DEFAULT_CPTRA_OBF_KEY: [u32; 8] = [
     0xa0a1a2a3, 0xb0b1b2b3, 0xc0c1c2c3, 0xd0d1d2d3, 0xe0e1e2e3, 0xf0f1f2f3, 0xa4a5a6a7, 0xb4b5b6b7,
 ];
 
-pub const DEFAULT_PQC_KEY_TYPE: u32 = 0x1; // MLDLSA = 1, LMS = 3.
+pub const DEFAULT_PQC_KEY_TYPE: u32 = FwVerificationPqcKeyType::MLDSA as u32;
 
 // Based on device_lifecycle_e from RTL
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]

--- a/builder/src/version.rs
+++ b/builder/src/version.rs
@@ -1,15 +1,15 @@
 // Licensed under the Apache-2.0 license
 
-pub const ROM_VERSION_MAJOR: u16 = 1;
-pub const ROM_VERSION_MINOR: u16 = 2;
+pub const ROM_VERSION_MAJOR: u16 = 2;
+pub const ROM_VERSION_MINOR: u16 = 0;
 pub const ROM_VERSION_PATCH: u16 = 0;
 
-pub const FMC_VERSION_MAJOR: u16 = 1;
-pub const FMC_VERSION_MINOR: u16 = 1;
+pub const FMC_VERSION_MAJOR: u16 = 2;
+pub const FMC_VERSION_MINOR: u16 = 0;
 pub const FMC_VERSION_PATCH: u16 = 0;
 
-pub const RUNTIME_VERSION_MAJOR: u32 = 1;
-pub const RUNTIME_VERSION_MINOR: u32 = 1;
+pub const RUNTIME_VERSION_MAJOR: u32 = 2;
+pub const RUNTIME_VERSION_MINOR: u32 = 0;
 pub const RUNTIME_VERSION_PATCH: u32 = 0;
 
 // ROM Version - 16 bits

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -189,4 +189,11 @@ impl<'a, 'b> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a, 'b> 
     fn set_fw_extended_error(&mut self, err: u32) {
         self.soc_ifc.set_fw_extended_error(err);
     }
+
+    fn pqc_key_type_fuse(&self) -> CaliptraResult<FwVerificationPqcKeyType> {
+        let pqc_key_type =
+            FwVerificationPqcKeyType::from_u8(self.soc_ifc.fuse_bank().pqc_key_type() as u8)
+                .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE)?;
+        Ok(pqc_key_type)
+    }
 }

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -325,6 +325,18 @@ impl FuseBank<'_> {
         let soc_ifc_regs = self.soc_ifc.regs();
         soc_ifc_regs.fuse_lms_revocation().read()
     }
+
+    /// Get the PQC (MLDSA or LMS) key type.
+    ///
+    /// # Arguments
+    /// * None
+    ///
+    /// # Returns
+    ///    PQC key type (1 for MLDSA, 3 for LMS)
+    ///
+    pub fn pqc_key_type(&self) -> u32 {
+        self.soc_ifc.regs().fuse_pqc_key_type().read().into()
+    }
 }
 
 #[cfg(test)]

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -104,9 +104,6 @@ impl FuseBank<'_> {
 
     /// Get the manufacturer serial number.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     manufacturer serial number
     ///
@@ -206,9 +203,6 @@ impl FuseBank<'_> {
 
     /// Get the vendor public key info hash.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     vendor public key info hash
     ///
@@ -218,9 +212,6 @@ impl FuseBank<'_> {
     }
 
     /// Get the ecc vendor public key revocation mask.
-    ///
-    /// # Arguments
-    /// * None
     ///
     /// # Returns
     ///     ecc vendor public key revocation mask
@@ -234,9 +225,6 @@ impl FuseBank<'_> {
 
     /// Get the lms vendor public key revocation mask.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     lms vendor public key revocation mask
     ///
@@ -246,9 +234,6 @@ impl FuseBank<'_> {
     }
 
     /// Get the mldsa vendor public key revocation mask.
-    ///
-    /// # Arguments
-    /// * None
     ///
     /// # Returns
     ///     mldsa vendor public key revocation mask
@@ -260,9 +245,6 @@ impl FuseBank<'_> {
 
     /// Get the owner public key hash.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     owner public key hash
     ///
@@ -273,9 +255,6 @@ impl FuseBank<'_> {
 
     /// Get the rollback disability setting.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     rollback disability setting
     ///
@@ -285,9 +264,6 @@ impl FuseBank<'_> {
     }
 
     /// Get the fmc fuse security version number.
-    ///
-    /// # Arguments
-    /// * None
     ///
     /// # Returns
     ///     fmc security version number
@@ -302,9 +278,6 @@ impl FuseBank<'_> {
 
     /// Get the runtime fuse security version number.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
     ///     runtime security version number
     ///
@@ -314,9 +287,6 @@ impl FuseBank<'_> {
     }
 
     /// Get the lms revocation bits.
-    ///
-    /// # Arguments
-    /// * None
     ///
     /// # Returns
     ///     lms revocation bits
@@ -328,11 +298,8 @@ impl FuseBank<'_> {
 
     /// Get the PQC (MLDSA or LMS) key type.
     ///
-    /// # Arguments
-    /// * None
-    ///
     /// # Returns
-    ///    PQC key type (1 for MLDSA, 3 for LMS)
+    ///    PQC key type set in the fuses.
     ///
     pub fn pqc_key_type(&self) -> u32 {
         self.soc_ifc.regs().fuse_pqc_key_type().read().into()

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -280,7 +280,7 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b0047);
     pub const IMAGE_VERIFIER_ERR_PQC_KEY_DESCRIPTOR_INVALID_HASH_COUNT: CaliptraError =
         CaliptraError::new_const(0x000b0048);
-    pub const IMAGE_VERIFIER_ERR_FW_IMAGE_VERIFICATION_KEY_TYPE_INVALID: CaliptraError =
+    pub const IMAGE_VERIFIER_ERR_PQC_KEY_TYPE_INVALID: CaliptraError =
         CaliptraError::new_const(0x000b0049);
     pub const IMAGE_VERIFIER_ERR_LMS_VENDOR_PUB_KEY_INVALID: CaliptraError =
         CaliptraError::new_const(0x000b004a);
@@ -316,6 +316,10 @@ impl CaliptraError {
         CaliptraError::new_const(0x000b0059);
     pub const IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_DIGEST_MISMATCH: CaliptraError =
         CaliptraError::new_const(0x000b005a);
+    pub const IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE: CaliptraError =
+        CaliptraError::new_const(0x000b005b);
+    pub const IMAGE_VERIFIER_ERR_PQC_KEY_TYPE_MISMATCH: CaliptraError =
+        CaliptraError::new_const(0x000b005c);
 
     /// Driver Error: LMS
     pub const DRIVER_LMS_INVALID_LMS_ALGO_TYPE: CaliptraError =

--- a/hw-model/types/src/lib.rs
+++ b/hw-model/types/src/lib.rs
@@ -127,6 +127,7 @@ impl std::fmt::Debug for FusesWrapper {
             .field("fuse_lms_revocation", &self.0.fuse_lms_revocation)
             .field("fuse_mldsa_revocation", &self.0.fuse_mldsa_revocation)
             .field("soc_stepping_id", &self.0.soc_stepping_id)
+            .field("fuse_pqc_key_type", &self.0.fuse_pqc_key_type)
             .finish()
     }
 }

--- a/image/app/src/create/mod.rs
+++ b/image/app/src/create/mod.rs
@@ -174,11 +174,8 @@ pub(crate) fn run_cmd(args: &ArgMatches) -> anyhow::Result<()> {
         .parent()
         .with_context(|| "Invalid parent path")?;
 
-    let pqc_key_type = if *pqc_key_type == 1 {
-        FwVerificationPqcKeyType::LMS
-    } else {
-        FwVerificationPqcKeyType::MLDSA
-    };
+    let pqc_key_type = FwVerificationPqcKeyType::from_u8(*pqc_key_type as u8)
+        .ok_or_else(|| anyhow!("Unsupported PQC key type: {}", pqc_key_type))?;
 
     let gen_config = ImageGeneratorConfig::<ElfExecutable> {
         pqc_key_type,

--- a/image/app/src/main.rs
+++ b/image/app/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let sub_cmds = vec![Command::new("create")
         .about("Create a new firmware image bundle")
         .arg(
-            arg!(--"pqc-key-type" <U32> "Type of image keys: 1: ECC + LMS; 2: ECC + MLDSA")
+            arg!(--"pqc-key-type" <U32> "Type of PQC key validation: 1: MLDSA; 3: LMS")
                 .required(true)
                 .value_parser(value_parser!(u32)),
         )

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -192,8 +192,8 @@ impl Default for ImagePqcSignature {
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum FwVerificationPqcKeyType {
-    LMS = 1,
-    MLDSA = 2,
+    MLDSA = 1,
+    LMS = 3,
 }
 
 impl From<FwVerificationPqcKeyType> for u8 {
@@ -211,8 +211,8 @@ impl Default for FwVerificationPqcKeyType {
 impl FwVerificationPqcKeyType {
     pub fn from_u8(value: u8) -> Option<FwVerificationPqcKeyType> {
         match value {
-            1 => Some(FwVerificationPqcKeyType::LMS),
-            2 => Some(FwVerificationPqcKeyType::MLDSA),
+            1 => Some(FwVerificationPqcKeyType::MLDSA),
+            3 => Some(FwVerificationPqcKeyType::LMS),
             _ => None,
         }
     }

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -172,4 +172,7 @@ pub trait ImageVerificationEnv {
 
     // Set the extended error code
     fn set_fw_extended_error(&mut self, err: u32);
+
+    // Get the PQC Key Type from the fuse.
+    fn pqc_key_type_fuse(&self) -> CaliptraResult<FwVerificationPqcKeyType>;
 }

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -16,8 +16,8 @@ TARGET_DIR=../../target/riscv32imc-unknown-none-elf/firmware
 CURRENT_DIR = $(shell pwd)
 GIT_REV = $(shell git rev-parse HEAD)
 EXTRA_CARGO_CONFIG = target.'cfg(all())'.rustflags = [\"-Dwarnings\"]
-# Default to MLDSA key type.
-PQC_KEY_TYPE ?= 2
+# MLDSA (default): 1, LMS: 3.
+PQC_KEY_TYPE ?= 1
 
 default: build
 
@@ -127,6 +127,7 @@ run: build-emu build-fw-image build-rom
 		--rom $(TARGET_DIR)/caliptra-rom.bin \
 		--recovery-image-fw $(TARGET_DIR)/caliptra-rom-test-fw \
 		--device-lifecycle unprovisioned \
+		--pqc-key-type $(PQC_KEY_TYPE) \
 
 run-active: build-emu build-fw-image build-rom
 	cargo \

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -753,7 +753,7 @@ Alias FMC Layer includes the measurement of the FMC and other security states. T
         FW_SVN,
         FW_FUSE_SVN (or 0 if `FUSE_ANTI_ROLLBACK_DISABLE`),
         VENDOR_PQC_PK_INDEX,
-        ROM_VERIFY_CONFIG,
+        PQC_KEY_TYPE,
         OWNER_PK_HASH_FROM_FUSES (0 or 1),
     ])
     pcr_extend(Pcr0 && Pcr1, MANUFACTURER_PK)
@@ -995,6 +995,7 @@ The following are the pre-conditions that should be satisfied:
   - fuse_mldsa_revocation : This is the bitmask of the MLDSA keys which are revoked.
   - fuse_owner_pk_hash : The hash of the owner public keys in preamble.
   - fuse_runtime_svn : Used in RT validation to make sure that the runtime image's version number is good.
+  - fuse_pqc_key_type: This bitmask specifies the enabled PQC key type for firmware validation, indicating either MLDSA or LMS.
 - The SOC has written the data to the mailbox.
 - The SOC has written the data length in the DLEN mailbox register.
 - The SOC has put the FW_DOWNLOAD command in the command register.

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -31,7 +31,7 @@ use caliptra_common::{
     PcrLogEntry, PcrLogEntryId, RomBootStatus::*,
 };
 use caliptra_drivers::{pcr_log::MeasurementLogEntry, *};
-use caliptra_image_types::{ImageManifest, IMAGE_BYTE_SIZE};
+use caliptra_image_types::{FwVerificationPqcKeyType, ImageManifest, IMAGE_BYTE_SIZE};
 use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier};
 use caliptra_kat::KatsEnv;
 use caliptra_x509::{NotAfter, NotBefore};
@@ -449,7 +449,7 @@ impl FirmwareProcessor {
         cprintln!(
             "[fwproc] Img verified w/ Vendor ECC Key Idx {}, PQC Key Type: {}, PQC Key Idx {}, with SVN {} and effective fuse SVN {}",
             info.vendor_ecc_pub_key_idx,
-            manifest.pqc_key_type,
+            if FwVerificationPqcKeyType::from_u8(manifest.pqc_key_type) == Some(FwVerificationPqcKeyType::MLDSA)  { "MLDSA" } else { "LMS" },
             info.vendor_pqc_pub_key_idx,
             info.fw_svn,
             info.effective_fuse_svn,

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -409,4 +409,11 @@ impl<'a, 'b> ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'a, 'b> {
     fn set_fw_extended_error(&mut self, err: u32) {
         self.soc_ifc.set_fw_extended_error(err);
     }
+
+    fn pqc_key_type_fuse(&self) -> CaliptraResult<FwVerificationPqcKeyType> {
+        let pqc_key_type =
+            FwVerificationPqcKeyType::from_u8(self.soc_ifc.fuse_bank().pqc_key_type() as u8)
+                .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE)?;
+        Ok(pqc_key_type)
+    }
 }

--- a/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
+++ b/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
@@ -21,8 +21,13 @@ fn test_cold_reset_status_reporting() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let (mut hw, image_bundle) =
-            helpers::build_hw_model_and_image_bundle(Fuses::default(), image_options);
+
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+
+        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
 
         hw.step_until_boot_status(CfiInitialized.into(), false);
         hw.step_until_boot_status(KatStarted.into(), false);
@@ -122,12 +127,18 @@ fn test_cold_reset_success() {
         )
         .unwrap();
 
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+
         let mut hw = caliptra_hw_model::new(
             InitParams {
                 rom: &rom,
                 ..Default::default()
             },
             BootParams {
+                fuses,
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
                 ..Default::default()
             },
@@ -155,12 +166,18 @@ fn test_cold_reset_no_rng() {
         )
         .unwrap();
 
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+
         let mut hw = caliptra_hw_model::new(
             InitParams {
                 rom: &rom,
                 ..Default::default()
             },
             BootParams {
+                fuses,
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
                 initial_dbg_manuf_service_reg: 0x2, // Disable RNG
                 ..Default::default()

--- a/rom/dev/tests/rom_integration_tests/test_fake_rom.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fake_rom.rs
@@ -110,7 +110,10 @@ fn test_fake_rom_fw_load() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(&ROM_FAKE_WITH_UART).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {
@@ -160,7 +163,10 @@ fn test_fake_rom_update_reset() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(&ROM_FAKE_WITH_UART).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {
@@ -224,7 +230,10 @@ fn test_image_verify() {
             ..Default::default()
         };
         const DBG_MANUF_FAKE_ROM_IMAGE_VERIFY: u32 = 0x1 << 31; // BIT 31 turns on image verify
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(&ROM_FAKE_WITH_UART).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {

--- a/rom/dev/tests/rom_integration_tests/test_fips_hooks.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fips_hooks.rs
@@ -5,7 +5,7 @@ use caliptra_api::SocManager;
 use caliptra_builder::firmware::{APP_WITH_UART, FMC_WITH_UART, ROM_WITH_FIPS_TEST_HOOKS};
 use caliptra_builder::ImageOptions;
 use caliptra_drivers::CaliptraError;
-use caliptra_hw_model::{BootParams, HwModel, InitParams};
+use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams};
 
 #[test]
 fn test_fips_hook_exit() {
@@ -15,6 +15,11 @@ fn test_fips_hook_exit() {
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_FIPS_TEST_HOOKS).unwrap();
+
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
 
         let image_bundle =
             caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_options)
@@ -28,6 +33,7 @@ fn test_fips_hook_exit() {
         };
 
         let boot_params = BootParams {
+            fuses,
             fw_image: Some(&image_bundle),
             ..Default::default()
         };

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -146,6 +146,7 @@ fn test_pcr_log() {
             anti_rollback_disable: true,
             vendor_pk_hash: vendor_pubkey_digest,
             owner_pk_hash: owner_pubkey_digest,
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -257,6 +258,7 @@ fn test_pcr_log_no_owner_key_digest_fuse() {
             vendor_pk_hash: gen
                 .vendor_pubkey_digest(&image_bundle.manifest.preamble)
                 .unwrap(),
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -357,6 +359,7 @@ fn test_pcr_log_fmc_fuse_svn() {
             owner_pk_hash: owner_pubkey_digest,
             fmc_key_manifest_svn: FMC_FUSE_SVN,
             runtime_svn: [0x3, 0, 0, 0], // TODO: add tooling to make this more ergonomic.
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -507,6 +510,7 @@ fn test_pcr_log_across_update_reset() {
             runtime_svn: [1, 0, 0, 0],
             vendor_pk_hash: vendor_pubkey_digest,
             owner_pk_hash: owner_pubkey_digest,
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -610,6 +614,7 @@ fn test_fuse_log() {
         anti_rollback_disable: true,
         fmc_key_manifest_svn: 0x0F,  // Value of FMC_SVN
         runtime_svn: [0xF, 0, 0, 0], // Value of RT_SVN
+        fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
         ..Default::default()
     };
 
@@ -755,6 +760,11 @@ fn test_fht_info() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {
@@ -762,7 +772,7 @@ fn test_fht_info() {
                 ..Default::default()
             },
             BootParams {
-                fuses: Fuses::default(),
+                fuses,
                 ..Default::default()
             },
         )
@@ -800,6 +810,7 @@ fn test_check_rom_cold_boot_status_reg() {
             ..Default::default()
         };
         let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -845,7 +856,10 @@ fn test_upload_single_measurement() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {
@@ -919,7 +933,10 @@ fn test_upload_measurement_limit() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {
@@ -1069,7 +1086,10 @@ fn test_upload_no_measurement() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let fuses = Fuses::default();
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let mut hw = caliptra_hw_model::new(
             InitParams {

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -59,8 +59,11 @@ fn test_generate_csr_envelop() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let (mut hw, image_bundle) =
-            helpers::build_hw_model_and_image_bundle(Fuses::default(), image_options);
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
         generate_csr_envelop(&mut hw, &image_bundle);
     }
 }
@@ -73,7 +76,10 @@ fn test_ecc_idev_subj_key_id_algo() {
             ..Default::default()
         };
         for algo in 0..(X509KeyIdAlgo::Fuse as u32 + 1) {
-            let mut fuses = Fuses::default();
+            let mut fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
+                ..Default::default()
+            };
             fuses.idevid_cert_attr[IdevidCertAttr::Flags as usize] = algo;
 
             let (mut hw, image_bundle) =
@@ -134,7 +140,8 @@ fn test_generate_csr_envelop_stress() {
         };
 
         for _ in 0..num_tests {
-            let fuses = fuses_with_random_uds();
+            let mut fuses = fuses_with_random_uds();
+            fuses.fuse_pqc_key_type = *pqc_key_type as u32;
             let (mut hw, image_bundle) =
                 helpers::build_hw_model_and_image_bundle(fuses.clone(), image_options.clone());
 

--- a/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
@@ -38,8 +38,11 @@ fn test_mailbox_command_aborted_after_handle_fatal_error() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let (mut hw, image_bundle) =
-            helpers::build_hw_model_and_image_bundle(Fuses::default(), image_options);
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
+        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
         assert_eq!(
             Err(ModelError::MailboxCmdFailed(
                 CaliptraError::FW_PROC_INVALID_IMAGE_SIZE.into()

--- a/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
+++ b/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
@@ -7,7 +7,7 @@ use caliptra_builder::{
     ImageOptions,
 };
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{BootParams, HwModel, InitParams};
+use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams};
 use caliptra_image_types::RomInfo;
 use zerocopy::{AsBytes, FromBytes};
 
@@ -60,6 +60,10 @@ fn test_read_rom_info_from_fmc() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let rom_info_from_image =
             RomInfo::read_from_prefix(&rom[find_rom_info_offset(&rom)..]).unwrap();
@@ -79,6 +83,7 @@ fn test_read_rom_info_from_fmc() {
             },
             BootParams {
                 fw_image: Some(&image_bundle),
+                fuses,
                 ..Default::default()
             },
         )

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -17,7 +17,7 @@ use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::DataVault;
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{BootParams, HwModel, InitParams};
+use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams};
 use caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0;
 use caliptra_image_gen::ImageGeneratorVendorConfig;
 use zerocopy::{AsBytes, FromBytes};
@@ -30,6 +30,10 @@ fn test_update_reset_success() {
     for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
         let image_options = ImageOptions {
             pqc_key_type: *pqc_key_type,
+            ..Default::default()
+        };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
@@ -47,6 +51,7 @@ fn test_update_reset_success() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -85,6 +90,10 @@ fn test_update_reset_no_mailbox_cmd() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_WITH_UART,
@@ -99,6 +108,7 @@ fn test_update_reset_no_mailbox_cmd() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -139,6 +149,10 @@ fn test_update_reset_non_fw_load_cmd() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_WITH_UART,
@@ -153,6 +167,7 @@ fn test_update_reset_non_fw_load_cmd() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -190,6 +205,10 @@ fn test_update_reset_verify_image_failure() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_WITH_UART,
@@ -204,6 +223,7 @@ fn test_update_reset_verify_image_failure() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -247,6 +267,10 @@ fn test_update_reset_boot_status() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_INTERACTIVE,
@@ -261,6 +285,7 @@ fn test_update_reset_boot_status() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -309,6 +334,10 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
             ecc_key_idx: 3,
             ..VENDOR_CONFIG_KEY_0
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let image_options = ImageOptions {
             vendor_config: vendor_config_cold_boot,
             pqc_key_type: *pqc_key_type,
@@ -327,6 +356,7 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -458,6 +488,10 @@ fn test_check_rom_update_reset_status_reg() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_INTERACTIVE,
@@ -473,6 +507,7 @@ fn test_check_rom_update_reset_status_reg() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )
@@ -562,6 +597,10 @@ fn test_update_reset_max_fw_image() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_INTERACTIVE,
@@ -577,6 +616,7 @@ fn test_update_reset_max_fw_image() {
             },
             BootParams {
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                fuses,
                 ..Default::default()
             },
         )

--- a/rom/dev/tests/rom_integration_tests/test_version.rs
+++ b/rom/dev/tests/rom_integration_tests/test_version.rs
@@ -12,7 +12,7 @@ use crate::helpers;
 
 // TODO: Find a better way to get this or make it a don't-care for this test
 //       This is not going to work when we start testing against multiple hw revs
-const HW_REV_ID: u32 = 0x11; // TODO 2.0
+const HW_REV_ID: u32 = 0x02;
 
 #[test]
 fn test_version() {

--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -108,6 +108,7 @@ fn test_warm_reset_during_cold_boot_during_image_validation() {
         };
         let fuses = Fuses {
             life_cycle: DeviceLifecycle::Unprovisioned,
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
 
@@ -149,6 +150,7 @@ fn test_warm_reset_during_cold_boot_after_image_validation() {
         };
         let fuses = Fuses {
             life_cycle: DeviceLifecycle::Unprovisioned,
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
 
@@ -183,6 +185,7 @@ fn test_warm_reset_during_update_reset() {
         };
         let fuses = Fuses {
             life_cycle: DeviceLifecycle::Unprovisioned,
+            fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
 

--- a/rom/dev/tests/rom_integration_tests/test_wdt_activation_and_stoppage.rs
+++ b/rom/dev/tests/rom_integration_tests/test_wdt_activation_and_stoppage.rs
@@ -8,7 +8,7 @@ use caliptra_builder::{
     ImageOptions,
 };
 use caliptra_common::RomBootStatus::{self, KatStarted};
-use caliptra_hw_model::{DeviceLifecycle, HwModel, SecurityState};
+use caliptra_hw_model::{BootParams, DeviceLifecycle, Fuses, HwModel, SecurityState};
 
 #[test]
 fn test_wdt_activation_and_stoppage() {
@@ -29,6 +29,10 @@ fn test_wdt_activation_and_stoppage() {
         )
         .unwrap();
 
+        let fuses = Fuses {
+            fuse_pqc_key_type: *pqc_key_type as u32,
+            ..Default::default()
+        };
         let rom = caliptra_builder::build_firmware_rom(caliptra_builder::firmware::rom_from_env())
             .unwrap();
         let mut hw = caliptra_hw_model::new(
@@ -37,7 +41,10 @@ fn test_wdt_activation_and_stoppage() {
                 security_state,
                 ..Default::default()
             },
-            caliptra_hw_model::BootParams::default(),
+            BootParams {
+                fuses,
+                ..Default::default()
+            },
         )
         .unwrap();
 

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -112,6 +112,7 @@ pub fn run_rt_test_lms(args: RuntimeTestArgs) -> DefaultHwModel {
         BootParams {
             fw_image: Some(&image.to_bytes().unwrap()),
             fuses: Fuses {
+                fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
                 ..Default::default()
             },
             initial_dbg_manuf_service_reg: boot_flags,

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -12,6 +12,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams};
+use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::{
     commands::{CertifyKeyCmd, CertifyKeyFlags, Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
@@ -57,6 +58,8 @@ fn test_rt_cert_with_custom_dates() {
         .copy_from_slice(OWNER_CONFIG.1.as_bytes());
 
     opts.owner_config = Some(own_config);
+
+    opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(opts),

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -7,10 +7,11 @@ use caliptra_common::mailbox_api::{
     CommandId, FipsVersionResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::HwModel;
+use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::FipsVersionCmd;
 use zerocopy::{AsBytes, FromBytes};
 
-const HW_REV_ID: u32 = 0x11; // TODO 2.0
+const HW_REV_ID: u32 = 0x02;
 
 #[test]
 fn test_fips_version() {
@@ -18,6 +19,7 @@ fn test_fips_version() {
         test_image_options: Some(ImageOptions {
             fmc_version: version::get_fmc_version(),
             app_version: version::get_runtime_version(),
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
             ..Default::default()
         }),
         ..Default::default()

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -104,6 +104,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
 fn test_pl1_derive_context_dpe_context_thresholds() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -210,6 +211,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
 fn test_pl1_init_ctx_dpe_context_thresholds() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -256,6 +258,7 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
 fn test_populate_idev_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -287,6 +290,7 @@ fn test_populate_idev_cannot_be_called_from_pl1() {
 fn test_stash_measurement_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -318,6 +322,7 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
 fn test_certify_key_x509_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -348,6 +353,7 @@ fn test_certify_key_x509_cannot_be_called_from_pl1() {
 fn test_certify_key_extended_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -384,6 +390,7 @@ fn test_certify_key_extended_cannot_be_called_from_pl1() {
 fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
+    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -515,7 +522,10 @@ fn test_measurement_log_pl_context_threshold() {
 
 #[test]
 fn test_pl0_unset_in_header() {
-    let fuses = Fuses::default();
+    let fuses = Fuses {
+        fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+        ..Default::default()
+    };
     let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
     let mut model = caliptra_hw_model::new(
         InitParams {

--- a/sw-emulator/app/src/main.rs
+++ b/sw-emulator/app/src/main.rs
@@ -170,6 +170,11 @@ fn main() -> io::Result<()> {
                 .required(false)
                 .action(ArgAction::SetTrue)
         )
+        .arg(
+            arg!(--"pqc-key-type" <U32> "Type of PQC key validation: 1: MLDSA; 3: LMS")
+                .required(true)
+                .value_parser(value_parser!(u32)),
+        )
         .get_matches();
 
     let args_rom = args.get_one::<PathBuf>("rom").unwrap();
@@ -196,6 +201,7 @@ fn main() -> io::Result<()> {
         }
     };
     let args_device_lifecycle = args.get_one::<String>("device-lifecycle").unwrap();
+    let pqc_key_type = args.get_one::<u32>("pqc-key-type").unwrap();
 
     if !Path::new(&args_rom).exists() {
         println!("ROM File {:?} does not exist", args_rom);
@@ -413,6 +419,11 @@ fn main() -> io::Result<()> {
             .at(1)
             .write(|_| (*wdt_timeout >> 32) as u32);
     }
+
+    // Populate the pqc_key_type fuse.
+    soc_ifc
+        .fuse_pqc_key_type()
+        .write(|w| w.key_type(*pqc_key_type));
 
     let cpu = Cpu::new(root_bus, clock);
 

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -700,6 +700,9 @@ struct SocRegistersImpl {
     #[register_array(offset = 0x34c)]
     fuse_manuf_dbg_unlock_token: [u32; FUSE_MANUF_DBG_UNLOCK_TOKEN_SIZE / 4],
 
+    #[register(offset = 0x35c)]
+    fuse_pqc_key_type: u32,
+
     #[register(offset = 0x510)]
     ss_recovery_ifc_base_addr_l: ReadOnlyRegister<u32>,
 
@@ -880,7 +883,7 @@ impl SocRegistersImpl {
             cptra_clk_gating_en: ReadOnlyRegister::new(0),
             cptra_generic_input_wires: Default::default(),
             cptra_generic_output_wires: Default::default(),
-            cptra_hw_rev_id: ReadOnlyRegister::new(0x11), // TODO 2.0
+            cptra_hw_rev_id: ReadOnlyRegister::new(0x02), // [3:0] Major, [7:4] Minor, [15:8] Patch
             cptra_fw_rev_id: Default::default(),
             cptra_hw_config: ReadWriteRegister::new(if args.active_mode {
                 Self::CALIPTRA_HW_CONFIG_ACTIVE_MODE
@@ -959,6 +962,7 @@ impl SocRegistersImpl {
             ss_dbg_manuf_service_reg_rsp: ReadWriteRegister::new(0),
             ss_uds_seed_base_addr_l: ReadOnlyRegister::new(0), // [TODO][CAP2] Program this
             ss_uds_seed_base_addr_h: ReadOnlyRegister::new(0), // [TODO][CAP2] Program this
+            fuse_pqc_key_type: 1,                              // MLDSA (default): 1, LMS: 3
         };
         regs
     }

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -14,6 +14,8 @@ use zerocopy::{transmute, AsBytes};
 
 #[cfg(test)]
 use caliptra_api_types::DeviceLifecycle;
+#[cfg(test)]
+use caliptra_image_types::FwVerificationPqcKeyType;
 
 use crate::{
     crypto::{self, derive_ecdsa_key, hmac384_drbg_keygen, hmac512, hmac512_kdf},
@@ -310,7 +312,7 @@ pub struct Pcr0Input {
     pub fmc_svn: u32,
     pub fmc_fuse_svn: u32,
     pub lms_vendor_pub_key_index: u32,
-    pub rom_verify_config: u32,
+    pub pqc_key_type: u32,
 }
 impl Pcr0Input {}
 
@@ -333,7 +335,7 @@ impl Pcr0 {
                 input.fmc_svn as u8,
                 input.fmc_fuse_svn as u8,
                 input.lms_vendor_pub_key_index as u8,
-                input.rom_verify_config as u8,
+                input.pqc_key_type as u8,
                 input.owner_pub_key_hash_from_fuses as u8,
             ],
         );
@@ -377,13 +379,13 @@ fn test_derive_pcr0() {
         fmc_svn: 5,
         fmc_fuse_svn: 2,
         lms_vendor_pub_key_index: u32::MAX,
-        rom_verify_config: 1, // RomVerifyConfig::EcdsaAndLms
+        pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
     });
     assert_eq!(
         pcr0,
         Pcr0([
-            132444429, 987394663, 2275449643, 2729083116, 322701188, 1268620383, 68534608,
-            1944581982, 1207702945, 1427901733, 3489811836, 435454516
+            1597321057, 3306746665, 3870835391, 3103173150, 3318383838, 3407565263, 3776158384,
+            4231654246, 1759479765, 3561253448, 1491479508, 1619944441
         ])
     )
 }

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -254,7 +254,7 @@ fn fake_boot_test() {
             // This is from the SVN in the fuses (7 bits set)
             fmc_fuse_svn: 7,
             lms_vendor_pub_key_index: u32::MAX,
-            rom_verify_config: 0, // RomVerifyConfig::EcdsaOnly
+            pqc_key_type: 0, // RomVerifyConfig::EcdsaOnly
         }),
         &expected_ldevid_key,
     );

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -197,6 +197,7 @@ fn smoke_test() {
         owner_pk_hash: owner_pk_hash_words,
         fmc_key_manifest_svn: 0b1111111,
         runtime_svn: [0x7F, 0, 0, 0], // Equals 7
+        fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
         ..Default::default()
     };
     let mut hw = caliptra_hw_model::new(
@@ -356,7 +357,7 @@ fn smoke_test() {
             // This is from the SVN in the fuses (7 bits set)
             fmc_fuse_svn: 7,
             lms_vendor_pub_key_index: image.manifest.header.vendor_pqc_pub_key_idx,
-            rom_verify_config: 1, // RomVerifyConfig::EcdsaAndLms
+            pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
         }),
         &expected_ldevid_key,
     );

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -33,9 +33,9 @@ pub struct HwExpVals {
     pub hw_revision: u32,
 }
 
-const HW_EXP_1_0_0: HwExpVals = HwExpVals { hw_revision: 0x1 };
+const HW_EXP_2_0_0: HwExpVals = HwExpVals { hw_revision: 0x2 };
 
-const HW_EXP_CURRENT: HwExpVals = HwExpVals { hw_revision: 0x11 };
+const HW_EXP_CURRENT: HwExpVals = HwExpVals { hw_revision: 0x2 };
 
 // ===  ROM  ===
 pub struct RomExpVals {
@@ -43,29 +43,14 @@ pub struct RomExpVals {
     pub capabilities: [u8; 16],
 }
 
-const ROM_EXP_1_0_1: RomExpVals = RomExpVals {
-    rom_version: 0x801, // 1.0.1
+const ROM_EXP_2_0_0: RomExpVals = RomExpVals {
+    rom_version: 0x1000, // 2.0.0
     capabilities: [
         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
     ],
 };
 
-const ROM_EXP_1_0_3: RomExpVals = RomExpVals {
-    rom_version: 0x803, // 1.0.3
-    ..ROM_EXP_1_0_1
-};
-
-const ROM_EXP_1_1_0: RomExpVals = RomExpVals {
-    rom_version: 0x840, // 1.1.0
-    ..ROM_EXP_1_0_3
-};
-
-const ROM_EXP_1_2_0: RomExpVals = RomExpVals {
-    rom_version: 0x880, // 1.2.0
-    ..ROM_EXP_1_1_0
-};
-
-const ROM_EXP_CURRENT: RomExpVals = RomExpVals { ..ROM_EXP_1_2_0 };
+const ROM_EXP_CURRENT: RomExpVals = RomExpVals { ..ROM_EXP_2_0_0 };
 
 // ===  RUNTIME  ===
 pub struct RtExpVals {
@@ -73,17 +58,12 @@ pub struct RtExpVals {
     pub fw_version: u32,
 }
 
-const RT_EXP_1_0_0: RtExpVals = RtExpVals {
-    fmc_version: 0x800,      // 1.0.0
-    fw_version: 0x0100_0000, // 1.0.0
+const RT_EXP_2_0_0: RtExpVals = RtExpVals {
+    fmc_version: 0x1000,     // 2.0.0
+    fw_version: 0x0200_0000, // 2.0.0
 };
 
-const RT_EXP_1_1_0: RtExpVals = RtExpVals {
-    fmc_version: 0x840,      // 1.1.0
-    fw_version: 0x0101_0000, // 1.1.0
-};
-
-const RT_EXP_CURRENT: RtExpVals = RtExpVals { ..RT_EXP_1_1_0 };
+const RT_EXP_CURRENT: RtExpVals = RtExpVals { ..RT_EXP_2_0_0 };
 
 // === Getter implementations ===
 // TODO: These could be improved
@@ -94,7 +74,7 @@ impl HwExpVals {
         if let Ok(version) = std::env::var("FIPS_TEST_HW_EXP_VERSION") {
             match version.as_str() {
                 // Add more versions here
-                "1_0_0" => HW_EXP_1_0_0,
+                "2_0_0" => HW_EXP_2_0_0,
                 _ => panic!(
                     "FIPS Test: Unknown version for expected HW values ({})",
                     version
@@ -110,8 +90,7 @@ impl RomExpVals {
         if let Ok(version) = std::env::var("FIPS_TEST_ROM_EXP_VERSION") {
             match version.as_str() {
                 // Add more versions here
-                "1_0_1" => ROM_EXP_1_0_1,
-                "1_0_3" => ROM_EXP_1_0_3,
+                "2_0_0" => ROM_EXP_2_0_0,
                 _ => panic!(
                     "FIPS Test: Unknown version for expected ROM values ({})",
                     version
@@ -127,7 +106,7 @@ impl RtExpVals {
         if let Ok(version) = std::env::var("FIPS_TEST_RT_EXP_VERSION") {
             match version.as_str() {
                 // Add more versions here
-                "1_0_0" => RT_EXP_1_0_0,
+                "2_0_0" => RT_EXP_2_0_0,
                 _ => panic!(
                     "FIPS Test: Unknown version for expected Runtime values ({})",
                     version


### PR DESCRIPTION
This change incorporates the newly added 'pqc_key_type' fuse check in the image verifier. The change ensures that the pqc key type value in the image is the same as the one in the pqc_key_type fuse.