### PR TITLE
CSRNG, PCR quote, and HMAC fixes to match hardware

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -950,7 +950,7 @@ pub struct QuotePcrsResp {
     /// The PCR values
     pub pcrs: [PcrValue; 32],
     pub nonce: [u8; 32],
-    pub digest: [u8; 48],
+    pub digest: [u8; 64],
     pub reset_ctrs: [u32; 32],
     pub signature_r: [u8; 48],
     pub signature_s: [u8; 48],

--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -191,7 +191,7 @@ fn check_for_alert_state(
 ) -> CaliptraResult<()> {
     // https://opentitan.org/book/hw/ip/entropy_src/doc/theory_of_operation.html#main-state-machine-diagram
     // https://github.com/chipsalliance/caliptra-rtl/blob/main/src/entropy_src/rtl/entropy_src_main_sm_pkg.sv
-    const ALERT_HANG: u32 = 0x15c;
+    const ALERT_HANG: u32 = 0x1fb;
     const CONT_HT_RUNNING: u32 = 0x1a2;
     const BOOT_PHASE_DONE: u32 = 0x8e;
 

--- a/drivers/src/hmac.rs
+++ b/drivers/src/hmac.rs
@@ -178,6 +178,7 @@ impl Hmac {
         mut tag: HmacTag<'a>,
         hmac_mode: HmacMode,
     ) -> CaliptraResult<HmacOp<'a>> {
+        Self::check_key(key, hmac_mode)?;
         let hmac = self.hmac.regs_mut();
         let mut csr_mode = false;
 
@@ -222,6 +223,20 @@ impl Hmac {
         Ok(op)
     }
 
+    /// Checks that the key and mode are valid for use in in the engine.
+    /// Submitting an invalid key can result in a hardware error, which we can't easily check for.
+    fn check_key(key: &HmacKey, mode: HmacMode) -> CaliptraResult<()> {
+        match key {
+            HmacKey::Array4x12(_) if mode == HmacMode::Hmac512 => {
+                Err(CaliptraError::DRIVER_HMAC_INDEX_OUT_OF_BOUNDS)
+            }
+            HmacKey::Array4x16(_) if mode == HmacMode::Hmac384 => {
+                Err(CaliptraError::DRIVER_HMAC_INDEX_OUT_OF_BOUNDS)
+            }
+            _ => Ok(()),
+        }
+    }
+
     /// Generate an LFSR seed and copy to keyvault.
     ///
     /// # Arguments
@@ -258,6 +273,7 @@ impl Hmac {
         tag: HmacTag,
         hmac_mode: HmacMode,
     ) -> CaliptraResult<()> {
+        Self::check_key(key, hmac_mode)?;
         let hmac = self.hmac.regs_mut();
         let mut tag = tag;
         let mut csr_mode: bool = false;
@@ -582,7 +598,14 @@ impl Hmac {
         }
 
         // Wait for the hmac operation to finish
-        wait::until(|| hmac.hmac512_status().read().valid());
+        wait::until(|| {
+            hmac.hmac512_status().read().valid() || hmac.hmac512_status().read().ready()
+        });
+
+        // check for a hardware error
+        if !hmac.hmac512_status().read().valid() {
+            return Err(CaliptraError::DRIVER_HMAC_INVALID_STATE);
+        }
 
         if let Some(dest_key) = dest_key {
             KvAccess::end_copy_to_kv(hmac.hmac512_kv_wr_status(), dest_key)

--- a/drivers/src/sha2_512_384.rs
+++ b/drivers/src/sha2_512_384.rs
@@ -240,7 +240,7 @@ impl Sha2_512_384 {
     /// # Returns
     ///
     /// * `buf` - Digest buffer
-    pub fn gen_pcr_hash(&mut self, nonce: Array4x8) -> CaliptraResult<Array4x12> {
+    pub fn gen_pcr_hash(&mut self, nonce: Array4x8) -> CaliptraResult<Array4x16> {
         let reg = self.sha512.regs_mut();
         let status_reg = reg.gen_pcr_hash_status();
 
@@ -261,7 +261,7 @@ impl Sha2_512_384 {
         wait::until(|| status_reg.read().ready());
 
         if status_reg.read().valid() {
-            Ok(reg.gen_pcr_hash_digest().truncate::<12>().read().into())
+            Ok(reg.gen_pcr_hash_digest().read().into())
         } else {
             Err(CaliptraError::DRIVER_SHA2_512_384_INVALID_STATE_ERR)
         }

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -176,7 +176,7 @@ struct caliptra_quote_pcrs_resp {
     struct caliptra_resp_header hdr;
     uint8_t pcrs[32][48];
     uint8_t nonce[32];
-    uint8_t digest[48];
+    uint8_t digest[64];
     uint32_t reset_ctrs[32];
     uint8_t signature_r[48];
     uint8_t signature_s[48];

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -186,12 +186,13 @@ impl FakeRomFlow {
 
 // Used to derive the firmware's key ladder.
 fn initialize_fake_ldevid_cdi(env: &mut RomEnv) -> CaliptraResult<()> {
+    let fake_key = Array4x16::from([0x1234_5678u32; 16]);
     env.hmac.hmac(
-        &HmacKey::Array4x12(&Array4x12::default()),
+        &HmacKey::Array4x16(&fake_key),
         &HmacData::Slice(b""),
         &mut env.trng,
         KeyWriteArgs::new(KEY_ID_ROM_FMC_CDI, KeyUsage::default().set_hmac_key_en()).into(),
-        HmacMode::Hmac384,
+        HmacMode::Hmac512,
     )
 }
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -19,6 +19,7 @@ v2.0:
 * Add support for passive mode (same as 1.x) and subsystem (or active) mode
 * [MCU Runtime loading](#boot-and-initialization) (subsystem mode)
 * [Cryptographic mailbox commands](#cryptographic-mailbox-commands-new-in-20)
+* `QUOTE_PCRS` now returns a SHA512 of the PCRs instead of a SHA384.
 
 ## Spec Opens
 
@@ -639,7 +640,7 @@ PcrValue is defined as u8[48]
 | fips\_status | u32          | Indicates if the command is FIPS approved or an error.
 | PCRs         | PcrValue[32] | Values of all PCRs.
 | nonce        | u8[32]       | Return the nonce used as input for convenience.
-| digest       | u8[48]       | Return the digest over the PCR values and the nonce.
+| digest       | u8[64]       | Return the digest over the PCR values and the nonce.
 | reset\_ctrs  | u32[32]      | Reset counters for all PCRs.
 | signature\_r | u8[48]       | R portion of the signature over the PCR quote.
 | signature\_s | u8[48]       | S portion of the signature over the PCR quote.
@@ -1005,7 +1006,7 @@ Command Code: `0x4154_5348` ("ATSH")
 | --------------- | -------- | -------------------------------------------------------------------------- |
 | chksum          | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | fips_status     | u32      | Indicates if the command is FIPS approved or an error.                     |
-| auth_req_result | u32      |AUTHORIZE_IMAGE (0xDEADC0DE), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB) 
+| auth_req_result | u32      |AUTHORIZE_IMAGE (0xDEADC0DE), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB)
 
 ### GET_IMAGE_LOAD_ADDRESS
 

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -54,11 +54,11 @@ fn test_pcr_quote() {
     let resp = QuotePcrsResp::read_from_bytes(resp.as_slice()).unwrap();
 
     // Compute the digest and compare to mailbox result
-    let mut h = Hasher::new(MessageDigest::sha384()).unwrap();
+    let mut h = Hasher::new(MessageDigest::sha512()).unwrap();
     resp.pcrs.iter().for_each(|x| h.update(x).unwrap());
     h.update(&resp.nonce).unwrap();
     let res = h.finish().unwrap();
-    let digest: [u8; 48] = res.as_bytes().try_into().unwrap();
+    let digest: [u8; 64] = res.as_bytes().try_into().unwrap();
     assert_eq!(resp.digest, digest);
 
     let pcr7_reset_counter: u32 = resp.reset_ctrs[usize::try_from(RESET_PCR).unwrap()];

--- a/sw-emulator/lib/periph/src/asym_ecc384.rs
+++ b/sw-emulator/lib/periph/src/asym_ecc384.rs
@@ -638,7 +638,10 @@ impl AsymEcc384 {
 
         let pcr_digest = self.hash_sha512.pcr_hash_digest();
 
-        let signature = Ecc384::sign(&pcr_key[..48].try_into().unwrap(), &pcr_digest);
+        let signature = Ecc384::sign(
+            &pcr_key[..48].try_into().unwrap(),
+            &pcr_digest[..48].try_into().unwrap(),
+        );
         self.sig_r = words_from_bytes_le(&signature.r);
         self.sig_s = words_from_bytes_le(&signature.s);
     }

--- a/sw-emulator/lib/periph/src/csrng.rs
+++ b/sw-emulator/lib/periph/src/csrng.rs
@@ -200,7 +200,7 @@ impl Csrng {
     fn main_sm_state_read(&mut self, _: RvSize) -> Result<RvData, BusError> {
         // https://opentitan.org/book/hw/ip/entropy_src/doc/theory_of_operation.html#main-state-machine-diagram
         // https://github.com/chipsalliance/caliptra-rtl/blob/main/src/entropy_src/rtl/entropy_src_main_sm_pkg.sv
-        const ALERT_HANG: u32 = 0x15c;
+        const ALERT_HANG: u32 = 0x1fb;
         const CONT_HT_RUNNING: u32 = 0x1a2;
 
         let state = if self.health_tester.failures() > 0 {

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -105,7 +105,6 @@ const SHA512_BLOCK_SIZE: usize = 128;
 const SHA512_BLOCK_SIZE_WORDS: usize = 128 >> 2;
 
 const SHA512_HASH_SIZE: usize = 64;
-const SHA384_HASH_SIZE: usize = 48;
 
 /// The number of CPU clock cycles it takes to perform initialization action.
 const INIT_TICKS: u64 = 1000;
@@ -201,9 +200,9 @@ pub struct HashSha512Regs {
     #[register(offset = 0x0000_0634)]
     pcr_hash_status: ReadOnlyRegister<u32, PcrHashStatus::Register>,
 
-    /// 12 32-bit registers storing the 384-bit digest output.
+    /// 16 32-bit registers storing the 384-bit digest output.
     #[register_array(offset = 0x0000_0638, write_fn = write_access_fault)]
-    pcr_hash_digest: [u32; SHA384_HASH_SIZE / 4],
+    pcr_hash_digest: [u32; SHA512_HASH_SIZE / 4],
 
     /// SHA512 engine
     sha512: Sha512,
@@ -660,7 +659,7 @@ impl HashSha512Regs {
         const PCR_SIZE: usize = 48;
         const NONCE_SIZE: usize = 32;
 
-        self.sha512.reset(Sha512Mode::Sha384);
+        self.sha512.reset(Sha512Mode::Sha512);
 
         for pcr_id in 0..PCR_COUNT {
             let mut pcr = self.key_vault.read_pcr(pcr_id.try_into().unwrap());
@@ -702,7 +701,7 @@ impl HashSha512 {
     }
 
     /// Export the PCR hash digest
-    pub fn pcr_hash_digest(&self) -> [u8; 48] {
+    pub fn pcr_hash_digest(&self) -> [u8; 64] {
         self.regs
             .borrow()
             .pcr_hash_digest


### PR DESCRIPTION
These were all found testing against the FPGA running the 2.0-rc1 RTL.

## Correct CSRNG entropy state machine hang alert enum to match latest hw

The CSRNG entropy state machine's enums were updated, and the ALERT_HANG enum value changed, so we need to update our emulator and driver to prevent the driver from hanging.

## QUOTE_PCRS now returns a SHA512

The PCR quote hardware functionality was changed to use SHA512 instead of SHA384.

This means we need to adapt the QUOTE_PCRS command to return a SHA512 digest as well.

**Open**: Should we change the QUOTE_PCRS requrest magic number?

## HMAC HW will fail if KV value is zero or wrong mode
    
The HMAC hardware gets an error if the KV value is all 0 or if an HMAC384 key is attempted to be used with HMAC512 mode.
    
This error condition presents as ready being true and valid being false.
    
So we update the emulator to reflect that behavior, protect against it in the driver, and fix the fake ROM flow to use the correct key size and not an all-zero key.
