### PR TITLE
runtime: Add cryptographic mailbox commands for SHA

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1092,6 +1092,10 @@ The sequence to use these are:
 
 For each command, the context from the previous command's output must be passed as an input.
 
+The `SHA_CONTEXT_SIZE` is always exactly 200 bytes long.
+
+The maximum supported data size for the SHA commands is 4096 bytes.
+
 Command Code: `0x434D_5349` ("CMSI")
 
 *Table: `CM_SHA_INIT` input arguments*
@@ -1101,26 +1105,24 @@ Command Code: `0x434D_5349` ("CMSI")
 | chksum         | u32           |                    |
 | hash algorithm | u32           | Enum.              |
 |                |               | Value 0 = reserved |
-|                |               | Value 1 = SHA2-256 |
-|                |               | Value 2 = SHA2-384 |
-|                |               | Value 3 = SHA2-512 |
+|                |               | Value 1 = SHA2-384 |
+|                |               | Value 2 = SHA2-512 |
 | data size      | u32           |                    |
 | data           | u8[data size] | Data to hash       |
 
 *Table: `CM_SHA_INIT` output arguments*
-| **Name**     | **Type**         | **Description**                            |
-| ------------ | ---------------- | ------------------------------------------ |
-| chksum       | u32              |                                            |
-| fips_status  | u32              | FIPS approved or an error                  |
-| context size | u32              |                                            |
-| context      | u8[context size] | Passed to `CM_SHA_UPDATE` / `CM_SHA_FINAL` |
+| **Name**     | **Type**             | **Description**                            |
+| ------------ | -------------------- | ------------------------------------------ |
+| chksum       | u32                  |                                            |
+| fips_status  | u32                  | FIPS approved or an error                  |
+| context      | u8[SHA_CONTEXT_SIZE] | Passed to `CM_SHA_UPDATE` / `CM_SHA_FINAL` |
 
 *Table: `CM_SHA_INIT` / `CM_SHA_UPDATE` / `CM_SHA_FINAL` internal context*
 | **Name**          | **Type** | **Description** |
 | ----------------- | -------- | --------------- |
 | input buffer      | u8[128]  |                 |
 | intermediate hash | u8[64]   |                 |
-| length            | u64      |                 |
+| length            | u32      |                 |
 | hash algorithm    | u32      |                 |
 
 ### CM_SHA_UPDATE
@@ -1132,21 +1134,19 @@ The context MUST be passed in from `CM_SHA_INIT` or `CM_SHA_UPDATE`.
 Command Code: `0x434D_5355` ("CMSU")
 
 *Table: `CM_SHA_UPDATE` input arguments*
-| **Name**     | **Type**         | **Description**                      |
-| ------------ | ---------------- | ------------------------------------ |
-| chksum       | u32              |                                      |
-| context size | u32              |                                      |
-| context      | u8[context size] | From `CM_SHA_INIT` / `CM_SHA_UPDATE` |
-| data size    | u32              |                                      |
-| data         | u8[data size]    | Data to hash                         |
+| **Name**     | **Type**             | **Description**                      |
+| ------------ | -------------------- | ------------------------------------ |
+| chksum       | u32                  |                                      |
+| context      | u8[SHA_CONTEXT_SIZE] | From `CM_SHA_INIT` / `CM_SHA_UPDATE` |
+| data size    | u32                  |                                      |
+| data         | u8[data size]        | Data to hash                         |
 
 *Table: `CM_SHA_UPDATE` output arguments*
-| **Name**     | **Type**         | **Description**                            |
-| ------------ | ---------------- | ------------------------------------------ |
-| chksum       | u32              |                                            |
-| fips_status  | u32              | FIPS approved or an error                  |
-| context size | u32              |                                            |
-| context      | u8[context size] | Passed to `CM_SHA_UPDATE` / `CM_SHA_FINAL` |
+| **Name**     | **Type**             | **Description**                            |
+| ------------ | -------------------- | ------------------------------------------ |
+| chksum       | u32                  |                                            |
+| fips_status  | u32                  | FIPS approved or an error                  |
+| context      | u8[SHA_CONTEXT_SIZE] | Passed to `CM_SHA_UPDATE` / `CM_SHA_FINAL` |
 
 ### CM_SHA_FINAL
 
@@ -1157,13 +1157,12 @@ The context MUST be passed in from `CM_SHA_INIT` or `CMA_SHA_UPDATE`.
 Command Code: `0x434D_5346` ("CMSF")
 
 *Table: `CM_SHA_FINAL` input arguments*
