### PR TITLE
[feat] Lock the datavault in DCCM using PMP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-image-verify",
  "caliptra-registers",
+ "riscv",
  "ufmt",
  "zerocopy",
  "zeroize",
@@ -1172,6 +1173,12 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
@@ -1411,6 +1418,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "errno"
@@ -2017,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2183,6 +2196,36 @@ dependencies = [
  "hmac",
  "subtle",
 ]
+
+[[package]]
+name = "riscv"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa3cdbeccae4359f6839a00e8b77e5736caa200ba216caf38d24e4c16e2b586"
+dependencies = [
+ "critical-section",
+ "embedded-hal",
+ "paste",
+ "riscv-macros",
+ "riscv-pac",
+]
+
+[[package]]
+name = "riscv-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "riscv-pac"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
 name = "rusticata-macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ regex = "1.10.2"
 ecdsa = { version = "0.16.9", features = ["pem"]}
 sec1 = { version = "0.7.3" }
 itertools = "0.12.0"
+riscv = "0.13.0"
 
 [profile.firmware]
 inherits = "release"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,6 +18,7 @@ caliptra-registers.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
 zeroize.workspace = true
+riscv.workspace = true
 
 [features]
 default = ["std"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod dice;
 pub mod error_handler;
 pub mod fips;
 pub mod keyids;
+pub mod pmp;
 pub mod verifier;
 pub mod wdt;
 pub mod x509;
@@ -37,6 +38,7 @@ pub use caliptra_drivers::printer::Printer;
 pub use error_handler::handle_fatal_error;
 pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
+pub use pmp::lock_datavault_region;
 
 pub const FMC_ORG: u32 = 0x40000000;
 pub const FMC_SIZE: u32 = 24 * 1024;

--- a/common/src/pmp.rs
+++ b/common/src/pmp.rs
@@ -1,0 +1,50 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    pmp.rs
+
+Abstract:
+
+    PMP support routine for locking the DataVault.
+
+--*/
+use riscv::register::{pmpaddr0, pmpaddr1, pmpaddr2, pmpaddr3, pmpcfg0, Permission, Range};
+
+/// Lock the DataVault region using PMP configuration.
+///
+/// # Arguments
+/// * `base_address` - Base address of the region
+/// * `region_size` - Size of the region
+/// * `cold_reset_region` - True if the region is for Cold Reset, false for Warm Reset
+///
+/// Note: If a PMP entry is locked, writes to the configuration register and
+/// associated address registers are ignored.
+///
+pub fn lock_datavault_region(base_address: usize, region_size: usize, cold_reset_region: bool) {
+    unsafe {
+        // Calculate the end address of the region
+        let end_address = base_address + region_size;
+
+        // PMP address register encodes Bits 33:2 of a 34-bit physical address.
+        let base_address = base_address >> 2;
+        let end_address = end_address >> 2;
+
+        let index: usize = if cold_reset_region {
+            // Use pmp1cfg for Cold Reset region.
+            pmpaddr0::write(base_address);
+            pmpaddr1::write(end_address);
+            1
+        } else {
+            // Use pmp3cfg for Warm Reset region.
+            pmpaddr2::write(base_address);
+            pmpaddr3::write(end_address);
+            3
+        };
+
+        // Set the PMP configuration.
+        pmpcfg0::set_pmp(index, Range::TOR, Permission::R, true);
+    }
+}

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -50,8 +50,8 @@ pub struct WarmResetEntries {
 #[repr(C)]
 #[derive(Default, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 pub struct DataVault {
-    cold_reset_entries: ColdResetEntries,
-    warm_reset_entries: WarmResetEntries,
+    pub cold_reset_entries: ColdResetEntries,
+    pub warm_reset_entries: WarmResetEntries,
 }
 
 impl DataVault {

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -258,6 +258,7 @@ pub struct PersistentData {
     pub manifest2: ImageManifest,
     reserved1: [u8; MAN2_SIZE as usize - size_of::<ImageManifest>()],
 
+    #[zeroize(skip)]
     pub data_vault: DataVault,
     reserved1_1: [u8; DATAVAULT_MAX_SIZE as usize - size_of::<DataVault>()],
 

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -24,6 +24,7 @@ use caliptra_kat::*;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use core::hint::black_box;
 
+use crate::lock::lock_cold_reset_reg;
 use caliptra_drivers::{
     cprintln, report_boot_status, report_fw_error_fatal, report_fw_error_non_fatal, CaliptraError,
     Ecc384, Hmac, KeyVault, Mailbox, ResetReason, Sha256, Sha2_512_384, Sha2_512_384Acc,
@@ -89,6 +90,13 @@ pub extern "C" fn rom_entry() -> ! {
 
     report_boot_status(RomBootStatus::CfiInitialized.into());
 
+    let reset_reason = env.soc_ifc.reset_reason();
+
+    // Lock the Cold Reset registers since they need to remain locked on an Update or Warm reset.
+    if reset_reason != ResetReason::ColdReset {
+        lock_cold_reset_reg(&mut env);
+    }
+
     let lifecyle = match env.soc_ifc.lifecycle() {
         caliptra_drivers::Lifecycle::Unprovisioned => "Unprovisioned",
         caliptra_drivers::Lifecycle::Manufacturing => "Manufacturing",
@@ -133,8 +141,6 @@ pub extern "C" fn rom_entry() -> ! {
 
     // Start the watchdog timer
     wdt::start_wdt(&mut env.soc_ifc);
-
-    let reset_reason = env.soc_ifc.reset_reason();
 
     if !cfg!(feature = "fake-rom") {
         let mut kats_env = caliptra_kat::KatsEnv {


### PR DESCRIPTION
This change locks the cold and warm reset entries in the DCCM via RISCV Physical Memory Protection support. These entries are unlocked on a hart reset (i.e either Cold or Warm reset) The Cold Reset entries are locked immediately on a Warm/Update reset since they need to remain locked during those reset types. Locking a locked configuration is an idempotent operation.