### PR TITLE
Allow soc user in sw model to be 0

### DIFF
--- a/hw-model/c-binding/src/caliptra_model.rs
+++ b/hw-model/c-binding/src/caliptra_model.rs
@@ -169,3 +169,11 @@ pub unsafe extern "C" fn caliptra_model_step_until_boot_status(
     assert!(!model.is_null());
     (*{ model as *mut DefaultHwModel }).step_until_boot_status(boot_status, true);
 }
+
+/// # Safety
+#[no_mangle]
+pub unsafe extern "C" fn caliptra_model_set_apb_pauser(model: *mut caliptra_model, pauser: c_uint) {
+    // Parameter check
+    assert!(!model.is_null());
+    (*{ model as *mut DefaultHwModel }).set_apb_pauser(pauser);
+}

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -191,7 +191,7 @@ pub enum MailboxRequester {
 impl From<u32> for MailboxRequester {
     fn from(value: u32) -> Self {
         match value {
-            0 => MailboxRequester::Caliptra,
+            0xFFFF_FFFF => MailboxRequester::Caliptra,
             _ => MailboxRequester::SocUser(value),
         }
     }
@@ -200,7 +200,7 @@ impl From<u32> for MailboxRequester {
 impl From<MailboxRequester> for u32 {
     fn from(val: MailboxRequester) -> Self {
         match val {
-            MailboxRequester::Caliptra => 0,
+            MailboxRequester::Caliptra => 0xFFFF_FFFF,
             MailboxRequester::SocUser(pauser) => pauser,
         }
     }
@@ -661,7 +661,7 @@ mod tests {
         // Confirm it is locked
         assert!(uc_regs.lock().read().lock());
 
-        assert_eq!(uc_regs.user().read(), 0);
+        assert_eq!(uc_regs.user().read(), 0xFFFF_FFFF);
 
         // Write command
         uc_regs.cmd().write(|_| 0x55);


### PR DESCRIPTION
* Change MailboxRequester::Caliptra to a non-zero representation so 0 can be used as a soc user
* Add pauser set API to hw-model C bindings