### PR TITLE
Cherry-pick for main-2.x: Update zerocopy from 0.6.6 to 0.8.8.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,12 +203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "caliptra-api"
 version = "0.1.0"
 dependencies = [
@@ -218,7 +212,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-registers",
  "ureg",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -239,7 +233,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -253,7 +247,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -276,7 +270,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml 0.7.3",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -294,7 +288,7 @@ dependencies = [
  "hex",
  "nix 0.26.2",
  "once_cell",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -387,7 +381,7 @@ dependencies = [
  "openssl",
  "ufmt",
  "ureg",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -403,7 +397,7 @@ dependencies = [
  "caliptra-registers",
  "caliptra-test-harness",
  "cfg-if 1.0.0",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -490,7 +484,7 @@ dependencies = [
  "sha3",
  "smlang",
  "tock-registers",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -525,7 +519,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "openssl",
  "ufmt",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -560,7 +554,7 @@ dependencies = [
  "sha2",
  "uio",
  "ureg",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -610,7 +604,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml 0.7.3",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -628,7 +622,7 @@ dependencies = [
  "rand",
  "sec1",
  "sha2",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -649,7 +643,7 @@ dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -663,7 +657,7 @@ dependencies = [
  "fips204",
  "memoffset 0.8.0",
  "rand",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -673,7 +667,7 @@ dependencies = [
  "anyhow",
  "caliptra-image-types",
  "memoffset 0.8.0",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -686,7 +680,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -701,7 +695,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra_common",
  "memoffset 0.8.0",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -711,7 +705,7 @@ dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
  "ufmt",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -721,7 +715,7 @@ dependencies = [
  "arbitrary",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -775,7 +769,7 @@ dependencies = [
  "sha2",
  "ufmt",
  "x509-parser",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -791,7 +785,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ufmt",
  "ureg",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -847,7 +841,7 @@ dependencies = [
  "ureg",
  "wycheproof",
  "x509-parser",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -864,7 +858,7 @@ dependencies = [
  "caliptra_common",
  "cfg-if 1.0.0",
  "ufmt",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -909,7 +903,7 @@ dependencies = [
  "rand",
  "regex",
  "ureg",
- "zerocopy 0.8.8",
+ "zerocopy",
 ]
 
 [[package]]
@@ -960,7 +954,7 @@ dependencies = [
  "caliptra-image-verify",
  "caliptra-registers",
  "ufmt",
- "zerocopy 0.8.8",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -1322,7 +1316,7 @@ dependencies = [
  "crypto",
  "platform",
  "ufmt",
- "zerocopy 0.6.6",
+ "zerocopy",
  "zeroize",
 ]
 
@@ -2968,32 +2962,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
 dependencies = [
- "zerocopy-derive 0.8.8",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "caliptra-api"
@@ -218,7 +218,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-registers",
  "ureg",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -276,7 +276,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml 0.7.3",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ dependencies = [
  "hex",
  "nix 0.26.2",
  "once_cell",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ dependencies = [
  "openssl",
  "ufmt",
  "ureg",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -403,7 +403,7 @@ dependencies = [
  "caliptra-registers",
  "caliptra-test-harness",
  "cfg-if 1.0.0",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -490,7 +490,7 @@ dependencies = [
  "sha3",
  "smlang",
  "tock-registers",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "openssl",
  "ufmt",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -560,7 +560,7 @@ dependencies = [
  "sha2",
  "uio",
  "ureg",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml 0.7.3",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -628,7 +628,7 @@ dependencies = [
  "rand",
  "sec1",
  "sha2",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -649,7 +649,7 @@ dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -663,7 +663,7 @@ dependencies = [
  "fips204",
  "memoffset 0.8.0",
  "rand",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ dependencies = [
  "anyhow",
  "caliptra-image-types",
  "memoffset 0.8.0",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -686,7 +686,7 @@ dependencies = [
  "caliptra-error",
  "caliptra-lms-types",
  "memoffset 0.8.0",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -701,7 +701,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra_common",
  "memoffset 0.8.0",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -711,7 +711,7 @@ dependencies = [
  "caliptra-drivers",
  "caliptra-lms-types",
  "ufmt",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
  "arbitrary",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -775,7 +775,7 @@ dependencies = [
  "sha2",
  "ufmt",
  "x509-parser",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -791,7 +791,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ufmt",
  "ureg",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -847,7 +847,7 @@ dependencies = [
  "ureg",
  "wycheproof",
  "x509-parser",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -864,7 +864,7 @@ dependencies = [
  "caliptra_common",
  "cfg-if 1.0.0",
  "ufmt",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -909,7 +909,7 @@ dependencies = [
  "rand",
  "regex",
  "ureg",
- "zerocopy",
+ "zerocopy 0.8.8",
 ]
 
 [[package]]
@@ -960,7 +960,7 @@ dependencies = [
  "caliptra-image-verify",
  "caliptra-registers",
  "ufmt",
- "zerocopy",
+ "zerocopy 0.8.8",
  "zeroize",
 ]
 
@@ -1322,7 +1322,7 @@ dependencies = [
  "crypto",
  "platform",
  "ufmt",
- "zerocopy",
+ "zerocopy 0.6.6",
  "zeroize",
 ]
 
@@ -2973,7 +2973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
+dependencies = [
+ "zerocopy-derive 0.8.8",
 ]
 
 [[package]]
@@ -2981,6 +2990,17 @@ name = "zerocopy-derive"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
 wycheproof = "0.5.1"
 x509-parser = "0.15.0"
-zerocopy = "0.6.6"
+zerocopy = { version = "0.8.8", features = ["derive"] }
 serial_test = "2.0.0"
 nix = "0.26.2"
 libc = "0.2"

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-df4a72ee4a88d12d7216f8d23c6567b479694dec959e7332d69094098d312ea2dbf35de1117db156635ad41a78bf3c14  caliptra-rom-no-log.bin
-02db1204eea812bee28904ce877ec7604746169fa7bfa82471cf10af239852466c1a16b2d5b3b9ad26b4ccfe2ca0a1b5  caliptra-rom-with-log.bin
+a0c760bba301d669c7d7ce3f60d9451d2b4ed9f3d9b237a6eaabd6b7d8a7172573d7664c4d1dfc3f519d0babeae702de  caliptra-rom-no-log.bin
+92c38d0f250cb2eee89536ab7b9b81e356c0197b365da2ef04aef946347db46690ea51dad0447cf3acf0a9fc235f7951  caliptra-rom-with-log.bin

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1095,7 +1095,7 @@ impl Response for AuthorizeAndStashResp {}
 
 // MANUF_DEBUG_UNLOCK_REQ_TOKEN
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq, Default)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq, Default)]
 pub struct ManufDebugUnlockTokenReq {
     pub hdr: MailboxReqHeader,
     pub token: [u8; 16],
@@ -1107,7 +1107,7 @@ impl Request for ManufDebugUnlockTokenReq {
 
 // PRODUCTION_AUTH_DEBUG_UNLOCK_REQ
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq, Default)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq, Default)]
 pub struct ProductionAuthDebugUnlockReq {
     pub hdr: MailboxReqHeader,
     pub vendor_id: u16,           // Vendor ID (2 bytes)
@@ -1126,7 +1126,7 @@ impl Request for ProductionAuthDebugUnlockReq {
 
 // PRODUCTION_AUTH_DEBUG_UNLOCK_CHALLENGE
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq)]
 pub struct ProductionAuthDebugUnlockChallenge {
     pub hdr: MailboxRespHeader,
     pub vendor_id: u16,                     // Vendor ID (2 bytes)
@@ -1155,7 +1155,7 @@ impl Response for ProductionAuthDebugUnlockChallenge {}
 
 // PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Eq)]
 pub struct ProductionAuthDebugUnlockToken {
     pub hdr: MailboxReqHeader,
     pub vendor_id: u16,                     // Vendor ID (2 bytes)

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -3,7 +3,7 @@
 use bitflags::bitflags;
 use caliptra_error::{CaliptraError, CaliptraResult};
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref};
 
 use crate::CaliptraApiError;
 use caliptra_registers::mbox;
@@ -78,12 +78,12 @@ impl From<CommandId> for u32 {
 
 /// A trait implemented by request types. Describes the associated command ID
 /// and response type.
-pub trait Request: AsBytes + FromBytes {
+pub trait Request: IntoBytes + FromBytes + Immutable + KnownLayout {
     const ID: CommandId;
     type Resp: Response;
 }
 
-pub trait Response: AsBytes + FromBytes
+pub trait Response: IntoBytes + FromBytes
 where
     Self: Sized,
 {
@@ -94,31 +94,29 @@ where
 
     fn populate_chksum(&mut self) {
         // Note: This will panic if sizeof::<Self>() < 4
-        populate_checksum(self.as_bytes_mut());
+        populate_checksum(self.as_mut_bytes());
     }
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, Default, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, Default, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct MailboxRespHeaderVarSize {
     pub hdr: MailboxRespHeader,
     pub data_len: u32,
 }
-pub trait ResponseVarSize: AsBytes + FromBytes {
+pub trait ResponseVarSize: IntoBytes + FromBytes + Immutable + KnownLayout {
     fn data(&self) -> CaliptraResult<&[u8]> {
         // Will panic if sizeof<Self>() is smaller than MailboxRespHeaderVarSize
         // or Self doesn't have compatible alignment with
-        // MailboxRespHeaderVarSize (should be impossible if MailboxRespHeaderVarSize is the first field)
-        let (hdr, data) =
-            LayoutVerified::<_, MailboxRespHeaderVarSize>::new_from_prefix(self.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+        // MailboxRespHeaderVarSize (should be impossible if MailboxRespHeaderVarSiz is the first field)                                                                 ..
+        let (hdr, data) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
         data.get(..hdr.data_len as usize)
             .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)
     }
     fn partial_len(&self) -> CaliptraResult<usize> {
-        let (hdr, _) =
-            LayoutVerified::<_, MailboxRespHeaderVarSize>::new_from_prefix(self.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+        let (hdr, _) = MailboxRespHeaderVarSize::ref_from_prefix(self.as_bytes())
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
         Ok(size_of::<MailboxRespHeaderVarSize>() + hdr.data_len as usize)
     }
     fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
@@ -128,7 +126,7 @@ pub trait ResponseVarSize: AsBytes + FromBytes {
     }
     fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
         let partial_len = self.partial_len()?;
-        self.as_bytes_mut()
+        self.as_mut_bytes()
             .get_mut(..partial_len)
             .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)
     }
@@ -187,24 +185,24 @@ impl MailboxResp {
         }
     }
 
-    pub fn as_bytes_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+    pub fn as_mut_bytes(&mut self) -> CaliptraResult<&mut [u8]> {
         match self {
-            MailboxResp::Header(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::Header(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetIdevCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::GetIdevInfo(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::GetIdevInfo(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetLdevCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::StashMeasurement(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::StashMeasurement(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::InvokeDpeCommand(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::FipsVersion(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::FwInfo(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::Capabilities(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::GetTaggedTci(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::FipsVersion(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::FwInfo(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::Capabilities(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::GetTaggedTci(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetFmcAliasCert(resp) => resp.as_bytes_partial_mut(),
             MailboxResp::GetRtAliasCert(resp) => resp.as_bytes_partial_mut(),
-            MailboxResp::QuotePcrs(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes_mut()),
-            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes_mut()),
+            MailboxResp::QuotePcrs(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::GetIdevCsr(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -218,16 +216,14 @@ impl MailboxResp {
         }
         let checksum = crate::checksum::calc_checksum(0, &resp_bytes[size_of::<u32>()..]);
 
-        let mut_resp_bytes = self.as_bytes_mut()?;
+        let mut_resp_bytes = self.as_mut_bytes()?;
         if size_of::<MailboxRespHeader>() > mut_resp_bytes.len() {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE);
         }
-        // cast as header struct
-        let hdr: &mut MailboxRespHeader = LayoutVerified::<&mut [u8], MailboxRespHeader>::new(
+        let hdr: &mut MailboxRespHeader = MailboxRespHeader::mut_from_bytes(
             &mut mut_resp_bytes[..size_of::<MailboxRespHeader>()],
         )
-        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
-        .into_mut();
+        .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         // Set the chksum field
         hdr.chksum = checksum;
@@ -293,28 +289,28 @@ impl MailboxReq {
         }
     }
 
-    pub fn as_bytes_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+    pub fn as_mut_bytes(&mut self) -> CaliptraResult<&mut [u8]> {
         match self {
-            MailboxReq::EcdsaVerify(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::LmsVerify(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetLdevCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::StashMeasurement(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::EcdsaVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::LmsVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetLdevCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::StashMeasurement(req) => Ok(req.as_mut_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial_mut(),
-            MailboxReq::FipsVersion(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::FwInfo(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::FipsVersion(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::FwInfo(req) => Ok(req.as_mut_bytes()),
             MailboxReq::PopulateIdevCert(req) => req.as_bytes_partial_mut(),
             MailboxReq::GetIdevCert(req) => req.as_bytes_partial_mut(),
-            MailboxReq::TagTci(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetTaggedTci(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetFmcAliasCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::GetRtAliasCert(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::IncrementPcrResetCounter(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::QuotePcrs(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::ExtendPcr(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::TagTci(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetTaggedTci(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetFmcAliasCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::GetRtAliasCert(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::IncrementPcrResetCounter(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::QuotePcrs(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::ExtendPcr(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AddSubjectAltName(req) => req.as_bytes_partial_mut(),
-            MailboxReq::CertifyKeyExtended(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::SetAuthManifest(req) => Ok(req.as_bytes_mut()),
-            MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes_mut()),
+            MailboxReq::CertifyKeyExtended(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::SetAuthManifest(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -351,12 +347,10 @@ impl MailboxReq {
             &self.as_bytes()?[size_of::<i32>()..],
         );
 
-        // cast as header struct
-        let hdr: &mut MailboxReqHeader = LayoutVerified::<&mut [u8], MailboxReqHeader>::new(
-            &mut self.as_bytes_mut()?[..size_of::<MailboxReqHeader>()],
+        let hdr: &mut MailboxReqHeader = MailboxReqHeader::mut_from_bytes(
+            &mut self.as_mut_bytes()?[..size_of::<MailboxReqHeader>()],
         )
-        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
-        .into_mut();
+        .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         // Set the chksum field
         hdr.chksum = checksum;
@@ -367,13 +361,13 @@ impl MailboxReq {
 
 // HEADER
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct MailboxReqHeader {
     pub chksum: u32,
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct MailboxRespHeader {
     pub chksum: u32,
     pub fips_status: u32,
@@ -395,7 +389,7 @@ impl Default for MailboxRespHeader {
 
 // GET_IDEV_CERT
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevCertReq {
     pub hdr: MailboxReqHeader,
     pub tbs_size: u32,
@@ -419,7 +413,7 @@ impl GetIdevCertReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::DATA_MAX_SIZE - self.tbs_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for GetIdevCertReq {
@@ -435,7 +429,7 @@ impl Default for GetIdevCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevCertResp {
     pub hdr: MailboxRespHeader,
     pub cert_size: u32,
@@ -459,7 +453,7 @@ impl Default for GetIdevCertResp {
 // GET_IDEV_INFO
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetIdevInfoResp {
     pub hdr: MailboxRespHeader,
     pub idev_pub_x: [u8; 48],
@@ -468,7 +462,7 @@ pub struct GetIdevInfoResp {
 
 // GET_LDEV_CERT
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetLdevCertReq {
     header: MailboxReqHeader,
 }
@@ -479,7 +473,7 @@ impl Request for GetLdevCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetLdevCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -502,7 +496,7 @@ impl Default for GetLdevCertResp {
 
 // GET_RT_ALIAS_CERT
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetRtAliasCertReq {
     header: MailboxReqHeader,
 }
@@ -512,7 +506,7 @@ impl Request for GetRtAliasCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetRtAliasCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -539,7 +533,7 @@ impl Default for GetRtAliasCertResp {
 
 // ECDSA384_SIGNATURE_VERIFY
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct EcdsaVerifyReq {
     pub hdr: MailboxReqHeader,
     pub pub_key_x: [u8; 48],
@@ -555,7 +549,7 @@ impl Request for EcdsaVerifyReq {
 
 // LMS_SIGNATURE_VERIFY
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct LmsVerifyReq {
     pub hdr: MailboxReqHeader,
     pub pub_key_tree_type: u32,
@@ -575,7 +569,7 @@ impl Request for LmsVerifyReq {
 
 // STASH_MEASUREMENT
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct StashMeasurementReq {
     pub hdr: MailboxReqHeader,
     pub metadata: [u8; 4],
@@ -600,7 +594,7 @@ impl Request for StashMeasurementReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct StashMeasurementResp {
     pub hdr: MailboxRespHeader,
     pub dpe_result: u32,
@@ -613,7 +607,7 @@ impl Response for StashMeasurementResp {}
 
 // CERTIFY_KEY_EXTENDED
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CertifyKeyExtendedReq {
     pub hdr: MailboxReqHeader,
     pub flags: CertifyKeyExtendedFlags,
@@ -628,7 +622,7 @@ impl Request for CertifyKeyExtendedReq {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, FromBytes, AsBytes)]
+#[derive(Debug, PartialEq, Eq, FromBytes, Immutable, KnownLayout, IntoBytes)]
 pub struct CertifyKeyExtendedFlags(pub u32);
 
 bitflags! {
@@ -638,7 +632,7 @@ bitflags! {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CertifyKeyExtendedResp {
     pub hdr: MailboxRespHeader,
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
@@ -650,7 +644,7 @@ impl Response for CertifyKeyExtendedResp {}
 
 // INVOKE_DPE_COMMAND
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct InvokeDpeReq {
     pub hdr: MailboxReqHeader,
     pub data_size: u32,
@@ -673,7 +667,7 @@ impl InvokeDpeReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for InvokeDpeReq {
@@ -692,7 +686,7 @@ impl Request for InvokeDpeReq {
 
 // EXTEND_PCR
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct ExtendPcrReq {
     pub hdr: MailboxReqHeader,
     pub pcr_idx: u32,
@@ -707,7 +701,7 @@ impl Request for ExtendPcrReq {
 // No command-specific output args
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct InvokeDpeResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -730,7 +724,7 @@ impl Default for InvokeDpeResp {
 
 // GET_FMC_ALIAS_CERT
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetFmcAliasCertReq {
     header: MailboxReqHeader,
 }
@@ -740,7 +734,7 @@ impl Request for GetFmcAliasCertReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetFmcAliasCertResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -768,7 +762,7 @@ impl Default for GetFmcAliasCertResp {
 // FIPS_GET_VERSION
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct FipsVersionResp {
     pub hdr: MailboxRespHeader,
     pub mode: u32,
@@ -780,7 +774,7 @@ impl Response for FipsVersionResp {}
 // FW_INFO
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct FwInfoResp {
     pub hdr: MailboxRespHeader,
     pub pl0_pauser: u32,
@@ -800,7 +794,7 @@ pub struct FwInfoResp {
 // CAPABILITIES
 // No command-specific input args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CapabilitiesResp {
     pub hdr: MailboxRespHeader,
     pub capabilities: [u8; crate::capabilities::Capabilities::SIZE_IN_BYTES],
@@ -810,7 +804,7 @@ impl Response for CapabilitiesResp {}
 // ADD_SUBJECT_ALT_NAME
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AddSubjectAltNameReq {
     pub hdr: MailboxReqHeader,
     pub dmtf_device_info_size: u32,
@@ -832,7 +826,7 @@ impl AddSubjectAltNameReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_DEVICE_INFO_LEN - self.dmtf_device_info_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for AddSubjectAltNameReq {
@@ -848,7 +842,7 @@ impl Default for AddSubjectAltNameReq {
 // POPULATE_IDEV_CERT
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct PopulateIdevCertReq {
     pub hdr: MailboxReqHeader,
     pub cert_size: u32,
@@ -870,7 +864,7 @@ impl PopulateIdevCertReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_CERT_SIZE - self.cert_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for PopulateIdevCertReq {
@@ -886,7 +880,7 @@ impl Default for PopulateIdevCertReq {
 // DPE_TAG_TCI
 // No command-specific output args
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct TagTciReq {
     pub hdr: MailboxReqHeader,
     pub handle: [u8; 16],
@@ -895,13 +889,13 @@ pub struct TagTciReq {
 
 // DPE_GET_TAGGED_TCI
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetTaggedTciReq {
     pub hdr: MailboxReqHeader,
     pub tag: u32,
 }
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetTaggedTciResp {
     pub hdr: MailboxRespHeader,
     pub tci_cumulative: [u8; 48],
@@ -911,7 +905,7 @@ pub struct GetTaggedTciResp {
 // INCREMENT_PCR_RESET_COUNTER request
 // No command specific output
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct IncrementPcrResetCounterReq {
     pub hdr: MailboxReqHeader,
     pub index: u32,
@@ -924,7 +918,7 @@ impl Request for IncrementPcrResetCounterReq {
 
 /// QUOTE_PCRS input arguments
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct QuotePcrsReq {
     pub hdr: MailboxReqHeader,
     pub nonce: [u8; 32],
@@ -934,7 +928,7 @@ pub type PcrValue = [u8; 48];
 
 /// QUOTE_PCRS output
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct QuotePcrsResp {
     pub hdr: MailboxRespHeader,
     /// The PCR values
@@ -955,7 +949,7 @@ impl Request for QuotePcrsReq {
 
 // SET_AUTH_MANIFEST
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct SetAuthManifestReq {
     pub hdr: MailboxReqHeader,
     pub manifest_size: u32,
@@ -977,7 +971,7 @@ impl SetAuthManifestReq {
             return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
         }
         let unused_byte_count = Self::MAX_MAN_SIZE - self.manifest_size as usize;
-        Ok(&mut self.as_bytes_mut()[..size_of::<Self>() - unused_byte_count])
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
     }
 }
 impl Default for SetAuthManifestReq {
@@ -992,7 +986,7 @@ impl Default for SetAuthManifestReq {
 
 // GET_IDEVID_CSR
 #[repr(C)]
-#[derive(Default, Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Default, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct GetIdevCsrReq {
     pub hdr: MailboxReqHeader,
 }
@@ -1003,7 +997,7 @@ impl Request for GetIdevCsrReq {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct GetIdevCsrResp {
     pub hdr: MailboxRespHeader,
     pub data_size: u32,
@@ -1063,7 +1057,7 @@ impl AuthAndStashFlags {
 
 // AUTHORIZE_AND_STASH
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AuthorizeAndStashReq {
     pub hdr: MailboxReqHeader,
     pub fw_id: [u8; 4],
@@ -1092,7 +1086,7 @@ impl Request for AuthorizeAndStashReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct AuthorizeAndStashResp {
     pub hdr: MailboxRespHeader,
     pub auth_req_result: u32,
@@ -1239,15 +1233,15 @@ pub fn mbox_read_fifo(
         .ok_or(CaliptraApiError::UnableToReadMailbox)?;
 
     let len_words = buf.len() / size_of::<u32>();
-    let (mut buf_words, suffix) = LayoutVerified::new_slice_unaligned_from_prefix(buf, len_words)
-        .ok_or(CaliptraApiError::ReadBuffTooSmall)?;
+    let (mut buf_words, suffix) = Ref::from_prefix_with_elems(buf, len_words)
+        .map_err(|_| CaliptraApiError::ReadBuffTooSmall)?;
 
     dequeue_words(&mbox, &mut buf_words);
     if !suffix.is_empty() {
         let last_word = mbox.dataout().read();
         let suffix_len = suffix.len();
         suffix
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&last_word.as_bytes()[..suffix_len]);
     }
 

--- a/api/src/soc_mgr.rs
+++ b/api/src/soc_mgr.rs
@@ -11,7 +11,7 @@ use crate::{
 use caliptra_api_types::Fuses;
 use core::mem;
 use ureg::MmioMut;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
 pub const NUM_PAUSERS: usize = 5;
 
@@ -312,12 +312,11 @@ pub trait SocManager {
             return Err(CaliptraApiError::MailboxRespTypeTooSmall);
         }
         let (header_bytes, payload_bytes) = req
-            .as_bytes_mut()
+            .as_mut_bytes()
             .split_at_mut(mem::size_of::<MailboxReqHeader>());
 
-        let mut header = MailboxReqHeader::read_from(header_bytes as &[u8]).unwrap();
+        let mut header = MailboxReqHeader::mut_from_bytes(header_bytes as &mut [u8]).unwrap();
         header.chksum = calc_checksum(R::ID.into(), payload_bytes);
-        header_bytes.copy_from_slice(header.as_bytes());
 
         let Some(data) = SocManager::mailbox_exec(self, R::ID.into(), req.as_bytes(), resp_bytes)? else {
                 return Err(CaliptraApiError::MailboxNoResponseData);
@@ -332,9 +331,9 @@ pub trait SocManager {
         }
 
         let mut response = R::Resp::new_zeroed();
-        response.as_bytes_mut()[..data.len()].copy_from_slice(data);
+        response.as_mut_bytes()[..data.len()].copy_from_slice(data);
 
-        let response_header = MailboxRespHeader::read_from_prefix(data).unwrap();
+        let (response_header, _) = MailboxRespHeader::read_from_prefix(data).unwrap();
         let actual_checksum = calc_checksum(0, &data[4..]);
         if actual_checksum != response_header.chksum {
             return Err(CaliptraApiError::MailboxRespInvalidChecksum {

--- a/auth-manifest/app/src/main.rs
+++ b/auth-manifest/app/src/main.rs
@@ -23,7 +23,7 @@ use clap::ArgMatches;
 use clap::{arg, value_parser, Command};
 use std::io::Write;
 use std::path::PathBuf;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 mod config;
 

--- a/auth-manifest/gen/src/generator.rs
+++ b/auth-manifest/gen/src/generator.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_image_gen::ImageGeneratorCrypto;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::*;
 use core::mem::size_of;

--- a/auth-manifest/types/src/lib.rs
+++ b/auth-manifest/types/src/lib.rs
@@ -192,7 +192,7 @@ pub struct AuthorizationManifest {
 #[cfg(test)]
 mod test {
     use crate::{AuthManifestPreamble, AUTH_MANIFEST_PREAMBLE_SIZE};
-    use zerocopy::AsBytes;
+    use zerocopy::IntoBytes;
 
     #[test]
     fn test_auth_preamble_size() {

--- a/auth-manifest/types/src/lib.rs
+++ b/auth-manifest/types/src/lib.rs
@@ -19,7 +19,7 @@ use caliptra_image_types::*;
 use core::default::Default;
 use core::ops::Range;
 use memoffset::span_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const AUTH_MANIFEST_MARKER: u32 = 0x4154_4D4E;
@@ -41,7 +41,7 @@ impl From<u32> for AuthManifestFlags {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestPubKeys {
     pub ecc_pub_key: ImageEccPubKey,
@@ -50,7 +50,7 @@ pub struct AuthManifestPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, FromBytes, KnownLayout, Immutable, Default, Debug, Clone, Copy, Zeroize)]
 pub struct AuthManifestPrivKeys {
     pub ecc_priv_key: ImageEccPrivKey,
     #[zeroize(skip)]
@@ -58,7 +58,7 @@ pub struct AuthManifestPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestSignatures {
     pub ecc_sig: ImageEccSignature,
@@ -68,7 +68,7 @@ pub struct AuthManifestSignatures {
 
 /// Caliptra Authorization Image Manifest Preamble
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize, Default)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestPreamble {
     pub marker: u32,
@@ -139,7 +139,7 @@ bitfield! {
 
 /// Caliptra Authorization Manifest Image Metadata
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestImageMetadata {
     pub fw_id: u32,
@@ -161,7 +161,7 @@ impl Default for AuthManifestImageMetadata {
 
 /// Caliptra Authorization Manifest Image Metadata Collection
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestImageMetadataCollection {
     pub entry_count: u32,
@@ -181,7 +181,7 @@ impl Default for AuthManifestImageMetadataCollection {
 
 /// Caliptra Image Authorization Manifest
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize, Default)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthorizationManifest {
     pub preamble: AuthManifestPreamble,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -23,7 +23,7 @@ use caliptra_image_gen::{
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle, ImageRevision, RomInfo};
 use elf::endian::LittleEndian;
 use nix::fcntl::FlockArg;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 mod elf_symbols;
 pub mod firmware;

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -16,7 +16,7 @@ use caliptra_drivers::*;
 use caliptra_image_types::*;
 use caliptra_image_verify::ImageVerificationEnv;
 use core::ops::Range;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use caliptra_drivers::memory_layout::ICCM_RANGE;
 
@@ -104,8 +104,9 @@ impl<'a, 'b> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a, 'b> 
             .as_bytes()
             .try_into()
             .map_err(|_| CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED)?;
-        let pub_key = Mldsa87PubKey::read_from(pub_key_bytes.as_bytes())
-            .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED)?;
+        let pub_key = Mldsa87PubKey::read_from_bytes(pub_key_bytes.as_bytes()).or(Err(
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED,
+        ))?;
 
         // Signature is received in hw format from the image. No conversion needed.
         let sig_bytes: [u8; MLDSA87_SIGNATURE_BYTE_SIZE] = sig
@@ -113,8 +114,9 @@ impl<'a, 'b> ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'a, 'b> 
             .as_bytes()
             .try_into()
             .map_err(|_| CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED)?;
-        let sig = Mldsa87Signature::read_from(sig_bytes.as_bytes())
-            .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED)?;
+        let sig = Mldsa87Signature::read_from_bytes(sig_bytes.as_bytes()).or(Err(
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED,
+        ))?;
 
         // digest is received in hw format. No conversion needed.
         let msg = digest.into();

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -14,7 +14,7 @@ Abstract:
 use caliptra_drivers::*;
 use core::mem::size_of;
 use core::usize;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::crypto::PubKey;
 

--- a/drivers/src/array.rs
+++ b/drivers/src/array.rs
@@ -15,7 +15,7 @@ Abstract:
 
 use caliptra_cfi_derive::Launder;
 use core::mem::MaybeUninit;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 macro_rules! static_assert {
@@ -27,7 +27,19 @@ macro_rules! static_assert {
 /// The `Array4xN` type represents large arrays in the native format of the Caliptra
 /// cryptographic hardware, and provides From traits for converting to/from byte arrays.
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Launder, Zeroize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    PartialEq,
+    Eq,
+    Launder,
+    Zeroize,
+)]
 pub struct Array4xN<const W: usize, const B: usize>(pub [u32; W]);
 impl<const W: usize, const B: usize> Array4xN<W, B> {
     pub const fn new(val: [u32; W]) -> Self {
@@ -43,15 +55,9 @@ impl<const W: usize, const B: usize> Default for Array4xN<W, B> {
 
 //// Ensure there is no padding in the struct
 static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
-unsafe impl<const W: usize, const B: usize> AsBytes for Array4xN<W, B> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 //// Ensure there is no padding in the struct
 static_assert!(core::mem::size_of::<Array4xN<1, 4>>() == 4);
-unsafe impl<const W: usize, const B: usize> FromBytes for Array4xN<W, B> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 impl<const W: usize, const B: usize> Array4xN<W, B> {
     #[inline(always)]

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -13,11 +13,11 @@ Abstract:
 --*/
 
 use crate::{Array4x12, Ecc384PubKey, Ecc384Signature, Mldsa87PubKey, Mldsa87Signature};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[repr(C)]
-#[derive(FromBytes, AsBytes, Zeroize, Default)]
+#[derive(Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 pub struct ColdResetEntries {
     ldev_dice_ecc_sig: Ecc384Signature,
     ldev_dice_ecc_pk: Ecc384PubKey,
@@ -37,7 +37,7 @@ pub struct ColdResetEntries {
 }
 
 #[repr(C)]
-#[derive(FromBytes, AsBytes, Zeroize, Default)]
+#[derive(Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 pub struct WarmResetEntries {
     rt_tci: Array4x12,
     fw_svn: u32,
@@ -48,7 +48,7 @@ pub struct WarmResetEntries {
 }
 
 #[repr(C)]
-#[derive(FromBytes, AsBytes, Zeroize, Default)]
+#[derive(Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 pub struct DataVault {
     cold_reset_entries: ColdResetEntries,
     warm_reset_entries: WarmResetEntries,

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -21,7 +21,7 @@ use caliptra_registers::i3ccsr::RegisterBlock as I3CRegisterBlock;
 use core::cell::Cell;
 use core::ops::Add;
 use ureg::{Mmio, MmioMut, RealMmioMut};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::cprintln;
 
@@ -300,7 +300,7 @@ impl Dma {
     /// * `CaliptraResult<u32>` - Read value or error code
     pub fn read_dword(&self, read_addr: AxiAddr) -> CaliptraResult<u32> {
         let mut read_val: u32 = 0;
-        self.read_buffer(read_addr, read_val.as_bytes_mut())?;
+        self.read_buffer(read_addr, read_val.as_mut_bytes())?;
         Ok(read_val)
     }
 

--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -21,7 +21,7 @@ use crate::{
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_registers::ecc::{EccReg, RegisterBlock};
 use core::cmp::Ordering;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 /// ECC-384 Coordinate
@@ -116,7 +116,19 @@ impl<'a> From<Ecc384PrivKeyOut<'a>> for Ecc384PrivKeyIn<'a> {
 
 /// ECC-384 Public Key
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 pub struct Ecc384PubKey {
     /// X coordinate
     pub x: Ecc384Scalar,
@@ -135,7 +147,19 @@ impl Ecc384PubKey {
 
 /// ECC-384 Signature
 #[repr(C)]
-#[derive(Debug, Default, AsBytes, FromBytes, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Debug,
+    Default,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 pub struct Ecc384Signature {
     /// Random point
     pub r: Ecc384Scalar,

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::{Array4x12, Array4x4};
 use caliptra_cfi_derive::Launder;
 use caliptra_registers::soc_ifc::SocIfcReg;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct FuseBank<'a> {
     pub(crate) soc_ifc: &'a SocIfcReg,

--- a/drivers/src/fuse_log.rs
+++ b/drivers/src/fuse_log.rs
@@ -11,7 +11,7 @@ Abstract:
 
 --*/
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[repr(u32)]
@@ -53,7 +53,7 @@ impl From<u32> for FuseLogEntryId {
 
 /// Fuse log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, KnownLayout, Immutable, Zeroize)]
 pub struct FuseLogEntry {
     /// Entry identifier
     pub entry_id: u32,

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -7,14 +7,14 @@ use bitfield::{bitfield_bitrange, bitfield_fields};
 use caliptra_error::CaliptraError;
 use caliptra_image_types::RomInfo;
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 pub const FHT_MARKER: u32 = 0x54484643;
 pub const FHT_INVALID_ADDRESS: u32 = u32::MAX;
 
 #[repr(C)]
-#[derive(AsBytes, Copy, Clone, Debug, FromBytes, PartialEq, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, Copy, Clone, Debug, FromBytes, PartialEq, Zeroize)]
 pub struct HandOffDataHandle(pub u32);
 pub const FHT_INVALID_HANDLE: HandOffDataHandle = HandOffDataHandle(u32::MAX);
 
@@ -123,7 +123,7 @@ const FHT_RESERVED_SIZE: usize = 1664;
 const _: () = assert!(size_of::<FirmwareHandoffTable>() == 2048);
 const _: () = assert!(size_of::<FirmwareHandoffTable>() <= memory_layout::FHT_SIZE as usize);
 #[repr(C)]
-#[derive(Clone, Debug, AsBytes, FromBytes, Zeroize)]
+#[derive(Clone, Debug, IntoBytes, TryFromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct FirmwareHandoffTable {
     /// Magic Number marking start of table. Value must be 0x54484643
     /// (‘CFHT’ when viewed as little-endian ASCII).

--- a/drivers/src/lms.rs
+++ b/drivers/src/lms.rs
@@ -21,7 +21,7 @@ use caliptra_error::CaliptraError;
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmsAlgorithmType, LmsIdentifier, LmsPublicKey, LmsSignature,
 };
-use zerocopy::{AsBytes, LittleEndian, U32};
+use zerocopy::{IntoBytes, LittleEndian, U32};
 use zeroize::Zeroize;
 
 pub const D_PBLC: u16 = 0x8080;

--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -21,7 +21,7 @@ use caliptra_registers::soc_ifc::SocIfcReg;
 use core::cmp::min;
 use core::mem::size_of;
 use core::slice;
-use zerocopy::{AsBytes, LayoutVerified, Unalign};
+use zerocopy::{FromBytes, IntoBytes, Unalign};
 
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
 /// Malbox operational states
@@ -313,15 +313,14 @@ mod fifo {
         }
 
         let len_words = buf.len() / size_of::<u32>();
-        let (mut buf_words, suffix) =
-            LayoutVerified::new_slice_unaligned_from_prefix(buf, len_words).unwrap();
-
-        dequeue_words(mbox, &mut buf_words);
-        if !suffix.is_empty() {
+        let (buf_words, suffix) =
+            <[Unalign<u32>]>::mut_from_prefix_with_elems(buf, len_words).unwrap();
+        dequeue_words(mbox, buf_words);
+        if !suffix.is_empty() && suffix.len() <= size_of::<u32>() {
             let last_word = mbox.regs().dataout().read();
             let suffix_len = suffix.len();
             suffix
-                .as_bytes_mut()
+                .as_mut_bytes()
                 .copy_from_slice(&last_word.as_bytes()[..suffix_len]);
         }
     }
@@ -339,17 +338,14 @@ mod fifo {
         if mbox.regs().dlen().read() as usize != buf.len() {
             return Err(CaliptraError::DRIVER_MAILBOX_ENQUEUE_ERR);
         }
-
-        let (buf_words, suffix) =
-            LayoutVerified::new_slice_unaligned_from_prefix(buf, buf.len() / size_of::<u32>())
-                .unwrap();
-        enqueue_words(mbox, &buf_words);
-        if !suffix.is_empty() {
+        let count = buf.len() / size_of::<u32>();
+        let (buf_words, suffix) = <[Unalign<u32>]>::ref_from_prefix_with_elems(buf, count).unwrap();
+        enqueue_words(mbox, buf_words);
+        if !suffix.is_empty() && suffix.len() <= size_of::<u32>() {
             let mut last_word = 0_u32;
-            last_word.as_bytes_mut()[..suffix.len()].copy_from_slice(suffix);
+            last_word.as_mut_bytes()[..suffix.len()].copy_from_slice(suffix);
             enqueue_words(mbox, &[Unalign::new(last_word)]);
         }
-
         Ok(())
     }
 }

--- a/drivers/src/pcr_log.rs
+++ b/drivers/src/pcr_log.rs
@@ -12,7 +12,7 @@ Abstract:
 --*/
 
 use crate::PcrId;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const PCR_ID_FMC_CURRENT: PcrId = PcrId::PcrId0;
@@ -52,7 +52,7 @@ impl From<u16> for PcrLogEntryId {
 
 /// PCR log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct PcrLogEntry {
     /// Entry identifier
     pub id: u16,
@@ -85,7 +85,7 @@ impl PcrLogEntry {
 
 /// Measurement log entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, Debug, Default, FromBytes, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, Debug, Default, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct MeasurementLogEntry {
     pub pcr_entry: PcrLogEntry,
     pub metadata: [u8; 4],

--- a/drivers/src/pcr_reset.rs
+++ b/drivers/src/pcr_reset.rs
@@ -13,11 +13,11 @@ Abstract:
 
 use crate::pcr_bank::{PcrBank, PcrId};
 use core::ops::{Index, IndexMut};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[repr(C, align(4))]
-#[derive(AsBytes, FromBytes, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct PcrResetCounter {
     counter: [u32; PcrBank::ALL_PCR_IDS.len()],
 }

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -11,7 +11,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::{ImageManifest, SHA384_DIGEST_BYTE_SIZE, SHA512_DIGEST_BYTE_SIZE};
 #[cfg(feature = "runtime")]
 use dpe::{DpeInstance, U8Bool, MAX_HANDLES};
-use zerocopy::{IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 use crate::{
@@ -46,14 +46,14 @@ pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
 pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
-#[derive(Clone, TryFromBytes, IntoBytes, Zeroize)]
+#[derive(Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes, Zeroize)]
 #[repr(C)]
 pub struct Ecc384IdevIdCsr {
     pub csr_len: u32,
     pub csr: [u8; ECC384_MAX_CSR_SIZE],
 }
 
-#[derive(Clone, FromBytes, AsBytes, Zeroize)]
+#[derive(Clone, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct Mldsa87IdevIdCsr {
     pub csr_len: u32,
@@ -133,7 +133,7 @@ pub const IDEVID_CSR_ENVELOP_MARKER: u32 = 0x43_5352;
 
 /// Calipatra IDEVID CSR Envelope
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Zeroize)]
+#[derive(Clone, IntoBytes, Immutable, KnownLayout, TryFromBytes, Zeroize)]
 pub struct InitDevIdCsrEnvelope {
     /// Marker
     pub marker: u32,

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -11,7 +11,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::{ImageManifest, SHA384_DIGEST_BYTE_SIZE, SHA512_DIGEST_BYTE_SIZE};
 #[cfg(feature = "runtime")]
 use dpe::{DpeInstance, U8Bool, MAX_HANDLES};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 use crate::{
@@ -46,7 +46,7 @@ pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
 pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
-#[derive(Clone, FromBytes, AsBytes, Zeroize)]
+#[derive(Clone, TryFromBytes, IntoBytes, Zeroize)]
 #[repr(C)]
 pub struct Ecc384IdevIdCsr {
     pub csr_len: u32,
@@ -167,7 +167,7 @@ impl Default for InitDevIdCsrEnvelope {
     }
 }
 
-#[derive(FromBytes, AsBytes, Zeroize)]
+#[derive(TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct PersistentData {
     pub manifest1: ImageManifest,
@@ -342,7 +342,7 @@ impl PersistentDataAccessor {
 }
 
 #[inline(always)]
-unsafe fn ref_from_addr<'a, T: FromBytes>(addr: u32) -> &'a T {
+unsafe fn ref_from_addr<'a, T: TryFromBytes>(addr: u32) -> &'a T {
     // LTO should be able to optimize out the assertions to maintain panic_is_missing
 
     // dereferencing zero is undefined behavior
@@ -353,7 +353,7 @@ unsafe fn ref_from_addr<'a, T: FromBytes>(addr: u32) -> &'a T {
 }
 
 #[inline(always)]
-unsafe fn ref_mut_from_addr<'a, T: FromBytes>(addr: u32) -> &'a mut T {
+unsafe fn ref_mut_from_addr<'a, T: TryFromBytes>(addr: u32) -> &'a mut T {
     // LTO should be able to optimize out the assertions to maintain panic_is_missing
 
     // dereferencing zero is undefined behavior

--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -29,7 +29,7 @@ use caliptra_registers::{
     csrng::CsrngReg, doe::DoeReg, entropy_src::EntropySrcReg, hmac::HmacReg, mbox::MboxCsr,
 };
 use caliptra_test_harness::test_suite;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 fn export_result_from_kv(ecc: &mut Ecc384, trng: &mut Trng, key_id: KeyId) -> Ecc384PubKey {
     ecc.key_pair(

--- a/drivers/test-fw/src/bin/mailbox_driver_responder.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_responder.rs
@@ -11,7 +11,7 @@ use caliptra_test_harness::{self, println};
 
 use caliptra_drivers::{self, Mailbox};
 use caliptra_registers::mbox::MboxCsr;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[panic_handler]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {
@@ -32,7 +32,7 @@ extern "C" fn main() {
                 let mut buf = [0u32; 4];
                 let dlen = txn.dlen();
                 println!("dlen: {dlen}");
-                txn.recv_request(buf.as_bytes_mut()).unwrap();
+                txn.recv_request(buf.as_mut_bytes()).unwrap();
                 println!("buf: {:08x?}", buf);
             }
             // Test recv_request with non-multiple-of-4 result buffer
@@ -50,7 +50,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -72,7 +72,7 @@ extern "C" fn main() {
                 let rem_words = dlen_words / 2;
                 let mut buf = [0u32; 1];
                 for _ in 0..rem_words {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.complete(true).unwrap();
@@ -88,7 +88,7 @@ extern "C" fn main() {
                 let dlen_words = (dlen + 3) / 4;
                 println!("dlen: {dlen}");
                 for _ in 0..((dlen_words + (buf.len() - 1)) / buf.len()) {
-                    txn.copy_request(buf.as_bytes_mut()).unwrap();
+                    txn.copy_request(buf.as_mut_bytes()).unwrap();
                     println!("buf: {:08x?}", buf);
                 }
                 txn.send_response(&[0x98, 0x76]).unwrap();

--- a/drivers/test-fw/src/bin/trng_driver_responder.rs
+++ b/drivers/test-fw/src/bin/trng_driver_responder.rs
@@ -14,7 +14,7 @@ use caliptra_registers::{
     csrng::CsrngReg, entropy_src::EntropySrcReg, mbox::MboxCsr, soc_ifc::SocIfcReg,
     soc_ifc_trng::SocIfcTrngReg,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[panic_handler]
 pub fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/drivers/test-fw/src/lib.rs
+++ b/drivers/test-fw/src/lib.rs
@@ -7,7 +7,7 @@ use caliptra_drivers::Ecc384PubKey;
 /// Code shared between the caliptra-drivers integration_test.rs (running on the
 /// host) and the test binaries (running inside the hw-model).
 use core::fmt::Debug;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const DOE_TEST_IV: [u32; 4] = [0xc6b407a2, 0xd119a37d, 0xb7a5bdeb, 0x26214aed];
 
@@ -16,7 +16,7 @@ pub const DOE_TEST_HMAC_KEY: [u32; 12] = [
     0xc6879874, 0x0aa49a0f, 0x4e740e9c, 0x2c9f9aad,
 ];
 
-#[derive(AsBytes, Clone, Copy, Default, Eq, PartialEq, FromBytes)]
+#[derive(IntoBytes, KnownLayout, Immutable, Clone, Copy, Default, Eq, PartialEq, FromBytes)]
 #[repr(C)]
 pub struct DoeTestResults {
     /// HMAC result of the UDS as key, and b"Hello world!" as data.

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -23,7 +23,7 @@ use caliptra_test::{
 };
 use openssl::{hash::MessageDigest, pkey::PKey};
 use ureg::ResettableReg;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 fn default_init_params() -> InitParams<'static> {
     InitParams {
@@ -222,7 +222,7 @@ fn test_doe_when_debug_not_locked() {
     .unwrap();
 
     let txn = model.wait_for_mailbox_receive().unwrap();
-    let test_results = DoeTestResults::read_from(txn.req.data.as_slice()).unwrap();
+    let test_results = DoeTestResults::read_from_bytes(txn.req.data.as_slice()).unwrap();
     assert_eq!(
         test_results,
         DOE_TEST_VECTORS_DEBUG_MODE.expected_test_results
@@ -317,7 +317,7 @@ fn test_doe_when_debug_locked() {
     .unwrap();
 
     let txn = model.wait_for_mailbox_receive().unwrap();
-    let test_results = DoeTestResults::read_from(txn.req.data.as_slice()).unwrap();
+    let test_results = DoeTestResults::read_from_bytes(txn.req.data.as_slice()).unwrap();
     assert_eq!(test_results, DOE_TEST_VECTORS.expected_test_results);
     txn.respond_success();
     model.step_until_exit_success().unwrap();

--- a/fmc/src/flow/pcr.rs
+++ b/fmc/src/flow/pcr.rs
@@ -31,7 +31,7 @@ use caliptra_drivers::{
     CaliptraResult, PersistentData,
 };
 use caliptra_error::CaliptraError;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Extend common data into the RT current and journey PCRs
 ///
@@ -92,7 +92,7 @@ fn log_pcr(
         pcr_ids,
         ..Default::default()
     };
-    dst.pcr_data.as_bytes_mut()[..data.len()].copy_from_slice(data);
+    dst.pcr_data.as_mut_bytes()[..data.len()].copy_from_slice(data);
     fht.pcr_log_index += 1;
 
     Ok(())

--- a/fmc/src/flow/tci.rs
+++ b/fmc/src/flow/tci.rs
@@ -18,7 +18,7 @@ Environment:
 --*/
 use crate::fmc_env::FmcEnv;
 use caliptra_drivers::{Array4x12, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct Tci {}
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -18,7 +18,7 @@ use caliptra_hw_model_types::{
     ErrorInjectionMode, EtrngResponse, HexBytes, HexSlice, RandomEtrngResponses, RandomNibbles,
     DEFAULT_CPTRA_OBF_KEY,
 };
-use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unalign};
+use zerocopy::{FromBytes, FromZeros, IntoBytes, Ref, Unalign};
 
 use caliptra_registers::mbox;
 use caliptra_registers::mbox::enums::{MboxFsmE, MboxStatusE};
@@ -864,7 +864,7 @@ pub trait HwModel: SocManager {
     ) -> std::result::Result<R::Resp, ModelError> {
         let mut response = R::Resp::new_zeroed();
 
-        self.mailbox_exec_req(req, response.as_bytes_mut())
+        self.mailbox_exec_req(req, response.as_mut_bytes())
             .map_err(ModelError::from)
     }
 
@@ -1001,13 +1001,9 @@ pub trait HwModel: SocManager {
 
         // Unwrap cannot fail, count * sizeof(u32) is always smaller than data.len()
         let (prefix_words, suffix_bytes) =
-            LayoutVerified::<_, [Unalign<u32>]>::new_slice_unaligned_from_prefix(
-                data,
-                data.len() / 4,
-            )
-            .unwrap();
+            Ref::<_, [Unalign<u32>]>::from_prefix_with_elems(data, data.len() / 4).unwrap();
 
-        for word in prefix_words.into_slice() {
+        for word in Ref::into_ref(prefix_words) {
             self.soc_sha512_acc()
                 .datain()
                 .write(|_| word.get().swap_bytes());
@@ -1094,8 +1090,8 @@ pub trait HwModel: SocManager {
         let response = response.ok_or(ModelError::UploadMeasurementResponseError)?;
 
         // Get response as a response header struct
-        let response = api::mailbox::StashMeasurementResp::read_from(response.as_slice())
-            .ok_or(ModelError::UploadMeasurementResponseError)?;
+        let response = api::mailbox::StashMeasurementResp::ref_from_bytes(response.as_slice())
+            .map_err(|_| ModelError::UploadMeasurementResponseError)?;
 
         // Verify checksum and FIPS status
         if !api::verify_checksum(
@@ -1125,7 +1121,7 @@ mod tests {
     use caliptra_emu_bus::Bus;
     use caliptra_emu_types::RvSize;
     use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc};
-    use zerocopy::{AsBytes, FromBytes};
+    use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
     use crate as caliptra_hw_model;
 
@@ -1472,7 +1468,7 @@ mod tests {
         // Send command that echoes the command and input message
         let mut resp_data = [0u8; 128];
         assert_eq!(
-            model.mailbox_exec(0x1000_0000, &message[..8], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x1000_0000, &message[..8], resp_data.as_mut_bytes()),
             Ok(Some(
                 [0x00, 0x00, 0x00, 0x10, 0x90, 0x5e, 0x1f, 0xad, 0x8b, 0x60, 0xb0, 0xbf].as_slice()
             )),
@@ -1483,19 +1479,19 @@ mod tests {
         let mut resp_data = [0u8; 128];
 
         assert_eq!(
-            model.mailbox_exec(0x1000_1000, &[42], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x1000_1000, &[42], resp_data.as_mut_bytes()),
             Ok(Some([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd].as_slice())),
         );
 
         // Send command that returns success with no output
         assert_eq!(
-            model.mailbox_exec(0x2000_0000, &[], resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x2000_0000, &[], resp_data.as_mut_bytes()),
             Ok(None)
         );
 
         // Send command that returns failure
         assert_eq!(
-            model.mailbox_exec(0x4000_0000, &message, resp_data.as_bytes_mut()),
+            model.mailbox_exec(0x4000_0000, &message, resp_data.as_mut_bytes()),
             Err(CaliptraApiError::MailboxCmdFailed(0))
         );
     }
@@ -1636,7 +1632,7 @@ mod tests {
         const GET_RESPONSE_CMD: u32 = 0x3000_0001;
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Default, Immutable, KnownLayout)]
         struct TestReq {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1646,7 +1642,7 @@ mod tests {
             type Resp = TestResp;
         }
         #[repr(C)]
-        #[derive(AsBytes, Debug, FromBytes, PartialEq, Eq)]
+        #[derive(IntoBytes, Immutable, KnownLayout, Debug, FromBytes, PartialEq, Eq)]
         struct TestResp {
             hdr: MailboxRespHeader,
             data: [u8; 4],
@@ -1654,7 +1650,7 @@ mod tests {
         impl mailbox::Response for TestResp {}
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReqNoData {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1750,7 +1746,7 @@ mod tests {
                     data: *b"Hi!!",
                     ..Default::default()
                 },
-                packet.as_bytes_mut(),
+                packet.as_mut_bytes(),
             )
             .map_err(ModelError::from);
         assert_eq!(
@@ -1800,7 +1796,7 @@ mod tests {
         const GET_RESPONSE_CMD: u32 = 0x3000_0001;
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReq {
             hdr: MailboxReqHeader,
             data: [u8; 4],
@@ -1810,7 +1806,7 @@ mod tests {
             type Resp = TestResp;
         }
         #[repr(C)]
-        #[derive(AsBytes, Debug, FromBytes, PartialEq, Eq)]
+        #[derive(IntoBytes, Debug, FromBytes, PartialEq, Eq)]
         struct TestResp {
             hdr: MailboxRespHeader,
             data: [u8; 4],
@@ -1818,7 +1814,7 @@ mod tests {
         impl mailbox::Response for TestResp {}
 
         #[repr(C)]
-        #[derive(AsBytes, FromBytes, Default)]
+        #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default)]
         struct TestReqNoData {
             hdr: MailboxReqHeader,
             data: [u8; 4],

--- a/image/app/src/create/mod.rs
+++ b/image/app/src/create/mod.rs
@@ -29,7 +29,7 @@ use clap::ArgMatches;
 use hex::ToHex;
 use std::path::Path;
 use std::path::PathBuf;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use caliptra_image_elf::ElfExecutable;
 use config::{OwnerKeyConfig, VendorKeyConfig};

--- a/image/crypto/src/lib.rs
+++ b/image/crypto/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::openssl::*;
 #[cfg(feature = "rustcrypto")]
 pub use crate::rustcrypto::*;
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const LMS_TREE_GEN_SUPPORTED_FULL_HEIGHT: u8 = 10u8;
 const SUPPORTED_LMS_Q_VALUE: u32 = 5u32;
@@ -67,7 +67,8 @@ pub fn lms_pub_key_from_pem(path: &PathBuf) -> anyhow::Result<ImageLmsPublicKey>
     let key_bytes = std::fs::read(path)
         .with_context(|| format!("Failed to read public key PEM file {}", path.display()))?;
 
-    ImageLmsPublicKey::read_from(&key_bytes[..]).ok_or(anyhow!("Error parsing LMS public key"))
+    ImageLmsPublicKey::read_from_bytes(&key_bytes[..])
+        .map_err(|_| anyhow!("Error parsing LMS public key"))
 }
 
 /// Read LMS SHA192 private Key from PEM file
@@ -75,7 +76,8 @@ pub fn lms_priv_key_from_pem(path: &PathBuf) -> anyhow::Result<ImageLmsPrivKey> 
     let key_bytes = std::fs::read(path)
         .with_context(|| format!("Failed to read private key PEM file {}", path.display()))?;
 
-    ImageLmsPrivKey::read_from(&key_bytes[..]).ok_or(anyhow!("Error parsing LMS priv key"))
+    ImageLmsPrivKey::read_from_bytes(&key_bytes[..])
+        .map_err(|_| anyhow!("Error parsing LMS priv key"))
 }
 
 fn generate_lmots_pubkey_helper<T: Sha256Hasher>(
@@ -232,7 +234,7 @@ fn generate_lms_pubkey_helper<T: Sha256Hasher>(
             if cur_node == target_node + 1 {
                 if let Some(sig_val) = sig.as_mut() {
                     sig_val.tree_path[level]
-                        .as_bytes_mut()
+                        .as_mut_bytes()
                         .copy_from_slice(stack_top(&pub_key_stack, stack_idx));
                     level += 1;
                 }
@@ -244,7 +246,7 @@ fn generate_lms_pubkey_helper<T: Sha256Hasher>(
             if cur_node == target_node {
                 if let Some(sig_val) = sig.as_mut() {
                     sig_val.tree_path[level]
-                        .as_bytes_mut()
+                        .as_mut_bytes()
                         .copy_from_slice(&k[..]);
                     level += 1;
                 }
@@ -273,7 +275,7 @@ fn generate_lms_pubkey_helper<T: Sha256Hasher>(
         stack_idx -= 1;
         pub_key_val
             .digest
-            .as_bytes_mut()
+            .as_mut_bytes()
             .clone_from_slice(stack_top(&pub_key_stack, stack_idx));
     }
 }
@@ -295,7 +297,7 @@ fn generate_ots_signature_helper<T: Sha256Hasher>(
         ots_type: ots_alg,
         ..Default::default()
     };
-    sig.nonce.as_bytes_mut().clone_from_slice(rand);
+    sig.nonce.as_mut_bytes().clone_from_slice(rand);
 
     let mut q_arr = [0u8; SHA192_DIGEST_BYTE_SIZE];
     let mut hasher = T::new();
@@ -340,7 +342,7 @@ fn generate_ots_signature_helper<T: Sha256Hasher>(
             tmp.copy_from_slice(&hasher.finish()[..SHA192_DIGEST_BYTE_SIZE]);
         }
         let sig_val = &mut sig.y[i];
-        sig_val.as_bytes_mut().clone_from_slice(tmp);
+        sig_val.as_mut_bytes().clone_from_slice(tmp);
     }
 
     sig
@@ -456,11 +458,11 @@ mod tests {
             #[cfg(feature = "openssl")]
             rand_bytes(&mut priv_key.id).unwrap();
             #[cfg(feature = "openssl")]
-            rand_bytes(priv_key.seed.as_bytes_mut()).unwrap();
+            rand_bytes(priv_key.seed.as_mut_bytes()).unwrap();
             #[cfg(feature = "rustcrypto")]
             OsRng.fill_bytes(&mut priv_key.id);
             #[cfg(feature = "rustcrypto")]
-            OsRng.fill_bytes(priv_key.seed.as_bytes_mut());
+            OsRng.fill_bytes(priv_key.seed.as_mut_bytes());
             #[cfg(feature = "openssl")]
             let pub_key = generate_lms_pubkey::<OpensslHasher>(&priv_key).unwrap();
             #[cfg(feature = "rustcrypto")]
@@ -472,11 +474,11 @@ mod tests {
             #[cfg(feature = "openssl")]
             rand_bytes(&mut priv_key.id).unwrap();
             #[cfg(feature = "openssl")]
-            rand_bytes(priv_key.seed.as_bytes_mut()).unwrap();
+            rand_bytes(priv_key.seed.as_mut_bytes()).unwrap();
             #[cfg(feature = "rustcrypto")]
             OsRng.fill_bytes(&mut priv_key.id);
             #[cfg(feature = "rustcrypto")]
-            OsRng.fill_bytes(priv_key.seed.as_bytes_mut());
+            OsRng.fill_bytes(priv_key.seed.as_mut_bytes());
             #[cfg(feature = "openssl")]
             let pub_key = generate_lms_pubkey::<OpensslHasher>(&priv_key).unwrap();
             #[cfg(feature = "rustcrypto")]

--- a/image/fake-keys/src/lib.rs
+++ b/image/fake-keys/src/lib.rs
@@ -14,7 +14,7 @@ use std::fs;
 #[cfg(test)]
 use std::io::Write; // bring trait into scope
 #[cfg(test)]
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Generated with
 ///

--- a/image/gen/src/generator.rs
+++ b/image/gen/src/generator.rs
@@ -16,7 +16,7 @@ use caliptra_image_types::*;
 use fips204::ml_dsa_87::{PrivateKey, SIG_LEN};
 use fips204::traits::{SerDes, Signer};
 use memoffset::offset_of;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::*;
 

--- a/image/gen/src/generator.rs
+++ b/image/gen/src/generator.rs
@@ -435,12 +435,12 @@ impl<Crypto: ImageGeneratorCrypto> ImageGenerator<Crypto> {
             ImageTocEntryId::Runtime => &config.runtime,
         };
 
-        let r#type = ImageTocEntryType::Executable;
+        let toc_type = ImageTocEntryType::Executable;
         let digest = self.crypto.sha384_digest(image.content())?;
 
         let entry = ImageTocEntry {
             id: id.into(),
-            r#type: r#type.into(),
+            toc_type: toc_type.into(),
             revision: *image.rev(),
             version: image.version(),
             reserved: [0; 2],

--- a/image/serde/src/lib.rs
+++ b/image/serde/src/lib.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 use caliptra_image_types::*;
 use std::io::Write;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Image Bundle Writer
 pub struct ImageBundleWriter<W: Write> {

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -95,7 +95,9 @@ pub type ImageLmsPublicKey = LmsPublicKey<SHA192_DIGEST_WORD_SIZE>;
 pub type ImageLmsPrivKey = LmsPrivateKey<SHA192_DIGEST_WORD_SIZE>;
 
 #[repr(C)]
-#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageMldsaPubKey(pub [u32; MLDSA87_PUB_KEY_WORD_SIZE]);
 
@@ -106,7 +108,9 @@ impl Default for ImageMldsaPubKey {
 }
 
 #[repr(C)]
-#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageMldsaPrivKey(pub [u32; MLDSA87_PRIV_KEY_WORD_SIZE]);
 
@@ -117,7 +121,9 @@ impl Default for ImageMldsaPrivKey {
 }
 
 #[repr(C)]
-#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePqcPubKey(pub [u8; PQC_PUB_KEY_BYTE_SIZE]);
 
@@ -129,7 +135,17 @@ impl Default for ImagePqcPubKey {
 
 #[repr(C)]
 #[derive(
-    KnownLayout, IntoBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    FromBytes,
+    Immutable,
+    IntoBytes,
+    KnownLayout,
+    PartialEq,
+    Zeroize,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccSignature {
@@ -145,7 +161,9 @@ pub type ImageLmsSignature =
 pub type ImageLmOTSSignature = LmotsSignature<SHA192_DIGEST_WORD_SIZE, IMAGE_LMS_OTS_P_PARAM>;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageMldsaSignature(pub [u32; MLDSA87_SIGNATURE_WORD_SIZE]);
 
@@ -155,27 +173,10 @@ impl Default for ImageMldsaSignature {
     }
 }
 
-// [TODO][CAP2] Remove this once ZeroCopy crate is updated to 0.8.13
-impl ImageMldsaSignature {
-    pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &*(bytes.as_ptr() as *const Self) })
-        } else {
-            None
-        }
-    }
-
-    pub fn mut_ref_from_prefix(bytes: &mut [u8]) -> Option<&mut Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &mut *(bytes.as_mut_ptr() as *mut Self) })
-        } else {
-            None
-        }
-    }
-}
-
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePqcSignature(pub [u8; PQC_SIGNATURE_BYTE_SIZE]);
 
@@ -353,7 +354,7 @@ pub struct ImageVendorPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(Clone, Copy, Debug, Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageVendorPubKeyInfo {
     pub ecc_key_descriptor: ImageEccKeyDescriptor,
@@ -371,7 +372,7 @@ pub struct ImageVendorPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 pub struct OwnerPubKeyConfig {
     pub ecc_pub_key: ImageEccPubKey,
     #[zeroize(skip)]
@@ -406,7 +407,7 @@ pub struct ImageSignatures {
 
 /// Caliptra Image ECC Key Descriptor
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, Default, Debug, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccKeyDescriptor {
     pub version: u16,
@@ -417,7 +418,7 @@ pub struct ImageEccKeyDescriptor {
 
 /// Caliptra Image LMS/MLDSA Key Descriptor
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, Debug, Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePqcKeyDescriptor {
     pub version: u16,

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -23,7 +23,7 @@ use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPrivateKey, LmsPublicKey, LmsSignature,
 };
 use memoffset::{offset_of, span_of};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const MANIFEST_MARKER: u32 = 0x4E414D43;
 pub const KEY_DESCRIPTOR_VERSION: u16 = 1;
@@ -69,7 +69,19 @@ pub type ImageRevision = [u8; IMAGE_REVISION_BYTE_SIZE];
 pub type ImageEccPrivKey = ImageScalar;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Default,
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccPubKey {
     /// X Coordinate
@@ -83,7 +95,7 @@ pub type ImageLmsPublicKey = LmsPublicKey<SHA192_DIGEST_WORD_SIZE>;
 pub type ImageLmsPrivKey = LmsPrivateKey<SHA192_DIGEST_WORD_SIZE>;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageMldsaPubKey(pub [u32; MLDSA87_PUB_KEY_WORD_SIZE]);
 
@@ -93,27 +105,8 @@ impl Default for ImageMldsaPubKey {
     }
 }
 
-// [TODO][CAP2] Remove this once ZeroCopy crate is updated to 0.8.13
-impl ImageMldsaPubKey {
-    pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &*(bytes.as_ptr() as *const Self) })
-        } else {
-            None
-        }
-    }
-
-    pub fn mut_ref_from_prefix(bytes: &mut [u8]) -> Option<&mut Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &mut *(bytes.as_mut_ptr() as *mut Self) })
-        } else {
-            None
-        }
-    }
-}
-
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageMldsaPrivKey(pub [u32; MLDSA87_PRIV_KEY_WORD_SIZE]);
 
@@ -124,7 +117,7 @@ impl Default for ImageMldsaPrivKey {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(IntoBytes, FromBytes, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePqcPubKey(pub [u8; PQC_PUB_KEY_BYTE_SIZE]);
 
@@ -135,7 +128,9 @@ impl Default for ImagePqcPubKey {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize)]
+#[derive(
+    KnownLayout, IntoBytes, FromBytes, Default, Debug, Copy, Clone, Eq, PartialEq, Zeroize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageEccSignature {
     /// Random point
@@ -278,7 +273,7 @@ impl ImageBundle {
 ///
 /// NOTE: only the header, fmc, and runtime portions of this struct are covered by signature.
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Clone, Copy, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageManifest {
     /// Marker
@@ -348,7 +343,7 @@ impl ImageManifest {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageVendorPubKeys {
     pub ecc_pub_keys: [ImageEccPubKey; VENDOR_ECC_MAX_KEY_COUNT as usize],
@@ -367,7 +362,7 @@ pub struct ImageVendorPubKeyInfo {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 pub struct ImageVendorPrivKeys {
     pub ecc_priv_keys: [ImageEccPrivKey; VENDOR_ECC_MAX_KEY_COUNT as usize],
     #[zeroize(skip)]
@@ -385,7 +380,7 @@ pub struct OwnerPubKeyConfig {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageOwnerPubKeys {
     pub ecc_pub_key: ImageEccPubKey,
@@ -393,7 +388,7 @@ pub struct ImageOwnerPubKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Clone, Copy, Zeroize)]
 pub struct ImageOwnerPrivKeys {
     pub ecc_priv_key: ImageEccPrivKey,
     #[zeroize(skip)]
@@ -402,7 +397,7 @@ pub struct ImageOwnerPrivKeys {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageSignatures {
     pub ecc_sig: ImageEccSignature,
@@ -436,7 +431,7 @@ pub type ImagePqcKeyHashes = [ImageDigest384; VENDOR_PQC_MAX_KEY_COUNT as usize]
 
 /// Caliptra Image Bundle Preamble
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImagePreamble {
     /// Vendor Public Key Descriptor + Key Hashes
@@ -467,7 +462,7 @@ pub struct ImagePreamble {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct VendorSignedData {
     /// Vendor Start Date [ASN1 Time Format] For FMC alias certificate.
@@ -480,7 +475,7 @@ pub struct VendorSignedData {
 }
 
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OwnerSignedData {
     /// Owner Start Date [ASN1 Time Format] For FMC alias certificate: Takes Preference over vendor start date
@@ -494,7 +489,7 @@ pub struct OwnerSignedData {
 
 /// Caliptra Image header
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageHeader {
     /// Revision
@@ -560,7 +555,7 @@ impl From<ImageTocEntryId> for u32 {
 
 /// Caliptra Table of contents entry
 #[repr(C)]
-#[derive(AsBytes, Clone, Copy, FromBytes, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageTocEntry {
     /// ID
@@ -613,7 +608,7 @@ impl ImageTocEntry {
 
 /// Information about the ROM image.
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Default, Debug)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Default, Debug)]
 pub struct RomInfo {
     // sha256 digest with big-endian words, where each 4-byte segment of the
     // digested data has the bytes reversed.

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -563,7 +563,7 @@ pub struct ImageTocEntry {
     pub id: u32,
 
     /// Type
-    pub r#type: u32,
+    pub toc_type: u32,
 
     /// Commit revision
     pub revision: ImageRevision,

--- a/lms-types/src/lib.rs
+++ b/lms-types/src/lib.rs
@@ -118,26 +118,6 @@ static_assert!(
             + size_of::<[U32<LittleEndian>; 1]>())
 );
 
-impl<const N: usize> LmsPublicKey<N> {
-    pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &*(bytes.as_ptr() as *const Self) })
-        } else {
-            None
-        }
-    }
-}
-
-impl<const N: usize> LmsPublicKey<N> {
-    pub fn mut_ref_from_prefix(bytes: &mut [u8]) -> Option<&mut Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &mut *(bytes.as_mut_ptr() as *mut Self) })
-        } else {
-            None
-        }
-    }
-}
-
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(
     Copy,
@@ -213,33 +193,33 @@ static_assert!(
             + size_of::<[[U32<LittleEndian>; 1]; 1]>())
 );
 // Derive doesn't support const generic arrays
-unsafe impl<const N: usize, const P: usize, const H: usize> AsBytes for LmsSignature<N, P, H> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize, const P: usize, const H: usize> FromBytes for LmsSignature<N, P, H> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-impl<const N: usize, const P: usize, const H: usize> LmsSignature<N, P, H> {
-    pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
-        if bytes.len() >= size_of::<Self>() {
-            Some(unsafe { &*(bytes.as_ptr() as *const Self) })
-        } else {
-            None
-        }
-    }
-}
+// // unsafe impl<const N: usize, const P: usize, const H: usize> IntoBytes for LmsSignature<N, P, H> {
+// //     fn only_derive_is_allowed_to_implement_this_trait() {}
+// // }
+// // unsafe impl<const N: usize, const P: usize, const H: usize> FromBytes for LmsSignature<N, P, H> {
+// //     fn only_derive_is_allowed_to_implement_this_trait() {}
+// // }
+// impl<const N: usize, const P: usize, const H: usize> LmsSignature<N, P, H> {
+//     pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
+//         if bytes.len() >= size_of::<Self>() {
+//             Some(unsafe { &*(bytes.as_ptr() as *const Self) })
+//         } else {
+//             None
+//         }
+//     }
+// }
 
-impl<const N: usize, const P: usize, const H: usize> LmsSignature<N, P, H> {
-    pub fn mut_ref_from_prefix(bytes: &mut [u8]) -> Option<&mut Self> {
-        {
-            if bytes.len() >= size_of::<Self>() {
-                Some(unsafe { &mut *(bytes.as_mut_ptr() as *mut Self) })
-            } else {
-                None
-            }
-        }
-    }
-}
+// impl<const N: usize, const P: usize, const H: usize> LmsSignature<N, P, H> {
+//     pub fn mut_ref_from_prefix(bytes: &mut [u8]) -> Option<&mut Self> {
+//         {
+//             if bytes.len() >= size_of::<Self>() {
+//                 Some(unsafe { &mut *(bytes.as_mut_ptr() as *mut Self) })
+//             } else {
+//                 None
+//             }
+//         }
+//     }
+// }
 
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Eq, PartialEq)]
 #[repr(C)]

--- a/lms-types/src/lib.rs
+++ b/lms-types/src/lib.rs
@@ -5,7 +5,9 @@
 use core::mem::size_of;
 
 use caliptra_cfi_derive::Launder;
-use zerocopy::{AsBytes, BigEndian, FromBytes, LittleEndian, U32};
+use zerocopy::{
+    BigEndian, FromBytes, Immutable, IntoBytes, KnownLayout, LittleEndian, Unaligned, U32,
+};
 use zeroize::Zeroize;
 
 pub type LmsIdentifier = [u8; 16];
@@ -17,7 +19,19 @@ macro_rules! static_assert {
 }
 
 #[repr(transparent)]
-#[derive(AsBytes, FromBytes, Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Copy,
+    Clone,
+    Debug,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Default,
+    PartialEq,
+    Eq,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LmsAlgorithmType(pub U32<BigEndian>);
 impl LmsAlgorithmType {
@@ -40,7 +54,19 @@ impl LmsAlgorithmType {
 }
 
 #[repr(transparent)]
-#[derive(AsBytes, FromBytes, Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(
+    IntoBytes,
+    FromBytes,
+    Debug,
+    Immutable,
+    KnownLayout,
+    Unaligned,
+    Default,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LmotsAlgorithmType(pub U32<BigEndian>);
 
@@ -61,7 +87,9 @@ impl LmotsAlgorithmType {
     pub const LmotsSha256N24W8: Self = Self::new(8);
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Launder)]
+#[derive(
+    Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Launder,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(C)]
 pub struct LmsPublicKey<const N: usize> {
@@ -81,7 +109,7 @@ impl<const N: usize> Default for LmsPublicKey<N> {
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmsPublicKey<1>>()
         == (size_of::<LmsAlgorithmType>()
@@ -89,13 +117,6 @@ static_assert!(
             + size_of::<[u8; 16]>()
             + size_of::<[U32<LittleEndian>; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize> AsBytes for LmsPublicKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize> FromBytes for LmsPublicKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 impl<const N: usize> LmsPublicKey<N> {
     pub fn ref_from_prefix(bytes: &[u8]) -> Option<&Self> {
@@ -118,7 +139,19 @@ impl<const N: usize> LmsPublicKey<N> {
 }
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Zeroize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    IntoBytes,
+    Immutable,
+    KnownLayout,
+    Unaligned,
+    FromBytes,
+    PartialEq,
+    Eq,
+    Zeroize,
+)]
 #[repr(C)]
 pub struct LmotsSignature<const N: usize, const P: usize> {
     #[zeroize(skip)]
@@ -139,23 +172,18 @@ impl<const N: usize, const P: usize> Default for LmotsSignature<N, P> {
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmotsSignature<1, 1>>()
         == (size_of::<LmotsAlgorithmType>()
             + size_of::<[U32<LittleEndian>; 1]>()
             + size_of::<[[U32<LittleEndian>; 1]; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize, const P: usize> AsBytes for LmotsSignature<N, P> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize, const P: usize> FromBytes for LmotsSignature<N, P> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Launder)]
+#[derive(
+    Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq, Launder,
+)]
 #[repr(C)]
 pub struct LmsSignature<const N: usize, const P: usize, const H: usize> {
     pub q: U32<BigEndian>,
@@ -176,7 +204,7 @@ impl<const N: usize, const P: usize, const H: usize> Default for LmsSignature<N,
         }
     }
 }
-// Ensure there is no padding (required for AsBytes safety)
+// Ensure there is no padding (required for IntoBytes safety)
 static_assert!(
     size_of::<LmsSignature<1, 1, 1>>()
         == (size_of::<U32<BigEndian>>()
@@ -213,7 +241,7 @@ impl<const N: usize, const P: usize, const H: usize> LmsSignature<N, P, H> {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes, Eq, PartialEq)]
 #[repr(C)]
 pub struct LmsPrivateKey<const N: usize> {
     pub tree_type: LmsAlgorithmType,
@@ -241,13 +269,6 @@ static_assert!(
             + size_of::<LmsIdentifier>()
             + size_of::<[U32<LittleEndian>; 1]>())
 );
-// Derive doesn't support const generic arrays
-unsafe impl<const N: usize> AsBytes for LmsPrivateKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
-unsafe impl<const N: usize> FromBytes for LmsPrivateKey<N> {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
 
 /// Converts a byte array to word arrays as used in the LMS types. Intended for
 /// use at compile-time or in tests / host utilities; not optimized for use in

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -38,7 +38,7 @@ use caliptra_x509::{
     FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params, FmcAliasCertTbsMlDsa87,
     FmcAliasCertTbsMlDsa87Params,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 #[derive(Default)]

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -410,7 +410,7 @@ impl FirmwareProcessor {
         let manifest = &mut persistent_data.get_mut().manifest1;
         if active_mode {
             let mbox_sram = txn.raw_mailbox_contents();
-            let manifest_buf = manifest.as_bytes_mut();
+            let manifest_buf = manifest.as_mut_bytes();
             if mbox_sram.len() < manifest_buf.len() {
                 Err(CaliptraError::FW_PROC_INVALID_IMAGE_SIZE)?;
             }

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -39,7 +39,7 @@ use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, Ima
 use caliptra_kat::KatsEnv;
 use caliptra_x509::{NotAfter, NotBefore};
 use core::mem::{size_of, ManuallyDrop};
-use zerocopy::{AsBytes, LayoutVerified};
+use zerocopy::{FromBytes, IntoBytes};
 use zeroize::Zeroize;
 
 const RESERVED_PAUSER: u32 = 0xFFFFFFFF;
@@ -252,7 +252,7 @@ impl FirmwareProcessor {
                 match CommandId::from(txn.cmd()) {
                     CommandId::VERSION => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         let mut resp = FipsVersionCmd::execute(soc_ifc)?;
                         resp.populate_chksum();
@@ -260,7 +260,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::SELF_TEST_START => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         if self_test_in_progress {
                             // TODO: set non-fatal error register?
@@ -275,7 +275,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::SELF_TEST_GET_RESULTS => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         if !self_test_in_progress {
                             // TODO: set non-fatal error register?
@@ -289,7 +289,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::SHUTDOWN => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         let mut resp = MailboxRespHeader::default();
                         resp.populate_chksum();
@@ -300,7 +300,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::CAPABILITIES => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         let mut capabilities = Capabilities::default();
                         capabilities |= Capabilities::ROM_BASE;
@@ -341,7 +341,7 @@ impl FirmwareProcessor {
                     }
                     CommandId::GET_IDEV_ECC_CSR => {
                         let mut request = MailboxReqHeader::default();
-                        Self::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
                         let csr_persistent_mem = &persistent_data.idevid_csr_envelop.ecc_csr;
                         let mut resp = GetIdevCsrResp::default();
@@ -416,7 +416,7 @@ impl FirmwareProcessor {
             }
             manifest_buf.copy_from_slice(&mbox_sram[..manifest_buf.len()]);
         } else {
-            txn.copy_request(manifest.as_bytes_mut())?;
+            txn.copy_request(manifest.as_mut_bytes())?;
         }
         report_boot_status(FwProcessorManifestLoadComplete.into());
         Ok(*manifest)
@@ -592,7 +592,8 @@ impl FirmwareProcessor {
                 let addr = (manifest.fmc.load_addr) as *mut u32;
                 core::slice::from_raw_parts_mut(addr, manifest.fmc.size as usize / 4)
             };
-            txn.copy_request(fmc_dest.as_bytes_mut())?;
+
+            txn.copy_request(fmc_dest.as_mut_bytes())?;
         }
 
         cprintln!(
@@ -618,7 +619,8 @@ impl FirmwareProcessor {
                 let addr = (manifest.runtime.load_addr) as *mut u32;
                 core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
             };
-            txn.copy_request(runtime_dest.as_bytes_mut())?;
+
+            txn.copy_request(runtime_dest.as_mut_bytes())?;
         }
 
         report_boot_status(FwProcessorLoadImageComplete.into());
@@ -734,11 +736,9 @@ impl FirmwareProcessor {
         txn.copy_request(data)?;
 
         // Extract header out from the rest of the request
-        let req_hdr: &MailboxReqHeader = LayoutVerified::<&[u8], MailboxReqHeader>::new(
-            &data[..core::mem::size_of::<MailboxReqHeader>()],
-        )
-        .ok_or(CaliptraError::FW_PROC_MAILBOX_PROCESS_FAILURE)?
-        .into_ref();
+        let req_hdr =
+            MailboxReqHeader::ref_from_bytes(&data[..core::mem::size_of::<MailboxReqHeader>()])
+                .map_err(|_| CaliptraError::FW_PROC_MAILBOX_PROCESS_FAILURE)?;
 
         // Verify checksum
         if !caliptra_common::checksum::verify_checksum(
@@ -770,7 +770,7 @@ impl FirmwareProcessor {
         txn: &mut MailboxRecvTxn,
     ) -> CaliptraResult<()> {
         let mut measurement = StashMeasurementReq::default();
-        Self::copy_req_verify_chksum(txn, measurement.as_bytes_mut())?;
+        Self::copy_req_verify_chksum(txn, measurement.as_mut_bytes())?;
 
         // Extend measurement into PCR31.
         Self::extend_measurement(pcr_bank, sha2, persistent_data, &measurement)?;

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -33,7 +33,7 @@ use caliptra_common::{
 };
 use caliptra_drivers::*;
 use caliptra_x509::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 /// Initialization Vector used by Deobfuscation Engine during UDS / field entropy decryption.

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -33,7 +33,7 @@ use caliptra_common::{
 };
 use caliptra_drivers::*;
 use caliptra_x509::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 /// Dice Local Device Identity (IDEVID) Layer

--- a/rom/dev/src/flow/debug_unlock.rs
+++ b/rom/dev/src/flow/debug_unlock.rs
@@ -29,7 +29,7 @@ use caliptra_drivers::{
     ShaAccLockState,
 };
 use caliptra_error::CaliptraError;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::rom_env::RomEnv;
 
@@ -76,7 +76,7 @@ fn handle_manufacturing(env: &mut RomEnv) -> CaliptraResult<()> {
 
     let mut txn = ManuallyDrop::new(txn.start_txn());
     let mut request = ManufDebugUnlockTokenReq::default();
-    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
     env.soc_ifc.set_ss_dbg_unlock_in_progress(true);
 
@@ -157,7 +157,7 @@ fn handle_production_request(
 
     let mut txn = ManuallyDrop::new(txn.start_txn());
     let mut request = ProductionAuthDebugUnlockReq::default();
-    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_bytes_mut())?;
+    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
 
     let payload_length = |length: [u8; 3]| {
         let mut len: usize = 0;
@@ -249,7 +249,7 @@ fn handle_production_token(
 
     let mut txn = ManuallyDrop::new(txn.start_txn());
     let mut token = ProductionAuthDebugUnlockToken::default();
-    FirmwareProcessor::copy_req_verify_chksum(&mut txn, token.as_bytes_mut())?;
+    FirmwareProcessor::copy_req_verify_chksum(&mut txn, token.as_mut_bytes())?;
 
     // Validate payload
     if payload_length(token.length)

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -165,7 +165,7 @@ impl FakeRomFlow {
                 // In real ROM, this is done as part of executing the SHA-ACC KAT.
                 let sha_op = env
                     .sha2_512_384_acc
-                    .try_start_operation(ShaAccLockState::AssumedLocked)?
+                    .try_start_operation(ShaAccLockState::AssumedLocked)
                     .unwrap();
                 drop(sha_op);
 

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -26,7 +26,7 @@ use caliptra_drivers::{DataVault, PersistentData};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
 use caliptra_image_verify::{ImageVerificationInfo, ImageVerifier};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[derive(Default)]
 pub struct UpdateResetFlow {}
@@ -189,7 +189,7 @@ impl UpdateResetFlow {
             core::slice::from_raw_parts_mut(addr, manifest.runtime.size as usize / 4)
         };
 
-        txn.copy_request(runtime_dest.as_bytes_mut())?;
+        txn.copy_request(runtime_dest.as_mut_bytes())?;
 
         //Call the complete here to reset the execute bit
         txn.complete(true)?;
@@ -207,7 +207,7 @@ impl UpdateResetFlow {
         persistent_data: &mut PersistentData,
         txn: &mut MailboxRecvTxn,
     ) -> CaliptraResult<()> {
-        txn.copy_request(persistent_data.manifest2.as_bytes_mut())?;
+        txn.copy_request(persistent_data.manifest2.as_mut_bytes())?;
         Ok(())
     }
 

--- a/rom/dev/src/fuse.rs
+++ b/rom/dev/src/fuse.rs
@@ -14,7 +14,7 @@ Abstract:
 use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_common::{FuseLogEntry, FuseLogEntryId};
 use caliptra_drivers::{CaliptraError, CaliptraResult, FuseLogArray};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 /// Log Fuse data
 ///
@@ -43,7 +43,7 @@ pub fn log_fuse_data(
         entry_id: entry_id as u32,
         ..Default::default()
     };
-    let Some(data_dest) = log_entry.log_data.as_bytes_mut().get_mut(..data.len()) else {
+    let Some(data_dest) = log_entry.log_data.as_mut_bytes().get_mut(..data.len()) else {
         return Err(CaliptraError::ROM_GLOBAL_FUSE_LOG_UNSUPPORTED_DATA_LENGTH);
     };
     data_dest.copy_from_slice(data);

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -31,7 +31,7 @@ use caliptra_drivers::{
     CaliptraError, CaliptraResult, PcrBank, PersistentData, Sha2_512_384, SocIfc,
 };
 use caliptra_image_verify::ImageVerificationInfo;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 struct PcrExtender<'a> {
     persistent_data: &'a mut PersistentData,
@@ -151,7 +151,7 @@ pub fn log_pcr(
         pcr_ids,
         ..Default::default()
     };
-    let Some(dest_data) = pcr_log_entry.pcr_data.as_bytes_mut().get_mut(..data.len()) else {
+    let Some(dest_data) = pcr_log_entry.pcr_data.as_mut_bytes().get_mut(..data.len()) else {
         return Err(CaliptraError::ROM_GLOBAL_PCR_LOG_UNSUPPORTED_DATA_LENGTH);
     };
     dest_data.copy_from_slice(data);

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -15,7 +15,7 @@ use caliptra_hw_model::{
 };
 use caliptra_hw_model::{DefaultHwModel, ModelError};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
-use zerocopy::FromBytes;
+use zerocopy::TryFromBytes;
 
 pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,
@@ -93,7 +93,7 @@ pub fn get_csr_envelop(hw: &mut DefaultHwModel) -> Result<InitDevIdCsrEnvelope, 
     let result = mem::take(&mut txn.req.data);
     txn.respond_success();
     hw.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
-    let csr_envelop = InitDevIdCsrEnvelope::read_from_prefix(&*result).unwrap();
+    let (csr_envelop, _) = InitDevIdCsrEnvelope::try_read_from_prefix(&result).unwrap();
     Ok(csr_envelop)
 }
 

--- a/rom/dev/tests/rom_integration_tests/test_capabilities.rs
+++ b/rom/dev/tests/rom_integration_tests/test_capabilities.rs
@@ -6,7 +6,7 @@ use caliptra_common::mailbox_api::{
     CapabilitiesResp, CommandId, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::{Fuses, HwModel};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -24,7 +24,7 @@ fn test_capabilities() {
         .unwrap()
         .unwrap();
 
-    let capabilities_resp = CapabilitiesResp::read_from(response.as_bytes()).unwrap();
+    let capabilities_resp = CapabilitiesResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     // Verify response checksum
     assert!(caliptra_common::checksum::verify_checksum(

--- a/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
@@ -16,7 +16,7 @@ use fips204::traits::{SerDes, Signer};
 use p384::ecdsa::VerifyingKey;
 use rand::{rngs::StdRng, SeedableRng};
 use sha2::Digest;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 #[test]
 fn test_dbg_unlock_manuf_passive_mode() {
@@ -289,7 +289,7 @@ fn test_dbg_unlock_prod() {
         .unwrap()
         .unwrap();
 
-    let challenge = ProductionAuthDebugUnlockChallenge::read_from(resp.as_slice()).unwrap();
+    let challenge = ProductionAuthDebugUnlockChallenge::read_from_bytes(resp.as_slice()).unwrap();
 
     let mut sha384 = sha2::Sha384::new();
     sha384.update(challenge.challenge);
@@ -502,7 +502,7 @@ fn test_dbg_unlock_prod_invalid_token_challenage() {
         .unwrap()
         .unwrap();
 
-    let challenge = ProductionAuthDebugUnlockChallenge::read_from(resp.as_slice()).unwrap();
+    let challenge = ProductionAuthDebugUnlockChallenge::read_from_bytes(resp.as_slice()).unwrap();
 
     // Create an invalid token by using a different challenge than what was received
     let invalid_challenge = [0u8; 48];
@@ -624,7 +624,7 @@ fn test_dbg_unlock_prod_invalid_signature() {
         .unwrap()
         .unwrap();
 
-    let challenge = ProductionAuthDebugUnlockChallenge::read_from(resp.as_slice()).unwrap();
+    let challenge = ProductionAuthDebugUnlockChallenge::read_from_bytes(resp.as_slice()).unwrap();
 
     let mut sha512 = sha2::Sha512::new();
     sha512.update(challenge.challenge);
@@ -771,7 +771,7 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
         .unwrap()
         .unwrap();
 
-    let challenge = ProductionAuthDebugUnlockChallenge::read_from(resp.as_slice()).unwrap();
+    let challenge = ProductionAuthDebugUnlockChallenge::read_from_bytes(resp.as_slice()).unwrap();
 
     let token = ProductionAuthDebugUnlockToken {
         length: {

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -24,7 +24,7 @@ use caliptra_image_gen::ImageGenerator;
 use caliptra_image_types::{FwVerificationPqcKeyType, IMAGE_BYTE_SIZE};
 use caliptra_test::swap_word_bytes;
 use openssl::hash::{Hasher, MessageDigest};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 use crate::helpers;
 
@@ -97,7 +97,7 @@ fn check_pcr_log_entry(
     pcr_data: &[u8],
 ) {
     let offset = pcr_entry_index * PCR_ENTRY_SIZE;
-    let entry = PcrLogEntry::read_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
+    let (entry, _) = PcrLogEntry::ref_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
 
     assert_eq!(entry.id, entry_id as u16);
     assert_eq!(entry.pcr_ids, pcr_ids);
@@ -110,8 +110,8 @@ fn check_measurement_log_entry(
     measurement_req: &StashMeasurementReq,
 ) {
     let offset = measurement_entry_index * MEASUREMENT_ENTRY_SIZE;
-    let entry =
-        MeasurementLogEntry::read_from_prefix(measurement_entry_arr[offset..].as_bytes()).unwrap();
+    let (entry, _) =
+        MeasurementLogEntry::ref_from_prefix(measurement_entry_arr[offset..].as_bytes()).unwrap();
 
     assert_eq!(entry.pcr_entry.id, PcrLogEntryId::StashMeasurement as u16);
     assert_eq!(entry.pcr_entry.pcr_ids, PCR31_EXTENDED_ID);
@@ -445,14 +445,14 @@ fn hash_pcr_log_entries(initial_pcr: &[u8; 48], pcr_entry_arr: &[u8], pcr_id: Pc
             break;
         }
 
-        let entry = PcrLogEntry::read_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
+        let (entry, _) = PcrLogEntry::ref_from_prefix(pcr_entry_arr[offset..].as_bytes()).unwrap();
         offset += PCR_ENTRY_SIZE;
 
         if (entry.pcr_ids & (1 << pcr_id as u8)) == 0 {
             continue;
         }
 
-        hash_pcr_log_entry(&entry, &mut pcr);
+        hash_pcr_log_entry(entry, &mut pcr);
     }
 
     pcr
@@ -469,8 +469,8 @@ fn hash_measurement_log_entries(measurement_entry_arr: &[u8]) -> [u8; 48] {
             break;
         }
 
-        let entry =
-            MeasurementLogEntry::read_from_prefix(measurement_entry_arr[offset..].as_bytes())
+        let (entry, _) =
+            MeasurementLogEntry::ref_from_prefix(measurement_entry_arr[offset..].as_bytes())
                 .unwrap();
         offset += MEASUREMENT_ENTRY_SIZE;
 
@@ -649,8 +649,8 @@ fn test_fuse_log() {
     let mut fuse_log_entry_offset = 0;
 
     // Check entry for VendorPubKeyIndex.
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
 
     assert_eq!(
         fuse_log_entry.entry_id,
@@ -661,8 +661,8 @@ fn test_fuse_log() {
 
     // Validate that the ID is VendorPubKeyRevocation
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::VendorEccPubKeyRevocation as u32
@@ -671,8 +671,8 @@ fn test_fuse_log() {
 
     // Validate the ColdBootFwSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::ColdBootFwSvn as u32
@@ -681,8 +681,8 @@ fn test_fuse_log() {
 
     // Validate the ManifestReserved0
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::ManifestReserved0 as u32
@@ -691,8 +691,8 @@ fn test_fuse_log() {
 
     // Validate the _DeprecatedFuseFmcSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::_DeprecatedFuseFmcSvn as u32
@@ -702,7 +702,7 @@ fn test_fuse_log() {
     // Validate the ManifestFwSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
     let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::ManifestFwSvn as u32
@@ -711,8 +711,8 @@ fn test_fuse_log() {
 
     // Validate the ManifestReserved1
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::ManifestReserved1 as u32
@@ -722,14 +722,14 @@ fn test_fuse_log() {
     // Validate the FuseFwSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
     let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(fuse_log_entry.entry_id, FuseLogEntryId::FuseFwSvn as u32);
     assert_eq!(fuse_log_entry.log_data[0], FW_FUSE_SVN);
 
     // Validate the VendorPqcPubKeyIndex
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::VendorPqcPubKeyIndex as u32
@@ -738,8 +738,8 @@ fn test_fuse_log() {
 
     // Validate that the ID is VendorPubKeyRevocation
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
-        FuseLogEntry::read_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
+    let (fuse_log_entry, _) =
+        FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
         FuseLogEntryId::VendorPqcPubKeyRevocation as u32
@@ -784,7 +784,7 @@ fn test_fht_info() {
         hw.step_until_boot_status(u32::from(ColdResetComplete), true);
 
         let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
-        let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+        let fht = FirmwareHandoffTable::ref_from_prefix(data.as_bytes()).unwrap();
         // [TODO][CAP2] add mldsa equivalents
         assert_eq!(fht.ecc_ldevid_tbs_size, 552);
         assert_eq!(fht.ecc_fmcalias_tbs_size, 753);
@@ -834,7 +834,7 @@ fn test_check_rom_cold_boot_status_reg() {
         hw.step_until_boot_status(u32::from(ColdResetComplete), true);
 
         let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
-        let data_vault = DataVault::read_from_prefix(data_vault.as_bytes()).unwrap();
+        let data_vault = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
 
         assert_eq!(
             data_vault.rom_cold_boot_status(),
@@ -1005,7 +1005,7 @@ fn test_upload_measurement_limit() {
         assert_eq!(pcr31.as_bytes(), expected_pcr);
 
         let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
-        let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+        let fht = FirmwareHandoffTable::try_ref_from_bytes(data.as_bytes()).unwrap();
         assert_eq!(fht.meas_log_index, MEASUREMENT_MAX_COUNT as u32);
     }
 }
@@ -1119,7 +1119,7 @@ fn test_upload_no_measurement() {
         assert_eq!(measurement_log.len(), 0);
 
         let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
-        let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+        let fht = FirmwareHandoffTable::try_ref_from_bytes(data.as_bytes()).unwrap();
         assert_eq!(fht.meas_log_index, 0);
     }
 }

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -701,7 +701,7 @@ fn test_fuse_log() {
 
     // Validate the ManifestFwSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
+    let (fuse_log_entry, _) =
         FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(
         fuse_log_entry.entry_id,
@@ -721,7 +721,7 @@ fn test_fuse_log() {
 
     // Validate the FuseFwSvn
     fuse_log_entry_offset += core::mem::size_of::<FuseLogEntry>();
-    let fuse_log_entry =
+    let (fuse_log_entry, _) =
         FuseLogEntry::ref_from_prefix(fuse_entry_arr[fuse_log_entry_offset..].as_bytes()).unwrap();
     assert_eq!(fuse_log_entry.entry_id, FuseLogEntryId::FuseFwSvn as u32);
     assert_eq!(fuse_log_entry.log_data[0], FW_FUSE_SVN);
@@ -784,7 +784,7 @@ fn test_fht_info() {
         hw.step_until_boot_status(u32::from(ColdResetComplete), true);
 
         let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
-        let fht = FirmwareHandoffTable::ref_from_prefix(data.as_bytes()).unwrap();
+        let (fht, _) = FirmwareHandoffTable::try_ref_from_prefix(data.as_bytes()).unwrap();
         // [TODO][CAP2] add mldsa equivalents
         assert_eq!(fht.ecc_ldevid_tbs_size, 552);
         assert_eq!(fht.ecc_fmcalias_tbs_size, 753);
@@ -834,7 +834,7 @@ fn test_check_rom_cold_boot_status_reg() {
         hw.step_until_boot_status(u32::from(ColdResetComplete), true);
 
         let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
-        let data_vault = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
+        let (data_vault, _) = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
 
         assert_eq!(
             data_vault.rom_cold_boot_status(),
@@ -915,7 +915,7 @@ fn test_upload_single_measurement() {
         assert_eq!(pcr31.as_bytes(), expected_pcr);
 
         let data = hw.mailbox_execute(0x1000_0003, &[]).unwrap().unwrap();
-        let fht = FirmwareHandoffTable::read_from_prefix(data.as_bytes()).unwrap();
+        let (fht, _) = FirmwareHandoffTable::try_ref_from_prefix(data.as_bytes()).unwrap();
         assert_eq!(fht.meas_log_index, 1);
     }
 }

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -9,7 +9,7 @@ use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
 use openssl::pkey::{PKey, Public};
 use openssl::x509::X509;
 use openssl::{rand::rand_bytes, x509::X509Req};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 
@@ -203,7 +203,7 @@ fn verify_key(
 
     assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
     let mut cert_resp = GetLdevCertResp::default();
-    cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Extract the certificate from the response
     let cert_der = &cert_resp.data[..(cert_resp.data_size as usize)];

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -40,7 +40,7 @@ use openssl::{
     x509::{X509Req, X509},
 };
 use std::str;
-use zerocopy::IntoBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -936,13 +936,13 @@ fn test_header_verify_vendor_lms_sig_mismatch() {
     // Modify the vendor public key.
     let lms_pub_key_backup = image_bundle.manifest.preamble.vendor_pqc_active_pub_key;
 
-    let lms_pub_key = ImageLmsPublicKey::mut_ref_from_prefix(
+    let (lms_pub_key, _) = ImageLmsPublicKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_pqc_active_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     lms_pub_key.digest = [Default::default(); 6];
@@ -967,14 +967,14 @@ fn test_header_verify_vendor_lms_sig_mismatch() {
 
     // Modify the vendor signature.
     image_bundle.manifest.preamble.vendor_pqc_active_pub_key = lms_pub_key_backup;
-    let lms_sig = ImageLmsSignature::mut_ref_from_prefix(
+    let (lms_sig, _) = ImageLmsSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     lms_sig.tree_path[0] = [Default::default(); 6];
@@ -1007,14 +1007,14 @@ fn test_header_verify_owner_lms_sig_mismatch() {
     // Modify the owner public key.
     let lms_pub_key_backup = image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key;
 
-    let lms_pub_key = ImageLmsPublicKey::mut_ref_from_prefix(
+    let (lms_pub_key, _) = ImageLmsPublicKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     lms_pub_key.digest = [Default::default(); 6];
@@ -1039,14 +1039,14 @@ fn test_header_verify_owner_lms_sig_mismatch() {
 
     // Modify the owner signature.
     image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key = lms_pub_key_backup;
-    let lms_sig = ImageLmsSignature::mut_ref_from_prefix(
+    let (lms_sig, _) = ImageLmsSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     lms_sig.tree_path[0] = [Default::default(); 6];
@@ -3045,13 +3045,13 @@ fn test_header_verify_vendor_mldsa_sig_zero() {
     // Modify the vendor public key.
     let mldsa_pub_key_backup = image_bundle.manifest.preamble.vendor_pqc_active_pub_key;
 
-    let mldsa_pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (mldsa_pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_pqc_active_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -3069,14 +3069,14 @@ fn test_header_verify_vendor_mldsa_sig_zero() {
 
     // Modify the vendor signature.
     image_bundle.manifest.preamble.vendor_pqc_active_pub_key = mldsa_pub_key_backup;
-    let mldsa_sig = ImageMldsaSignature::mut_ref_from_prefix(
+    let (mldsa_sig, _) = ImageMldsaSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     *mldsa_sig = Default::default();
@@ -3101,13 +3101,13 @@ fn test_header_verify_vendor_mldsa_sig_mismatch() {
     // Modify the vendor public key.
     let mldsa_pub_key_backup = image_bundle.manifest.preamble.vendor_pqc_active_pub_key;
 
-    let mldsa_pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (mldsa_pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_pqc_active_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -3125,14 +3125,14 @@ fn test_header_verify_vendor_mldsa_sig_mismatch() {
 
     // Modify the vendor signature.
     image_bundle.manifest.preamble.vendor_pqc_active_pub_key = mldsa_pub_key_backup;
-    let mldsa_sig = ImageMldsaSignature::mut_ref_from_prefix(
+    let (mldsa_sig, _) = ImageMldsaSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .vendor_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -3161,14 +3161,14 @@ fn test_header_verify_owner_mldsa_sig_zero() {
     // Modify the owner public key.
     let mldsa_pub_key_backup = image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key;
 
-    let mldsa_pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (mldsa_pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -3186,14 +3186,14 @@ fn test_header_verify_owner_mldsa_sig_zero() {
 
     // Modify the owner signature.
     image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key = mldsa_pub_key_backup;
-    let mldsa_sig = ImageMldsaSignature::mut_ref_from_prefix(
+    let (mldsa_sig, _) = ImageMldsaSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     *mldsa_sig = Default::default();
@@ -3218,14 +3218,14 @@ fn test_header_verify_owner_mldsa_sig_mismatch() {
     // Modify the owner public key.
     let mldsa_pub_key_backup = image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key;
 
-    let mldsa_pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (mldsa_pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -3243,14 +3243,14 @@ fn test_header_verify_owner_mldsa_sig_mismatch() {
 
     // Modify the owner signature.
     image_bundle.manifest.preamble.owner_pub_keys.pqc_pub_key = mldsa_pub_key_backup;
-    let mldsa_sig = ImageMldsaSignature::mut_ref_from_prefix(
+    let (mldsa_sig, _) = ImageMldsaSignature::mut_from_prefix(
         image_bundle
             .manifest
             .preamble
             .owner_sigs
             .pqc_sig
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -40,7 +40,7 @@ use openssl::{
     x509::{X509Req, X509},
 };
 use std::str;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 

--- a/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
@@ -4,7 +4,7 @@ use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, StashMeasurementReq};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 

--- a/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
+++ b/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
@@ -9,7 +9,7 @@ use caliptra_builder::{
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams};
 use caliptra_image_types::RomInfo;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 fn find_rom_info_offset(rom: &[u8]) -> usize {
     for i in (0..rom.len()).step_by(64).rev() {
@@ -66,7 +66,7 @@ fn test_read_rom_info_from_fmc() {
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
         let rom_info_from_image =
-            RomInfo::read_from_prefix(&rom[find_rom_info_offset(&rom)..]).unwrap();
+            RomInfo::ref_from_prefix(&rom[find_rom_info_offset(&rom)..]).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_WITH_UART,
             &APP_WITH_UART,
@@ -90,7 +90,7 @@ fn test_read_rom_info_from_fmc() {
         .unwrap();
 
         // 0x1000_0008 is test-fmc/read_rom_info()
-        let rom_info_from_fw = RomInfo::read_from(
+        let rom_info_from_fw = RomInfo::ref_from_bytes(
             hw.mailbox_execute(0x1000_0008, &[])
                 .unwrap()
                 .unwrap()

--- a/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
+++ b/rom/dev/tests/rom_integration_tests/test_rom_integrity.rs
@@ -65,7 +65,7 @@ fn test_read_rom_info_from_fmc() {
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let rom_info_from_image =
+        let (rom_info_from_image, _) =
             RomInfo::ref_from_prefix(&rom[find_rom_info_offset(&rom)..]).unwrap();
         let image_bundle = caliptra_builder::build_and_sign_image(
             &TEST_FMC_WITH_UART,
@@ -90,13 +90,8 @@ fn test_read_rom_info_from_fmc() {
         .unwrap();
 
         // 0x1000_0008 is test-fmc/read_rom_info()
-        let rom_info_from_fw = RomInfo::ref_from_bytes(
-            hw.mailbox_execute(0x1000_0008, &[])
-                .unwrap()
-                .unwrap()
-                .as_slice(),
-        )
-        .unwrap();
+        let rom_info_from_hw = hw.mailbox_execute(0x1000_0008, &[]).unwrap().unwrap();
+        let rom_info_from_fw = RomInfo::ref_from_bytes(&rom_info_from_hw).unwrap();
         assert_eq!(rom_info_from_fw.as_bytes(), rom_info_from_image.as_bytes());
     }
 }

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -20,7 +20,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams};
 use caliptra_image_fake_keys::VENDOR_CONFIG_KEY_0;
 use caliptra_image_gen::ImageGeneratorVendorConfig;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const TEST_FMC_CMD_RESET_FOR_UPDATE: u32 = 0x1000_0004;
 const TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD: u32 = 0x1000_000B;
@@ -560,7 +560,7 @@ fn test_check_rom_update_reset_status_reg() {
             hw.step_until_boot_status(UpdateResetComplete.into(), true);
 
             let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
-            let data_vault = DataVault::read_from_prefix(data_vault.as_bytes()).unwrap();
+            let data_vault = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
             assert_eq!(
                 data_vault.rom_update_reset_status(),
                 u32::from(UpdateResetComplete)

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -560,7 +560,7 @@ fn test_check_rom_update_reset_status_reg() {
             hw.step_until_boot_status(UpdateResetComplete.into(), true);
 
             let data_vault = hw.mailbox_execute(0x1000_0005, &[]).unwrap().unwrap();
-            let data_vault = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
+            let (data_vault, _) = DataVault::ref_from_prefix(data_vault.as_bytes()).unwrap();
             assert_eq!(
                 data_vault.rom_update_reset_status(),
                 u32::from(UpdateResetComplete)

--- a/rom/dev/tests/rom_integration_tests/test_version.rs
+++ b/rom/dev/tests/rom_integration_tests/test_version.rs
@@ -6,7 +6,7 @@ use caliptra_common::mailbox_api::{
     CommandId, FipsVersionResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::{Fuses, HwModel};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -28,7 +28,7 @@ fn test_version() {
         .unwrap()
         .unwrap();
 
-    let version_resp = FipsVersionResp::read_from(response.as_bytes()).unwrap();
+    let version_resp = FipsVersionResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     // Verify response checksum
     assert!(caliptra_common::checksum::verify_checksum(

--- a/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
+++ b/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
@@ -8,7 +8,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{Fuses, HwModel, ModelError};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use openssl::{hash::MessageDigest, memcmp, pkey::PKey, sign::Signer};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -53,7 +53,7 @@ fn test_get_ecc_csr() {
         .unwrap()
         .unwrap();
 
-    let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
+    let get_idv_csr_resp = GetIdevCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
 
     assert!(caliptra_common::checksum::verify_checksum(
         get_idv_csr_resp.hdr.chksum,

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -25,7 +25,7 @@ use caliptra_x509::{
     Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbsEcc384, LocalDevIdCertTbsEcc384,
 };
 use ureg::RealMmioMut;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[cfg(not(feature = "std"))]
 core::arch::global_asm!(include_str!("start.S"));

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -43,7 +43,7 @@ use dpe::{
     response::DpeErrorCode,
 };
 use memoffset::offset_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
 pub const IMAGE_NOT_AUTHORIZED: u32 = 0x21523F21; // FW ID not found in the image metadata entry collection.
@@ -54,7 +54,7 @@ impl AuthorizeAndStashCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = AuthorizeAndStashReq::read_from(cmd_args) {
+        if let Ok(cmd) = AuthorizeAndStashReq::ref_from_bytes(cmd_args) {
             if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
                 Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
             }

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -85,8 +85,9 @@ impl CertifyKeyExtendedCmd {
         };
 
         let mut dpe = &mut pdata.dpe;
-        let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..])
-            .ok_or(CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+        let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..]).or(Err(
+            CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+        ))?;
         let locality = drivers.mbox.id();
         let resp = certify_key_cmd.execute(dpe, &mut env, locality);
 

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -25,7 +25,7 @@ use dpe::{
     commands::{CertifyKeyCmd, Command, CommandExecution},
     response::Response,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::{
     CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges, MAX_CERT_CHAIN_SIZE,
@@ -36,8 +36,8 @@ pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = CertifyKeyExtendedReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = CertifyKeyExtendedReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         match drivers.caller_privilege_level() {
             // CERTIFY_KEY_EXTENDED MUST only be called from PL0
@@ -85,7 +85,7 @@ impl CertifyKeyExtendedCmd {
         };
 
         let mut dpe = &mut pdata.dpe;
-        let certify_key_cmd = CertifyKeyCmd::read_from(&cmd.certify_key_req[..])
+        let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..])
             .ok_or(CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let locality = drivers.mbox.id();
         let resp = certify_key_cmd.execute(dpe, &mut env, locality);

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -24,7 +24,7 @@ use caliptra_drivers::{
     PersistentData,
 };
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
@@ -32,7 +32,7 @@ impl IDevIdCertCmd {
     pub(crate) fn execute(cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<GetIdevCertReq>() {
             let mut cmd = GetIdevCertReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             // Validate tbs
             if cmd.tbs_size as usize > cmd.tbs.len() {

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -25,7 +25,7 @@ use caliptra_drivers::{
     Sha2_512_384, Trng,
 };
 use crypto::{AlgLen, Crypto, CryptoBuf, CryptoError, Digest, EcdsaPub, EcdsaSig, Hasher, HmacSig};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 pub struct DpeCrypto<'a> {

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -28,7 +28,7 @@ use platform::{
     MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
     MAX_SN_SIZE,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{subject_alt_name::AddSubjectAltNameCmd, MAX_CERT_CHAIN_SIZE};
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -68,7 +68,7 @@ use dpe::{
 
 use core::cmp::Ordering::{Equal, Greater};
 use crypto::{AlgLen, Crypto, CryptoBuf, Hasher};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[derive(PartialEq, Clone)]
 pub enum PauserPrivileges {

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -71,7 +71,7 @@ pub mod fips_self_test_cmd {
     use caliptra_drivers::{ResetReason, ShaAccLockState};
     use caliptra_image_types::{ImageTocEntry, RomInfo};
     use caliptra_image_verify::ImageVerifier;
-    use zerocopy::AsBytes;
+    use zerocopy::IntoBytes;
 
     // Helper function to create a slice from a memory region
     unsafe fn create_slice(toc: &ImageTocEntry) -> &'static [u8] {

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -13,14 +13,14 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use caliptra_drivers::Ecc384IdevIdCsr;
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct GetIdevCsrCmd;
 impl GetIdevCsrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Some(cmd) = GetIdevCsrReq::read_from(cmd_args) {
+        if let Some(cmd) = GetIdevCsrReq::ref_from_bytes(cmd_args) {
             let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr_envelop.ecc_csr;
 
             match csr_persistent_mem.get_csr_len() {
@@ -33,24 +33,21 @@ impl GetIdevCsrCmd {
                         .get()
                         .ok_or(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)?;
 
-                    let mut resp = GetIdevCsrResp {
-                        data_size: len,
-                        ..Default::default()
-                    };
-                    // NOTE: This code will not panic.
-                    //
-                    // csr is guranteed to be the same size as `len`, and therefore
-                    // `resp.data_size` by the `IDevIDCsr::get` API.
-                    //
-                    // A valid `IDevIDCsr` cannot be larger than `MAX_CSR_SIZE`, which is the max
-                    // size of the buffer in `GetIdevCsrResp`
-                    resp.data[..resp.data_size as usize].copy_from_slice(csr);
+                let mut resp = GetIdevCsrResp {
+                    data_size: len,
+                    ..Default::default()
+                };
+                // NOTE: This code will not panic.
+                //
+                // csr is guranteed to be the same size as `len`, and therefore
+                // `resp.data_size` by the `IDevIDCsr::get` API.
+                //
+                // A valid `IDevIDCsr` cannot be larger than `MAX_CSR_SIZE`, which is the max
+                // size of the buffer in `GetIdevIdCsrResp`
+                resp.data[..resp.data_size as usize].copy_from_slice(csr);
 
-                    Ok(MailboxResp::GetIdevCsr(resp))
-                }
+                Ok(MailboxResp::GetIdevCsr(resp))
             }
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 }

--- a/runtime/src/hmac.rs
+++ b/runtime/src/hmac.rs
@@ -20,7 +20,7 @@ use caliptra_drivers::{
     HmacKey, HmacMode, HmacTag, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
 };
 use caliptra_error::CaliptraResult;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 use crate::Drivers;

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -27,7 +27,7 @@ use dpe::{
     response::{Response, ResponseHdr},
     DpeInstance, U8Bool, MAX_HANDLES,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
@@ -36,7 +36,7 @@ impl InvokeDpeCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<InvokeDpeReq>() {
             let mut cmd = InvokeDpeReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             // Validate data length
             if cmd.data_size as usize > cmd.data.len() {
@@ -76,6 +76,11 @@ impl InvokeDpeCmd {
             };
 
             let locality = drivers.mbox.id();
+            // This check already happened, but without it the compiler believes the below slice is
+            // out of bounds.
+            if cmd.data_size as usize > cmd.data.len() {
+                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+            }
             let command = Command::deserialize(&cmd.data[..cmd.data_size as usize])
                 .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
             let flags = pdata.manifest1.header.flags;
@@ -90,7 +95,7 @@ impl InvokeDpeCmd {
                 )),
                 Command::InitCtx(cmd) => {
                     // InitCtx can only create new contexts if they are simulation contexts.
-                    if InitCtxCmd::flag_is_simulation(&cmd) {
+                    if InitCtxCmd::flag_is_simulation(cmd) {
                         dpe_context_threshold_err?;
                     }
                     cmd.execute(dpe, &mut env, locality)
@@ -99,10 +104,10 @@ impl InvokeDpeCmd {
                     // If the recursive flag is not set, DeriveContext will generate a new context.
                     // If recursive _is_ set, it will extend the existing one, which will not count
                     // against the context threshold.
-                    if !DeriveContextCmd::is_recursive(&cmd) {
+                    if !DeriveContextCmd::is_recursive(cmd) {
                         dpe_context_threshold_err?;
                     }
-                    if DeriveContextCmd::changes_locality(&cmd)
+                    if DeriveContextCmd::changes_locality(cmd)
                         && cmd.target_locality == pl0_pauser
                         && caller_privilege_level != PauserPrivileges::PL0
                     {

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use core::mem::size_of;
 use core::slice;
 
 use caliptra_drivers::{memory_layout, CaliptraResult};
@@ -20,7 +21,7 @@ use caliptra_registers::mbox::{
     enums::{MboxFsmE, MboxStatusE},
     MboxCsr,
 };
-use zerocopy::{AsBytes, LayoutVerified, Unalign};
+use zerocopy::{FromBytes, IntoBytes, Unalign};
 
 use crate::CommandId;
 
@@ -133,12 +134,12 @@ impl Mailbox {
 
     /// Copies word-aligned `buf` to the mailbox
     pub fn copy_bytes_to_mbox(&mut self, buf: &[u8]) -> CaliptraResult<()> {
-        let (buf_words, suffix) =
-            LayoutVerified::new_slice_unaligned_from_prefix(buf, buf.len() / 4).unwrap();
-        self.copy_words_to_mbox(&buf_words);
-        if !suffix.is_empty() {
+        let count = buf.len() / size_of::<u32>();
+        let (buf_words, suffix) = <[Unalign<u32>]>::ref_from_prefix_with_elems(buf, count).unwrap();
+        self.copy_words_to_mbox(buf_words);
+        if !suffix.is_empty() && suffix.len() <= size_of::<u32>() {
             let mut last_word = 0_u32;
-            last_word.as_bytes_mut()[..suffix.len()].copy_from_slice(suffix);
+            last_word.as_mut_bytes()[..suffix.len()].copy_from_slice(suffix);
             self.copy_words_to_mbox(&[Unalign::new(last_word)]);
         }
         Ok(())

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -26,8 +26,8 @@ impl IncrementPcrResetCounterCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = IncrementPcrResetCounterReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = IncrementPcrResetCounterReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let index =
             u8::try_from(cmd.index).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
@@ -48,8 +48,8 @@ impl GetPcrQuoteCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
-        let args: QuotePcrsReq = QuotePcrsReq::read_from(cmd_bytes)
-            .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let args: &QuotePcrsReq = QuotePcrsReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
         let pcr_hash = drivers.sha2_512_384.gen_pcr_hash(args.nonce.into())?;
         let signature = drivers.ecc384.pcr_sign_flow(&mut drivers.trng)?;
@@ -77,8 +77,8 @@ impl ExtendPcrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd =
-            ExtendPcrReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = ExtendPcrReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let idx =
             u8::try_from(cmd.pcr_idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -15,7 +15,7 @@ Abstract:
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{MailboxResp, PopulateIdevCertReq};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
 
@@ -25,7 +25,7 @@ impl PopulateIDevIdCertCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<PopulateIdevCertReq>() {
             let mut cmd = PopulateIdevCertReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             let cert_size = cmd.cert_size as usize;
             if cert_size > cmd.cert.len() {

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -26,7 +26,7 @@ use core::{
     cell::{Cell, RefCell},
 };
 use ureg::{Mmio, MmioMut, Uint, UintType};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub enum RecoveryFlow {}
 
@@ -43,7 +43,7 @@ impl RecoveryFlow {
 
         // // download SoC manifest
         let _soc_size_bytes = dma_recovery.download_image_to_mbox(SOC_MANIFEST_INDEX)?;
-        let Some(manifest) = AuthorizationManifest::read_from_prefix(drivers.mbox.raw_mailbox_contents()) else {
+        let Ok((manifest, _)) = AuthorizationManifest::read_from_prefix(drivers.mbox.raw_mailbox_contents()) else {
             return Err(CaliptraError::IMAGE_VERIFIER_ERR_MANIFEST_SIZE_MISMATCH);
         };
         // [TODO][CAP2]: authenticate SoC manifest using keys available through Caliptra Image

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -43,7 +43,7 @@ use dpe::{
     response::DpeErrorCode,
 };
 use memoffset::offset_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 use zeroize::Zeroize;
 
 pub struct SetAuthManifestCmd;
@@ -407,7 +407,7 @@ impl SetAuthManifestCmd {
         metadata_persistent.zeroize();
 
         // Copy the image metadata collection to the persistent data.
-        metadata_persistent.as_bytes_mut()[..buf.len()].copy_from_slice(buf);
+        metadata_persistent.as_mut_bytes()[..buf.len()].copy_from_slice(buf);
 
         Ok(())
     }
@@ -471,8 +471,8 @@ impl SetAuthManifestCmd {
         let preamble_size = size_of::<AuthManifestPreamble>();
         let auth_manifest_preamble = {
             let err = CaliptraError::RUNTIME_AUTH_MANIFEST_PREAMBLE_SIZE_LT_MIN;
-            AuthManifestPreamble::read_from(manifest_buf.get(..preamble_size).ok_or(err)?)
-                .ok_or(err)?
+            let bytes = manifest_buf.get(..preamble_size).ok_or(err)?;
+            AuthManifestPreamble::ref_from_bytes(bytes).map_err(|_| err)?
         };
 
         // Check if the preamble has the required marker.
@@ -488,7 +488,7 @@ impl SetAuthManifestCmd {
         let persistent_data = drivers.persistent_data.get_mut();
         // Verify the vendor signed data (vendor public keys + flags).
         Self::verify_vendor_signed_data(
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
@@ -498,7 +498,7 @@ impl SetAuthManifestCmd {
 
         // Verify the owner public keys.
         Self::verify_owner_pub_keys(
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
@@ -510,7 +510,7 @@ impl SetAuthManifestCmd {
             manifest_buf
                 .get(preamble_size..)
                 .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
-            &auth_manifest_preamble,
+            auth_manifest_preamble,
             &mut persistent_data.auth_manifest_image_metadata_col,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -135,9 +135,11 @@ impl SetAuthManifestCmd {
         }
 
         // Verify vendor LMS signature.
-        let vendor_fw_lms_key =
+        let (vendor_fw_lms_key, _) =
             ImageLmsPublicKey::ref_from_prefix(fw_preamble.vendor_pqc_active_pub_key.0.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_LMS_VENDOR_PUB_KEY_INVALID)?;
+                .or(Err(
+                    CaliptraError::RUNTIME_AUTH_MANIFEST_LMS_VENDOR_PUB_KEY_INVALID,
+                ))?;
 
         let candidate_key = Self::lms_verify(
             sha256,
@@ -195,9 +197,11 @@ impl SetAuthManifestCmd {
         }
 
         // Verify owner LMS signature.
-        let owner_fw_lms_key =
+        let (owner_fw_lms_key, _) =
             ImageLmsPublicKey::ref_from_prefix(fw_preamble.owner_pub_keys.pqc_pub_key.0.as_bytes())
-                .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_LMS_OWNER_PUB_KEY_INVALID)?;
+                .or(Err(
+                    CaliptraError::RUNTIME_AUTH_MANIFEST_LMS_OWNER_PUB_KEY_INVALID,
+                ))?;
 
         let candidate_key = Self::lms_verify(
             sha256,

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -25,7 +25,7 @@ use dpe::{
     dpe_instance::DpeEnv,
     response::DpeErrorCode,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
@@ -115,8 +115,8 @@ impl StashMeasurementCmd {
     }
 
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = StashMeasurementReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = StashMeasurementReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
         let dpe_result = Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement)?;
 

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -17,7 +17,7 @@ use core::str::from_utf8;
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
 
@@ -31,7 +31,7 @@ impl AddSubjectAltNameCmd {
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         if cmd_args.len() <= core::mem::size_of::<AddSubjectAltNameReq>() {
             let mut cmd = AddSubjectAltNameReq::default();
-            cmd.as_bytes_mut()[..cmd_args.len()].copy_from_slice(cmd_args);
+            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
             let dmtf_device_info_size = cmd.dmtf_device_info_size as usize;
             if dmtf_device_info_size > cmd.dmtf_device_info.len() {

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -33,8 +33,8 @@ impl TagTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd =
-            TagTciReq::read_from(cmd_args).ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = TagTciReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let pdata_mut = drivers.persistent_data.get_mut();
         let mut dpe = &mut pdata_mut.dpe;
         let mut context_has_tag = &mut pdata_mut.context_has_tag;
@@ -72,8 +72,8 @@ impl GetTaggedTciCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = GetTaggedTciReq::read_from(cmd_args)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let cmd = GetTaggedTciReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let persistent_data = drivers.persistent_data.get();
         let context_has_tag = &persistent_data.context_has_tag;
         let context_tags = &persistent_data.context_tags;

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -18,7 +18,7 @@ use caliptra_runtime::{
     RtBootStatus, TciMeasurement, U8Bool, MAX_HANDLES,
 };
 use caliptra_test_harness::{runtime_handlers, test_suite};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 const OPCODE_READ_RT_FW_JOURNEY: u32 = 0x1000_0000;
 const OPCODE_READ_MBOX_PAUSER_HASH: u32 = 0x2000_0000;
@@ -170,16 +170,22 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             CommandId(OPCODE_CORRUPT_CONTEXT_TAGS) => {
                 let input_bytes = read_request(&drivers.mbox);
 
-                let corrupted_context_tags = <[u32; MAX_HANDLES]>::read_from(input_bytes).unwrap();
+                let corrupted_context_tags =
+                    <[u32; MAX_HANDLES]>::read_from_bytes(input_bytes).unwrap();
                 drivers.persistent_data.get_mut().context_tags = corrupted_context_tags;
                 write_response(&mut drivers.mbox, &[]);
             }
             CommandId(OPCODE_CORRUPT_CONTEXT_HAS_TAG) => {
                 let input_bytes = read_request(&drivers.mbox);
 
+                // NOTE: `read_from_bytes` is not used here to avoid an alignment exception.
                 let corrupted_context_has_tag =
-                    <[U8Bool; MAX_HANDLES]>::read_from(input_bytes).unwrap();
-                drivers.persistent_data.get_mut().context_has_tag = corrupted_context_has_tag;
+                    <[U8Bool; MAX_HANDLES]>::ref_from_bytes(input_bytes).unwrap();
+                drivers
+                    .persistent_data
+                    .get_mut()
+                    .context_has_tag
+                    .clone_from_slice(corrupted_context_has_tag);
                 write_response(&mut drivers.mbox, &[]);
             }
             CommandId(OPCODE_READ_DPE_INSTANCE) => {
@@ -191,7 +197,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             CommandId(OPCODE_CORRUPT_DPE_INSTANCE) => {
                 let input_bytes = read_request(&drivers.mbox);
 
-                let corrupted_dpe = DpeInstance::read_from(input_bytes).unwrap();
+                let corrupted_dpe = DpeInstance::try_read_from_bytes(input_bytes).unwrap();
                 drivers.persistent_data.get_mut().dpe = corrupted_dpe;
                 write_response(&mut drivers.mbox, &[]);
             }

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -230,7 +230,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             // Computes a digest from the key ladder for a given target SVN.
             CommandId(OPCODE_READ_KEY_LADDER_DIGEST) => {
-                let target_svn = u32::read_from(read_request(&drivers.mbox)).unwrap();
+                let target_svn = u32::read_from_bytes(read_request(&drivers.mbox)).unwrap();
 
                 KeyLadder::derive_secret(drivers, target_svn, b"", KEY_ID_TMP)?;
 

--- a/runtime/test-fw/src/mock_rt_test_interactive.rs
+++ b/runtime/test-fw/src/mock_rt_test_interactive.rs
@@ -12,7 +12,7 @@ use caliptra_registers::pv::PvReg;
 use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc::SocIfcReg};
 use caliptra_runtime::{mailbox::Mailbox, Drivers, RtBootStatus};
 use caliptra_test_harness::{runtime_handlers, test_suite};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 const OPCODE_FW_LOAD: u32 = CommandId::FIRMWARE_LOAD.0;
 

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -36,7 +36,7 @@ use openssl::{
     x509::{X509Builder, X509},
     x509::{X509Name, X509NameBuilder},
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const TEST_LABEL: [u8; 48] = [
     48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25,
@@ -263,7 +263,7 @@ fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
     }
 }
 
-fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
+fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
     match dpe_cmd {
         Command::CertifyKey(cmd) => cmd.as_bytes(),
         Command::DeriveContext(cmd) => cmd.as_bytes(),
@@ -279,19 +279,27 @@ fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
 fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
         Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::read_from(resp_bytes).unwrap())
+            Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
         }
         Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::read_from(resp_bytes).unwrap())
+            Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::GetCertificateChain(_) => {
-            Response::GetCertificateChain(GetCertificateChainResp::read_from(resp_bytes).unwrap())
+        Command::GetCertificateChain(_) => Response::GetCertificateChain(
+            GetCertificateChainResp::read_from_bytes(resp_bytes).unwrap(),
+        ),
+        Command::DestroyCtx(_) => {
+            Response::DestroyCtx(ResponseHdr::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::DestroyCtx(_) => Response::DestroyCtx(ResponseHdr::read_from(resp_bytes).unwrap()),
-        Command::GetProfile => Response::GetProfile(GetProfileResp::read_from(resp_bytes).unwrap()),
-        Command::InitCtx(_) => Response::InitCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::RotateCtx(_) => Response::RotateCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::Sign(_) => Response::Sign(SignResp::read_from(resp_bytes).unwrap()),
+        Command::GetProfile => {
+            Response::GetProfile(GetProfileResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::InitCtx(_) => {
+            Response::InitCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::RotateCtx(_) => {
+            Response::RotateCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::Sign(_) => Response::Sign(SignResp::read_from_bytes(resp_bytes).unwrap()),
     }
 }
 
@@ -332,7 +340,7 @@ pub fn execute_dpe_cmd(
 
     assert!(resp.len() <= std::mem::size_of::<InvokeDpeResp>());
     let mut resp_hdr = InvokeDpeResp::default();
-    resp_hdr.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     assert!(caliptra_common::checksum::verify_checksum(
         resp_hdr.hdr.chksum,
@@ -343,7 +351,7 @@ pub fn execute_dpe_cmd(
     let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
     Some(match expected_result {
         DpeResult::Success => parse_dpe_response(dpe_cmd, resp_bytes),
-        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::read_from(resp_bytes).unwrap()),
+        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::read_from_bytes(resp_bytes).unwrap()),
         DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
     })
 }
@@ -377,7 +385,7 @@ pub fn get_fmc_alias_cert(model: &mut DefaultHwModel) -> GetFmcAliasCertResp {
         .unwrap();
     assert!(resp.len() <= std::mem::size_of::<GetFmcAliasCertResp>());
     let mut fmc_resp = GetFmcAliasCertResp::default();
-    fmc_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    fmc_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
     fmc_resp
 }
 
@@ -394,6 +402,6 @@ pub fn get_rt_alias_cert(model: &mut DefaultHwModel) -> GetRtAliasCertResp {
         .unwrap();
     assert!(resp.len() <= std::mem::size_of::<GetRtAliasCertResp>());
     let mut rt_resp = GetRtAliasCertResp::default();
-    rt_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    rt_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
     rt_resp
 }

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -19,8 +19,7 @@ use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use caliptra_runtime::{IMAGE_AUTHORIZED, IMAGE_NOT_AUTHORIZED};
 use sha2::{Digest, Sha384};
-use zerocopy::AsBytes;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 const IMAGE_HASH_MISMATCH: u32 = 0x8BFB95CB; // FW ID matched, but image digest mismatched.
 
@@ -109,7 +108,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::ref_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -172,7 +171,7 @@ fn test_authorize_and_stash_cmd_success() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 
     // create a new fw image with the runtime replaced by the mbox responder
@@ -231,7 +230,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -259,7 +258,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_NOT_AUTHORIZED
@@ -288,7 +287,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         authorize_and_stash_resp.auth_req_result,
         IMAGE_HASH_MISMATCH
@@ -317,7 +316,7 @@ fn test_authorize_and_stash_cmd_success_skip_auth() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -355,7 +354,7 @@ fn test_authorize_and_stash_fwid_0() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -393,7 +392,7 @@ fn test_authorize_and_stash_fwid_127() {
         .unwrap()
         .expect("We should have received a response");
 
-    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
@@ -420,7 +419,8 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
             .unwrap()
             .expect("We should have received a response");
 
-        let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+        let authorize_and_stash_resp =
+            AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
         assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
     }
 
@@ -455,7 +455,8 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
             .unwrap()
             .expect("We should have received a response");
 
-        let authorize_and_stash_resp = AuthorizeAndStashResp::read_from(resp.as_slice()).unwrap();
+        let authorize_and_stash_resp =
+            AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
         assert_eq!(
             authorize_and_stash_resp.auth_req_result,
             IMAGE_HASH_MISMATCH

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -12,7 +12,7 @@ use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{
     run_rt_test, RuntimeTestArgs, DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQC_KEY_TYPE,

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -15,7 +15,7 @@ use dpe::{
 use x509_parser::{
     certificate::X509Certificate, extensions::GeneralName, oid_registry::asn1_rs::FromDer,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs, TEST_LABEL};
 
@@ -99,9 +99,10 @@ fn test_dmtf_other_name_extension_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
 
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
@@ -151,9 +152,10 @@ fn test_dmtf_other_name_extension_not_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();
@@ -194,9 +196,10 @@ fn test_dmtf_other_name_extension_not_present() {
         )
         .unwrap()
         .expect("We should have received a response");
-    let certify_key_extended_resp = CertifyKeyExtendedResp::read_from(resp.as_slice()).unwrap();
+    let certify_key_extended_resp =
+        CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -485,7 +485,7 @@ pub fn test_all_measurement_apis() {
         };
         let resp = execute_dpe_cmd(
             &mut hw,
-            &mut Command::DeriveContext(derive_context_cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(_derive_ctx_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -31,7 +31,7 @@ use openssl::{
         store::X509StoreBuilder, verify::X509VerifyFlags, X509StoreContext, X509VerifyResult, X509,
     },
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 #[test]
 // Check if the owner and vendor cert validity dates are present in RT Alias cert
@@ -82,7 +82,7 @@ fn test_rt_cert_with_custom_dates() {
             .unwrap();
         assert!(resp.len() <= std::mem::size_of::<GetRtAliasCertResp>());
         let mut rt_resp = GetRtAliasCertResp::default();
-        rt_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+        rt_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
         let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
@@ -138,7 +138,7 @@ fn test_idev_id_cert() {
 
     assert!(resp.len() <= std::mem::size_of::<GetIdevCertResp>());
     let mut cert = GetIdevCertResp::default();
-    cert.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    cert.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     assert!(caliptra_common::checksum::verify_checksum(
         cert.hdr.chksum,
@@ -177,7 +177,7 @@ fn get_ldev_cert(model: &mut DefaultHwModel) -> GetLdevCertResp {
         .unwrap();
     assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
     let mut ldev_resp = GetLdevCertResp::default();
-    ldev_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    ldev_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
     ldev_resp
 }
 
@@ -196,7 +196,7 @@ fn test_ldev_cert() {
         .mailbox_execute(u32::from(CommandId::GET_IDEV_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let idev_resp = GetIdevInfoResp::read_from(resp.as_slice()).unwrap();
+    let idev_resp = GetIdevInfoResp::read_from_bytes(resp.as_slice()).unwrap();
 
     // Check the LDevID is signed by IDevID
     let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
@@ -266,7 +266,7 @@ fn test_dpe_leaf_cert() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -331,7 +331,7 @@ fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyResp {
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -480,7 +480,7 @@ pub fn test_all_measurement_apis() {
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::INPUT_ALLOW_CA
                 | DeriveContextFlags::INPUT_ALLOW_X509,
-            tci_type: u32::read_from(&tci_type[..]).unwrap(),
+            tci_type: u32::read_from_bytes(&tci_type[..]).unwrap(),
             target_locality: 0,
         };
         let resp = execute_dpe_cmd(

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -19,7 +19,7 @@ use openssl::{
     nid::Nid,
     x509::X509,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
     execute_dpe_cmd, get_rt_alias_cert, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST,
@@ -37,7 +37,11 @@ fn test_disable_attestation_cmd() {
         flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -55,7 +59,7 @@ fn test_disable_attestation_cmd() {
         )
         .unwrap()
         .unwrap();
-    let resp_hdr = MailboxRespHeader::read_from(resp.as_bytes()).unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
     assert_eq!(
         resp_hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -70,7 +74,7 @@ fn test_disable_attestation_cmd() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -110,7 +114,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
         )
         .unwrap()
         .unwrap();
-    let resp_hdr = MailboxRespHeader::read_from(resp.as_bytes()).unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
     assert_eq!(
         resp_hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -138,7 +142,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 
     // test that attestation is really disabled by checking that
@@ -154,7 +158,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -7,7 +7,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_hw_model::{HwModel, ShaAccMode};
 use caliptra_runtime::RtBootStatus;
-use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+use zerocopy::{FromBytes, IntoBytes};
 
 // This file includes some tests from Wycheproof to testing specific common
 // ECDSA problems.
@@ -117,7 +117,7 @@ fn ecdsa_cmd_run_wycheproof() {
                     }
                     Ok(Some(resp)) => {
                         // Verify the checksum and FIPS status
-                        let resp_hdr = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
+                        let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
                         assert_eq!(
                             resp_hdr.fips_status,
                             MailboxRespHeader::FIPS_STATUS_APPROVED
@@ -211,10 +211,7 @@ fn test_ecdsa_verify_cmd() {
         .unwrap()
         .expect("We should have received a response");
 
-    let resp_hdr: &MailboxRespHeader =
-        LayoutVerified::<&[u8], MailboxRespHeader>::new(resp.as_bytes())
-            .unwrap()
-            .into_ref();
+    let resp_hdr: &MailboxRespHeader = MailboxRespHeader::ref_from_bytes(resp.as_bytes()).unwrap();
 
     assert_eq!(
         resp_hdr.fips_status,

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -9,7 +9,7 @@ use caliptra_common::mailbox_api::{
 use caliptra_hw_model::HwModel;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::FipsVersionCmd;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const HW_REV_ID: u32 = 0x02;
 
@@ -42,7 +42,7 @@ fn test_fips_version() {
     let fips_version_bytes: &[u8] = fips_version_resp.as_bytes();
 
     // Check values against expected.
-    let fips_version = FipsVersionResp::read_from(fips_version_bytes).unwrap();
+    let fips_version = FipsVersionResp::read_from_bytes(fips_version_bytes).unwrap();
     assert!(caliptra_common::checksum::verify_checksum(
         fips_version.hdr.chksum,
         0x0,
@@ -88,7 +88,7 @@ fn test_fips_shutdown() {
         .unwrap()
         .unwrap();
 
-    let resp = MailboxRespHeader::read_from(resp.as_slice()).unwrap();
+    let resp = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
     // Verify checksum and FIPS status
     assert!(caliptra_common::checksum::verify_checksum(
         resp.chksum,

--- a/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
@@ -8,7 +8,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError};
 use caliptra_runtime::RtBootStatus;
 use openssl::x509::X509Req;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -35,7 +35,7 @@ fn test_get_ecc_csr() {
         CiRomVersion::Latest => {
             let response = result.unwrap().unwrap();
 
-            let get_idv_csr_resp = GetIdevCsrResp::read_from(response.as_bytes()).unwrap();
+            let get_idv_csr_resp = GetIdevCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
             assert_ne!(
                 Ecc384IdevIdCsr::UNPROVISIONED_CSR,
                 get_idv_csr_resp.data_size

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -102,7 +102,7 @@ fn test_fw_info() {
                 .unwrap()
                 .unwrap();
 
-            let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+            let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
 
             // Verify checksum and FIPS status
             assert!(caliptra_common::checksum::verify_checksum(

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -18,7 +18,7 @@ use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_gen::ImageGenerator;
 use caliptra_image_types::RomInfo;
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
@@ -31,8 +31,9 @@ fn find_rom_info(rom: &[u8]) -> Option<RomInfo> {
         // Check if the chunk contains non-zero data
         if chunk.iter().any(|&byte| byte != 0) {
             // Found non-zero data, return RomInfo constructed from the data
-            let rom_info = RomInfo::read_from(&rom[i..i + size_of::<RomInfo>()])?;
-            return Some(rom_info);
+            if let Ok(rom_info) = RomInfo::read_from_bytes(&rom[i..i + size_of::<RomInfo>()]) {
+                return Some(rom_info);
+            }
         }
     }
 
@@ -191,7 +192,7 @@ fn test_idev_id_info() {
         .mailbox_execute(u32::from(CommandId::GET_IDEV_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    GetIdevInfoResp::read_from(resp.as_slice()).unwrap();
+    GetIdevInfoResp::read_from_bytes(resp.as_slice()).unwrap();
 }
 
 #[test]
@@ -204,7 +205,7 @@ fn test_capabilities() {
         .mailbox_execute(u32::from(CommandId::CAPABILITIES), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let capabilities_resp = CapabilitiesResp::read_from(resp.as_slice()).unwrap();
+    let capabilities_resp = CapabilitiesResp::read_from_bytes(resp.as_slice()).unwrap();
     let capabilities = Capabilities::try_from(capabilities_resp.capabilities.as_bytes()).unwrap();
     assert!(capabilities.contains(Capabilities::RT_BASE));
 }

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -78,7 +78,7 @@ fn test_invoke_dpe_get_certificate_chain_cmd() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chain)) = resp else {
@@ -99,7 +99,11 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
         flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -112,7 +116,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -148,7 +152,11 @@ fn test_invoke_dpe_symmetric_sign() {
         flags: SignFlags::IS_SYMMETRIC,
         digest: TEST_DIGEST,
     };
-    let resp = execute_dpe_cmd(&mut model, &mut Command::Sign(sign_cmd), DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::Sign(&sign_cmd),
+        DpeResult::Success,
+    );
     let Some(Response::Sign(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
@@ -171,7 +179,7 @@ fn test_dpe_header_error_code() {
     let init_ctx_cmd = InitCtxCmd::new_use_default();
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::InitCtx(init_ctx_cmd),
+        &mut Command::InitCtx(&init_ctx_cmd),
         DpeResult::DpeCmdFailure,
     );
     let Some(Response::Error(hdr)) = resp else {
@@ -199,7 +207,7 @@ fn test_invoke_dpe_certify_key_csr() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::Success,
     );
     let Some(Response::CertifyKey(certify_key_resp)) = resp else {
@@ -266,7 +274,7 @@ fn test_invoke_dpe_rotate_context() {
 
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {
@@ -282,7 +290,7 @@ fn test_invoke_dpe_rotate_context() {
 
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_mailbox.rs
@@ -3,7 +3,7 @@
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
 use caliptra_hw_model::HwModel;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -30,7 +30,7 @@ use dpe::{
     response::Response,
     DPE_PROFILE,
 };
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 use crate::common::{
     assert_error, execute_dpe_cmd, run_rt_test, run_rt_test_pqc, DpeResult, RuntimeTestArgs,
@@ -55,7 +55,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::RotateCtx(rotate_ctx_cmd),
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::RotateCtx(rotate_ctx_resp)) = resp else {
@@ -81,7 +81,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(derive_context_cmd),
+                &mut Command::DeriveContext(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -92,7 +92,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(derive_context_cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -155,7 +155,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
             if i == num_iterations - 1 {
                 let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(derive_context_cmd),
+                &mut Command::DeriveContext(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -193,7 +193,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::InitCtx(init_ctx_cmd),
+                &mut Command::InitCtx(&init_ctx_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -204,7 +204,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::InitCtx(init_ctx_cmd),
+            &mut Command::InitCtx(&init_ctx_cmd),
             DpeResult::Success,
         );
         let Some(Response::InitCtx(_)) = resp else {
@@ -243,7 +243,7 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
             if i == num_iterations - 1 {
                 let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::InitCtx(init_ctx_cmd),
+                &mut Command::InitCtx(&init_ctx_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -648,7 +648,7 @@ fn test_pl0_unset_in_header() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(certify_key_cmd),
+        &mut Command::CertifyKey(&certify_key_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
     assert!(resp.is_none());

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -128,7 +128,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
         let init_ctx_cmd = InitCtxCmd::new_simulation();
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::InitCtx(init_ctx_cmd),
+            &mut Command::InitCtx(&init_ctx_cmd),
             DpeResult::Success,
         );
         let Some(Response::InitCtx(init_ctx_resp)) = resp else {
@@ -166,7 +166,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
 
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(derive_context_cmd),
+                &mut Command::DeriveContext(&derive_context_cmd),
                 DpeResult::Success,
             );
             let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -254,7 +254,7 @@ fn test_pl1_init_ctx_dpe_context_thresholds() {
 
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::InitCtx(init_ctx_cmd),
+                &mut Command::InitCtx(&init_ctx_cmd),
                 DpeResult::Success,
             );
             let Some(Response::InitCtx(_)) = resp else {
@@ -364,7 +364,7 @@ fn test_certify_key_x509_cannot_be_called_from_pl1() {
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::CertifyKey(certify_key_cmd),
+            &mut Command::CertifyKey(&certify_key_cmd),
             DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
         );
         assert!(resp.is_none());
@@ -436,7 +436,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
         let init_ctx_cmd = InitCtxCmd::new_simulation();
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::InitCtx(init_ctx_cmd),
+            &mut Command::InitCtx(&init_ctx_cmd),
             DpeResult::Success,
         );
         let Some(Response::InitCtx(init_ctx_resp)) = resp else {
@@ -452,7 +452,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(derive_context_cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::MboxCmdFailure(
                 caliptra_drivers::CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
             ),
@@ -700,7 +700,7 @@ fn test_user_not_pl0() {
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::CertifyKey(certify_key_cmd),
+            &mut Command::CertifyKey(&certify_key_cmd),
             DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
         );
         assert!(resp.is_none());

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -16,7 +16,7 @@ use openssl::{
     hash::{Hasher, MessageDigest},
     x509::X509,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 #[test]
 fn test_pcr_quote() {
@@ -51,7 +51,7 @@ fn test_pcr_quote() {
         .unwrap()
         .unwrap();
 
-    let resp = QuotePcrsResp::read_from(resp.as_slice()).unwrap();
+    let resp = QuotePcrsResp::read_from_bytes(resp.as_slice()).unwrap();
 
     // Compute the digest and compare to mailbox result
     let mut h = Hasher::new(MessageDigest::sha384()).unwrap();
@@ -100,7 +100,9 @@ pub fn get_model_pcrs(model: &mut DefaultHwModel) -> [[u8; 48]; 32] {
         .unwrap()
         .unwrap();
 
-    return QuotePcrsResp::read_from(resp.as_slice()).unwrap().pcrs;
+    return QuotePcrsResp::read_from_bytes(resp.as_slice())
+        .unwrap()
+        .pcrs;
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_populate_idev.rs
+++ b/runtime/tests/runtime_integration_tests/test_populate_idev.rs
@@ -27,7 +27,7 @@ fn get_full_cert_chain(model: &mut DefaultHwModel, out: &mut [u8; 4096]) -> usiz
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chunk_1)) = resp else {
@@ -43,7 +43,7 @@ fn get_full_cert_chain(model: &mut DefaultHwModel, out: &mut [u8; 4096]) -> usiz
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::GetCertificateChain(get_cert_chain_cmd),
+        &mut Command::GetCertificateChain(&get_cert_chain_cmd),
         DpeResult::Success,
     );
     let Some(Response::GetCertificateChain(cert_chunk_2)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -18,7 +18,7 @@ use caliptra_hw_model::HwModel;
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_fake_keys::*;
 use caliptra_runtime::RtBootStatus;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub fn create_auth_manifest(manifest_flags: AuthManifestFlags) -> AuthorizationManifest {
     let vendor_fw_key_info: AuthManifestGeneratorKeyConfig = AuthManifestGeneratorKeyConfig {

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -12,7 +12,7 @@ use caliptra_hw_model::HwModel;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
-use zerocopy::{AsBytes, LayoutVerified};
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -51,9 +51,7 @@ fn test_stash_measurement() {
         .expect("We should have received a response");
 
     let resp_hdr: &StashMeasurementResp =
-        LayoutVerified::<&[u8], StashMeasurementResp>::new(resp.as_bytes())
-            .unwrap()
-            .into_ref();
+        StashMeasurementResp::ref_from_bytes(resp.as_bytes()).unwrap();
 
     assert_eq!(resp_hdr.dpe_result, 0);
 

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -47,7 +47,7 @@ fn test_tagging_default_context() {
         )
         .unwrap()
         .expect("We expected a response");
-    let _ = GetTaggedTciResp::read_from(resp.as_slice()).unwrap();
+    let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn test_tagging_destroyed_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DestroyCtx(destroy_ctx_cmd),
+        &mut Command::DestroyCtx(&destroy_ctx_cmd),
         DpeResult::Success,
     );
     let Some(Response::DestroyCtx(_)) = resp else {
@@ -222,7 +222,7 @@ fn test_tagging_retired_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(derive_context_cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -268,7 +268,7 @@ fn test_tagging_retired_context() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(derive_context_cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(_)) = resp else {
@@ -288,5 +288,5 @@ fn test_tagging_retired_context() {
         )
         .unwrap()
         .expect("We expected a response");
-    let _ = GetTaggedTciResp::read_from(resp.as_slice()).unwrap();
+    let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
 }

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -27,7 +27,7 @@ use dpe::{
     validation::ValidationError,
     DpeInstance, U8Bool, DPE_PROFILE, MAX_HANDLES,
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -194,7 +194,7 @@ fn test_dpe_validation_deformed_structure() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating multiple normal connected components
     dpe.contexts[0].children = 0;
@@ -230,7 +230,7 @@ fn test_dpe_validation_deformed_structure() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 
@@ -249,7 +249,7 @@ fn test_dpe_validation_illegal_state() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE state by messing up parent-child links
     dpe.contexts[1].children = 0b1;
@@ -283,7 +283,7 @@ fn test_dpe_validation_illegal_state() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 
@@ -302,7 +302,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::read_from(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating PL0_DPE_ACTIVE_CONTEXT_THRESHOLD contexts
     let pl0_pauser = ImageOptions::default().vendor_config.pl0_pauser.unwrap();
@@ -342,7 +342,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
         .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
         .unwrap()
         .unwrap();
-    let info = FwInfoResp::read_from(resp.as_slice()).unwrap();
+    let info = FwInfoResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(info.attestation_disabled, 1);
 }
 

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::registers::InMemoryRegister;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 register_bitfields! [
     u32,
@@ -670,7 +670,7 @@ impl HashSha512Regs {
         self.sha512.update_bytes(self.pcr_gen_hash_nonce.as_bytes());
         self.sha512
             .finalize((PCR_COUNT * PCR_SIZE + NONCE_SIZE).try_into().unwrap());
-        self.sha512.copy_hash(self.pcr_hash_digest.as_bytes_mut());
+        self.sha512.copy_hash(self.pcr_hash_digest.as_mut_bytes());
 
         self.pcr_hash_status
             .reg

--- a/sw-emulator/lib/periph/src/hmac.rs
+++ b/sw-emulator/lib/periph/src/hmac.rs
@@ -22,7 +22,7 @@ use caliptra_emu_types::{RvData, RvSize};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::registers::InMemoryRegister;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 register_bitfields! [
     u32,
@@ -535,7 +535,7 @@ impl HmacSha {
     fn op_complete(&mut self) {
         // Retrieve the tag
         let key_len = self.key_len();
-        self.hmac.tag(self.tag[..key_len].as_bytes_mut());
+        self.hmac.tag(self.tag[..key_len].as_mut_bytes());
         // Don't reveal the tag to the CPU if the inputs came from the
         // key-vault.
         self.hide_tag_from_cpu = self.block_from_kv || self.key_from_kv;
@@ -587,7 +587,7 @@ impl HmacSha {
             // key from the KV slot even though the actual key might be shorter.
             // Peripherals using the key material will size it appropriately.
             self.key[..HMAC_KEY_SIZE_DWORD_512]
-                .as_bytes_mut()
+                .as_mut_bytes()
                 .copy_from_slice(key.as_bytes());
         }
 
@@ -653,7 +653,7 @@ impl HmacSha {
         block_arr[HMAC_BLOCK_SIZE - 16..].copy_from_slice(&len.to_be_bytes());
 
         block_arr.to_big_endian();
-        self.block.as_bytes_mut().copy_from_slice(&block_arr);
+        self.block.as_mut_bytes().copy_from_slice(&block_arr);
     }
 
     fn tag_write_complete(&mut self) {

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -10,7 +10,7 @@ use openssl::{
     pkey::{PKey, Public},
     sha::{sha256, sha384},
 };
-use zerocopy::{transmute, AsBytes};
+use zerocopy::{transmute, IntoBytes};
 
 #[cfg(test)]
 use caliptra_api_types::DeviceLifecycle;
@@ -100,7 +100,7 @@ impl DoeOutput {
 
         result
             .uds
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&aes256_decrypt_blocks(
                 swap_word_bytes(&input.doe_obf_key).as_bytes(),
                 swap_word_bytes(&input.doe_iv).as_bytes(),
@@ -109,7 +109,7 @@ impl DoeOutput {
         swap_word_bytes_inplace(&mut result.uds);
 
         result.field_entropy[0..8]
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&aes256_decrypt_blocks(
                 swap_word_bytes(&input.doe_obf_key).as_bytes(),
                 swap_word_bytes(&input.doe_iv).as_bytes(),
@@ -472,7 +472,7 @@ impl RtAliasKey {
         let mut tci: [u8; 96] = [0; 96];
         tci[0..48].copy_from_slice(swap_word_bytes(&tci_input.runtime_digest).as_bytes());
         tci[48..96]
-            .as_bytes_mut()
+            .as_mut_bytes()
             .copy_from_slice(&sha384(tci_input.manifest.as_bytes()));
 
         let mut cdi: [u32; 16] = transmute!(hmac512_kdf(

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -6,7 +6,7 @@ use caliptra_builder::{
     FwId, ImageOptions,
 };
 use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams};
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 pub mod crypto;
 pub mod derive;

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -18,7 +18,7 @@ use caliptra_test::{
 };
 use openssl::sha::sha384;
 use std::io::Write;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
@@ -109,7 +109,7 @@ fn fake_boot_test() {
 
     assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
     let mut ldev_cert_resp = GetLdevCertResp::default();
-    ldev_cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    ldev_cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Verify checksum and FIPS approval
     assert!(caliptra_common::checksum::verify_checksum(
@@ -175,7 +175,7 @@ fn fake_boot_test() {
 
     assert!(resp.len() <= std::mem::size_of::<GetFmcAliasCertResp>());
     let mut fmc_alias_cert_resp = GetFmcAliasCertResp::default();
-    fmc_alias_cert_resp.as_bytes_mut()[..resp.len()].copy_from_slice(&resp);
+    fmc_alias_cert_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
 
     // Verify checksum and FIPS approval
     assert!(caliptra_common::checksum::verify_checksum(

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -25,7 +25,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use regex::Regex;
 use std::mem;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -25,7 +25,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use regex::Regex;
 use std::mem;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{IntoBytes, TryFromBytes};
 
 pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,
@@ -97,8 +97,8 @@ fn retrieve_csr_test() {
     .unwrap();
 
     let mut txn = hw.wait_for_mailbox_receive().unwrap();
-    let csr_envelop =
-        InitDevIdCsrEnvelope::read_from_prefix(&*mem::take(&mut txn.req.data)).unwrap();
+    let (csr_envelop, _) =
+        InitDevIdCsrEnvelope::try_read_from_prefix(&mem::take(&mut txn.req.data)).unwrap();
     txn.respond_success();
 
     let ecc_csr_der = &csr_envelop.ecc_csr.csr[..csr_envelop.ecc_csr.csr_len as usize];

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -14,7 +14,7 @@ use dpe::{
         Response, ResponseHdr, SignResp,
     },
 };
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,
@@ -236,7 +236,7 @@ pub fn fips_test_init_to_rt(
     // HW model will complete FW upload cmd, nothing to wait for
 }
 
-pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
+pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + IntoBytes>(
     hw: &mut T,
     cmd: u32,
     req_payload: &[u8],
@@ -244,9 +244,10 @@ pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
     let resp_bytes = hw.mailbox_execute(cmd, req_payload)?.unwrap();
 
     // Check values against expected.
-    let resp_hdr =
-        MailboxRespHeader::read_from(&resp_bytes[..core::mem::size_of::<MailboxRespHeader>()])
-            .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(
+        &resp_bytes[..core::mem::size_of::<MailboxRespHeader>()],
+    )
+    .unwrap();
     assert!(caliptra_common::checksum::verify_checksum(
         resp_hdr.chksum,
         0x0,
@@ -260,11 +261,11 @@ pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + AsBytes>(
     // Handle variable-sized responses
     assert!(resp_bytes.len() <= std::mem::size_of::<U>());
     let mut typed_resp = U::new_zeroed();
-    typed_resp.as_bytes_mut()[..resp_bytes.len()].copy_from_slice(&resp_bytes);
+    typed_resp.as_mut_bytes()[..resp_bytes.len()].copy_from_slice(&resp_bytes);
     Ok(typed_resp)
 
     // TODO: Add option for fixed-length enforcement
-    //Ok(U::read_from(resp_bytes.as_bytes()).unwrap())
+    //Ok(U::read_from_bytes(resp_bytes.as_bytes()).unwrap())
 }
 
 fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
@@ -279,7 +280,7 @@ fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
         Command::GetCertificateChain(_) => Command::GET_CERTIFICATE_CHAIN,
     }
 }
-pub fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
+pub fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
     match dpe_cmd {
         Command::CertifyKey(cmd) => cmd.as_bytes(),
         Command::DeriveContext(cmd) => cmd.as_bytes(),
@@ -295,19 +296,27 @@ pub fn as_bytes(dpe_cmd: &mut Command) -> &[u8] {
 pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
         Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::read_from(resp_bytes).unwrap())
+            Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
         }
         Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::read_from(resp_bytes).unwrap())
+            Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::GetCertificateChain(_) => {
-            Response::GetCertificateChain(GetCertificateChainResp::read_from(resp_bytes).unwrap())
+        Command::GetCertificateChain(_) => Response::GetCertificateChain(
+            GetCertificateChainResp::read_from_bytes(resp_bytes).unwrap(),
+        ),
+        Command::DestroyCtx(_) => {
+            Response::DestroyCtx(ResponseHdr::read_from_bytes(resp_bytes).unwrap())
         }
-        Command::DestroyCtx(_) => Response::DestroyCtx(ResponseHdr::read_from(resp_bytes).unwrap()),
-        Command::GetProfile => Response::GetProfile(GetProfileResp::read_from(resp_bytes).unwrap()),
-        Command::InitCtx(_) => Response::InitCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::RotateCtx(_) => Response::RotateCtx(NewHandleResp::read_from(resp_bytes).unwrap()),
-        Command::Sign(_) => Response::Sign(SignResp::read_from(resp_bytes).unwrap()),
+        Command::GetProfile => {
+            Response::GetProfile(GetProfileResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::InitCtx(_) => {
+            Response::InitCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::RotateCtx(_) => {
+            Response::RotateCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+        }
+        Command::Sign(_) => Response::Sign(SignResp::read_from_bytes(resp_bytes).unwrap()),
     }
 }
 

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -23,7 +23,7 @@ use caliptra_image_types::{
 use caliptra_test::image_pk_desc_hash;
 
 use common::*;
-use zerocopy::IntoBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 #[allow(dead_code)]
 #[derive(PartialEq, Eq)]
@@ -1380,13 +1380,13 @@ fn fw_load_error_vendor_lms_signature_invalid() {
     let mut fw_image = build_fw_image(image_options);
 
     // Get a mutable reference to the LMS public key.
-    let lms_pub_key = ImageLmsPublicKey::mut_ref_from_prefix(
+    let (lms_pub_key, _) = ImageLmsPublicKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .vendor_pqc_active_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -1411,13 +1411,13 @@ fn fw_load_error_vendor_mldsa_signature_invalid() {
     let mut fw_image = build_fw_image(image_options);
 
     // Get a mutable reference to the public key.
-    let pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .vendor_pqc_active_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -1488,14 +1488,14 @@ fn fw_load_error_owner_lms_signature_invalid() {
     let mut fw_image = build_fw_image(image_options);
 
     // Get a mutable reference to the LMS public key.
-    let lms_pub_key = ImageLmsPublicKey::mut_ref_from_prefix(
+    let (lms_pub_key, _) = ImageLmsPublicKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -1520,14 +1520,14 @@ fn fw_load_error_owner_mldsa_signature_invalid() {
     let mut fw_image = build_fw_image(image_options);
 
     // Get a mutable reference to the public key.
-    let pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
 
@@ -1859,14 +1859,14 @@ fn fw_load_bad_owner_lms_pub_key() {
     let mut fw_image = build_fw_image(image_options);
 
     // Modify the pub key
-    let lms_pub_key = ImageLmsPublicKey::mut_ref_from_prefix(
+    let (lms_pub_key, _) = ImageLmsPublicKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     lms_pub_key.digest[0] = 0xDEADBEEF.into();
@@ -1886,14 +1886,14 @@ fn fw_load_bad_owner_mldsa_pub_key() {
     let mut fw_image = build_fw_image(image_options);
 
     // Modify the pub key
-    let pub_key = ImageMldsaPubKey::mut_ref_from_prefix(
+    let (pub_key, _) = ImageMldsaPubKey::mut_from_prefix(
         fw_image
             .manifest
             .preamble
             .owner_pub_keys
             .pqc_pub_key
             .0
-            .as_bytes_mut(),
+            .as_mut_bytes(),
     )
     .unwrap();
     *pub_key = ImageMldsaPubKey([0xDEADBEEF; MLDSA87_PUB_KEY_WORD_SIZE]);

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -23,7 +23,7 @@ use caliptra_image_types::{
 use caliptra_test::image_pk_desc_hash;
 
 use common::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[allow(dead_code)]
 #[derive(PartialEq, Eq)]

--- a/test/tests/fips_test_suite/security_parameters.rs
+++ b/test/tests/fips_test_suite/security_parameters.rs
@@ -157,7 +157,7 @@ pub fn attempt_ssp_access_fw_load() {
     let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_FIPS_TEST_HOOKS).unwrap();
 
     let fw_image = fips_fw_image();
-    let manifest = ImageManifest::read_from_prefix(&*fw_image).unwrap();
+    let (manifest, _) = ImageManifest::read_from_prefix(&fw_image).unwrap();
 
     let gen = ImageGenerator::new(Crypto::default());
     let vendor_pubkey_digest = gen.vendor_pubkey_digest(&manifest.preamble).unwrap();
@@ -208,7 +208,7 @@ pub fn attempt_ssp_access_fw_load() {
 #[test]
 pub fn attempt_ssp_access_rt() {
     let fw_image = fips_fw_image();
-    let manifest = ImageManifest::read_from_prefix(&*fw_image).unwrap();
+    let (manifest, _) = ImageManifest::read_from_prefix(&fw_image).unwrap();
 
     let gen = ImageGenerator::new(Crypto::default());
     let vendor_pubkey_digest = gen.vendor_pubkey_digest(&manifest.preamble).unwrap();

--- a/test/tests/fips_test_suite/self_tests.rs
+++ b/test/tests/fips_test_suite/self_tests.rs
@@ -12,7 +12,7 @@ use caliptra_drivers::CaliptraError;
 use caliptra_drivers::FipsTestHook;
 use caliptra_hw_model::{BootParams, HwModel, InitParams, ModelError, ShaAccMode};
 use common::*;
-use zerocopy::AsBytes;
+use zerocopy::IntoBytes;
 
 #[test]
 #[cfg(not(feature = "test_env_immutable_rom"))]


### PR DESCRIPTION
This is a cherry-pick of https://github.com/chipsalliance/caliptra-sw/pull/1765 along with fixups for the new functionality in 2.x.

Original description:

Update zerocopy from 0.6.6 to 0.8.8.
    
This PR does not optimize out a large portion of copies. Ideally it will
be done in follow up PRs.
    
There are portions of code that are slightly modified to keep panics out
of the final binary.