### PR TITLE
Put CFI behind a feature flag in caliptra-lms-types and caliptra-image-types.

### DIFF
--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -23,3 +23,4 @@ zeroize.workspace = true
 [features]
 default = ["std"]
 std = ["dep:serde", "dep:serde_derive", "caliptra-lms-types/std"]
+no-cfi = ["caliptra-lms-types/no-cfi"]

--- a/lms-types/Cargo.toml
+++ b/lms-types/Cargo.toml
@@ -19,3 +19,4 @@ zeroize.workspace = true
 [features]
 default = []
 std = ["dep:serde", "dep:serde_derive"]
+no-cfi = []

--- a/lms-types/src/lib.rs
+++ b/lms-types/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(all(not(feature = "std"), not(test), not(fuzzing)), no_std)]
 
+#[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::Launder;
 use core::mem::size_of;
 #[cfg(feature = "std")]
@@ -114,10 +115,9 @@ impl<'de> Deserialize<'de> for LmotsAlgorithmType {
     }
 }
 
-#[derive(
-    Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Launder,
-)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(not(feature = "no-cfi"), derive(Launder))]
 #[repr(C)]
 pub struct LmsPublicKey<const N: usize> {
     pub tree_type: LmsAlgorithmType,
@@ -287,10 +287,9 @@ static_assert!(
             + size_of::<[[U32<LittleEndian>; 1]; 1]>())
 );
 
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(
-    Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq, Launder,
-)]
+#[cfg_attr(not(feature = "no-cfi"), derive(Launder))]
 #[repr(C)]
 pub struct LmsSignature<const N: usize, const P: usize, const H: usize> {
     pub q: U32<BigEndian>,


### PR DESCRIPTION
This makes it possible to build these crates without cfi.
