### PR TITLE
Updating nightly publish website deploy-pages to v4 from v1

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -42,4 +42,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The nightly is failing after updating the upload-pages-artifact step to the latest v3 from v1 (required by v1 being deprecated). The failure is due to the artifact now being named "github-pages.zip" instead of "github-pages".

I am theorizing this can be fixed by also updating the related deploy-pages action to the latest v4 version from v1. There are [published examples](https://github.com/actions/starter-workflows/blob/55eb18560f57898549b12afa6defe7cc79705d6a/pages/gatsby.yml#L88) using this same pair of versions in the same way we are attempting to use them

I cannot test this on this repo since it can only be run from main. I did [run on my fork](https://github.com/nquarton/caliptra-sw/actions/runs/13168134264/job/36753111203) thanks to some advice from Jordan. This does appear to resolve the artifact lookup issue. There was a later failure, but I believe that is due to GitHub pages not being set up for my fork.