### PR TITLE
Store runtime execution status in DCCM

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -51,6 +51,7 @@ pub const MEASUREMENT_MAX_COUNT: usize = 8;
 const DPE_DCCM_STORAGE: usize = size_of::<DpeInstance>()
     + size_of::<u32>() * MAX_HANDLES
     + size_of::<U8Bool>() * MAX_HANDLES
+    + size_of::<U8Bool>()
     + size_of::<U8Bool>();
 
 #[cfg(feature = "runtime")]
@@ -236,6 +237,8 @@ pub struct PersistentData {
     pub context_has_tag: [U8Bool; MAX_HANDLES],
     #[cfg(feature = "runtime")]
     pub attestation_disabled: U8Bool,
+    #[cfg(feature = "runtime")]
+    pub runtime_cmd_active: U8Bool,
     #[cfg(feature = "runtime")]
     reserved6: [u8; DPE_SIZE as usize - DPE_DCCM_STORAGE],
     #[cfg(not(feature = "runtime"))]

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -9,7 +9,7 @@ use caliptra_common::{handle_fatal_error, mailbox_api::CommandId};
 use caliptra_drivers::{
     cprintln,
     pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_JOURNEY_PCR},
-    Array4x12, CaliptraError, CaliptraResult,
+    Array4x12, CaliptraError, CaliptraResult, ResetReason,
 };
 use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc::SocIfcReg};
 use caliptra_runtime::{
@@ -83,12 +83,26 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
     // Indicator to SOC that RT firmware is ready
     drivers.soc_ifc.assert_ready_for_runtime();
     caliptra_drivers::report_boot_status(RtBootStatus::RtReadyForCommands.into());
+
+    let command_was_running = drivers.persistent_data.get().runtime_cmd_active.get();
+    if command_was_running {
+        let reset_reason = drivers.soc_ifc.reset_reason();
+        if reset_reason == ResetReason::WarmReset {
+            caliptra_drivers::report_fw_error_non_fatal(
+                CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET.into(),
+            );
+        }
+    }
+
     loop {
         if drivers.is_shutdown {
             return Err(CaliptraError::RUNTIME_SHUTDOWN);
         }
+        drivers.soc_ifc.flow_status_set_mailbox_flow_done(true);
 
         if drivers.mbox.is_cmd_ready() {
+            drivers.soc_ifc.flow_status_set_mailbox_flow_done(false);
+
             caliptra_drivers::report_fw_error_non_fatal(0);
             match handle_command(drivers) {
                 Ok(status) => {
@@ -222,7 +236,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     .write(|w| w.core_rst(true));
             }
             CommandId(OPCODE_HOLD_COMMAND_BUSY) => {
-                drivers.soc_ifc.flow_status_set_mailbox_flow_done(false);
+                drivers.persistent_data.get_mut().runtime_cmd_active = U8Bool::new(true);
                 write_response(&mut drivers.mbox, &[]);
             }
             _ => {


### PR DESCRIPTION
This is because the `mailbox_flow_done` register is zeroed on warm resets.