### PR TITLE
Add jhand2 to CODEOWNERS for libcaliptra

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,4 +10,4 @@
 /fmc/ @FerralCoder @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims
 /runtime/ @jhand2 @fdamato @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims
 /hw-model/ @korran @fdamato @jlmahowa-amd @mhatrevi @jhand2 @swenson @vsonims
-/libcaliptra/ @fdamato @wmaroneAMD @JohnTraverAmd @jlmahowa-amd @korran @mhatrevi @swenson @vsonims @nquarton
+/libcaliptra/ @fdamato @wmaroneAMD @JohnTraverAmd @jlmahowa-amd @korran @mhatrevi @swenson @vsonims @nquarton @jhand2


### PR DESCRIPTION
Google has been making many recent improvements to libcaliptra. Add jhand2 to CODEOWNERS for that directory to streamline code review.