### PR TITLE
Update DPE to mark TCG DICE extensions as non-critical

### DIFF
--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -47,6 +47,7 @@ use caliptra_registers::{
 };
 use caliptra_x509::{NotAfter, NotBefore};
 use dpe::context::{Context, ContextState, ContextType};
+use dpe::dpe_instance::DpeInstanceFlags;
 use dpe::tci::TciMeasurement;
 use dpe::validation::DpeValidator;
 use dpe::MAX_HANDLES;
@@ -416,6 +417,7 @@ impl Drivers {
             DPE_SUPPORT,
             u32::from_be_bytes(*b"RTJM"),
             rt_journey_measurement,
+            DpeInstanceFlags::empty(),
         )
         .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
 

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -16,8 +16,8 @@ use cms::{
 };
 use dpe::{
     commands::{
-        CertifyKeyCmd, CertifyKeyFlags, Command, GetCertificateChainCmd, InitCtxCmd, RotateCtxCmd,
-        RotateCtxFlags, SignCmd, SignFlags,
+        CertifyKeyCmd, CertifyKeyFlags, Command, DeriveContextCmd, DeriveContextFlags,
+        GetCertificateChainCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags, SignCmd, SignFlags,
     },
     context::ContextHandle,
     response::{DpeErrorCode, Response},
@@ -31,6 +31,7 @@ use openssl::{
     x509::X509,
 };
 use sha2::{Digest, Sha384};
+use x509_parser::{nom::Parser, prelude::*};
 
 #[test]
 fn test_invoke_dpe_get_profile_cmd() {
@@ -296,4 +297,70 @@ fn test_invoke_dpe_rotate_context() {
     };
 
     assert!(rotate_ctx_resp.handle.is_default());
+}
+
+fn check_dice_extension_criticality(cert: &[u8], expected_criticality: bool) {
+    let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+    let Ok((_, cert)) = parser
+            .parse(cert) else {
+                panic!("Could not parse x509 certificate from CertifyKey!");
+            };
+    for extension in cert.iter_extensions() {
+        // Unknown extensions are DICE extensions, and they should match the
+        // criticality set by the DPE instance.
+        if extension.parsed_extension().unsupported() {
+            assert_eq!(extension.critical, expected_criticality);
+        }
+    }
+}
+
+#[test]
+fn test_invoke_dpe_certify_key_with_non_critical_dice_extensions() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    let certify_key_cmd = CertifyKeyCmd {
+        handle: ContextHandle::default(),
+        label: TEST_LABEL,
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCmd::FORMAT_X509,
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::CertifyKey(&certify_key_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::CertifyKey(resp)) = resp else {
+            panic!("Wrong response type!");
+        };
+    check_dice_extension_criticality(&resp.cert[..resp.cert_size.try_into().unwrap()], false);
+}
+
+#[test]
+fn test_invoke_dpe_export_cdi_with_non_critical_dice_extensions() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: [0; DPE_PROFILE.get_tci_size()],
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
+        panic!("expected derive context resp!");
+    };
+    check_dice_extension_criticality(
+        &resp.new_certificate[..resp.certificate_size.try_into().unwrap()],
+        false,
+    );
 }


### PR DESCRIPTION
By default these extensions are marked non-critical.

This PR does not expose a way to configure this outside of the firmware interacting directly with DPE.