### PR TITLE
Automatically calculate DATA_SIZE

### DIFF
--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -51,13 +51,19 @@ pub const MBOX_SIZE: u32 = 256 * 1024;
 pub const ICCM_SIZE: u32 = 256 * 1024;
 pub const DCCM_SIZE: u32 = 256 * 1024;
 pub const ROM_DATA_SIZE: u32 = 996;
-pub const DATA_SIZE: u32 = 66 * 1024;
-pub const STACK_SIZE: u32 = 93 * 1024;
+pub const STACK_SIZE: u32 = 97 * 1024;
 pub const ROM_STACK_SIZE: u32 = 62 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const ROM_ESTACK_SIZE: u32 = 1024;
 pub const NSTACK_SIZE: u32 = 1024;
 pub const ROM_NSTACK_SIZE: u32 = 1024;
+// This is mostly used for relaxation ptrs and is basically padding otherwise.
+pub const DATA_SIZE: u32 = DCCM_SIZE
+    - NSTACK_SIZE
+    - ROM_ESTACK_SIZE
+    - STACK_SIZE
+    - size_of::<PersistentData>() as u32
+    - (PERSISTENT_DATA_ORG - DCCM_ORG);
 
 pub const ICCM_RANGE: core::ops::Range<u32> = core::ops::Range {
     start: ICCM_ORG,
@@ -77,6 +83,8 @@ fn mem_layout_test_persistent_data() {
 #[allow(clippy::assertions_on_constants)]
 fn mem_layout_test_data() {
     assert_eq!((STACK_ORG - DATA_ORG), DATA_SIZE);
+    // we must leave room for 0x800 bytes for the relaxation pointers
+    assert!(DATA_SIZE >= 2 * 1024);
 }
 
 #[test]


### PR DESCRIPTION
When I needed to adjust the stack size to make room for some additional data, it was not clear to me that I needed to take space away from `DATA_SIZE`.

Looking at the LD script, it appears that `DATA_SIZE` is almost empty except for relaxation pointers used by the linker. Since our ROM and firmware are not loaded by an operation system linker, it's not really possible to load rodata there, and we don't use it for a heap.

So, I automated the process of reducing the `DATA_SIZE` by calculating it automatically from the "leftovers" in DCCM, and added a check to ensure that there is enough room for the relaxation pointers at least.