### PR TITLE
Add libcaliptra APIs to check if ready for certain boot milestones.

### DIFF
--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -41,14 +41,32 @@ bool caliptra_ready_for_fuses(void);
 int caliptra_init_fuses(const struct caliptra_fuses *fuses);
 
 /**
+ * caliptra_is_ready_for_firmware
+ *
+ * Checks if Caliptra hardware is ready for firmware upload
+ *
+ * @return bool True if ready, false otherwise
+ */
+uint32_t caliptra_is_ready_for_firmware(void);
+
+/**
  * caliptra_ready_for_firmware
  *
  * Waits until Caliptra hardware is ready for firmware upload or until
  * Caliptra reports an error
  *
- * @return bool True if ready, false otherwise
+ * @return int 0 if ready, Caliptra error otherwise
  */
 uint32_t caliptra_ready_for_firmware(void);
+
+/**
+ * caliptra_is_ready_for_runtime
+ *
+ * Checks if Caliptra hardware is ready for runtime commands
+ *
+ * @return bool True if ready, false otherwise
+ */
+uint32_t caliptra_is_ready_for_runtime(void);
 
 /**
  * caliptra_ready_for_runtime

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -325,29 +325,40 @@ uint32_t caliptra_read_fw_fatal_error()
 }
 
 /**
+ * caliptra_is_ready_for_firmware
+ *
+ * Checks if Caliptra hardware is ready for firmware upload
+ *
+ * @return bool True if ready, false otherwise
+ */
+uint32_t caliptra_is_ready_for_firmware(void)
+{
+    uint32_t status = caliptra_read_status();
+    return (status & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FW_MASK) == GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FW_MASK;
+}
+
+/**
  * caliptra_ready_for_firmware
  *
  * Waits until Caliptra hardware is ready for firmware upload or until
  * Caliptra reports an error
  *
- * @return bool True if ready, false otherwise
+ * @return int 0 if ready, Caliptra error otherwise
  */
 uint32_t caliptra_ready_for_firmware(void)
 {
-    uint32_t status;
     uint32_t fatal_error;
     bool ready = false;
 
     do
     {
-        status = caliptra_read_status();
         fatal_error = caliptra_read_fw_fatal_error();
 
         if (fatal_error != 0)
         {
             return fatal_error;
         }
-        else if ((status & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FW_MASK) == GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_FW_MASK)
+        else if (caliptra_is_ready_for_firmware())
         {
             ready = true;
         }
@@ -361,6 +372,19 @@ uint32_t caliptra_ready_for_firmware(void)
 }
 
 /**
+ * caliptra_is_ready_for_runtime
+ *
+ * Checks if Caliptra hardware is ready for runtime commands
+ *
+ * @return bool True if ready, false otherwise
+ */
+uint32_t caliptra_is_ready_for_runtime(void)
+{
+    uint32_t status = caliptra_read_status();
+    return (status & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK) == GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK;
+}
+
+/**
  * caliptra_ready_for_runtime
  *
  * Waits until Caliptra hardware is ready for runtime commands or until
@@ -370,20 +394,18 @@ uint32_t caliptra_ready_for_firmware(void)
  */
 uint32_t caliptra_ready_for_runtime(void)
 {
-    uint32_t status;
     uint32_t fatal_error;
     bool ready = false;
 
     do
     {
-        status = caliptra_read_status();
         fatal_error = caliptra_read_fw_fatal_error();
 
         if (fatal_error != 0)
         {
             return fatal_error;
         }
-        else if ((status & GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK) == GENERIC_AND_FUSE_REG_CPTRA_FLOW_STATUS_READY_FOR_RUNTIME_MASK)
+        else if (caliptra_is_ready_for_runtime())
         {
             ready = true;
         }


### PR DESCRIPTION
Previously the only APIs blocked until it reached those milestones. Now they can be checked asynchronously. This is also how `caliptra_is_csr_ready` works.