### PR TITLE
Add REVOKE_EXPORTED_CDI_HANDLE command

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -60,6 +60,9 @@ impl CommandId {
 
     // The sign with exported ecdsa command.
     pub const SIGN_WITH_EXPORTED_ECDSA: Self = Self(0x5357_4545); // "SWEE"
+
+    // The revoke exported CDI handle command.
+    pub const REVOKE_EXPORTED_CDI_HANDLE: Self = Self(0x5256_4348); // "RVCH"
 }
 
 impl From<u32> for CommandId {
@@ -161,6 +164,7 @@ pub enum MailboxResp {
     GetIdevCsr(GetIdevCsrResp),
     GetFmcAliasCsr(GetFmcAliasCsrResp),
     SignWithExportedEcdsa(SignWithExportedEcdsaResp),
+    RevokeExportedCdiHandle(RevokeExportedCdiHandleResp),
 }
 
 impl MailboxResp {
@@ -184,6 +188,7 @@ impl MailboxResp {
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_bytes()),
             MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_bytes()),
+            MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_bytes()),
         }
     }
 
@@ -207,6 +212,7 @@ impl MailboxResp {
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -266,6 +272,7 @@ pub enum MailboxReq {
     SetAuthManifest(SetAuthManifestReq),
     AuthorizeAndStash(AuthorizeAndStashReq),
     SignWithExportedEcdsa(SignWithExportedEcdsaReq),
+    RevokeExportedCdiHandle(RevokeExportedCdiHandleReq),
 }
 
 impl MailboxReq {
@@ -292,6 +299,7 @@ impl MailboxReq {
             MailboxReq::SetAuthManifest(req) => Ok(req.as_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_bytes()),
+            MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -318,6 +326,7 @@ impl MailboxReq {
             MailboxReq::SetAuthManifest(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -344,6 +353,7 @@ impl MailboxReq {
             MailboxReq::SetAuthManifest(_) => CommandId::SET_AUTH_MANIFEST,
             MailboxReq::AuthorizeAndStash(_) => CommandId::AUTHORIZE_AND_STASH,
             MailboxReq::SignWithExportedEcdsa(_) => CommandId::SIGN_WITH_EXPORTED_ECDSA,
+            MailboxReq::RevokeExportedCdiHandle(_) => CommandId::REVOKE_EXPORTED_CDI_HANDLE,
         }
     }
 
@@ -1119,6 +1129,39 @@ impl Default for SignWithExportedEcdsaResp {
             derived_pubkey_y: [0u8; Self::Y_SIZE],
         }
     }
+}
+
+// REVOKE_EXPORTED_CDI_HANDLE
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct RevokeExportedCdiHandleReq {
+    pub hdr: MailboxReqHeader,
+    pub exported_cdi_handle: [u8; Self::EXPORTED_CDI_MAX_SIZE],
+}
+
+impl Default for RevokeExportedCdiHandleReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            exported_cdi_handle: [0u8; Self::EXPORTED_CDI_MAX_SIZE],
+        }
+    }
+}
+
+impl RevokeExportedCdiHandleReq {
+    pub const EXPORTED_CDI_MAX_SIZE: usize = 32;
+}
+
+impl Request for RevokeExportedCdiHandleReq {
+    const ID: CommandId = CommandId::REVOKE_EXPORTED_CDI_HANDLE;
+    type Resp = RevokeExportedCdiHandleResp;
+}
+impl Response for RevokeExportedCdiHandleResp {}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct RevokeExportedCdiHandleResp {
+    pub hdr: MailboxRespHeader,
 }
 
 #[repr(u32)]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -464,6 +464,9 @@ impl CaliptraError {
     pub const RUNTIME_GET_FMC_CSR_UNSUPPORTED_FMC: CaliptraError =
         CaliptraError::new_const(0x000E0055);
 
