### PR TITLE
[fix] MLDSA driver fix for zero signatures

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -313,6 +313,11 @@ impl CaliptraError {
             "Driver Error: MLDSA87 key generation seed bad usage"
         ),
         (
+            DRIVER_MLDSA87_UNSUPPORTED_SIGNATURE,
+            0x00058006,
+            "Driver Error: MLDSA87 signature is not supported"
+        ),
+        (
             DRIVER_KV_ERASE_USE_LOCK_SET_FAILURE,
             0x00060001,
             "Driver Error: KV erase use lock set failure"


### PR DESCRIPTION
This update modifies the MLDSA driver to handle signatures where the last 64 bytes (known as verify_result) are zero. Since the MLDSA hardware returns a verify_result of all zeros when a signature verification fails, it becomes impossible to differentiate between valid and invalid signatures that end with 64 zero bytes. With this change, any signature with the last 64 bytes as zeros will be treated as invalid.