### PR TITLE
Reduce code size by enforcing ascii instead of utf-8

### DIFF
--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,9 +12,6 @@ Abstract:
 
 --*/
 
-use core::str::from_utf8;
-
-use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use caliptra_common::mailbox_api::{
     CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxResp,


### PR DESCRIPTION
Checking that byte slice is utf-8 requires a significant amount of code space. By enforcing ascii this space can be saved at the cost of disallowing subject alt names that contain non-ascii utf-8 characters.