### PR TITLE
Check MailBox FSM before disabling attestation

### DIFF
--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -47,6 +47,12 @@ impl Mailbox {
         mbox.status().read().status().cmd_busy()
     }
 
+    /// Get the current state of the mailbox FSM
+    pub fn mailbox_state(&self) -> MboxFsmE {
+        let mbox = self.mbox.regs();
+        mbox.status().read().mbox_fsm_ps()
+    }
+
     /// Get the length of the current mailbox data in bytes
     pub fn dlen(&self) -> u32 {
         let mbox = self.mbox.regs();

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -7,7 +7,7 @@ use caliptra_builder::{
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState};
-use caliptra_registers::mbox::enums::MboxStatusE;
+use caliptra_registers::mbox::enums::MboxFsmE;
 use dpe::DPE_PROFILE;
 use openssl::sha::sha384;
 use zerocopy::IntoBytes;
@@ -90,6 +90,7 @@ fn test_rt_journey_pcr_validation() {
 }
 
 #[test]
+#[cfg(not(feature = "fpga_realtime"))]
 fn test_mbox_busy_during_warm_reset() {
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
@@ -132,10 +133,79 @@ fn test_mbox_busy_during_warm_reset() {
     // Wait for boot
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
-    model
-        .soc_mbox()
-        .status()
-        .write(|w| w.status(|_| MboxStatusE::CmdBusy));
+    // Perform warm reset
+    model.warm_reset_flow(&Fuses {
+        key_manifest_pk_hash: vendor_pk_hash,
+        owner_pk_hash,
+        fmc_key_manifest_svn: 0b1111111,
+        ..Default::default()
+    });
+
+    model.soc_mbox().unlock().write(|w| w.unlock(true));
+    if model.soc_mbox().lock().read().lock() {
+        panic!("Failed to lock mailbox after forcing it unlocked.");
+    }
+
+    // Mailbox lock value should read 1 now
+    // If not, the reads are likely being blocked by the PAUSER check or some other issue
+    if !(model.soc_mbox().lock().read().lock()) {
+        panic!("Mailbox should be locked");
+    }
+
+    assert!(model.soc_mbox().status().read().mbox_fsm_ps() != MboxFsmE::MboxIdle);
+    assert!(model.soc_mbox().status().read().status().cmd_busy());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_fw_error_non_fatal().read()
+            == u32::from(CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET)
+    });
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+}
+
+#[test]
+fn test_mbox_idle_during_warm_reset() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions {
+            fmc_svn: 9,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let vendor_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.vendor_pub_keys.as_bytes()));
+    let owner_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.owner_pub_keys.as_bytes()));
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            security_state,
+            ..Default::default()
+        },
+        BootParams {
+            fuses: Fuses {
+                key_manifest_pk_hash: vendor_pk_hash,
+                owner_pk_hash,
+                fmc_key_manifest_svn: 0b1111111,
+                ..Default::default()
+            },
+            fw_image: Some(&image.to_bytes().unwrap()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
     // Perform warm reset
     model.warm_reset_flow(&Fuses {
@@ -146,10 +216,11 @@ fn test_mbox_busy_during_warm_reset() {
     });
 
     model.step_until(|m| {
-        m.soc_ifc().cptra_fw_error_non_fatal().read()
+        if m.soc_ifc().cptra_fw_error_non_fatal().read()
             == u32::from(CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET)
+        {
+            panic!("Did not expect RUNTIME_CMD_BUSY_DURING_WARM_RESET during warm reset!");
+        }
+        m.soc_ifc().cptra_flow_status().read().ready_for_runtime()
     });
-
-    // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 }


### PR DESCRIPTION
A warm reset should not disable attestation if the mailbox is idle.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/2019.
