### PR TITLE
Set lifecycle to MFG for retrieve_csr_test

### DIFF
--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -79,16 +79,16 @@ fn assert_output_contains_regex(haystack: &str, needle: &str) {
     }
 }
 
-//TODO: https://github.com/chipsalliance/caliptra-sw/issues/2070
 #[test]
-#[cfg(not(feature = "fpga_realtime"))]
 fn retrieve_csr_test() {
     const GENERATE_IDEVID_CSR: u32 = 1;
     let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
     let mut hw = caliptra_hw_model::new(
         InitParams {
             rom: &rom,
-            security_state: *SecurityState::default().set_debug_locked(true),
+            security_state: *SecurityState::default()
+                .set_debug_locked(true)
+                .set_device_lifecycle(DeviceLifecycle::Manufacturing),
             ..Default::default()
         },
         BootParams {


### PR DESCRIPTION
Caliptra 2.0 RTL prevents real secrets from being used  when debug_locked is not set or in a mode other than Manufacturing or Prod. This test appears to rely on those secrets and needs to use Manufacturing or Prod to pass on RTL.