### PR TITLE
Respect the no-cfi feature in the drivers crate.

### DIFF
--- a/drivers/src/array.rs
+++ b/drivers/src/array.rs
@@ -13,6 +13,7 @@ Abstract:
 
 --*/
 
+#[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::Launder;
 use core::mem::MaybeUninit;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -28,18 +29,9 @@ macro_rules! static_assert {
 /// cryptographic hardware, and provides From traits for converting to/from byte arrays.
 #[repr(transparent)]
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    IntoBytes,
-    FromBytes,
-    Immutable,
-    KnownLayout,
-    PartialEq,
-    Eq,
-    Launder,
-    Zeroize,
+    Debug, Clone, Copy, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Zeroize,
 )]
+#[cfg_attr(not(feature = "no-cfi"), derive(Launder))]
 pub struct Array4xN<const W: usize, const B: usize>(pub [u32; W]);
 impl<const W: usize, const B: usize> Array4xN<W, B> {
     pub const fn new(val: [u32; W]) -> Self {

--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -515,10 +515,11 @@ impl Ecc384 {
         let sig = okmutref(&mut sig_result)?;
 
         // Verify the signature just created
-        let r = self.verify_r(pub_key, data, sig)?;
+        let _r = self.verify_r(pub_key, data, sig)?;
         // Not using standard error flow here for increased CFI safety
         // An error here will end up reporting the CFI assert failure
-        caliptra_cfi_lib::cfi_assert_eq_12_words(&r.0, &sig.r.0);
+        #[cfg(not(feature = "no-cfi"))]
+        caliptra_cfi_lib::cfi_assert_eq_12_words(&_r.0, &sig.r.0);
 
         #[cfg(feature = "fips-test-hooks")]
         let sig_result = Ok(unsafe {
@@ -558,6 +559,7 @@ impl Ecc384 {
 
         // compare the hardware generate `r` with one in signature
         let result = if verify_r == signature.r {
+            #[cfg(not(feature = "no-cfi"))]
             caliptra_cfi_lib::cfi_assert_eq_12_words(&verify_r.0, &signature.r.0);
             Ecc384Result::Success
         } else {

--- a/drivers/src/fuse_bank.rs
+++ b/drivers/src/fuse_bank.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 use crate::Array4x12;
+#[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::Launder;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use zerocopy::IntoBytes;
@@ -34,7 +35,8 @@ pub enum X509KeyIdAlgo {
 }
 
 bitflags::bitflags! {
-    #[derive(Default, Copy, Clone, Debug, Launder)]
+    #[derive(Default, Copy, Clone, Debug)]
+    #[cfg_attr(not(feature = "no-cfi"), derive(Launder))]
     pub struct VendorPubKeyRevocation : u32 {
         const KEY0 = 0b0001;
         const KEY1 = 0b0010;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -104,16 +104,16 @@ pub use soc_ifc::{report_boot_status, Lifecycle, MfgFlags, ResetReason, SocIfc};
 pub use trng::Trng;
 
 #[allow(unused_imports)]
-#[cfg(not(feature = "runtime"))]
+#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
 use caliptra_cfi_derive;
 #[allow(unused_imports)]
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_derive_git as caliptra_cfi_derive;
 #[allow(unused_imports)]
-#[cfg(not(feature = "runtime"))]
+#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
 use caliptra_cfi_lib;
 #[allow(unused_imports)]
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_lib_git as caliptra_cfi_lib;
 
 cfg_if::cfg_if! {

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+#[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::Launder;
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_registers::soc_ifc::enums::DeviceLifecycleE;
@@ -383,7 +384,8 @@ impl From<u32> for MfgFlags {
 }
 
 /// Reset Reason
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Launder)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(not(feature = "no-cfi"), derive(Launder))]
 pub enum ResetReason {
     /// Cold Reset
     ColdReset,


### PR DESCRIPTION
caliptra-drivers fails to compile with the "no-cfi" feature. There are portions of CFI code that is not guarded by the "no-cfi" feature.
