### PR TITLE
Downgrade GCE Instance size for FPGA builder

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -101,7 +101,7 @@ jobs:
           retention-days: 1
 
   build_test_binaries:
-    runs-on: [e2-standard-16]
+    runs-on: [e2-standard-8]
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
`e2-standard-16` often is at capacity in us-central-1. Downgrading the builder size to `e2-standard-8` should increase instance availability at the cost of slower builds.