### PR TITLE
[WIP] rt: add FMC compatibility checks

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -467,6 +467,8 @@ impl CaliptraError {
     pub const RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND: CaliptraError =
         CaliptraError::new_const(0x000E005A);
 
+    pub const RUNTIME_FMC_NOT_COMPATIBLE: CaliptraError = CaliptraError::new_const(0x000E005B);
+
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);
     pub const FMC_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x000F0002);

--- a/runtime/src/compatibility.rs
+++ b/runtime/src/compatibility.rs
@@ -1,0 +1,51 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    compatibility.rs
+
+Abstract:
+
+    File contains compatibility functions to to check if the runtime is
+    compatible with FMC.
+
+--*/
+
+use caliptra_common::{cprint, FirmwareHandoffTable};
+use caliptra_image_types::ImageManifest;
+
+// From the official documentation:
+// "The Major and Minor version numbers of the Firmware Handoff Table.
+// All FHT versions with the same Major version number must remain backward compatible.""
+pub fn is_fmc_compatible(fht: &FirmwareHandoffTable, manifest: &ImageManifest) -> bool {
+    cprint!(
+        "[rt] FHT major: {}, Manifest FMC version: {}\n",
+        fht.fht_major_ver,
+        manifest.fmc.version
+    );
+    u32::from(fht.fht_major_ver) == manifest.fmc.version
+}
+
+#[test]
+fn test_is_fmc_compatible() {
+    let mut fht = FirmwareHandoffTable::default();
+    let mut manifest = ImageManifest::default();
+
+    fht.fht_major_ver = 1;
+    fht.fht_minor_ver = 0;
+    manifest.fmc.version = 1;
+
+    assert!(is_fmc_compatible(&fht, &manifest));
+
+    // change minor version should not affect compatibility
+    fht.fht_minor_ver = 1;
+    assert!(is_fmc_compatible(&fht, &manifest));
+
+    fht.fht_minor_ver = 0xff;
+    assert!(is_fmc_compatible(&fht, &manifest));
+
+    fht.fht_major_ver = 2;
+    assert!(!is_fmc_compatible(&fht, &manifest));
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,6 +16,7 @@ Abstract:
 mod authorize_and_stash;
 mod capabilities;
 mod certify_key_extended;
+pub mod compatibility;
 pub mod dice;
 mod disable;
 mod dpe_crypto;


### PR DESCRIPTION
Addresses issue #1425

Add compatibility check function to test FMC compatibility in runtime by checking for the versions supplied via the FHT and the build version.