### PR TITLE
dma: Remove use of `Cell<Option<>>` in DMA driver

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -113,36 +113,25 @@ pub struct DmaWriteTransaction {
 }
 
 /// Dma Widget
-pub struct Dma {
-    dma: Cell<Option<AxiDmaReg>>,
-}
+/// Safety: only one instance of the DMA widget should be created.
+#[derive(Default)]
+pub struct Dma {}
 
 impl Dma {
-    /// Create a new DMA instance
-    ///
-    /// # Arguments
-    ///
-    /// * `dma` - DMA register block
-    pub fn new(dma: AxiDmaReg) -> Self {
-        Self {
-            dma: Cell::new(Some(dma)),
-        }
+    /// Safety: This should never be called in a nested manner to avoid
+    /// programming conflicts with the underlying DMA registers.
+    pub fn with_dma<T>(&self, f: impl FnOnce(RegisterBlock<RealMmioMut>) -> T) -> T {
+        // Safety: Caliptra is single-threaded and only one caller to with_dma
+        // is allowed at a time, so it is safe to create and consume the
+        // zero-sized AxiDmaReg here and create a new one each time.
+        // Since the Mmio interface is immutable, we can't generate a
+        // around mutable reference to a shared AxiDmaReg without using
+        // Cell, which bloats the code.
+        let mut dma = unsafe { AxiDmaReg::new() };
+        f(dma.regs_mut())
     }
 
-    pub fn with_dma<T>(
-        &self,
-        f: impl FnOnce(RegisterBlock<RealMmioMut>) -> T,
-    ) -> CaliptraResult<T> {
-        if let Some(mut dma) = self.dma.take() {
-            let result = f(dma.regs_mut());
-            self.dma.set(Some(dma));
-            Ok(result)
-        } else {
-            Err(CaliptraError::DRIVER_DMA_INTERNAL) // should never happen
-        }
-    }
-
-    pub fn flush(&self) -> CaliptraResult<()> {
+    pub fn flush(&self) {
         self.with_dma(|dma| {
             dma.ctrl().write(|c| c.flush(true));
             // Wait till we're not busy and have no errors
@@ -156,11 +145,11 @@ impl Dma {
         })
     }
 
-    pub fn set_block_size(&self, block_size: u32) -> CaliptraResult<()> {
+    pub fn set_block_size(&self, block_size: u32) {
         self.with_dma(|dma| dma.block_size().write(|f| f.size(block_size)))
     }
 
-    pub fn setup_dma_read(&self, read_transaction: DmaReadTransaction) -> CaliptraResult<()> {
+    pub fn setup_dma_read(&self, read_transaction: DmaReadTransaction) {
         self.with_dma(|dma| {
             let read_addr = read_transaction.read_addr;
             dma.src_addr_l().write(|_| read_addr.lo);
@@ -188,7 +177,7 @@ impl Dma {
         })
     }
 
-    fn setup_dma_write(&self, write_transaction: DmaWriteTransaction) -> CaliptraResult<()> {
+    fn setup_dma_write(&self, write_transaction: DmaWriteTransaction) {
         self.with_dma(|dma| {
             let write_addr = write_transaction.write_addr;
             dma.dst_addr_l().write(|_| write_addr.lo);
@@ -247,7 +236,7 @@ impl Dma {
                 }
             });
             Ok(())
-        })?
+        })
     }
 
     fn dma_write_fifo(&self, write_data: &[u8]) -> CaliptraResult<()> {
@@ -272,7 +261,7 @@ impl Dma {
                 }
             });
             Ok(())
-        })?
+        })
     }
 
     pub fn do_transaction(&self) -> CaliptraResult<()> {
@@ -295,7 +284,7 @@ impl Dma {
             }
 
             Ok(())
-        })?
+        })
     }
 
     /// Read a 32-bit word from the specified address
