### PR TITLE
rom active mode unit test

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -609,10 +609,12 @@ impl<'a> DmaRecovery<'a> {
             // [TODO][CAP2] we need to program CMS bits, currently they are not available in RDL. Using bytes[4:7] for now for size
 
             // Read the image size from INDIRECT_FIFO_CTRL:Byte[2:5]. Image size in DWORDs.
-            let indirect_fifo_ctrl_val0 = recovery.indirect_fifo_ctrl_0().read();
+            //let indirect_fifo_ctrl_val0 = recovery.indirect_fifo_ctrl_0().read();
             let indirect_fifo_ctrl_val1 = recovery.indirect_fifo_ctrl_1().read();
-            let image_size_dwords = ((indirect_fifo_ctrl_val0 >> 16) & 0xFFFF)
-                | ((indirect_fifo_ctrl_val1 & 0xFFFF) << 16);
+
+            // let image_size_dwords = ((indirect_fifo_ctrl_val0 >> 16) & 0xFFFF)
+            //     | ((indirect_fifo_ctrl_val1 & 0xFFFF) << 16);
+            let image_size_dwords = indirect_fifo_ctrl_val1;
 
             image_size_dwords * 4
         })?;

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -364,7 +364,6 @@ impl FirmwareProcessor {
                             txn.complete(false)?;
                             Err(CaliptraError::FW_PROC_MAILBOX_INVALID_COMMAND)?;
                         }
-                        txn.complete(true)?;
 
                         // Download the firmware image from the recovery interface.
                         let image_size_bytes =

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -27,320 +27,419 @@ const TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD: u32 = 0x1000_000B;
 
 #[test]
 fn test_update_reset_success() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_INTERACTIVE,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
 
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
 
-        // Trigger an update reset with "new" firmware
-        hw.start_mailbox_execute(
-            CommandId::FIRMWARE_LOAD.into(),
-            &image_bundle.to_bytes().unwrap(),
-        )
-        .unwrap();
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        if cfg!(not(feature = "fpga_realtime")) {
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            // Trigger an update reset with "new" firmware
+            hw.start_mailbox_execute(
+                CommandId::FIRMWARE_LOAD.into(),
+                &image_bundle.to_bytes().unwrap(),
+            )
+            .unwrap();
+
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+                hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            }
+
+            assert_eq!(hw.finish_mailbox_execute(), Ok(None));
+
+            hw.step_until_boot_status(UpdateResetComplete.into(), true);
+
+            // Exit test-fmc with success
+            hw.mailbox_execute(0x1000_000C, &[]).unwrap();
+
+            hw.step_until_exit_success().unwrap();
         }
-
-        assert_eq!(hw.finish_mailbox_execute(), Ok(None));
-
-        hw.step_until_boot_status(UpdateResetComplete.into(), true);
-
-        // Exit test-fmc with success
-        hw.mailbox_execute(0x1000_000C, &[]).unwrap();
-
-        hw.step_until_exit_success().unwrap();
     }
 }
 
 #[test]
 fn test_update_reset_no_mailbox_cmd() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_WITH_UART,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
-
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
-
-        // This command tells the test-fmc to do an update reset after clearing
-        // itself from the mailbox.
-        hw.mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE, &[])
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_WITH_UART,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
-        hw.step_until_boot_status(KatStarted.into(), true);
-        hw.step_until_boot_status(KatComplete.into(), true);
-        hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        // No command in the mailbox.
-        hw.step_until(|m| m.soc_ifc().cptra_fw_error_non_fatal().read() != 0);
-        assert_eq!(
-            hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-            u32::from(CaliptraError::ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE)
-        );
+            // This command tells the test-fmc to do an update reset after clearing
+            // itself from the mailbox.
+            hw.mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE, &[])
+                .unwrap();
 
-        let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
-        hw.step_until_exit_success().unwrap();
+            hw.step_until_boot_status(KatStarted.into(), true);
+            hw.step_until_boot_status(KatComplete.into(), true);
+            hw.step_until_boot_status(UpdateResetStarted.into(), false);
 