+    pub const RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND: CaliptraError =
+        CaliptraError::new_const(0x000E005A);
+
     /// FMC Errors
     pub const FMC_GLOBAL_NMI: CaliptraError = CaliptraError::new_const(0x000F0001);
     pub const FMC_GLOBAL_EXCEPTION: CaliptraError = CaliptraError::new_const(0x000F0002);

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -221,6 +221,9 @@ int caliptra_get_idev_csr(struct caliptra_get_idev_csr_resp *resp, bool async);
 // Sign with Exported Ecdsa
 int caliptra_sign_with_exported_ecdsa(struct caliptra_sign_with_exported_ecdsa_req *req, struct caliptra_sign_with_exported_ecdsa_resp *resp, bool async);
 
+// Revoke Exported CDI Handle
+int caliptra_revoke_exported_cdi_handle(struct caliptra_revoke_exported_cdi_handle_req *req, bool async);
+
 // Self test start
 int caliptra_self_test_start(bool async);
 

--- a/libcaliptra/inc/caliptra_enums.h
+++ b/libcaliptra/inc/caliptra_enums.h
@@ -103,6 +103,7 @@ enum dpe_error_codes {
 };
 
 enum dpe_derive_context_cmd_flags {
+    DPE_DERIVE_CONTEXT_FLAG_RECURSIVE          = ( 1UL << 24),
     DPE_DERIVE_CONTEXT_FLAG_EXPORT_CDI         = ( 1UL << 23),
     DPE_DERIVE_CONTEXT_FLAG_CREATE_CERTIFICATE = ( 1UL << 22),
 };

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -239,6 +239,11 @@ struct caliptra_sign_with_exported_ecdsa_resp {
     uint8_t signature_s[48];
 };
 
+struct caliptra_revoke_exported_cdi_handle_req {
+    struct caliptra_req_header hdr;
+    uint8_t exported_cdi_handle[32];
+};
+
 // DPE commands
 
 #define DPE_MAGIC    0x44504543 // "DPEC"

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1263,6 +1263,21 @@ int caliptra_sign_with_exported_ecdsa(struct caliptra_sign_with_exported_ecdsa_r
     return pack_and_execute_command(&p, async);
 }
 
