### PR TITLE
runtime: Set device status to running recovery in to load additional images

### DIFF
--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -45,6 +45,8 @@ impl RecoveryFlow {
                 drivers.soc_ifc.mci_base_addr().into(),
                 dma,
             );
+            // need to make sure the device status is correct to load the next image
+            dma_recovery.set_device_status(DmaRecovery::DEVICE_STATUS_RUNNING_RECOVERY_IMAGE)?;
 
             // download SoC manifest
             dma_recovery.download_image_to_mbox(SOC_MANIFEST_INDEX, false)
@@ -61,6 +63,8 @@ impl RecoveryFlow {
                 drivers.soc_ifc.mci_base_addr().into(),
                 dma,
             );
+            // need to make sure the device status is correct to load the next image
+            dma_recovery.set_device_status(DmaRecovery::DEVICE_STATUS_RUNNING_RECOVERY_IMAGE)?;
             cprintln!("[rt] Uploading MCU firmware");
             let mcu_size_bytes = dma_recovery.download_image_to_mcu(MCU_FIRMWARE_INDEX, false)?;
             cprintln!("[rt] Calculating MCU digest");

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -144,7 +144,7 @@ impl AxiRootBus {
                             Device::MCU,
                             EventData::MemoryWrite {
                                 start_addr: (addr - Self::MCU_SRAM_OFFSET) as u32,
-                                data: val.to_be_bytes().to_vec(),
+                                data: val.to_le_bytes().to_vec(),
                             },
                         ))
                         .unwrap();
@@ -170,7 +170,7 @@ impl AxiRootBus {
             data,
         } = &event.event
         {
-            // we only access read responses from the MCU
+            // we only allow read responses from the MCU
             if event.src == Device::MCU {
                 self.dma_result = Some(words_from_bytes_be_vec(&data.clone()));
             }

--- a/sw-emulator/lib/periph/src/dma/recovery.rs
+++ b/sw-emulator/lib/periph/src/dma/recovery.rs
@@ -401,27 +401,22 @@ impl RecoveryRegisterInterface {
                     RecoveryCommandCode::DeviceId => (),     // read-only
                     RecoveryCommandCode::DeviceStatus => (), // read-only
                     RecoveryCommandCode::DeviceReset => {
-                        self.device_reset.reg.set(Self::read_max_bytes(&payload, 3));
+                        self.device_reset.reg.set(Self::read_max_bytes(payload, 3));
                     }
                     RecoveryCommandCode::RecoveryCtrl => {
-                        self.recovery_ctrl
-                            .reg
-                            .set(Self::read_max_bytes(&payload, 3));
+                        self.recovery_ctrl.reg.set(Self::read_max_bytes(payload, 3));
                     }
                     RecoveryCommandCode::RecoveryStatus => (), // read-only,
                     RecoveryCommandCode::HwStatus => (),       // read-only
                     RecoveryCommandCode::IndirectCtrl => {
                         // unsupported
-                        return;
                     }
                     RecoveryCommandCode::IndirectStatus => (), // read-only
                     RecoveryCommandCode::IndirectData => {
                         // not supported
-                        return;
                     }
                     RecoveryCommandCode::Vendor => {
                         // not supported
-                        return;
                     }
                     RecoveryCommandCode::IndirectFifoCtrl => {
                         if payload.len() < 6 {


### PR DESCRIPTION
And add support in the emulator recovery interface to accept incoming recovery block writes so that the MCU emulator (or other code) can write to the recovery registers. This is necessary for the MCU recovery flow to complete.

This is tested and working with the MCU emulator as working.