### PR TITLE
[feat] Update QUOTE_PCR command with MLDSA signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ dependencies = [
  "caliptra-api-types",
  "caliptra-emu-types",
  "caliptra-error",
+ "caliptra-image-types",
  "caliptra-registers",
  "ureg",
  "zerocopy",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,3 +15,4 @@ caliptra-emu-types.workspace = true
 caliptra-registers.workspace = true
 caliptra-api-types.workspace = true
 ureg.workspace = true
+caliptra-image-types = { workspace = true, default-features = false }

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -2,6 +2,7 @@
 
 use bitflags::bitflags;
 use caliptra_error::{CaliptraError, CaliptraResult};
+use caliptra_image_types::MLDSA87_SIGNATURE_BYTE_SIZE;
 use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref};
 
@@ -968,8 +969,9 @@ pub struct QuotePcrsResp {
     pub nonce: [u8; 32],
     pub digest: [u8; 64],
     pub reset_ctrs: [u32; 32],
-    pub signature_r: [u8; 48],
-    pub signature_s: [u8; 48],
+    pub ecc_signature_r: [u8; 48],
+    pub ecc_signature_s: [u8; 48],
+    pub mldsa_signature: [u8; MLDSA87_SIGNATURE_BYTE_SIZE],
 }
 
 impl Response for QuotePcrsResp {}

--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -401,7 +401,8 @@ impl Ecc384 {
         Ok(pub_key)
     }
 
-    /// Sign the PCR digest with PCR signing private key.
+    /// Sign the PCR digest with PCR signing private key in keyvault slot 7 (KV7).
+    /// KV7 contains the Alias FMC ECC private key.
     ///
     /// # Arguments
     ///
