### PR TITLE
Add OpenOCD and JTAG tests back to FPGA

### DIFF
--- a/test/tests/caliptra_integration_tests/jtag_test.rs
+++ b/test/tests/caliptra_integration_tests/jtag_test.rs
@@ -68,9 +68,7 @@ fn gdb_mem_test<R>(
     }
 }
 
-//TODO: https://github.com/chipsalliance/caliptra-sw/issues/2070
 #[test]
-#[cfg(not(feature = "fpga_realtime"))]
 fn gdb_test() {
     #![cfg_attr(not(feature = "fpga_realtime"), ignore)]
 

--- a/test/tests/fips_test_suite/jtag_locked.rs
+++ b/test/tests/fips_test_suite/jtag_locked.rs
@@ -32,9 +32,7 @@ fn check_jtag_accessible(
     );
 }
 
-//TODO: https://github.com/chipsalliance/caliptra-sw/issues/2070
 #[test]
-#[cfg(not(feature = "fpga_realtime"))]
 fn jtag_locked() {
     #![cfg_attr(not(feature = "fpga_realtime"), ignore)]
 


### PR DESCRIPTION
These tests were disabled because the previous test image did not have these tools installed.