-| **Name**     | **Type**         | **Description**                      |
-| ------------ | ---------------- | ------------------------------------ |
-| chksum       | u32              |                                      |
-| context size | u32              |                                      |
-| context      | u8[context size] | From `CM_SHA_INIT` / `CM_SHA_UPDATE` |
-| data size    | u32              | May be 0                             |
-| data         | u8[data size]    | Data to hash                         |
+| **Name**     | **Type**             | **Description**                      |
+| ------------ | -------------------- | ------------------------------------ |
+| chksum       | u32                  |                                      |
+| context      | u8[SHA_CONTEXT_SIZE] | From `CM_SHA_INIT` / `CM_SHA_UPDATE` |
+| data size    | u32                  | May be 0                             |
+| data         | u8[data size]        | Data to hash                         |
 
 *Table: `CM_SHA_FINAL` output arguments*
 | **Name**    | **Type**      | **Description**           |

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,6 +241,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         // Cryptographic mailbox commands
         CommandId::CM_IMPORT => cryptographic_mailbox::Commands::import(drivers, cmd_bytes),
         CommandId::CM_STATUS => cryptographic_mailbox::Commands::status(drivers),
+        CommandId::CM_SHA_INIT => cryptographic_mailbox::Commands::sha_init(drivers, cmd_bytes),
+        CommandId::CM_SHA_UPDATE => cryptographic_mailbox::Commands::sha_update(drivers, cmd_bytes),
+        CommandId::CM_SHA_FINAL => cryptographic_mailbox::Commands::sha_final(drivers, cmd_bytes),
 
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     };

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -2,12 +2,15 @@
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use caliptra_api::mailbox::{
-    CmImportReq, CmImportResp, CmKeyUsage, CmStatusResp, MailboxReq, CMK_SIZE_BYTES,
+    CmImportReq, CmImportResp, CmKeyUsage, CmShaFinalReq, CmShaFinalResp, CmShaInitReq,
+    CmShaInitResp, CmShaUpdateReq, CmStatusResp, MailboxReq, MailboxResp, CMK_SIZE_BYTES,
+    MAX_CMB_DATA_SIZE,
 };
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
+use sha2::{Digest, Sha384, Sha512};
 use zerocopy::{FromBytes, IntoBytes};
 
 #[test]