+// Revoke Exported CDI Handle
+int caliptra_revoke_exported_cdi_handle(struct caliptra_revoke_exported_cdi_handle_req *req, bool async)
+{
+    if (!req)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_resp_header resp_hdr = {};
+
+    CREATE_PARCEL(p, OP_REVOKE_EXPORTED_CDI_HANDLE, req, &resp_hdr);
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Self test start
 int caliptra_self_test_start(bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -53,6 +53,7 @@ enum mailbox_command {
     OP_CAPABILITIES                = 0x43415053, // "CAPS"
     OP_GET_IDEV_CSR                = 0x49444352, // "IDCR"
     OP_SIGN_WITH_EXPORTED_ECDSA    = 0x53574545, // "SWEE"
+    OP_REVOKE_EXPORTED_CDI_HANDLE  = 0x52564348, // "RVCH"
 };
 
 struct parcel {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -928,6 +928,8 @@ When the `mfg_flag_gen_idev_id_csr` flag has been set, the SoC **MUST** wait for
 
 Command Code: `0x5357_4545` ("SWEE")
 
+**Note**: This command is only available in the locality of the PL0 PAUSER. 
+
 *Table: `SIGN_WITH_EXPORTED_ECDSA` input arguments*
 
 | **Name**             | **Type** | **Description**
@@ -945,6 +947,24 @@ Command Code: `0x5357_4545` ("SWEE")
 | signature_s        | u8[48]   | The S BigNum of an ECDSA signature.                                        |
 
 The `exported_cdi` can be created by calling `DeriveContext` with the `export-cdi` and `create-certificate` flags.
+
+### REVOKE\_EXPORTED\_CDI\_HANDLE
+
+Command Code: `5256_4348` ("RVCH")
+
+**Note**: This command is only available in the locality of the PL0 PAUSER. 
+
+*Table: `REVOKE_EXPORTED_CDI_HANDLE` input arguments*
+
+| **Name**             | **Type** | **Description**
+| --------             | -------- | ---------------
+| chksum               | u32      | Checksum over other input arguments, computed by the caller. Little endian.         |
+| exported_cdi_handle  | u8[32]   | The Exported CDI handle returned by the DPE `DeriveContext` command. Little endian. |
+
+The `exported_cdi` can be created by calling `DeriveContext` with the `export-cdi` and `create-certificate` flags.
+
+The `exported_cdi_handle` is no longer usable after calling `REVOKE_EXPORTED_CDI_HANDLE` with it. After the `exported_cdi_handle` 
+has been revoked, a new exported CDI can be created by calling `DeriveContext` with the `export-cdi` and `create-certificate` flags.
 
 ## Checksum
 
@@ -1091,6 +1111,7 @@ Caliptra DPE supports the following commands:
 * GetProfile
 * InitializeContext
 * DeriveContext
+    * **Note**: The "export-cdi" flag is only available in the locality of the PL0 PAUSER. 
 * CertifyKey
   * Caliptra DPE supports two formats for CertifyKey: X.509 and PKCS#10 CSR.
     X.509 is only available to PL0 PAUSERs.

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -232,7 +232,7 @@ impl Drivers {
             }
             match result {
                 Ok(_) => {
-                    cprintln!("Disabled attest : DPE valid fail");
+                    cprintln!("Disabled attest: DPE valid fail");
                     // store specific validation error in CPTRA_FW_EXTENDED_ERROR_INFO
                     drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
                     caliptra_drivers::report_fw_error_non_fatal(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -30,6 +30,7 @@ pub mod info;
 mod invoke_dpe;
 mod pcr;
 mod populate_idev;
+mod revoke_exported_cdi_handle;
 mod set_auth_manifest;
 mod sign_with_exported_ecdsa;
 mod stash_measurement;
@@ -48,6 +49,7 @@ use mailbox::Mailbox;
 use crate::capabilities::CapabilitiesCmd;
 pub use crate::certify_key_extended::CertifyKeyExtendedCmd;
 pub use crate::hmac::Hmac;
+use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
@@ -232,6 +234,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::GET_FMC_ALIAS_CSR => GetFmcAliasCsrCmd::execute(drivers, cmd_bytes),
         CommandId::SIGN_WITH_EXPORTED_ECDSA => {
             SignWithExportedEcdsaCmd::execute(drivers, cmd_bytes)
+        }
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE => {
+            RevokeExportedCdiHandleCmd::execute(drivers, cmd_bytes)
         }
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     };

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -28,14 +28,7 @@ use core::hint::black_box;
 #[cfg(feature = "std")]
 pub fn main() {}
 
-const BANNER: &str = r#"
-  ____      _ _       _               ____ _____
- / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
-| |   / _` | | | '_ \| __| '__/ _` | | |_) || |
-| |__| (_| | | | |_) | |_| | | (_| | |  _ < | |
- \____\__,_|_|_| .__/ \__|_|  \__,_| |_| \_\|_|
-               |_|
-"#;
+const BANNER: &str = "Caliptra RT";
 
 #[no_mangle]
 #[allow(clippy::empty_loop)]
@@ -57,7 +50,7 @@ pub extern "C" fn entry_point() -> ! {
 
     let mut drivers = unsafe {
         Drivers::new_from_registers().unwrap_or_else(|e| {
-            cprintln!("[rt] Runtime can't load drivers");
+            cprintln!("[rt] RT can't load drivers");
             handle_fatal_error(e.into());
         })
     };
@@ -79,15 +72,15 @@ pub extern "C" fn entry_point() -> ! {
     }
 
     drivers.run_reset_flow().unwrap_or_else(|e| {
-        cprintln!("[rt] Runtime failed reset flow");
+        cprintln!("[rt] RT failed reset flow");
         handle_fatal_error(e.into());
     });
 
     if !drivers.persistent_data.get().fht.is_valid() {
-        cprintln!("[rt] Runtime can't load FHT");
+        cprintln!("[rt] RT can't load FHT");
         handle_fatal_error(caliptra_drivers::CaliptraError::RUNTIME_HANDOFF_FHT_NOT_LOADED.into());
     }
-    cprintln!("[rt] Runtime listening for mailbox commands...");
+    cprintln!("[rt] RT listening for mailbox commands...");
     if let Err(e) = caliptra_runtime::handle_mailbox_commands(&mut drivers) {
         handle_fatal_error(e.into());
     }

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -1,0 +1,49 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
+
+#[cfg(not(feature = "no-cfi"))]
+use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(not(feature = "no-cfi"))]
+use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+
+use caliptra_common::mailbox_api::{
+    MailboxResp, MailboxRespHeader, RevokeExportedCdiHandleReq, RevokeExportedCdiHandleResp,
+};
+use caliptra_error::{CaliptraError, CaliptraResult};
+
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct RevokeExportedCdiHandleCmd;
+impl RevokeExportedCdiHandleCmd {
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        let cmd = RevokeExportedCdiHandleReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        match drivers.caller_privilege_level() {
+            // REVOKE_EXPORTED_CDI_HANDLE MUST only be called from PL0
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+
+        for slot in drivers.exported_cdi_slots.iter_mut() {
+            match slot {
+                Some((cdi, handle)) if *handle == cmd.exported_cdi_handle => {
+                    #[cfg(not(feature = "no-cfi"))]
+                    cfi_assert!(*handle == cmd.exported_cdi_handle);
+
+                    *slot = None;
+                    return Ok(MailboxResp::RevokeExportedCdiHandle(
+                        RevokeExportedCdiHandleResp::default(),
+                    ));
+                }
+                _ => (),
+            }
+        }
+        Err(CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND)
+    }
+}

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -18,6 +18,7 @@ mod test_panic_missing;
 mod test_pauser_privilege_levels;
 mod test_pcr;
 mod test_populate_idev;
+mod test_revoke_exported_cdi_handle;
 mod test_set_auth_manifest;
 mod test_sign_with_export_ecdsa;
 mod test_stash_measurement;

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
@@ -1,0 +1,176 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::{mailbox::RevokeExportedCdiHandleReq, SocManager};
+use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxReqHeader};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::RtBootStatus;
+use dpe::{
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
+    context::ContextHandle,
+    response::Response,
+    DPE_PROFILE,
+};
+
+use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs};
+
+#[test]
+fn test_revoke_exported_cdi_handle() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("Expected REVOKE_EXPORTED_CDI_HANDLE to pass");
+}
+
+#[test]
+fn test_revoke_already_revoked_exported_cdi_handle() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("Expected REVOKE_EXPORTED_CDI_HANDLE to pass");
+
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.err().unwrap(),
+    );
+}
+
+#[test]
+fn test_revoke_non_existant_exported_cdi_handle() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFF; RevokeExportedCdiHandleReq::EXPORTED_CDI_MAX_SIZE],
+    });
+
+    cmd.populate_chksum().unwrap();
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.err().unwrap(),
+    );
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq::default());
+
+    cmd.populate_chksum().unwrap();
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.err().unwrap(),
+    );
+}
+
+#[test]
+fn test_export_cdi_after_revoke() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: resp.exported_cdi,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("Expected REVOKE_EXPORTED_CDI_HANDLE to pass");
+
+    let Some(Response::DeriveContextExportedCdi(_)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+}

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -1,17 +1,17 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::SocManager;
+use caliptra_api::{mailbox::RevokeExportedCdiHandleReq, SocManager};
 use caliptra_common::mailbox_api::{
     CommandId, MailboxReq, MailboxReqHeader, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError};
 use caliptra_runtime::RtBootStatus;
