### PR TITLE
Recovery register indirect fifo ctrl must be reset before reading image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "nix",
  "rand",
  "sha2",
+ "tock-registers",
  "uio",
  "ureg",
  "zerocopy",

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -650,6 +650,11 @@ impl<'a> DmaRecovery<'a> {
         let image_size_bytes = self.with_regs_mut(|regs_mut| {
             let recovery = regs_mut.sec_fw_recovery_if();
 
+            // set RESET signal to indirect control to load the next image
+            recovery
+                .indirect_fifo_ctrl_0()
+                .modify(|val| val.reset(Self::RESET_VAL));
+
             // Read the image size from INDIRECT_FIFO_CTRL1 register. Image size is in DWORDs.
             let image_size_dwords = recovery.indirect_fifo_ctrl_1().read();
             let image_size_bytes = image_size_dwords * size_of::<u32>() as u32;

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -35,6 +35,7 @@ nix.workspace = true
 libc.workspace = true
 caliptra-coverage = { workspace = true, optional = true }
 caliptra-image-types.workspace = true
+tock-registers.workspace = true
 
 [dev-dependencies]
 caliptra-builder.workspace = true


### PR DESCRIPTION
And something has to drive the image activation in the hw-model.