@@ -162,4 +165,152 @@ fn test_import_full() {
 #[test]
 fn test_import_wraparound() {
     // TODO: implement this when we have the clear and delete commands
+}
+
+#[test]
+fn test_sha384_simple() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let input_data = "a".repeat(129);
+    let input_data = input_data.as_bytes();
+
+    // Simple case
+    let mut req = CmShaInitReq {
+        hash_algorithm: 1, // SHA384
+        input_size: input_data.len() as u32,
+        ..Default::default()
+    };
+    req.input[..input_data.len()].copy_from_slice(input_data);
+
+    let mut init = MailboxReq::CmShaInit(req);
+    init.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(u32::from(CommandId::CM_SHA_INIT), init.as_bytes().unwrap())
+        .unwrap()
+        .expect("Should have gotten a context");
+    let resp = CmShaInitResp::ref_from_bytes(resp_bytes.as_slice()).unwrap();
+
+    let req = CmShaFinalReq {
+        context: resp.context,
+        ..Default::default()
+    };
+
+    let mut fin = MailboxReq::CmShaFinal(req);
+    fin.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(u32::from(CommandId::CM_SHA_FINAL), fin.as_bytes().unwrap())
+        .unwrap()
+        .expect("Should have gotten a context");
+
+    let mut expected_resp = CmShaFinalResp::default();
+    expected_resp.hdr.data_len = 48;
+
+    let mut hasher = Sha384::new();
+    hasher.update(input_data);
+    let expected_hash = hasher.finalize();
+    expected_resp.hash[..48].copy_from_slice(expected_hash.as_bytes());
+    let mut expected_resp = MailboxResp::CmShaFinal(expected_resp);
+    expected_resp.populate_chksum().unwrap();
+    let expected_bytes = expected_resp.as_bytes().unwrap();
+    assert_eq!(expected_bytes, resp_bytes);
+}
+
+#[test]
+fn test_sha_many() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // check sha384 and sha512
+    for sha in [1, 2] {
+        // 467 is a prime so should exercise different edge cases in sizes but not take too long
+        for i in (0..MAX_CMB_DATA_SIZE * 4).step_by(467) {
+            let input_str = "a".repeat(i);
+            let input_copy = input_str.clone();
+            let original_input_data = input_copy.as_bytes();
+            let mut input_data = input_str.as_bytes().to_vec();
+            let mut input_data = input_data.as_mut_slice();
+            println!("Checking size {}", input_str.len());
+
+            let process = input_data.len().min(MAX_CMB_DATA_SIZE);
+
+            let mut req: CmShaInitReq = CmShaInitReq {
+                hash_algorithm: sha,
+                input_size: process as u32,
+                ..Default::default()
+            };
+            req.input[..process].copy_from_slice(&input_data[..process]);
+            input_data = &mut input_data[process..];
+
+            let mut init = MailboxReq::CmShaInit(req);
+            init.populate_chksum().unwrap();
+            let resp_bytes = model
+                .mailbox_execute(u32::from(CommandId::CM_SHA_INIT), init.as_bytes().unwrap())
+                .unwrap()
+                .expect("Should have gotten a context");
+            let mut resp = CmShaInitResp::ref_from_bytes(resp_bytes.as_slice()).unwrap();
+            let mut resp_bytes: Vec<u8>;
+
+            while input_data.len() > MAX_CMB_DATA_SIZE {
+                let mut req = CmShaUpdateReq {
+                    input_size: MAX_CMB_DATA_SIZE as u32,
+                    context: resp.context,
+                    ..Default::default()
+                };
+                req.input.copy_from_slice(&input_data[..MAX_CMB_DATA_SIZE]);
+
+                let mut update = MailboxReq::CmShaUpdate(req);
+                update.populate_chksum().unwrap();
+                resp_bytes = model
+                    .mailbox_execute(
+                        u32::from(CommandId::CM_SHA_UPDATE),
+                        update.as_bytes().unwrap(),
+                    )
+                    .unwrap()
+                    .expect("Should have gotten a context");
+
+                resp = CmShaInitResp::ref_from_bytes(resp_bytes.as_slice()).unwrap();
+                input_data = &mut input_data[MAX_CMB_DATA_SIZE..];
+            }
+
+            let mut req = CmShaFinalReq {
+                input_size: input_data.len() as u32,
+                context: resp.context,
+                ..Default::default()
+            };
+            req.input[..input_data.len()].copy_from_slice(input_data);
+
+            let mut fin = MailboxReq::CmShaFinal(req);
+            fin.populate_chksum().unwrap();
+            let resp_bytes = model
+                .mailbox_execute(u32::from(CommandId::CM_SHA_FINAL), fin.as_bytes().unwrap())
+                .unwrap()
+                .expect("Should have gotten a context");
+
+            let mut expected_resp = CmShaFinalResp::default();
+            if sha == 1 {
+                let mut hasher = Sha384::new();
+                hasher.update(original_input_data);
+                let expected_hash = hasher.finalize();
+                expected_resp.hash[..48].copy_from_slice(expected_hash.as_bytes());
+                expected_resp.hdr.data_len = 48;
+            } else {
+                let mut hasher = Sha512::new();
+                hasher.update(original_input_data);
+                let expected_hash = hasher.finalize();
+                expected_resp.hash.copy_from_slice(expected_hash.as_bytes());
+                expected_resp.hdr.data_len = 64;
+            };
+            let mut expected_resp = MailboxResp::CmShaFinal(expected_resp);
+            expected_resp.populate_chksum().unwrap();
+            let expected_bytes = expected_resp.as_bytes().unwrap();
+            assert_eq!(expected_bytes, resp_bytes);
+        }
+    }
 }

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -54,7 +54,7 @@ fn test_loads_mcu_fw() {
     assert!(found);
 }
 
-#[cfg(all(not(feature = "verilator"), not(feature = "fpga_realtime")))]
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
 #[test]
 fn test_mcu_fw_bad_signature() {
     // Test that the recovery flow runs and loads MCU's firmware

--- a/sw-emulator/lib/crypto/src/sha512.rs
+++ b/sw-emulator/lib/crypto/src/sha512.rs
@@ -116,6 +116,14 @@ impl Sha512 {
         }
     }
 
+    pub fn set_hash(&mut self, hash: &[u8]) {
+        let mut hash = Vec::from(hash);
+        hash.to_big_endian();
+        for i in 0..Self::HASH_SIZE / 8 {
+            self.hash[i] = u64::from_be_bytes(hash[i * 8..(i + 1) * 8].try_into().unwrap());
+        }
+    }
+
     /// Reset the state
     pub fn reset(&mut self, mode: Sha512Mode) {
         self.mode = mode;


### PR DESCRIPTION
Adds `SHA_INIT`, `SHA_UPDATE`, and `SHA_FINAL` commands using the hardware "restore" functionality for SHA384 and SHA512.

The hardware does not support restore functionality for SHA256, so I deleted that from the spec.

This was tested on the FPGA as well. I also manually tested every size between 0 and 16383 but didn't check it in since it would be too slow.