### PR TITLE
FPGA fixes for 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -288,7 +288,7 @@ dependencies = [
  "elf",
  "hex",
  "memoffset 0.8.0",
- "nix 0.26.2",
+ "nix",
  "once_cell",
  "serde",
  "serde_derive",
@@ -358,7 +358,7 @@ version = "0.1.0"
 dependencies = [
  "caliptra-drivers",
  "caliptra-registers",
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "caliptra-lms-types",
  "caliptra-registers",
  "caliptra-test",
- "cfg-if 1.0.0",
+ "cfg-if",
  "dpe",
  "openssl",
  "ufmt",
@@ -402,7 +402,7 @@ dependencies = [
  "caliptra-lms-types",
  "caliptra-registers",
  "caliptra-test-harness",
- "cfg-if 1.0.0",
+ "cfg-if",
  "zerocopy",
 ]
 
@@ -523,7 +523,7 @@ dependencies = [
  "caliptra-test",
  "caliptra-x509",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
  "openssl",
  "ufmt",
  "zerocopy",
@@ -557,7 +557,7 @@ dependencies = [
  "caliptra-test-harness-types",
  "caliptra-verilated",
  "libc",
- "nix 0.26.2",
+ "nix",
  "rand",
  "sha2",
  "uio",
@@ -625,7 +625,7 @@ dependencies = [
  "caliptra-image-gen",
  "caliptra-image-types",
  "caliptra-lms-types",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "openssl",
  "p384",
@@ -776,7 +776,7 @@ dependencies = [
  "caliptra-test",
  "caliptra-x509",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
  "elf",
  "fips204",
  "hex",
@@ -800,7 +800,7 @@ dependencies = [
  "caliptra-registers",
  "caliptra-x509",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ufmt",
  "ureg",
  "zerocopy",
@@ -813,7 +813,7 @@ dependencies = [
  "caliptra-cpu",
  "caliptra-drivers",
  "caliptra-image-types",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ufmt",
 ]
 
@@ -848,7 +848,7 @@ dependencies = [
  "caliptra-test",
  "caliptra-x509",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cms",
  "crypto",
  "dpe",
@@ -875,7 +875,7 @@ dependencies = [
  "caliptra-runtime",
  "caliptra-test-harness",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ufmt",
  "zerocopy",
 ]
@@ -930,7 +930,7 @@ name = "caliptra-test-harness"
 version = "0.1.0"
 dependencies = [
  "caliptra-drivers",
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -971,7 +971,7 @@ dependencies = [
  "caliptra-gen-linker-scripts",
  "caliptra-hw-model",
  "caliptra_common",
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1038,12 +1038,6 @@ checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -1279,7 +1273,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -1380,7 +1374,7 @@ dependencies = [
  "bitflags 2.4.0",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
  "crypto",
  "platform",
@@ -1592,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4fddc6f9d12cbef29e395d9a6b48c128f513c8a2ded7048c97ed5c484e53e7"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "managed",
  "num-traits",
@@ -1626,7 +1620,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -1734,7 +1728,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1815,7 +1809,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1864,25 +1858,12 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becb657d662f1cd2ef38c7ad480ec6b8cf9e96b27adb543e594f9cf0f2e6065c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -1957,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
  "bitflags 2.4.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2032,7 +2013,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2087,7 +2068,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ufmt",
 ]
 
@@ -2364,7 +2345,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2486,7 +2467,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
@@ -2658,13 +2639,13 @@ source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81
 
 [[package]]
 name = "uio"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5073b92c4a389c020d930424896f62c431b8cd858920519647aa1b1de5968fd1"
+checksum = "fe6429670644060fac2d02d8d284c7f9369a1e71948a654d7f064dbba07fb508"
 dependencies = [
  "fs2",
  "libc",
- "nix 0.11.1",
+ "nix",
 ]
 
 [[package]]
@@ -2737,12 +2718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,7 +2729,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ tinytemplate = "1.1"
 tock-registers = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 toml = "0.7.0"
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
-uio = { version = "0.2.0" }
+uio = { version = "0.4.0" }
 ureg = { path = "ureg" }
 ureg-codegen = { path = "ureg/lib/codegen" }
 ureg-schema = { path = "ureg/lib/schema" }

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -37,6 +37,10 @@ pub fn report_boot_status(val: u32) {
     if !soc_ifc.regs().cptra_security_state().read().debug_locked() {
         soc_ifc.regs_mut().cptra_boot_status().write(|_| val);
     }
+    // TODO: remove this when debug unlock is fixed
+    if cfg!(feature = "fpga_realtime") {
+        soc_ifc.regs_mut().cptra_boot_status().write(|_| val);
+    }
 }
 
 pub fn reset_reason() -> ResetReason {

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -37,7 +37,7 @@ pub fn report_boot_status(val: u32) {
     if !soc_ifc.regs().cptra_security_state().read().debug_locked() {
         soc_ifc.regs_mut().cptra_boot_status().write(|_| val);
     }
-    // TODO: remove this when debug unlock is fixed
+    // [TODO][CAP2]: remove this when debug unlock is fixed
     if cfg!(feature = "fpga_realtime") {
         soc_ifc.regs_mut().cptra_boot_status().write(|_| val);
     }

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -353,7 +353,59 @@ impl HwModel for ModelFpgaRealtime {
     }
 
     fn step(&mut self) {
+        // The FPGA can't be stopped.
+        // Never stop never stopping.
         self.handle_log();
+    }
+
+    fn step_until_boot_status(
+        &mut self,
+        expected_status_u32: u32,
+        ignore_intermediate_status: bool,
+    ) {
+        // We need to check the cycle count from the FPGA, and do so quickly
+        // as possible since the ARM host core is slow.
+
+        // do an immediate check
+        let initial_boot_status_u32: u32 = self.soc_ifc().cptra_boot_status().read();
+        if initial_boot_status_u32 == expected_status_u32 {
+            return;
+        }
+
+        // Since the boot takes about 30M cycles, we know something is wrong if
+        // we're stuck at the same state for that duration.
+        const MAX_WAIT_CYCLES: u32 = 30_000_000;
+        // only check the log every 4096 cycles for performance reasons
+        const LOG_CYCLES: usize = 0x1000;
+
+        let start_cycle_count = self.cycle_count();
+        for i in 0..usize::MAX {
+            let actual_status_u32 = self.soc_ifc().cptra_boot_status().read();
+            if expected_status_u32 == actual_status_u32 {
+                break;
+            }
+
+            if !ignore_intermediate_status && actual_status_u32 != initial_boot_status_u32 {
+                let cycle_count = self.cycle_count().wrapping_sub(start_cycle_count);
+                panic!(
+                    "{cycle_count} Expected the next boot_status to be \
+                    ({expected_status_u32}), but status changed from \
+                    {initial_boot_status_u32} to {actual_status_u32})"
+                );
+            }
+
+            // only handle the log sometimes so that we don't miss a state transition
+            if i & (LOG_CYCLES - 1) == 0 {
+                self.handle_log();
+            }
+            let cycle_count = self.cycle_count().wrapping_sub(start_cycle_count);
+            if cycle_count >= MAX_WAIT_CYCLES {
+                panic!(
+                    "Expected boot_status to be \
+                    ({expected_status_u32}), but was stuck at ({actual_status_u32})"
+                );
+            }
+        }
     }
 
     fn new_unbooted(params: crate::InitParams) -> Result<Self, Box<dyn std::error::Error>>
@@ -362,7 +414,8 @@ impl HwModel for ModelFpgaRealtime {
     {
         let output = Output::new(params.log_writer);
         let uio_num = usize::from_str(&env::var("CPTRA_UIO_NUM")?)?;
-        let dev = UioDevice::new(uio_num)?;
+        // This locks the device, and so acts as a test mutex so that only one test can run at a time.
+        let dev = UioDevice::blocking_new(uio_num)?;
 
         let wrapper = dev
             .map_mapping(FPGA_WRAPPER_MAPPING)
@@ -478,11 +531,7 @@ impl HwModel for ModelFpgaRealtime {
     }
 
     fn output(&mut self) -> &mut crate::Output {
-        let cycle = unsafe {
-            self.wrapper
-                .offset(FPGA_WRAPPER_CYCLE_COUNT_OFFSET)
-                .read_volatile()
-        };
+        let cycle = self.cycle_count();
         self.output.sink().set_now(u64::from(cycle));
         &mut self.output
     }
@@ -548,6 +597,14 @@ impl HwModel for ModelFpgaRealtime {
 }
 
 impl ModelFpgaRealtime {
+    fn cycle_count(&self) -> u32 {
+        unsafe {
+            self.wrapper
+                .offset(FPGA_WRAPPER_CYCLE_COUNT_OFFSET)
+                .read_volatile()
+        }
+    }
+
     pub fn launch_openocd(&mut self) -> Result<(), OpenOcdError> {
         let _ = Command::new("sudo")
             .arg("pkill")

--- a/hw-model/tests/model_tests.rs
+++ b/hw-model/tests/model_tests.rs
@@ -296,6 +296,7 @@ fn test_pcr_extend() {
 
 #[test]
 #[cfg(feature = "fpga_realtime")]
+#[ignore] // TODO: this will hard crash the FPGA host in 2.0 until we update the test binary
 fn test_mbox_pauser_sigbus() {
     fn find_binary_path() -> Option<&'static str> {
         // Use this path when running on github.

--- a/hw/fpga/io_module/io_module.c
+++ b/hw/fpga/io_module/io_module.c
@@ -36,7 +36,7 @@ int init_module(void)
     // Caliptra MMIO interface
     uio_info.mem[1].name = "caliptra";
     uio_info.mem[1].addr = 0xA4100000;
-    uio_info.mem[1].size = 0x00040000;
+    uio_info.mem[1].size = 0x00100000;
     uio_info.mem[1].memtype = UIO_MEM_PHYS;
 
     // Caliptra ROM
@@ -78,4 +78,3 @@ void cleanup_module(void)
 }
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Linux");
-

--- a/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
+++ b/rom/dev/tests/rom_integration_tests/test_dice_derivations.rs
@@ -14,6 +14,7 @@ use caliptra_hw_model::InitParams;
 
 use crate::helpers;
 
+#[cfg_attr(feature = "fpga_realtime", ignore)] // The FPGA is too fast for the host to catch these state transitions.
 #[test]
 fn test_cold_reset_status_reporting() {
     for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -40,20 +41,13 @@ fn test_cold_reset_status_reporting() {
         hw.step_until_boot_status(IDevIdKeyPairDerivationComplete.into(), false);
         hw.step_until_boot_status(IDevIdSubjIdSnGenerationComplete.into(), false);
         hw.step_until_boot_status(IDevIdSubjKeyIdGenerationComplete.into(), false);
-        // step_until_boot_status(IDevIdMakeCsrEnvelopeComplete, false);
-        // step_until_boot_status(IDevIdSendCsrEnvelopeComplete, false);
         hw.step_until_boot_status(IDevIdDerivationComplete.into(), false);
         hw.step_until_boot_status(LDevIdCdiDerivationComplete.into(), false);
         hw.step_until_boot_status(LDevIdKeyPairDerivationComplete.into(), false);
         hw.step_until_boot_status(LDevIdSubjIdSnGenerationComplete.into(), false);
         hw.step_until_boot_status(LDevIdSubjKeyIdGenerationComplete.into(), false);
-        if cfg!(feature = "fpga_realtime") {
-            // Skip check for LDevIdCertSigGenerationComplete because it is set for too short of a time in nolog mode
-            hw.step_until_boot_status(LDevIdDerivationComplete.into(), true);
-        } else {
-            hw.step_until_boot_status(LDevIdCertSigGenerationComplete.into(), false);
-            hw.step_until_boot_status(LDevIdDerivationComplete.into(), false);
-        }
+        hw.step_until_boot_status(LDevIdCertSigGenerationComplete.into(), false);
+        hw.step_until_boot_status(LDevIdDerivationComplete.into(), false);
 
         // Wait for uploading firmware.
         hw.step_until(|m| {
@@ -92,15 +86,8 @@ fn test_cold_reset_status_reporting() {
         hw.step_until_boot_status(FwProcessorImageVerificationComplete.into(), false);
         hw.step_until_boot_status(FwProcessorPopulateDataVaultComplete.into(), false);
         hw.step_until_boot_status(FwProcessorExtendPcrComplete.into(), false);
-
-        if cfg!(feature = "fpga_realtime") {
-            // Skip check for FwProcessorLoadImageComplete because it is set for too short of a time in nolog mode
-            hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), true);
-        } else {
-            hw.step_until_boot_status(FwProcessorLoadImageComplete.into(), false);
-            hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), false);
-        }
-
+        hw.step_until_boot_status(FwProcessorLoadImageComplete.into(), false);
+        hw.step_until_boot_status(FwProcessorFirmwareDownloadTxComplete.into(), false);
         hw.step_until_boot_status(FwProcessorCalculateKeyLadderComplete.into(), false);
         hw.step_until_boot_status(FwProcessorComplete.into(), false);
         hw.step_until_boot_status(FmcAliasDeriveCdiComplete.into(), false);

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -2385,18 +2385,6 @@ fn cert_test_with_custom_dates() {
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
-        let mut hw = caliptra_hw_model::new(
-            InitParams {
-                rom: &rom,
-                security_state: SecurityState::from(fuses.life_cycle as u32),
-                ..Default::default()
-            },
-            BootParams {
-                fuses,
-                ..Default::default()
-            },
-        )
-        .unwrap();
 
         opts.vendor_config
             .not_before
@@ -2420,6 +2408,19 @@ fn cert_test_with_custom_dates() {
         let image_bundle =
             caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, opts)
                 .unwrap();
+
+        let mut hw = caliptra_hw_model::new(
+            InitParams {
+                rom: &rom,
+                security_state: SecurityState::from(fuses.life_cycle as u32),
+                ..Default::default()
+            },
+            BootParams {
+                fuses,
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let mut output = vec![];
 
@@ -2477,6 +2478,13 @@ fn cert_test() {
             ..Default::default()
         };
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+        let image_bundle = caliptra_builder::build_and_sign_image(
+            &TEST_FMC_WITH_UART,
+            &APP_WITH_UART,
+            image_options,
+        )
+        .unwrap();
+
         let mut hw = caliptra_hw_model::new(
             InitParams {
                 rom: &rom,
@@ -2487,13 +2495,6 @@ fn cert_test() {
                 fuses,
                 ..Default::default()
             },
-        )
-        .unwrap();
-
-        let image_bundle = caliptra_builder::build_and_sign_image(
-            &TEST_FMC_WITH_UART,
-            &APP_WITH_UART,
-            image_options,
         )
         .unwrap();
 
@@ -2554,6 +2555,10 @@ fn cert_test_with_ueid() {
         fuses.idevid_cert_attr[IdevidCertAttr::UeidType as usize] = 1;
 
         let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+        let image_bundle =
+            caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, opts)
+                .unwrap();
+
         let mut hw = caliptra_hw_model::new(
             InitParams {
                 rom: &rom,
@@ -2566,10 +2571,6 @@ fn cert_test_with_ueid() {
             },
         )
         .unwrap();
-
-        let image_bundle =
-            caliptra_builder::build_and_sign_image(&TEST_FMC_WITH_UART, &APP_WITH_UART, opts)
-                .unwrap();
 
         let mut output = vec![];
 

--- a/rom/dev/tests/rom_integration_tests/test_uds_programming.rs
+++ b/rom/dev/tests/rom_integration_tests/test_uds_programming.rs
@@ -16,6 +16,7 @@ use caliptra_builder::firmware::ROM_WITH_UART;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DbgManufServiceRegReq, DeviceLifecycle, HwModel, SecurityState};
 
+#[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI
 #[test]
 fn test_uds_programming_no_active_mode() {
     let security_state =
@@ -44,6 +45,7 @@ fn test_uds_programming_no_active_mode() {
     );
 }
 
+#[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI
 #[test]
 fn test_uds_programming_active_mode() {
     let security_state =

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -126,9 +126,11 @@ fn test_update_reset_no_mailbox_cmd() {
             hw.mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE, &[])
                 .unwrap();
 
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+            }
+            hw.step_until_boot_status(UpdateResetStarted.into(), true);
 
             // No command in the mailbox.
             hw.step_until(|m| m.soc_ifc().cptra_fw_error_non_fatal().read() != 0);
@@ -187,8 +189,11 @@ fn test_update_reset_non_fw_load_cmd() {
             // "unknown" command in the mailbox for the ROM to find
             hw.start_mailbox_execute(TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD, &[])
                 .unwrap();
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
+
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+            }
             hw.step_until_boot_status(UpdateResetStarted.into(), true);
 
             let _ = hw.mailbox_execute(0xDEADBEEF, &[]);
@@ -246,9 +251,11 @@ fn test_update_reset_verify_image_failure() {
             hw.start_mailbox_execute(CommandId::FIRMWARE_LOAD.into(), &[0u8; 4])
                 .unwrap();
 
-            hw.step_until_boot_status(KatStarted.into(), true);
-            hw.step_until_boot_status(KatComplete.into(), true);
-            hw.step_until_boot_status(UpdateResetStarted.into(), false);
+            if cfg!(not(feature = "fpga_realtime")) {
+                hw.step_until_boot_status(KatStarted.into(), true);
+                hw.step_until_boot_status(KatComplete.into(), true);
+            }
+            hw.step_until_boot_status(UpdateResetStarted.into(), true);
 
             assert_eq!(
                 hw.finish_mailbox_execute(),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -63,7 +63,7 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 emu = ["caliptra_common/emu", "caliptra-drivers/emu"]
-itrng = ["caliptra-hw-model/itrng"]
+itrng = ["caliptra-drivers/itrng", "caliptra-hw-model/itrng"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 slow_tests = []
@@ -74,5 +74,5 @@ no-cfi = [
     "caliptra-drivers/no-cfi",
     "dpe/no-cfi",
 ]
-fpga_realtime = ["caliptra-drivers/fpga_realtime"]
+fpga_realtime = ["caliptra-drivers/fpga_realtime", "caliptra-hw-model/fpga_realtime"]
 fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
+
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
-#[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, InitParams};
@@ -13,7 +13,7 @@ use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
-#[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
 #[test]
 fn test_loads_mcu_fw() {
     // Test that the recovery flow runs and loads MCU's firmware

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -576,25 +576,45 @@ fn make_model_with_security_state(
 fn test_key_ladder_changes_with_lifecycle() {
     // Test with several combinations of security state.
 
-    let mut model =
-        make_model_with_security_state(&FMC_WITH_UART, &MBOX, false, DeviceLifecycle::Production);
-    let ladder_a = get_ladder_digest(&mut model, 0);
+    let ladder_a = {
+        let mut model = make_model_with_security_state(
+            &FMC_WITH_UART,
+            &MBOX,
+            false,
+            DeviceLifecycle::Production,
+        );
+        get_ladder_digest(&mut model, 0)
+    };
 
-    model = make_model_with_security_state(
-        &FMC_WITH_UART,
-        &MBOX,
-        false,
-        DeviceLifecycle::Manufacturing,
-    );
-    let ladder_b = get_ladder_digest(&mut model, 0);
+    let ladder_b = {
+        let mut model = make_model_with_security_state(
+            &FMC_WITH_UART,
+            &MBOX,
+            false,
+            DeviceLifecycle::Manufacturing,
+        );
+        get_ladder_digest(&mut model, 0)
+    };
 
-    model =
-        make_model_with_security_state(&FMC_WITH_UART, &MBOX, true, DeviceLifecycle::Production);
-    let ladder_c = get_ladder_digest(&mut model, 0);
+    let ladder_c = {
+        let mut model = make_model_with_security_state(
+            &FMC_WITH_UART,
+            &MBOX,
+            true,
+            DeviceLifecycle::Production,
+        );
+        get_ladder_digest(&mut model, 0)
+    };
 
-    model =
-        make_model_with_security_state(&FMC_WITH_UART, &MBOX, true, DeviceLifecycle::Manufacturing);
-    let ladder_d = get_ladder_digest(&mut model, 0);
+    let ladder_d = {
+        let mut model = make_model_with_security_state(
+            &FMC_WITH_UART,
+            &MBOX,
+            true,
+            DeviceLifecycle::Manufacturing,
+        );
+        get_ladder_digest(&mut model, 0)
+    };
 
     assert_ne!(ladder_a, ladder_b);
     assert_ne!(ladder_a, ladder_c);
@@ -613,11 +633,17 @@ fn test_key_ladder_stable_across_fw_updates() {
     let (fmc_a, app_a) = (&FMC_WITH_UART, &MBOX);
     let (fmc_b, app_b) = (&FMC_FAKE_WITH_UART, &MBOX_WITHOUT_UART);
 
-    let mut model = make_model_with_security_state(fmc_a, app_a, true, DeviceLifecycle::Production);
-    let ladder_a = get_ladder_digest(&mut model, 0);
+    let ladder_a = {
+        let mut model =
+            make_model_with_security_state(fmc_a, app_a, true, DeviceLifecycle::Production);
+        get_ladder_digest(&mut model, 0)
+    };
 
-    model = make_model_with_security_state(fmc_b, app_b, true, DeviceLifecycle::Production);
-    let ladder_b = get_ladder_digest(&mut model, 0);
+    let ladder_b = {
+        let mut model =
+            make_model_with_security_state(fmc_b, app_b, true, DeviceLifecycle::Production);
+        get_ladder_digest(&mut model, 0)
+    };
 
     assert_eq!(ladder_a, ladder_b);
 }

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -686,6 +686,8 @@ pub fn execute_all_services_rt() {
     exec_cmd_get_rt_cert(&mut hw);
 
     // ECDSA384_VERIFY
+    // TODO: add LMS verify
+    // TODO: add MLDSA verify
     exec_cmd_ecdsa_verify(&mut hw);
 
     // STASH_MEASUREMENT


### PR DESCRIPTION
A collection of misc fixes for tests to run on the FPGA.

* Update `uio` to `0.4.0` so that when it `drop()`s it closes its file descriptor. (Otherwise, tests that run multiple hardware models will block forever.)
* The FPGA is faster and will miss fast boot status changes. We update the boot status check loop to be faster, and modify the tests to be more lax on checking state transitions when running on the FPGA.
* The boot status is currently not observable on the the FPGA due to bugs in debug unlock. So, we turn back on boot status observability in the FPGA unconditionally.
* The ARM host that the FPGA uses is slow, and if we start the `HwModel` before starting the build process, usually the FPGA will have run millions of cycles. So, we move builds to before starting the `HwModel` when timing is important.
* Fix some `fpga_realtime` feature propagation in `Cargo.toml` so that the right versions are used.
* Make sure we drop an `HwModel` before creating another one.