@@ -409,7 +410,7 @@ impl Ecc384 {
     ///
     /// # Returns
     ///
-    /// * `Ecc384Signature` - Generate signature
+    /// * `Ecc384Signature` - Generated signature
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn pcr_sign_flow(&mut self, trng: &mut Trng) -> CaliptraResult<Ecc384Signature> {
         let ecc = self.ecc.regs_mut();

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -180,8 +180,9 @@ struct caliptra_quote_pcrs_resp {
     uint8_t nonce[32];
     uint8_t digest[64];
     uint32_t reset_ctrs[32];
-    uint8_t signature_r[48];
-    uint8_t signature_s[48];
+    uint8_t ecc_signature_r[48];
+    uint8_t ecc_signature_s[48];
+    uint8_t mldsa_signature[4628];
 };
 
 struct caliptra_extend_pcr_req {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -638,16 +638,17 @@ PcrValue is defined as u8[48]
 
 *Table: `QUOTE_PCRS` output arguments*
 
-| **Name**     | **Type**     | **Description**
-| --------     | --------     | ---------------
-| chksum       | u32          | Checksum over other output arguments, computed by Caliptra. Little endian.
-| fips\_status | u32          | Indicates if the command is FIPS approved or an error.
-| PCRs         | PcrValue[32] | Values of all PCRs.
-| nonce        | u8[32]       | Return the nonce used as input for convenience.
-| digest       | u8[64]       | Return the digest over the PCR values and the nonce.
-| reset\_ctrs  | u32[32]      | Reset counters for all PCRs.
-| signature\_r | u8[48]       | R portion of the signature over the PCR quote.
-| signature\_s | u8[48]       | S portion of the signature over the PCR quote.
+| **Name**           | **Type**     | **Description**
+| --------           | --------     | ---------------
+| chksum             | u32          | Checksum over other output arguments, computed by Caliptra. Little endian.
+| fips\_status       | u32          | Indicates if the command is FIPS approved or an error.
+| PCRs               | PcrValue[32] | Values of all PCRs.
+| nonce              | u8[32]       | Return the nonce used as input for convenience.
+| digest             | u8[64]       | Return the digest over the PCR values and the nonce.
+| reset\_ctrs        | u32[32]      | Reset counters for all PCRs.
+| ecc_signature\_r   | u8[48]       | ECC P-384 R portion of the signature over the lower 48 bytes of the PCR quote digest. </br> The FMC Alias ECC P-384 private key stored in Key Vault slot 7 is utilized for the signing operation.
+| ecc_signature\_s   | u8[48]       | ECC P-384 S portion of the signature over the lower 48 bytes of the PCR quote digest.
+| mldsa_signature\_s | u8[4628]     | MLDSA-87 signature over the PCR quote digest (4627 bytes + 1 Reserved byte). </br> The FMC Alias MLDSA seed stored in Key Vault slot 8 is utilized to generate the private key, which is subsequently used for the signing operation.
 
 ### EXTEND\_PCR
 

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -66,8 +66,8 @@ fn test_pcr_quote() {
     assert_eq!(pcr7_reset_counter, 1);
 
     // verify signature
-    let big_r = BigNum::from_slice(&resp.signature_r).unwrap();
-    let big_s = BigNum::from_slice(&resp.signature_s).unwrap();
+    let big_r = BigNum::from_slice(&resp.ecc_signature_r).unwrap();
+    let big_s = BigNum::from_slice(&resp.ecc_signature_s).unwrap();
     let sig = EcdsaSig::from_private_components(big_r, big_s).unwrap();
 
     let fmc_resp = get_fmc_alias_cert(&mut model);

--- a/sw-emulator/lib/periph/src/asym_ecc384.rs
+++ b/sw-emulator/lib/periph/src/asym_ecc384.rs
@@ -687,7 +687,7 @@ impl AsymEcc384 {
             .read_key_locked(PCR_SIGN_KEY, key_usage)
             .unwrap();
 
-        let pcr_digest = self.hash_sha512.pcr_hash_digest();
+        let pcr_digest: [u8; 48] = self.hash_sha512.pcr_hash_digest()[..48].try_into().unwrap();
 
         let signature = Ecc384::sign(
             &pcr_key[..48].try_into().unwrap(),

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -103,7 +103,6 @@ register_bitfields! [
 
 const SHA512_BLOCK_SIZE: usize = 128;
 const SHA512_BLOCK_SIZE_WORDS: usize = 128 >> 2;
-
 const SHA512_HASH_SIZE: usize = 64;
 
 /// The number of CPU clock cycles it takes to perform initialization action.
@@ -200,7 +199,7 @@ pub struct HashSha512Regs {
     #[register(offset = 0x0000_0634)]
     pcr_hash_status: ReadOnlyRegister<u32, PcrHashStatus::Register>,
 
-    /// 16 32-bit registers storing the 384-bit digest output.
+    /// 16 32-bit registers storing the 512-bit digest output.
     #[register_array(offset = 0x0000_0638, write_fn = write_access_fault)]
     pcr_hash_digest: [u32; SHA512_HASH_SIZE / 4],
 

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -346,6 +346,7 @@ impl CaliptraRootBus {
         );
 
         let sha512 = HashSha512::new(clock, key_vault.clone());
+        let ml_dsa87 = Mldsa87::new(clock, key_vault.clone(), sha512.clone());
 
         Self {
             rom,
@@ -355,7 +356,7 @@ impl CaliptraRootBus {
             key_vault: key_vault.clone(),
             sha512,
             sha256: HashSha256::new(clock),
-            ml_dsa87: Mldsa87::new(clock, key_vault.clone()),
+            ml_dsa87,
             iccm,
             dccm: Ram::new(vec![0; Self::DCCM_SIZE]),
             uart: Uart::new(),

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -402,8 +402,8 @@ pub fn exec_cmd_quote_pcrs<T: HwModel>(hw: &mut T) {
     assert!(contains_some_data(&resp.nonce));
     assert!(contains_some_data(&resp.digest));
     assert!(contains_some_data(&resp.reset_ctrs));
-    assert!(contains_some_data(&resp.signature_r));
-    assert!(contains_some_data(&resp.signature_s));
+    assert!(contains_some_data(&resp.ecc_signature_r));
+    assert!(contains_some_data(&resp.ecc_signature_s));
 }
 
 pub fn exec_cmd_extend_pcr<T: HwModel>(hw: &mut T) {


### PR DESCRIPTION
This change updates the QUOTE_PCR command to add support for PCR quote signing with the MLDSA FMC Alias private key.