### PR TITLE
rom/runtime: Verify auth manifest in recovery flow

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -1,8 +1,14 @@
 // Licensed under the Apache-2.0 license
 use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
+use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
 #[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_hw_model::{HwModel, InitParams};
+use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_gen::from_hw_format;
+use caliptra_image_gen::ImageGeneratorCrypto;
+use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
@@ -10,8 +16,20 @@ const RT_READY_FOR_COMMANDS: u32 = 0x600;
 #[test]
 fn test_loads_mcu_fw() {
     // Test that the recovery flow runs and loads MCU's firmware
-    let soc_manifest = vec![0x12u8; 128];
+
     let mcu_fw = vec![0x34u8; 128];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 0,
+        flags: flags.0,
+        digest,
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata(metadata);
+    let soc_manifest = soc_manifest.as_bytes();
     let mut args = RuntimeTestArgs::default();
     let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
     args.init_params = Some(InitParams {
@@ -19,7 +37,7 @@ fn test_loads_mcu_fw() {
         active_mode: true,
         ..Default::default()
     });
-    args.soc_manifest = Some(&soc_manifest);
+    args.soc_manifest = Some(soc_manifest);
     args.mcu_fw_image = Some(&mcu_fw);
     let mut model = run_rt_test(args);
     model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);


### PR DESCRIPTION
This uses the same code as the SET_AUTH_MANIFEST command, which has been slightly refactored to accommodate reading directly from the entire mailbox as an option.

Due to a timing issue when writing the FW index, the Caliptra FW (index 0) was getting sent instead of the SoC manifest (index 1). To account for this, we made a small ROM change to pre-emptively set the recovery FW index to 1 when it is finishing up.

I did some cleanup on the constant names in the recovery interface, since it was not always clear which values were for the device status and which were for the recovery status.

This was verified as working with the MCU emulator.

Next step is validating the MCU firmware, but this will be more complex since we'll have to do some DMA gymnastics to ship the MCU SRAM to the SHA accelerator, so we will do that in a separate PR.