-        assert_eq!(
-            hw.soc_ifc().cptra_boot_status().read(),
-            u32::from(UpdateResetStarted)
-        );
+            // No command in the mailbox.
+            hw.step_until(|m| m.soc_ifc().cptra_fw_error_non_fatal().read() != 0);
+            assert_eq!(
+                hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+                u32::from(CaliptraError::ROM_UPDATE_RESET_FLOW_MAILBOX_ACCESS_FAILURE)
+            );
+
+            let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
+            hw.step_until_exit_success().unwrap();
+
+            assert_eq!(
+                hw.soc_ifc().cptra_boot_status().read(),
+                u32::from(UpdateResetStarted)
+            );
+        }
     }
 }
 
 #[test]
 fn test_update_reset_non_fw_load_cmd() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_WITH_UART,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
-
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
-
-        // This command tells the test-fmc to do an update reset but leave the
-        // "unknown" command in the mailbox for the ROM to find
-        hw.start_mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD, &[])
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_WITH_UART,
+                &APP_WITH_UART,
+                image_options,
+            )
             .unwrap();
-        hw.step_until_boot_status(KatStarted.into(), true);
-        hw.step_until_boot_status(KatComplete.into(), true);
-        hw.step_until_boot_status(UpdateResetStarted.into(), true);
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
 
-        let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
-        hw.step_until_exit_success().unwrap();
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        assert_eq!(
-            hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-            u32::from(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND)
-        );
+            // This command tells the test-fmc to do an update reset but leave the
+            // "unknown" command in the mailbox for the ROM to find
+            hw.start_mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD, &[])
+                .unwrap();
+            hw.step_until_boot_status(KatStarted.into(), true);
+            hw.step_until_boot_status(KatComplete.into(), true);
+            hw.step_until_boot_status(UpdateResetStarted.into(), true);
 
-        assert_eq!(
-            hw.soc_ifc().cptra_boot_status().read(),
-            u32::from(UpdateResetStarted)
-        );
+            let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
+            hw.step_until_exit_success().unwrap();
+
+            assert_eq!(
+                hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+                u32::from(CaliptraError::ROM_UPDATE_RESET_FLOW_INVALID_FIRMWARE_COMMAND)
+            );
+
+            assert_eq!(
+                hw.soc_ifc().cptra_boot_status().read(),
+                u32::from(UpdateResetStarted)
+            );
+        }
     }
 }
 
 #[test]
 fn test_update_reset_verify_image_failure() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_WITH_UART,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
-
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
-
-        // Upload invalid manifest
-        hw.start_mailbox_execute(CommandId::FIRMWARE_LOAD.into(), &[0u8; 4])
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_WITH_UART,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
             .unwrap();
 
-        hw.step_until_boot_status(KatStarted.into(), true);
-        hw.step_until_boot_status(KatComplete.into(), true);
-        hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        assert_eq!(
-            hw.finish_mailbox_execute(),
-            Err(caliptra_hw_model::ModelError::MailboxCmdFailed(
-                CaliptraError::IMAGE_VERIFIER_ERR_MANIFEST_MARKER_MISMATCH.into()
-            ))
-        );
+            // Upload invalid manifest
+            hw.start_mailbox_execute(CommandId::FIRMWARE_LOAD.into(), &[0u8; 4])
+                .unwrap();
 
-        hw.step_until_exit_success().unwrap();
+            hw.step_until_boot_status(KatStarted.into(), true);
+            hw.step_until_boot_status(KatComplete.into(), true);
+            hw.step_until_boot_status(UpdateResetStarted.into(), false);
 
-        assert_eq!(
-            hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-            u32::from(CaliptraError::IMAGE_VERIFIER_ERR_MANIFEST_MARKER_MISMATCH)
-        );
+            assert_eq!(
+                hw.finish_mailbox_execute(),
+                Err(caliptra_hw_model::ModelError::MailboxCmdFailed(
+                    CaliptraError::IMAGE_VERIFIER_ERR_MANIFEST_MARKER_MISMATCH.into()
+                ))
+            );
 
