### PR TITLE
Add kernel job build back to FPGA CI.

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -64,6 +64,85 @@ jobs:
             RTL_VERSION="latest"
           fi
           echo "rtl_cache_key=$(git rev-parse HEAD:hw/fpga/src)-$(git hash-object hw/fpga/fpga_configuration.tcl)-$(cd hw/${RTL_VERSION}/rtl && git rev-parse HEAD)-${{ inputs.fpga-itrng }}-${{ env.CACHE_BUSTER }}" >> $GITHUB_OUTPUT
+          echo "kmod_cache_key=fpga-kernel-modules-$(git rev-parse HEAD:hw/fpga/io_module)-$(git rev-parse HEAD:hw/fpga/rom_backdoor)-${{ env.CACHE_BUSTER }}" >> $GITHUB_OUTPUT
+
+      - name: Restore kernel modules from cache
+        uses: actions/cache/restore@v3
+        id: restore_kmod_cache
+        with:
+          path: /tmp/caliptra-fpga-kmod/
+          key: ${{ steps.cache_key.outputs.kmod_cache_key}}
+      - name: 'Upload kernel module artifacts'
+        if: steps.restore_kmod_cache.outputs.cache-hit
+        uses: actions/upload-artifact@v4
+        with:
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-fpga-kmod/
+          retention-days: 1
+
+  build_kernel_modules:
+    runs-on: ubuntu-22.04
+    needs: check_cache
+    if: "!needs.check_cache.outputs.kmod_cache_hit"
+    steps:
+      - name: Install sysroot pre-requisites
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools
+
+      - name: Setup xilinx sysroot
+        run: |
+          echo I am ${USER}
+
+          # NOTE: I would prefer to use
+          # iot-limerick-zcu-classic-desktop-2204-x05-2-20221123-58-sysroot.tar.xz,
+          # but it has source for kernel version 5.15.0-1014-xilinx-zynqmp
+          # instead of 5.15.0-1015-xilinx-zynqmp used by the pre-built kernel.
+          curl -o /tmp/sysroot.tar.gz https://people.canonical.com/~platform/images/xilinx/versal-ubuntu-22.04/iot-limerick-versal-classic-server-2204-x02-20230315-48-rootfs.tar.gz
+          SYSROOT="${GITHUB_WORKSPACE}/sysroot"
+          mkdir "${SYSROOT}"
+          sudo tar xf /tmp/sysroot.tar.gz -C "${SYSROOT}"
+          ls -l "${SYSROOT}"
+          sudo cp -L --remove-destination /etc/resolv.conf "${SYSROOT}/etc/"
+          sudo chroot "${SYSROOT}" mount -t proc proc /proc
+          sudo chroot "${SYSROOT}" mount -t devtmpfs devtmpfs /dev
+          sudo chroot "${SYSROOT}" mount -t tmpfs tmpfs /tmp/
+          sudo mkdir "${SYSROOT}/home/${USER}"
+          sudo chown "${USER}" "${SYSROOT}/home/${USER}"
+          #sudo chroot "${SYSROOT}" apt-get update
+          #sudo chroot "${SYSROOT}" apt-get -y install build-essential
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: sysroot/home/runner/caliptra-sw
+
+      - name: Build modules
+        run: |
+          SYSROOT="${GITHUB_WORKSPACE}/sysroot"
+          KERNEL=5.15.0-1015-xilinx-zynqmp
+          sudo chroot "${SYSROOT}" bash -c "cd /home/${USER}/caliptra-sw/hw/fpga/rom_backdoor && make KERNEL=${KERNEL}"
+          sudo chroot "${SYSROOT}" bash -c "cd /home/${USER}/caliptra-sw/hw/fpga/io_module && make KERNEL=${KERNEL}"
+          sudo ls -l "${SYSROOT}/home/${USER}/caliptra-sw/hw/fpga/io_module"
+          sudo ls -l "${SYSROOT}/home/${USER}/caliptra-sw/hw/fpga/rom_backdoor"
+
+          mkdir /tmp/caliptra-fpga-kmod
+          cp "${SYSROOT}/home/${USER}/caliptra-sw/hw/fpga/io_module/io_module.ko" /tmp/caliptra-fpga-kmod/
+          cp "${SYSROOT}/home/${USER}/caliptra-sw/hw/fpga/rom_backdoor/rom_backdoor.ko" /tmp/caliptra-fpga-kmod/
+
+      - name: Save kernel modules to cache
+        uses: actions/cache/save@v3
+        with:
+          path: /tmp/caliptra-fpga-kmod/
+          key: ${{ needs.check_cache.outputs.kmod_cache_key }}
+
+      - name: 'Upload kernel module artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-fpga-kmod/
+          retention-days: 1
+
 
   build_test_binaries:
     runs-on: [e2-standard-8]
@@ -179,17 +258,25 @@ jobs:
 
   test_artifacts:
     runs-on: vck190
-    needs: [check_cache, build_test_binaries]
+    needs: [check_cache, build_test_binaries, build_kernel_modules]
     if: |
       !cancelled() &&
       needs.check_cache.result == 'success' &&
-      (needs.build_test_binaries.result == 'success' || needs.build_test_binaries.result == 'skipped')
+      (needs.build_test_binaries.result == 'success' || needs.build_test_binaries.result == 'skipped') &&
+      (needs.build_kernel_modules.result == 'success' || needs.build_kernel_modules.result == 'skipped')
+
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           submodules: 'recursive' 
+
+      - name: 'Download kernel driver artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: caliptra-fpga-kmod${{ inputs.artifact-suffix }}
+          path: /tmp/caliptra-fpga-kmod/
 
       - name: 'Download Test Binaries Artifact'
         uses: actions/download-artifact@v4
@@ -215,9 +302,9 @@ jobs:
 
       - name: Install kernel modules
         run: |
-          sudo apt update
-          sudo apt install -y make gcc
-          sudo ./hw/fpga/setup_fpga.sh
+          ls -l /tmp/caliptra-fpga-kmod
+          sudo insmod /tmp/caliptra-fpga-kmod/io_module.ko
+          sudo insmod /tmp/caliptra-fpga-kmod/rom_backdoor.ko
 
       - name: Execute tests
         run: |


### PR DESCRIPTION
This is a pre-requisite to switching to a debian based image.