### PR TITLE
Adding hw-1.0 build test and FMC size fix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -107,6 +107,13 @@ jobs:
           (cd rom/dev && ./build.sh)
           sccache --show-stats
 
+      # Make sure FMC and runtime can build for hw-1.0
+      - name: hw-1.0 build test
+        run: |
+          mkdir hw-1.0_build_test
+          cargo run --manifest-path=builder/Cargo.toml --bin image --features=hw-1.0 -- --fw hw-1.0_build_test/image-bundle.bin
+          rm -r hw-1.0_build_test
+
       # Clippy needs to build crates as part of the check, so do it after the
       # build.
       - name: Clippy lint check

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -42,5 +42,9 @@ pub const FMC_SIZE: u32 = 21 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
 pub const RUNTIME_SIZE: u32 = 96 * 1024;
 
+// Max size of runtime code should be 118K to allow room for the manifest
+#[allow(clippy::assertions_on_constants)]
+const _: () = assert!((FMC_SIZE + RUNTIME_SIZE) < (118 * 1024));
+
 pub use memory_layout::{DATA_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};


### PR DESCRIPTION
Adding check that runs during build and test for FMC and RT build for hw-1.0
Adjusting FMC logging to fix size issue on hw-1.0
Adding compile-time check to limit runtime (FMC+FW) size to 118kB (128-10kB for the manifest)