-        assert_eq!(
-            hw.soc_ifc().cptra_boot_status().read(),
-            u32::from(UpdateResetLoadManifestComplete)
-        );
+            hw.step_until_exit_success().unwrap();
+
+            assert_eq!(
+                hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+                u32::from(CaliptraError::IMAGE_VERIFIER_ERR_MANIFEST_MARKER_MISMATCH)
+            );
+
+            assert_eq!(
+                hw.soc_ifc().cptra_boot_status().read(),
+                u32::from(UpdateResetLoadManifestComplete)
+            );
+        }
     }
 }
 
 #[test]
 fn test_update_reset_boot_status() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_INTERACTIVE,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
 
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        // Start the firmware update process
-        hw.start_mailbox_execute(
-            CommandId::FIRMWARE_LOAD.into(),
-            &image_bundle.to_bytes().unwrap(),
-        )
-        .unwrap();
+            // Start the firmware update process
+            hw.start_mailbox_execute(
+                CommandId::FIRMWARE_LOAD.into(),
+                &image_bundle.to_bytes().unwrap(),
+            )
+            .unwrap();
 
-        if cfg!(not(feature = "fpga_realtime")) {
-            hw.step_until_boot_status(CfiInitialized.into(), false);
-            hw.step_until_boot_status(KatStarted.into(), false);
-            hw.step_until_boot_status(KatComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
-            hw.step_until_boot_status(UpdateResetLoadManifestComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetImageVerificationComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetPopulateDataVaultComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetExtendPcrComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetLoadImageComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetOverwriteManifestComplete.into(), false);
-            hw.step_until_boot_status(UpdateResetComplete.into(), false);
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(CfiInitialized.into(), false);
+                hw.step_until_boot_status(KatStarted.into(), false);
+                hw.step_until_boot_status(KatComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetStarted.into(), false);
+                hw.step_until_boot_status(UpdateResetLoadManifestComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetImageVerificationComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetPopulateDataVaultComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetExtendPcrComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetLoadImageComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetOverwriteManifestComplete.into(), false);
+                hw.step_until_boot_status(UpdateResetComplete.into(), false);
+            }
+
+            hw.step_until_boot_status(UpdateResetComplete.into(), true);
+
+            assert_eq!(hw.finish_mailbox_execute(), Ok(None));
+
+            // Tell the test-fmc to "exit with success" (necessary because the FMC is in
+            // interactive mode)
+            hw.mailbox_execute(0x1000_000C, &[]).unwrap();
+
+            hw.step_until_exit_success().unwrap();
         }
