### PR TITLE
docs: Clarify `ATMN` and `CMAN` magic markers

### DIFF
--- a/auth-manifest/README.md
+++ b/auth-manifest/README.md
@@ -9,7 +9,7 @@ The Caliptra SOC manifest has two main components:
 
 | Field | Size (bytes) | Description|
 |-------|--------------|------------|
-| Manifest Marker | 4 | Magic Number marking the start of the manifest. The value must be 0x41544D4E (‘ATMN’ in ASCII)|
+| Manifest Marker | 4 | Magic Number marking the start of the manifest. The value must be the bytes, in order, `4E 4D 54 41` (`NMTA` in ASCII) |
 | Manifest Size | 4 | Size of the full manifest structure |
 | Version | 4 | Manifest version |
 | Flags | 4 | Feature flags.<br />**Bit0:** - Vendor Signature Required. If set, the vendor public keys will be used to verify the signatures signed with the <br />vendor private key. Otherwise, vendor signatures will not be used for verification.<br />**Bit1-Bit31:** Reserved  |

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -90,7 +90,7 @@ It is the unsigned portion of the manifest. Preamble contains the signing public
 
 | Field | Size (bytes) | Description|
 |-------|--------|------------|
-| Firmware Manifest Marker | 4 | Magic Number marking the start of the package manifest. The value must be 0x434D414E (‘CMAN’ in ASCII)|
+| Firmware Manifest Marker | 4 | Magic Number marking the start of the package manifest. The value must be the bytes, in order,`43 4D 41 4E` (`CMAN` in ASCII) |
 | Firmware Manifest Size | 4 | Size of the full manifest structure |
 | Manufacturer ECC Public Key 1 | 96 | ECC P-384 public key used to verify the Firmware Manifest Header Signature. <br> **X-Coordinate:** Public Key X-Coordinate (48 bytes) <br> **Y-Coordinate:** Public Key Y-Coordinate (48 bytes) |
 | Manufacturer ECC Public Key 2 | 96 | ECC P-384 public key used to verify the Firmware Manifest Header Signature. <br> **X-Coordinate:** Public Key X-Coordinate (48 bytes) <br> **Y-Coordinate:** Public Key Y-Coordinate (48 bytes) |


### PR DESCRIPTION
When debugging an issue, I noticed that the auth manifest magic marker was appearing as `NMTA` on disk:

```shell
$ hexdump -C soc-manifest | head -n 1
00000000  4e 4d 54 41 00 1c 00 00  01 00 00 00 01 00 00 00  |NMTA............|
```

This appears consistent with the current documentation, which says that the field should be the little-endian encoding of `0x41544D4E`.

However, this is inconsistent with how we interpret the FW magic marker, which is specified as the little-endian encoding of `0x434D414E` (which would be `NAMC`), but actually appears on disk as `CMAN`:

```shell
$ hexdump -C caliptra-fw-bundle.bin | head -n 1
00000000  43 4d 41 4e 3c 42 00 00  03 00 00 00 01 00 00 04  |CMAN<B..........|
```

The intent of the the auth manifest marker was probably to be `ATMN`, but right now it is easier to change the spec than the code.

I updated the spec for both to be crystal clear about the order of the bytes in both, and made them consistent with each other.