### PR TITLE
Update to the latest zerocopy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,18 +2972,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.8"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.8"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
 wycheproof = "0.5.1"
 x509-parser = "0.15.0"
-zerocopy = { version = "0.8.8", features = ["derive"] }
+zerocopy = { version = "0.8.17", features = ["derive"] }
 serial_test = "2.0.0"
 nix = "0.26.2"
 libc = "0.2"

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -472,7 +472,7 @@ pub struct GetIdevInfoResp {
 #[repr(C)]
 #[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetLdevCertReq {
-    header: MailboxReqHeader,
+    pub header: MailboxReqHeader,
 }
 
 impl Request for GetLdevCertReq {
@@ -506,7 +506,7 @@ impl Default for GetLdevCertResp {
 #[repr(C)]
 #[derive(Default, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetRtAliasCertReq {
-    header: MailboxReqHeader,
+    pub header: MailboxReqHeader,
 }
 impl Request for GetRtAliasCertReq {
     const ID: CommandId = CommandId::GET_RT_ALIAS_CERT;
@@ -734,7 +734,7 @@ impl Default for InvokeDpeResp {
 #[repr(C)]
 #[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetFmcAliasCertReq {
-    header: MailboxReqHeader,
+    pub header: MailboxReqHeader,
 }
 impl Request for GetFmcAliasCertReq {
     const ID: CommandId = CommandId::GET_FMC_ALIAS_CERT;

--- a/drivers/src/pcr_reset.rs
+++ b/drivers/src/pcr_reset.rs
@@ -19,7 +19,7 @@ use zeroize::Zeroize;
 #[repr(C, align(4))]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Zeroize)]
 pub struct PcrResetCounter {
-    counter: [u32; PcrBank::ALL_PCR_IDS.len()],
+    pub counter: [u32; PcrBank::ALL_PCR_IDS.len()],
 }
 
 impl Default for PcrResetCounter {

--- a/image/gen/src/generator.rs
+++ b/image/gen/src/generator.rs
@@ -245,12 +245,12 @@ impl<Crypto: ImageGeneratorCrypto> ImageGenerator<Crypto> {
     where
         E: ImageGenratorExecutable,
     {
-        let r#type = ImageTocEntryType::Executable;
+        let image_type = ImageTocEntryType::Executable;
         let digest = self.crypto.sha384_digest(image.content())?;
 
         let entry = ImageTocEntry {
             id: id.into(),
-            r#type: r#type.into(),
+            image_type: image_type.into(),
             revision: *image.rev(),
             version: image.version(),
             svn: image.svn(),

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -304,7 +304,7 @@ pub struct VendorSignedData {
     /// Vendor End Date [ASN1 Time Format] For FMC alias certificate.
     pub vendor_not_after: [u8; 15],
 
-    reserved: [u8; 10],
+    pub reserved: [u8; 10],
 }
 
 #[repr(C)]
@@ -320,7 +320,7 @@ pub struct OwnerSignedData {
     /// Owner epoch, used to diversify stable SVN keys.
     pub epoch: [u8; 2],
 
-    reserved: [u8; 8],
+    pub reserved: [u8; 8],
 }
 
 /// Caliptra Image header
@@ -396,7 +396,7 @@ pub struct ImageTocEntry {
     pub id: u32,
 
     /// Type
-    pub r#type: u32,
+    pub image_type: u32,
 
     /// Commit revision
     pub revision: ImageRevision,


### PR DESCRIPTION
Zerocopy's derive macro for KnownLayout has changed. Compiling in caliptra-sw fails because public interfaces are leaking these private types.

The solution is to mark them as a public field. There may be another workaround, but since these types are being serialized to and from raw bytes, it makes sense that these private fields should be visible to callers.