-
-        hw.step_until_boot_status(UpdateResetComplete.into(), true);
-
-        assert_eq!(hw.finish_mailbox_execute(), Ok(None));
-
-        // Tell the test-fmc to "exit with success" (necessary because the FMC is in
-        // interactive mode)
-        hw.mailbox_execute(0x1000_000C, &[]).unwrap();
-
-        hw.step_until_exit_success().unwrap();
     }
 }
 
 #[test]
 fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let vendor_config_cold_boot = ImageGeneratorVendorConfig {
+                ecc_key_idx: 3,
+                ..VENDOR_CONFIG_KEY_0
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
+                ..Default::default()
+            };
+            let image_options = ImageOptions {
+                vendor_config: vendor_config_cold_boot,
+                pqc_key_type: *pqc_key_type,
+                ..Default::default()
+            };
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
+
+            // Upload firmware with a different vendor ECC key index.
+            let vendor_config_update_reset = ImageGeneratorVendorConfig {
+                ecc_key_idx: 2,
+                ..VENDOR_CONFIG_KEY_0
+            };
+            let image_options = ImageOptions {
+                vendor_config: vendor_config_update_reset,
+                pqc_key_type: *pqc_key_type,
+                ..Default::default()
+            };
+
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_WITH_UART,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+
+            hw.start_mailbox_execute(
+                CommandId::FIRMWARE_LOAD.into(),
+                &image_bundle.to_bytes().unwrap(),
+            )
+            .unwrap();
+
+            hw.step_until_boot_status(UpdateResetStarted.into(), true);
+
+            assert_eq!(
+                hw.finish_mailbox_execute(),
+                Err(caliptra_hw_model::ModelError::MailboxCmdFailed(
+                    CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH
+                        .into()
+                ))
+            );
+
+            // Exit test-fmc with success
+            hw.mailbox_execute(0x1000_000C, &[]).unwrap();
+
+            hw.step_until_exit_success().unwrap();
+
+            assert_eq!(
+                hw.soc_ifc().cptra_fw_error_non_fatal().read(),
+                u32::from(
+                    CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH
+                )
+            );
+        }
+    }
+}
+
+#[test]
+fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
+    for active_mode in [false, true] {
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let vendor_config_cold_boot = ImageGeneratorVendorConfig {
-            ecc_key_idx: 3,
+            pqc_key_idx: 3,
             ..VENDOR_CONFIG_KEY_0
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
         };
         let image_options = ImageOptions {
             vendor_config: vendor_config_cold_boot,
-            pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
         let image_bundle = caliptra_builder::build_and_sign_image(
@@ -349,14 +448,34 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
             image_options,
         )
         .unwrap();
+
+        // Generate firmware with a different vendor LMS key index.
+        let vendor_config_update_reset = ImageGeneratorVendorConfig {
+            pqc_key_idx: 2,
+            ..VENDOR_CONFIG_KEY_0
+        };
+        let image_options = ImageOptions {
+            vendor_config: vendor_config_update_reset,
+            ..Default::default()
+        };
+        let image_bundle2 = caliptra_builder::build_and_sign_image(
+            &TEST_FMC_INTERACTIVE,
+            &APP_WITH_UART,
+            image_options,
+        )
+        .unwrap();
+
         let mut hw = caliptra_hw_model::new(
             InitParams {
                 rom: &rom,
+                active_mode,
                 ..Default::default()
             },
             BootParams {
+                fuses: caliptra_hw_model::Fuses {
+                    ..Default::default()
+                },
                 fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
                 ..Default::default()
             },
         )
@@ -364,36 +483,10 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
 
         hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        // Upload firmware with a different vendor ECC key index.
-        let vendor_config_update_reset = ImageGeneratorVendorConfig {
-            ecc_key_idx: 2,
-            ..VENDOR_CONFIG_KEY_0
-        };
-        let image_options = ImageOptions {
-            vendor_config: vendor_config_update_reset,
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_WITH_UART,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-
-        hw.start_mailbox_execute(
-            CommandId::FIRMWARE_LOAD.into(),
-            &image_bundle.to_bytes().unwrap(),
-        )
-        .unwrap();
-
-        hw.step_until_boot_status(UpdateResetStarted.into(), true);
-
         assert_eq!(
-            hw.finish_mailbox_execute(),
+            hw.upload_firmware(&image_bundle2.to_bytes().unwrap()),
             Err(caliptra_hw_model::ModelError::MailboxCmdFailed(
-                CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH
+                CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PQC_PUB_KEY_IDX_MISMATCH
                     .into()
             ))
         );
@@ -406,138 +499,72 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
         assert_eq!(
             hw.soc_ifc().cptra_fw_error_non_fatal().read(),
             u32::from(
-                CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_ECC_PUB_KEY_IDX_MISMATCH
+                CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PQC_PUB_KEY_IDX_MISMATCH
             )
         );
     }
 }
 
 #[test]
-fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
-    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-    let vendor_config_cold_boot = ImageGeneratorVendorConfig {
-        pqc_key_idx: 3,
-        ..VENDOR_CONFIG_KEY_0
-    };
-    let image_options = ImageOptions {
-        vendor_config: vendor_config_cold_boot,
-        ..Default::default()
-    };
-    let image_bundle = caliptra_builder::build_and_sign_image(
-        &TEST_FMC_INTERACTIVE,
-        &APP_WITH_UART,
-        image_options,
-    )
-    .unwrap();
-
-    // Generate firmware with a different vendor LMS key index.
-    let vendor_config_update_reset = ImageGeneratorVendorConfig {
-        pqc_key_idx: 2,
-        ..VENDOR_CONFIG_KEY_0
-    };
-    let image_options = ImageOptions {
-        vendor_config: vendor_config_update_reset,
-        ..Default::default()
-    };
-    let image_bundle2 = caliptra_builder::build_and_sign_image(
-        &TEST_FMC_INTERACTIVE,
-        &APP_WITH_UART,
-        image_options,
-    )
-    .unwrap();
-
-    let mut hw = caliptra_hw_model::new(
-        InitParams {
-            rom: &rom,
-            ..Default::default()
-        },
-        BootParams {
-            fuses: caliptra_hw_model::Fuses {
-                ..Default::default()
-            },
-            fw_image: Some(&image_bundle.to_bytes().unwrap()),
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    hw.step_until_boot_status(ColdResetComplete.into(), true);
-
-    assert_eq!(
-        hw.upload_firmware(&image_bundle2.to_bytes().unwrap()),
-        Err(caliptra_hw_model::ModelError::MailboxCmdFailed(
-            CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PQC_PUB_KEY_IDX_MISMATCH.into()
-        ))
-    );
-
-    // Exit test-fmc with success
-    hw.mailbox_execute(0x1000_000C, &[]).unwrap();
-
-    hw.step_until_exit_success().unwrap();
-
-    assert_eq!(
-        hw.soc_ifc().cptra_fw_error_non_fatal().read(),
-        u32::from(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_VENDOR_PQC_PUB_KEY_IDX_MISMATCH)
-    );
-}
-
-#[test]
 fn test_check_rom_update_reset_status_reg() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_INTERACTIVE,
-            &APP_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &APP_WITH_UART,
+                image_options,
+            )
+            .unwrap();
 
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
 
-        // Trigger an update reset with "new" firmware
-        hw.start_mailbox_execute(
-            CommandId::FIRMWARE_LOAD.into(),
-            &image_bundle.to_bytes().unwrap(),
-        )
-        .unwrap();
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
 
-        if cfg!(not(feature = "fpga_realtime")) {
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            // Trigger an update reset with "new" firmware
+            hw.start_mailbox_execute(
+                CommandId::FIRMWARE_LOAD.into(),
+                &image_bundle.to_bytes().unwrap(),
+            )
+            .unwrap();
+
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+                hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            }
+
+            assert_eq!(hw.finish_mailbox_execute(), Ok(None));
+
+            hw.step_until_boot_status(UpdateResetComplete.into(), true);
+
+            let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
+            let data_vault = DataVault::read_from_prefix(data_vault.as_bytes()).unwrap();
+            assert_eq!(
+                data_vault.rom_update_reset_status(),
+                u32::from(UpdateResetComplete)
+            );
         }