@@ -324,7 +313,7 @@ impl Dma {
     ///
     /// * CaliptraResult<()> - Success or failure
     pub fn read_buffer(&self, read_addr: AxiAddr, buffer: &mut [u8]) -> CaliptraResult<()> {
-        self.flush()?;
+        self.flush();
 
         let read_transaction = DmaReadTransaction {
             read_addr,
@@ -333,7 +322,7 @@ impl Dma {
             target: DmaReadTarget::AhbFifo,
         };
 
-        self.setup_dma_read(read_transaction)?;
+        self.setup_dma_read(read_transaction);
         self.do_transaction()?;
         self.dma_read_fifo(buffer)?;
         Ok(())
@@ -350,7 +339,7 @@ impl Dma {
     ///
     /// * `CaliptraResult<()>` - Success or error code
     pub fn write_dword(&self, write_addr: AxiAddr, write_val: u32) -> CaliptraResult<()> {
-        self.flush()?;
+        self.flush();
 
         let write_transaction = DmaWriteTransaction {
             write_addr,
@@ -359,7 +348,7 @@ impl Dma {
             origin: DmaWriteOrigin::AhbFifo,
         };
         self.dma_write_fifo(write_val.as_bytes())?;
-        self.setup_dma_write(write_transaction)?;
+        self.setup_dma_write(write_transaction);
         self.do_transaction()?;
         Ok(())
     }
@@ -385,7 +374,7 @@ impl Dma {
         fixed_addr: bool,
         block_size: u32,
     ) -> CaliptraResult<()> {
-        self.flush()?;
+        self.flush();
 
         let read_transaction = DmaReadTransaction {
             read_addr,
@@ -393,8 +382,8 @@ impl Dma {
             length: payload_len_bytes,
             target: DmaReadTarget::Mbox,
         };
-        self.setup_dma_read(read_transaction)?;
-        self.set_block_size(block_size)?;
+        self.setup_dma_read(read_transaction);
+        self.set_block_size(block_size);
         self.do_transaction()?;
         Ok(())
     }
@@ -404,7 +393,7 @@ impl Dma {
     /// # Returns
     /// true if payload is available, false otherwise
     ///
-    pub fn payload_available(&self) -> CaliptraResult<bool> {
+    pub fn payload_available(&self) -> bool {
         self.with_dma(|dma| dma.status0().read().payload_available())
     }
 }
@@ -501,10 +490,7 @@ impl<'a> DmaRecovery<'a> {
             )
         };
         let t = f(regs);
-        match mmio.last_error.take() {
-            Some(err) => Err(err),
-            None => Ok(t),
-        }
+        mmio.check_error(t)
     }
 
     /// Return a register block that can be used to read and
@@ -525,10 +511,7 @@ impl<'a> DmaRecovery<'a> {
             )
         };
         let t = f(regs);
-        match mmio.last_error.take() {
-            Some(err) => Err(err),
-            None => Ok(t),
-        }
+        mmio.check_error(t)
     }
 
     fn transfer_payload_to_mbox(
@@ -538,7 +521,7 @@ impl<'a> DmaRecovery<'a> {
         fixed_addr: bool,
         block_size: u32,
     ) -> CaliptraResult<()> {
-        self.dma.flush()?;
+        self.dma.flush();
 
         let read_transaction = DmaReadTransaction {
             read_addr,
@@ -546,8 +529,8 @@ impl<'a> DmaRecovery<'a> {
             length: payload_len_bytes,
             target: DmaReadTarget::Mbox,
         };
-        self.dma.setup_dma_read(read_transaction)?;
-        self.dma.set_block_size(block_size)?;
+        self.dma.setup_dma_read(read_transaction);
+        self.dma.set_block_size(block_size);
         self.dma.do_transaction()?;
         Ok(())
     }
@@ -559,7 +542,7 @@ impl<'a> DmaRecovery<'a> {
         write_addr: AxiAddr,
         fixed_addr: bool,
     ) -> CaliptraResult<()> {
-        self.dma.flush()?;
+        self.dma.flush();
 
         let write_transaction = DmaWriteTransaction {
             write_addr,
@@ -567,8 +550,8 @@ impl<'a> DmaRecovery<'a> {
             length: payload_len_bytes,
             origin: DmaWriteOrigin::Mbox,
         };
-        self.dma.setup_dma_write(write_transaction)?;
-        self.dma.set_block_size(block_size)?;
+        self.dma.setup_dma_write(write_transaction);
+        self.dma.set_block_size(block_size);
         self.dma.do_transaction()?;
         Ok(())
     }
@@ -602,7 +585,7 @@ impl<'a> DmaRecovery<'a> {
 
         // Loop on the 'payload_available' signal for the recovery image details to be available.
         cprintln!("[fwproc] Waiting for payload available signal...");
-        while !self.dma.payload_available()? {}
+        while !self.dma.payload_available() {}
         let image_size_bytes = self.with_regs_mut(|regs_mut| {
             let recovery = regs_mut.sec_fw_recovery_if();
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -383,7 +383,6 @@ impl CaliptraError {
     pub const DRIVER_DMA_FIFO_UNDERRUN: CaliptraError = CaliptraError::new_const(0x0000f002);
     pub const DRIVER_DMA_FIFO_OVERRUN: CaliptraError = CaliptraError::new_const(0x0000f003);
     pub const DRIVER_DMA_FIFO_INVALID_SIZE: CaliptraError = CaliptraError::new_const(0x0000f004);
-    pub const DRIVER_DMA_INTERNAL: CaliptraError = CaliptraError::new_const(0x0000f004);
 
     /// Runtime Errors
     pub const RUNTIME_INTERNAL: CaliptraError = CaliptraError::new_const(0x000E0001);

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -22,9 +22,9 @@ use caliptra_drivers::{
 };
 use caliptra_error::CaliptraResult;
 use caliptra_registers::{
-    axi_dma::AxiDmaReg, csrng::CsrngReg, doe::DoeReg, ecc::EccReg, entropy_src::EntropySrcReg,
-    hmac::HmacReg, kv::KvReg, mbox::MboxCsr, mldsa::MldsaReg, pv::PvReg, sha256::Sha256Reg,
-    sha512::Sha512Reg, sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
+    csrng::CsrngReg, doe::DoeReg, ecc::EccReg, entropy_src::EntropySrcReg, hmac::HmacReg,
+    kv::KvReg, mbox::MboxCsr, mldsa::MldsaReg, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
+    sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 
 /// Rom Context
@@ -107,7 +107,7 @@ impl RomEnv {
             trng,
             persistent_data: PersistentDataAccessor::new(),
             mldsa87: Mldsa87::new(MldsaReg::new()),
-            dma: Dma::new(AxiDmaReg::new()),
+            dma: Dma::default(),
         })
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -36,7 +36,6 @@ use caliptra_drivers::{
     Sha2_512_384Acc, SocIfc, Trng,
 };
 use caliptra_image_types::ImageManifest;
-use caliptra_registers::axi_dma::AxiDmaReg;
 use caliptra_registers::{
     csrng::CsrngReg,
     dv::DvReg,
@@ -159,7 +158,7 @@ impl Drivers {
             cert_chain: ArrayVec::new(),
             is_shutdown: false,
             dmtf_device_info: None,
-            dma: Dma::new(AxiDmaReg::new()),
+            dma: Dma::default(),
         })
     }
 


### PR DESCRIPTION
Generally we only like to keep one copy of `AxiDmaReg` in existence, and use Rust's borrowing rules around `&mut` to ensure that it is safely accessed. However, this is not generally possible when implementing the `Mmio` trait, since the method receiver must be immutable.

`Cell<Option<>>` or `RefCell` can provide interior mutability so that we can safely share mutable references from immutable receivers, but it complicates the code and adds bloat to the binary.

However, since Caliptra is single-threaded, as long as we are careful about how we structure the code so that we don't ever have two `AxiDmaReg` instances in existence at the same time (which might cause conflicts in programming the underlying registers), then we will have fulfilled the contract with the `unsafe` code. This safety is ensured as long as there are no nested callers of `Dma::with_dma`.

Based on feedback from #1904.