### PR TITLE
rom: csrng driver should not check ack flag

### DIFF
--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -347,7 +347,9 @@ fn send_command(csrng: &mut CsrngReg, command: Command) -> CaliptraResult<()> {
             return Err(err);
         }
 
-        if reg.cmd_rdy() && reg.cmd_ack() {
+        // TODO: if the hardware is fixed to make the ack flag sticky, we should
+        // check that as well before exiting the loop.
+        if reg.cmd_rdy() {
             return Ok(());
         }
     }


### PR DESCRIPTION
The ack flag is used to indicate that a command has been processed, and is set for only [a single clock
cycle](https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-response). The hardware register does not seem to persist that ack flag for any longer, so we are all but guaranteed to only ever see that flag as false.

This disables checking the ack flag for now.