### PR TITLE
Updating nightly publish-pages-artifact to v3 from v1

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -22,7 +22,7 @@ jobs:
           CPTRA_WWW_OUT=/tmp/www cargo run --release 
 
       - name: Generate GitHub Pages artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: /tmp/www
 


### PR DESCRIPTION
The nightly release publish step is failing with the message:

_This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`_

This version was deprecated 2024/1/29. This was called by actions/upload-pages-artifact@v1. This PR updates this to the latest v3 version and the only one to use actions/upload-artifact: v4

