### PR TITLE
rtool error logging on github request failure

### DIFF
--- a/ci-tools/github-runner/cmd/rtool/main.go
+++ b/ci-tools/github-runner/cmd/rtool/main.go
@@ -70,6 +70,8 @@ func main() {
 			runner, err := hello.GitHubRegisterRunner(ctx, client, labels, os.Args[5])
 			if err == nil {
 				fmt.Println(runner.JitConfig)
+			} else {
+				log.Fatal(err)
 			}
 		}
 		if err != nil {

--- a/ci-tools/github-runner/launch.go
+++ b/ci-tools/github-runner/launch.go
@@ -63,7 +63,6 @@ func GitHubRegisterRunner(ctx context.Context, client *github.Client, labels []s
 		if response != nil {
 			log.Printf("%+v\n", response.Body)
 		}
-		log.Printf("%+v\n", response.Body)
 		return RunnerInfo{}, err
 	}
 	return RunnerInfo{


### PR DESCRIPTION
* On an error, the response.body call will segfault.
* The `err` variable is not printed.