-
-        assert_eq!(hw.finish_mailbox_execute(), Ok(None));
-
-        hw.step_until_boot_status(UpdateResetComplete.into(), true);
-
-        let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
-        let data_vault = DataVault::read_from_prefix(data_vault.as_bytes()).unwrap();
-        assert_eq!(
-            data_vault.rom_update_reset_status(),
-            u32::from(UpdateResetComplete)
-        );
     }
 }
 
@@ -592,90 +619,93 @@ fn test_fmc_is_16k() {
 
 #[test]
 fn test_update_reset_max_fw_image() {
-    for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-        let image_options = ImageOptions {
-            pqc_key_type: *pqc_key_type,
-            ..Default::default()
-        };
-        let fuses = Fuses {
-            fuse_pqc_key_type: *pqc_key_type as u32,
-            ..Default::default()
-        };
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_INTERACTIVE,
-            &APP_WITH_UART,
-            image_options.clone(),
-        )
-        .unwrap();
-
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
+    for active_mode in [false, true] {
+        for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
+            let image_options = ImageOptions {
+                pqc_key_type: *pqc_key_type,
                 ..Default::default()
-            },
-            BootParams {
-                fw_image: Some(&image_bundle.to_bytes().unwrap()),
-                fuses,
+            };
+            let fuses = Fuses {
+                fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
-            },
-        )
-        .unwrap();
-
-        hw.step_until_boot_status(ColdResetComplete.into(), true);
-
-        // Trigger an update reset with new firmware
-        let updated_image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_INTERACTIVE,
-            &TEST_RT_WITH_UART,
-            image_options,
-        )
-        .unwrap();
-
-        let image_bytes = updated_image_bundle.to_bytes().unwrap();
-
-        // Sanity-check that the image is 128k
-        assert_eq!(
-            128 * 1024 - image_bytes.len() as isize,
-            0,
-            "Try adjusting PAD_LEN in rom/dev/tools/test-fmc/src/main.rs"
-        );
-
-        hw.start_mailbox_execute(CommandId::FIRMWARE_LOAD.into(), &image_bytes)
+            };
+            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &APP_WITH_UART,
+                image_options.clone(),
+            )
             .unwrap();
 