-use crypto::MAX_EXPORTED_CDI_SIZE;
+use crypto::{CryptoError, MAX_EXPORTED_CDI_SIZE};
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    response::Response,
+    response::{DeriveContextExportedCdiResp, DpeErrorCode, Response},
     DPE_PROFILE,
 };
 use openssl::{
@@ -23,10 +23,48 @@ use openssl::{
 };
 use zerocopy::{FromBytes, IntoBytes};
 
-use crate::common::{execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST};
+use crate::common::{
+    assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_DIGEST,
+};
+
+fn check_certificate_signature(
+    sign_resp: &SignWithExportedEcdsaResp,
+    exported_cdi_resp: &DeriveContextExportedCdiResp,
+) -> bool {
+    let sig = EcdsaSig::from_private_components(
+        BigNum::from_slice(&sign_resp.signature_r).unwrap(),
+        BigNum::from_slice(&sign_resp.signature_s).unwrap(),
+    )
+    .unwrap();
+
+    // Verify that the certificate from DeriveContext can verify the signature.
+    let x509 = X509::from_der(
+        &exported_cdi_resp.new_certificate
+            [..exported_cdi_resp.certificate_size.try_into().unwrap()],
+    )
+    .unwrap();
+    let ec_pub_key = x509.public_key().unwrap().ec_key().unwrap();
+    if !sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap() {
+        return false;
+    }
+
+    // Let's also check that the returned public key can verify the signature.
+    let x = BigNum::from_slice(&sign_resp.derived_pubkey_x).unwrap();
+    let y = BigNum::from_slice(&sign_resp.derived_pubkey_y).unwrap();
+    let ec_pub_key = EcKey::from_public_key_affine_coordinates(
+        &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
+        &x,
+        &y,
+    )
+    .unwrap();
+    sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap()
+}
 
 #[test]
 fn test_sign_with_exported_cdi() {
+    // Exports a CDI and then signs a well known hash.
+    // Verifies the signature using the CA certificate paired with the export-cdi, as well as the
+    // public key returned by SIGN_WITH_EXPORTED_ECDSA.
     let mut model = run_rt_test(RuntimeTestArgs::default());
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -45,14 +83,14 @@ fn test_sign_with_exported_cdi() {
         DpeResult::Success,
     );
 
-    let resp = match resp {
+    let derive_resp = match resp {
         Some(Response::DeriveContextExportedCdi(resp)) => resp,
         _ => panic!("expected derive context resp!"),
     };
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: resp.exported_cdi,
+        exported_cdi_handle: derive_resp.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -63,33 +101,13 @@ fn test_sign_with_exported_cdi() {
     );
 
     let response = result.unwrap().unwrap();
-    let response = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
-    let sig = EcdsaSig::from_private_components(
-        BigNum::from_slice(&response.signature_r).unwrap(),
-        BigNum::from_slice(&response.signature_s).unwrap(),
-    )
-    .unwrap();
-
-    // Verify that the certificate from DeriveContext can verify the signature.
-    let x509 =
-        X509::from_der(&resp.new_certificate[..resp.certificate_size.try_into().unwrap()]).unwrap();
-    let ec_pub_key = x509.public_key().unwrap().ec_key().unwrap();
-    assert!(sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap());
-
-    // Let's also check that the returned public key can verify the signature.
-    let x = BigNum::from_slice(&response.derived_pubkey_x).unwrap();
-    let y = BigNum::from_slice(&response.derived_pubkey_y).unwrap();
-    let ec_pub_key = EcKey::from_public_key_affine_coordinates(
-        &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
-        &x,
-        &y,
-    )
-    .unwrap();
-    assert!(sig.verify(&TEST_DIGEST, &ec_pub_key).unwrap());
+    let sign_resp = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(check_certificate_signature(sign_resp, &derive_resp));
 }
 
 #[test]
 fn test_sign_with_exported_incorrect_cdi_handle() {
+    // Verifies that an invalid CDI handle cannot derive an exported ECDSA key.
     let mut model = run_rt_test(RuntimeTestArgs::default());
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -134,6 +152,7 @@ fn test_sign_with_exported_incorrect_cdi_handle() {
 
 #[test]
 fn test_sign_with_exported_never_derived() {
+    // Verifies that an exported ECDSA key cannot be derived without first exporting a CDI.
     let mut model = run_rt_test(RuntimeTestArgs::default());
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
@@ -155,5 +174,258 @@ fn test_sign_with_exported_never_derived() {
         ModelError::MailboxCmdFailed(
             CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED.into(),
         )
+    );
+}
+
+#[test]
+fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
+    // Tests the following sequence:
+    // 1. Export a CDI.
+    //   - This CDI is know as the "original_cdi".
+    // 2. Verify signing of `SIGN_WITH_EXPORTED_ECDSA` with the CA signed by the "original_cdi".
+    // 3. Add a new measurement using the `DeriveContextFlags::RECURSIVE` flag.
+    // 4. Try to export a new CDI, verify that it failes with
+    //    `DpeErrorCode::Crypto(CryptoError::ExportedCdiHandleDuplicateCdi))`.
+    // 5. Verify signing of `SIGN_WITH_EXPORTED_ECDSA` with the CA signed by the "original_cdi".
+    //    This ensures that the failure in step 4 did not overwrite the "original_cdi".
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(check_certificate_signature(sign_resp, &original_cdi_resp));
+
+    let measurement_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0xa; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::RECURSIVE,
+        tci_type: u32::from_be_bytes(*b"MBVP"),
+        target_locality: 0,
+    };
+
+    let _ = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&measurement_cmd),
+        DpeResult::Success,
+    );
+
+    let Some(Response::Error(e)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::DpeCmdFailure,
+    ) else { panic!("Expected the second export cdi command to fail.")};
+    assert_eq!(
+        e.status,
+        DpeErrorCode::Crypto(CryptoError::ExportedCdiHandleDuplicateCdi).get_error_code()
+    );
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(check_certificate_signature(sign_resp, &original_cdi_resp));
+}
+
+#[test]
+fn test_sign_with_exported_cdi_measurement_update() {
+    // Tests the following sequence:
+    // 1. Export a CDI.
+    //   - This CDI is know as the "original_cdi".
+    // 2. Add a new measurement using the `DeriveContextFlags::RECURSIVE` flag.
+    // 3. Revoke the "original_cdi".
+    // 3. Export a new CDI known as the "updated_cdi".
+    // 4. Verify that the signature from `SIGN_WITH_EXPORTED_ECDSA` cannot be verified by the CA
+    //    cert paired with the "original_cdi".
+    // 5. Verify signing of `SIGN_WITH_EXPORTED_ECDSA` with the CA cert signed by the "updated_cdi"
+    //    to make sure that we can create valid signatures that map with the "update_cdi" CA cert.
+    // 6. Double check that the certificate and export_cdi have changed between "original_cdi" and
+    //    "update_cdi".
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let measurement_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0xa; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::RECURSIVE,
+        tci_type: u32::from_be_bytes(*b"MBVP"),
+        target_locality: 0,
+    };
+
+    let _ = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&measurement_cmd),
+        DpeResult::Success,
+    );
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+    });
+    cmd.populate_chksum().unwrap();
+
+    match model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    ) {
+        Ok(_) => (),
+        Err(e) => panic!("REVOKE_EXPORTED_CDI_HANDLE failed with {:?}", e),
+    }
+
+    let Some(Response::DeriveContextExportedCdi(updated_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: updated_cdi_resp.exported_cdi,
+        tbs: TEST_DIGEST,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedEcdsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+    // The original CDI was revoked.
+    assert!(!check_certificate_signature(sign_resp, &original_cdi_resp));
+    assert!(check_certificate_signature(sign_resp, &updated_cdi_resp));
+    assert_ne!(original_cdi_resp, updated_cdi_resp);
+    assert_ne!(
+        original_cdi_resp.exported_cdi,
+        updated_cdi_resp.exported_cdi
+    );
+    assert_ne!(
+        original_cdi_resp.new_certificate,
+        updated_cdi_resp.new_certificate
+    );
+}
+
+#[test]
+fn test_sign_with_revoked_exported_cdi() {
+    // This tests the following sequence:
+    // 1. Create an exported-cdi
+    // 2. Check that we can create a valid signature with it.
+    // 3. Revoke the exported-cdi.
+    // 4. Verify that we can no longer sign with the exported-cdi and that `SIGN_WITH_EXPORTED_ECDSA`
+    // returns `CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED`.
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+
+    let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else { panic!("expected derive context resp!") };
+
+    let mut sign_cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: cdi_resp.exported_cdi,
+        tbs: TEST_DIGEST,
+    });
+    sign_cmd.populate_chksum().unwrap();
+
+    let result = model
+        .mailbox_execute(
+            CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+            sign_cmd.as_bytes().unwrap(),
+        )
+        .expect("SIGN_WITH_EXPORTED_ECDSA should not fail until the handle is revoked")
+        .unwrap();
+    let sign_resp = SignWithExportedEcdsaResp::ref_from_bytes(result.as_bytes()).unwrap();
+    assert!(check_certificate_signature(sign_resp, &cdi_resp));
+
+    let mut revoke_cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: cdi_resp.exported_cdi,
+    });
+    revoke_cmd.populate_chksum().unwrap();
+
+    match model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        revoke_cmd.as_bytes().unwrap(),
+    ) {
+        Ok(_) => (),
+        Err(e) => panic!("REVOKE_EXPORTED_CDI_HANDLE failed with {:?}", e),
+    }
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_ECDSA.into(),
+        sign_cmd.as_bytes().unwrap(),
+    );
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED,
+        result.err().unwrap(),
     );
 }

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -93,14 +93,7 @@ fn fake_boot_test() {
     assert_output_contains(&output, "Running Caliptra ROM");
     assert_output_contains(&output, "[fake-rom-cold-reset]");
     assert_output_contains(&output, "Running Caliptra FMC");
-    assert_output_contains(
-        &output,
-        r#"
- / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
-| |   / _` | | | '_ \| __| '__/ _` | | |_) || |
-| |__| (_| | | | |_) | |_| | | (_| | |  _ < | |
- \____\__,_|_|_| .__/ \__|_|  \__,_| |_| \_\|_|"#,
-    );
+    assert_output_contains(&output, "Caliptra RT");
 
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_LDEV_CERT), &[]),