-        if cfg!(not(feature = "fpga_realtime")) {
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            let mut hw = caliptra_hw_model::new(
+                InitParams {
+                    rom: &rom,
+                    active_mode,
+                    ..Default::default()
+                },
+                BootParams {
+                    fw_image: Some(&image_bundle.to_bytes().unwrap()),
+                    fuses,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            hw.step_until_boot_status(ColdResetComplete.into(), true);
+
+            // Trigger an update reset with new firmware
+            let updated_image_bundle = caliptra_builder::build_and_sign_image(
+                &TEST_FMC_INTERACTIVE,
+                &TEST_RT_WITH_UART,
+                image_options,
+            )
+            .unwrap();
+
+            let image_bytes = updated_image_bundle.to_bytes().unwrap();
+
+            // Sanity-check that the image is 128k
+            assert_eq!(
+                128 * 1024 - image_bytes.len() as isize,
+                0,
+                "Try adjusting PAD_LEN in rom/dev/tools/test-fmc/src/main.rs"
+            );
+
+            hw.start_mailbox_execute(CommandId::FIRMWARE_LOAD.into(), &image_bytes)
+                .unwrap();
+
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+                hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            }
+
+            assert_eq!(hw.finish_mailbox_execute(), Ok(None));
+
+            hw.step_until_boot_status(UpdateResetComplete.into(), true);
+
+            let mut buf = vec![];
+            buf.append(
+                &mut updated_image_bundle
+                    .manifest
+                    .fmc
+                    .image_size()
+                    .to_le_bytes()
+                    .to_vec(),
+            );
+            buf.append(
+                &mut updated_image_bundle
+                    .manifest
+                    .runtime
+                    .image_size()
+                    .to_le_bytes()
+                    .to_vec(),
+            );
+            buf.append(&mut updated_image_bundle.fmc.to_vec());
+            buf.append(&mut updated_image_bundle.runtime.to_vec());
+
+            let iccm_cmp: Vec<u8> = hw.mailbox_execute(0x1000_000E, &buf).unwrap().unwrap();
+            assert_eq!(iccm_cmp.len(), 1);
+            assert_eq!(iccm_cmp[0], 0);
         }
-
-        assert_eq!(hw.finish_mailbox_execute(), Ok(None));
-
-        hw.step_until_boot_status(UpdateResetComplete.into(), true);
-
-        let mut buf = vec![];
-        buf.append(
-            &mut updated_image_bundle
-                .manifest
-                .fmc
-                .image_size()
-                .to_le_bytes()
-                .to_vec(),
-        );
-        buf.append(
-            &mut updated_image_bundle
-                .manifest
-                .runtime
-                .image_size()
-                .to_le_bytes()
-                .to_vec(),
-        );
-        buf.append(&mut updated_image_bundle.fmc.to_vec());
-        buf.append(&mut updated_image_bundle.runtime.to_vec());
-
-        let iccm_cmp: Vec<u8> = hw.mailbox_execute(0x1000_000E, &buf).unwrap().unwrap();
-        assert_eq!(iccm_cmp.len(), 1);
-        assert_eq!(iccm_cmp[0], 0);
     }
 }

--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -382,10 +382,12 @@ impl Dma {
                 .unwrap();
 
             // Check if FW is inficating that it is ready to receive the recovery image.
-            if ((addr & RECOVERY_STATUS_OFFSET) == RECOVERY_STATUS_OFFSET)
+            if addr
+                == axi_root_bus::AxiRootBus::RECOVERY_REGISTER_INTERFACE_OFFSET
+                    + RECOVERY_STATUS_OFFSET
                 && ((data & AWATING_RECOVERY_IMAGE) == AWATING_RECOVERY_IMAGE)
             {
-                self.status0.reg.write(Status0::PAYLOAD_AVAILABLE::CLEAR);
+                self.status0.reg.modify(Status0::PAYLOAD_AVAILABLE::CLEAR);
                 // Schedule the timer to indicate that the payload is available
                 self.op_payload_available_action =
                     Some(self.timer.schedule_poll_in(PAYLOAD_AVAILABLE_OP_TICKS));
@@ -426,7 +428,7 @@ impl Dma {
             self.op_complete();
         }
         if self.timer.fired(&mut self.op_payload_available_action) {
-            self.status0.reg.write(Status0::PAYLOAD_AVAILABLE::SET);
+            self.status0.reg.modify(Status0::PAYLOAD_AVAILABLE::SET);
         }
     }
 }


### PR DESCRIPTION
This  PR does the following:
- Updates the hw-model to allow active mode
- fixes a logic error in the rom where complete is called twice
- Add rom reset unit tests for both active and passive mode