--- a/test/tests/caliptra_integration_tests/jtag_test.rs
+++ b/test/tests/caliptra_integration_tests/jtag_test.rs
@@ -121,7 +121,7 @@ fn gdb_test() {
     .unwrap();
 
     hw.step();
-    hw.step_until_output_contains("[rt] Runtime listening for mailbox commands...\n")
+    hw.step_until_output_contains("[rt] RT listening for mailbox commands...\n")
         .unwrap();
 
     #[cfg(feature = "fpga_realtime")]

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -235,7 +235,7 @@ fn smoke_test() {
     .unwrap();
 
     if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
-        hw.step_until_output_contains("[rt] Runtime listening for mailbox commands...\n")
+        hw.step_until_output_contains("[rt] RT listening for mailbox commands...\n")
             .unwrap();
 
         let output = hw.output().take(usize::MAX);
@@ -251,14 +251,7 @@ fn smoke_test() {
         assert_output_contains(&output, "[kat] LMS");
         assert_output_contains(&output, "[kat] --");
         assert_output_contains(&output, "Running Caliptra FMC");
-        assert_output_contains(
-            &output,
-            r#"
- / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
-| |   / _` | | | '_ \| __| '__/ _` | | |_) || |
-| |__| (_| | | | |_) | |_| | | (_| | |  _ < | |
- \____\__,_|_|_| .__/ \__|_|  \__,_| |_| \_\|_|"#,
-        );
+        assert_output_contains(&output, "Caliptra RT");
     }
 
     let ldev_cert_resp = hw.mailbox_execute_req(GetLdevCertReq::default()).unwrap();


### PR DESCRIPTION
Also, check available CDI slots before derivation to avoid overwriting existing CDI.
