### PR TITLE
drivers: AES driver fixes and KAT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,38 @@
 version = 3
 
 [[package]]
-name = "aes"
-version = "0.8.2"
+name = "aead"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -452,6 +476,7 @@ name = "caliptra-emu-crypto"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "cbc",
  "p384",
  "rfc6979",
@@ -1221,7 +1246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1627,6 +1662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +1978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2122,18 @@ dependencies = [
  "arrayvec",
  "cfg-if",
  "ufmt",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2672,6 +2735,16 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "ureg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,8 @@ members = [
 ]
 
 [workspace.dependencies]
-aes = "0.8.2"
+aes = "0.8.4"
+aes-gcm = "0.10.3"
 anyhow = "1.0.70"
 arbitrary = { version = "1.3.0", features = ["derive"] }
 arrayref = "0.3.6"

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1910,6 +1910,21 @@ impl CaliptraError {
             "ROM KAT Error: LMS digest mismatch"
         ),
         (
+            KAT_AES_TAG_MISMATCH,
+            0x90090001,
+            "ROM KAT Error: AES tag mismatch"
+        ),
+        (
+            KAT_AES_CIPHERTEXT_MISMATCH,
+            0x90090002,
+            "ROM KAT Error: AES ciphertext mismatch"
+        ),
+        (
+            KAT_AES_PLAINTEXT_MISMATCH,
+            0x90090003,
+            "ROM KAT Error: AES plaintext mismatch"
+        ),
+        (
             KAT_SHA512_DIGEST_FAILURE,
             0x90020003,
             "ROM KAT Error: SHA512 digest failure"

--- a/kat/src/aes256gcm_kat.rs
+++ b/kat/src/aes256gcm_kat.rs
@@ -1,0 +1,91 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    aes256gcm_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for AES-256-GCM cryptography operations.
+
+--*/
+
+use caliptra_drivers::{Aes, AesKey, CaliptraError, CaliptraResult, Trng};
+
+// Taken from NIST test vectors: https://csrc.nist.gov/Projects/cryptographic-algorithm-validation-program/cavp-testing-block-cipher-modes#GCMVS
+
+// KEY = f0eaf7b41b42f4500635bc05d9cede11a5363d59a6288870f527bcffeb4d6e04
+// IV = 18f316781077a595c72d4c07
+// CT = 7a1b61009dce6b7cd4d1ea0203b179f1219dd5ce7407e12ea0a4c56c71bb791b
+// AAD = 42cade3a19204b7d4843628c425c2375
+// Tag = 4419180b0b963b7289a4fa3f45c535a3
+// PT = 400fb5ef32083b3abea957c4f068abad50c8d86bbf9351fa72e7da5171df38f9
+
+const KEY: [u8; 32] = [
+    0xf0, 0xea, 0xf7, 0xb4, 0x1b, 0x42, 0xf4, 0x50, 0x6, 0x35, 0xbc, 0x5, 0xd9, 0xce, 0xde, 0x11,
+    0xa5, 0x36, 0x3d, 0x59, 0xa6, 0x28, 0x88, 0x70, 0xf5, 0x27, 0xbc, 0xff, 0xeb, 0x4d, 0x6e, 0x4,
+];
+const IV: [u8; 12] = [
+    0x18, 0xf3, 0x16, 0x78, 0x10, 0x77, 0xa5, 0x95, 0xc7, 0x2d, 0x4c, 0x07,
+];
+const CT: [u8; 32] = [
+    0x7a, 0x1b, 0x61, 0x0, 0x9d, 0xce, 0x6b, 0x7c, 0xd4, 0xd1, 0xea, 0x2, 0x3, 0xb1, 0x79, 0xf1,
+    0x21, 0x9d, 0xd5, 0xce, 0x74, 0x7, 0xe1, 0x2e, 0xa0, 0xa4, 0xc5, 0x6c, 0x71, 0xbb, 0x79, 0x1b,
+];
+const AAD: [u8; 16] = [
+    0x42, 0xca, 0xde, 0x3a, 0x19, 0x20, 0x4b, 0x7d, 0x48, 0x43, 0x62, 0x8c, 0x42, 0x5c, 0x23, 0x75,
+];
+const TAG: [u8; 16] = [
+    0x44, 0x19, 0x18, 0xb, 0xb, 0x96, 0x3b, 0x72, 0x89, 0xa4, 0xfa, 0x3f, 0x45, 0xc5, 0x35, 0xa3,
+];
+const PT: [u8; 32] = [
+    0x40, 0xf, 0xb5, 0xef, 0x32, 0x8, 0x3b, 0x3a, 0xbe, 0xa9, 0x57, 0xc4, 0xf0, 0x68, 0xab, 0xad,
+    0x50, 0xc8, 0xd8, 0x6b, 0xbf, 0x93, 0x51, 0xfa, 0x72, 0xe7, 0xda, 0x51, 0x71, 0xdf, 0x38, 0xf9,
+];
+
+#[derive(Default, Debug)]
+pub struct Aes256GcmKat {}
+
+impl Aes256GcmKat {
+    /// This function executes the Known Answer Tests (aka KAT) for AES-256-GCM.
+    ///
+    /// Test vector source:
+    /// NIST test vectors
+    ///
+    /// # Arguments
+    ///
+    /// * `aes` - AES driver
+    /// * `trng` - TRNG driver
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self, aes: &mut Aes, trng: &mut Trng) -> CaliptraResult<()> {
+        self.encrypt_decrypt(aes, trng)
+    }
+
+    fn encrypt_decrypt(&self, aes: &mut Aes, trng: &mut Trng) -> CaliptraResult<()> {
+        let iv = (&IV).into();
+        let key = AesKey::Array(&KEY);
+        let mut ciphertext = [0u8; 32];
+        let (_, tag) =
+            aes.aes_256_gcm_encrypt(trng, iv, key, &AAD[..], &PT[..], &mut ciphertext, 16)?;
+
+        if ciphertext != CT {
+            Err(CaliptraError::KAT_AES_CIPHERTEXT_MISMATCH)?;
+        }
+        if tag != TAG {
+            Err(CaliptraError::KAT_AES_TAG_MISMATCH)?;
+        }
+
+        let mut plaintext = [0u8; 32];
+        aes.aes_256_gcm_decrypt(trng, &IV, key, &AAD[..], &CT[..], &mut plaintext, &TAG[..])?;
+        if plaintext != PT {
+            Err(CaliptraError::KAT_AES_PLAINTEXT_MISMATCH)?;
+        }
+
+        Ok(())
+    }
+}

--- a/kat/src/kats_env.rs
+++ b/kat/src/kats_env.rs
@@ -1,7 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_drivers::{
-    Ecc384, Hmac, Lms, Mldsa87, Sha1, Sha256, Sha2_512_384, Sha2_512_384Acc, ShaAccLockState, Trng,
+    Aes, Ecc384, Hmac, Lms, Mldsa87, Sha1, Sha256, Sha2_512_384, Sha2_512_384Acc, ShaAccLockState,
+    Trng,
 };
 
 pub struct KatsEnv<'a> {
@@ -34,4 +35,8 @@ pub struct KatsEnv<'a> {
 
     /// MLDSA Engine
     pub mldsa87: &'a mut Mldsa87,
+
+    /// AES Engine
+    //#[cfg(feature = "runtime")]
+    pub aes: &'a mut Aes,
 }

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -14,6 +14,7 @@ Abstract:
 
 #![no_std]
 
+mod aes256gcm_kat;
 mod ecc384_kat;
 mod hmac_kdf_kat;
 mod kats_env;
@@ -25,6 +26,7 @@ mod sha2_512_384acc_kat;
 mod sha384_kat;
 mod sha512_kat;
 
+pub use aes256gcm_kat::Aes256GcmKat;
 pub use caliptra_drivers::{CaliptraError, CaliptraResult};
 pub use ecc384_kat::Ecc384Kat;
 pub use hmac_kdf_kat::{Hmac384KdfKat, Hmac512KdfKat};
@@ -76,6 +78,9 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
 
     cprintln!("[kat] MLDSA87");
     Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
+
+    cprintln!("[kat] AES-256-GCM");
+    Aes256GcmKat::default().execute(env.aes, env.trng)?;
 
     cprintln!("[kat] --");
 

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -89,6 +89,9 @@ impl FirmwareProcessor {
             // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
+            // AES Engine
+            aes: &mut env.aes,
+
             // SHA Acc lock state
             sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -171,6 +171,9 @@ pub extern "C" fn rom_entry() -> ! {
             // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
+            // AES Engine
+            aes: &mut env.aes,
+
             // SHA Acc lock state.
             // SHA Acc is guaranteed to be locked on Cold and Warm Resets;
             // On an Update Reset, it is expected to be unlocked.

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,14 +16,14 @@ Abstract:
 --*/
 
 use caliptra_drivers::{
-    DeobfuscationEngine, Dma, Ecc384, Hmac, KeyVault, Lms, Mailbox, Mldsa87, PcrBank,
+    Aes, DeobfuscationEngine, Dma, Ecc384, Hmac, KeyVault, Lms, Mailbox, Mldsa87, PcrBank,
     PersistentDataAccessor, Sha1, Sha256, Sha2_512_384, Sha2_512_384Acc, SocIfc, Trng,
 };
 use caliptra_error::CaliptraResult;
 use caliptra_registers::{
-    csrng::CsrngReg, doe::DoeReg, ecc::EccReg, entropy_src::EntropySrcReg, hmac::HmacReg,
-    kv::KvReg, mbox::MboxCsr, mldsa::MldsaReg, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg,
-    sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
+    aes::AesReg, csrng::CsrngReg, doe::DoeReg, ecc::EccReg, entropy_src::EntropySrcReg,
+    hmac::HmacReg, kv::KvReg, mbox::MboxCsr, mldsa::MldsaReg, pv::PvReg, sha256::Sha256Reg,
+    sha512::Sha512Reg, sha512_acc::Sha512AccCsr, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 
 /// Rom Context
@@ -75,6 +75,9 @@ pub struct RomEnv {
 
     /// Dma engine
     pub dma: Dma,
+
+    /// AES engine
+    pub aes: Aes,
 }
 
 impl RomEnv {
@@ -103,6 +106,7 @@ impl RomEnv {
             persistent_data: PersistentDataAccessor::new(),
             mldsa87: Mldsa87::new(MldsaReg::new()),
             dma: Dma::default(),
+            aes: Aes::new(AesReg::new()),
         })
     }
 }

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -176,6 +176,9 @@ pub mod fips_self_test_cmd {
             // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
+            // AES Engine,
+            aes: &mut env.aes,
+
             // SHA Acc Lock State
             sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };

--- a/sw-emulator/lib/crypto/Cargo.toml
+++ b/sw-emulator/lib/crypto/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 
 [dependencies]
 aes.workspace = true
+aes-gcm.workspace = true
 cbc.workspace = true
 p384.workspace = true
 rfc6979.workspace = true

--- a/sw-emulator/lib/crypto/src/aes256cbc.rs
+++ b/sw-emulator/lib/crypto/src/aes256cbc.rs
@@ -14,12 +14,10 @@ Abstract:
 
 use cbc::cipher::{BlockDecryptMut, KeyIvInit};
 
-use crate::helpers::EndianessTransform;
+use crate::{helpers::EndianessTransform, AES_256_BLOCK_SIZE, AES_256_KEY_SIZE};
 
 pub enum Aes256Cbc {}
 
-const AES_256_BLOCK_SIZE: usize = 16;
-const AES_256_KEY_SIZE: usize = 32;
 const AES_256_IV_SIZE: usize = AES_256_BLOCK_SIZE;
 
 type Aes256Decryptor = cbc::Decryptor<aes::Aes256>;

--- a/sw-emulator/lib/crypto/src/aes256gcm.rs
+++ b/sw-emulator/lib/crypto/src/aes256gcm.rs
@@ -1,0 +1,99 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    aes256gcm.rs
+
+Abstract:
+
+    File contains implementation of AES-256 GCM algorithm.
+
+--*/
+
+use crate::AES_256_KEY_SIZE;
+use aes_gcm::{
+    aead::{AeadCore, AeadMutInPlace, KeyInit, OsRng},
+    Key,
+};
+
+const AES_256_GCM_IV_SIZE: usize = 12;
+const AES_256_GCM_TAG_SIZE: usize = 16;
+
+pub enum Aes256Gcm {}
+
+impl Aes256Gcm {
+    /// One-shot AES-256-GCM decryption.
+    pub fn decrypt(
+        key: &[u8; AES_256_KEY_SIZE],
+        iv: &[u8; AES_256_GCM_IV_SIZE],
+        aad: &[u8],
+        tag: &[u8; AES_256_GCM_TAG_SIZE],
+        ciphertext: &[u8],
+    ) -> Option<Vec<u8>> {
+        let key: &Key<aes_gcm::Aes256Gcm> = key.into();
+        let mut cipher = aes_gcm::Aes256Gcm::new(key);
+        let mut buffer = ciphertext.to_vec();
+        match cipher.decrypt_in_place_detached(iv.into(), aad, &mut buffer, tag.into()) {
+            Ok(_) => Some(buffer),
+            Err(_) => None,
+        }
+    }
+
+    /// One-shot AES-256-GCM encryption.
+    pub fn encrypt(
+        key: &[u8; AES_256_KEY_SIZE],
+        iv: Option<&[u8; AES_256_GCM_IV_SIZE]>,
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Option<(
+        [u8; AES_256_GCM_IV_SIZE],
+        Vec<u8>,
+        [u8; AES_256_GCM_TAG_SIZE],
+    )> {
+        let random_iv = aes_gcm::Aes256Gcm::generate_nonce(&mut OsRng).into();
+        let iv = iv.unwrap_or(&random_iv);
+        let key: &Key<aes_gcm::Aes256Gcm> = key.into();
+        let mut cipher = aes_gcm::Aes256Gcm::new(key);
+        let mut buffer = plaintext.to_vec();
+        match cipher.encrypt_in_place_detached(iv.into(), aad, &mut buffer) {
+            Ok(tag) => Some((*iv, buffer, tag.into())),
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Aes256Gcm;
+
+    #[test]
+    fn test_encrypt_decrypt() {
+        let expected_tag = [
+            0x9a, 0x4a, 0x25, 0x79, 0x52, 0x93, 0x1, 0xbc, 0xfb, 0x71, 0xc7, 0x8d, 0x40, 0x60,
+            0xf5, 0x2c,
+        ];
+        let expected_ciphertext = [0xe2, 0x7a, 0xbd, 0xd2, 0xd2, 0xa5, 0x3d, 0x2f, 0x13, 0x6b];
+        let fixed_iv = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+        ];
+        let key = [
+            0x92, 0xac, 0xe3, 0xe3, 0x48, 0xcd, 0x82, 0x10, 0x92, 0xcd, 0x92, 0x1a, 0xa3, 0x54,
+            0x63, 0x74, 0x29, 0x9a, 0xb4, 0x62, 0x9, 0x69, 0x1b, 0xc2, 0x8b, 0x87, 0x52, 0xd1,
+            0x7f, 0x12, 0x3c, 0x20,
+        ];
+        let aad = [0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff];
+        let expected_plaintext = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
+        // from https://github.com/C2SP/wycheproof/blob/master/testvectors/aes_gcm_test.json
+        let (iv, ciphertext, tag) =
+            Aes256Gcm::encrypt(&key, Some(&fixed_iv), &aad, &expected_plaintext).unwrap();
+        assert_eq!(&expected_ciphertext[..], &ciphertext);
+        assert_eq!(expected_tag, tag);
+        assert_eq!(fixed_iv, iv);
+
+        let plaintext =
+            Aes256Gcm::decrypt(&key, &fixed_iv, &aad, &expected_tag, &expected_ciphertext).unwrap();
+        assert_eq!(&expected_plaintext[..], plaintext);
+    }
+}

--- a/sw-emulator/lib/crypto/src/lib.rs
+++ b/sw-emulator/lib/crypto/src/lib.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 mod aes256cbc;
+mod aes256gcm;
 mod ecc384;
 mod helpers;
 mod hmac512;
@@ -32,6 +33,8 @@ pub use ecc384::Ecc384PrivKey;
 pub use ecc384::Ecc384PubKey;
 pub use ecc384::Ecc384Signature;
 
+pub const AES_256_BLOCK_SIZE: usize = 16;
+pub const AES_256_KEY_SIZE: usize = 32;
 pub use aes256cbc::Aes256Cbc;
-
+pub use aes256gcm::Aes256Gcm;
 pub use helpers::EndianessTransform;

--- a/sw-emulator/lib/periph/src/aes.rs
+++ b/sw-emulator/lib/periph/src/aes.rs
@@ -1,17 +1,18 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_emu_bus::{BusError, Clock, Event, ReadWriteRegister, Timer};
+use caliptra_emu_bus::{BusError, Event, ReadWriteRegister};
 use caliptra_emu_bus::{ReadOnlyRegister, WriteOnlyRegister};
+use caliptra_emu_crypto::Aes256Gcm;
 use caliptra_emu_derive::Bus;
 use caliptra_emu_types::{RvData, RvSize};
+use rand::Rng;
 use std::rc::Rc;
 use std::sync::mpsc;
+use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::register_bitfields;
 
 register_bitfields! [
     u32,
-
-    /// Status
     Status [
         IDLE OFFSET(0) NUMBITS(1) [],
         STALL OFFSET(1) NUMBITS(1) [],
@@ -21,10 +22,54 @@ register_bitfields! [
         ALERT_RECOV_CTRL_UPDATE_ERROR OFFSET(5) NUMBITS(1) [],
         ALERT_FATAL_FAULT OFFSET(6) NUMBITS(1) [],
     ],
+    Ctrl [
+        OP OFFSET(0) NUMBITS(2) [
+            ENCRYPT = 1,
+            DECRYPT = 2,
+        ],
+        MODE OFFSET(2) NUMBITS(6) [
+            ECB = 1,
+            CBC = 2,
+            CFB = 4,
+            OFB = 8,
+            CTR = 16,
+            GCM = 32,
+            NONE = 0x3f,
+        ],
+        KEY_LEN OFFSET(8) NUMBITS(3) [
+            KEY_128 = 1,
+            KEY_192 = 2,
+            KEY_256 = 4,
+        ],
+        SIDELOAD OFFSET(11) NUMBITS(1) [],
+        PRNG_RESEED_RATE OFFSET(12) NUMBITS(3) [],
+        MANUAL_OPERATION OFFSET(15) NUMBITS(1) [
+            DISABLED = 0,
+            ENABLED = 1,
+        ],
+    ],
+    GcmCtrl [
+        PHASE OFFSET(0) NUMBITS(6) [
+            INIT = 1,
+            RESTORE = 2,
+            AAD = 4,
+            TEXT = 8,
+            SAVE = 16,
+            TAG = 32,
+        ],
+        NUM_VALID_BYTES OFFSET(6) NUMBITS(5) [],
+    ],
+    Trigger [
+        START OFFSET(0) NUMBITS(1) [],
+        KEY_IV_DATA_IN_CLEAR OFFSET(1) NUMBITS(1) [],
+        DATA_OUT_CLEAR OFFSET(2) NUMBITS(1) [],
+        PRNG_RESEED OFFSET(3) NUMBITS(1) [],
+    ],
 ];
 
 /// AES peripheral implementation
 #[derive(Bus)]
+#[warm_reset_fn(warm_reset)]
 pub struct Aes {
     #[register_array(offset = 0x4, item_size = 4, len = 8)]
     key_share0: [u32; 8],
@@ -35,14 +80,14 @@ pub struct Aes {
     #[register_array(offset = 0x44, item_size = 4, len = 4)]
     iv: [u32; 4],
 
-    #[register_array(offset = 0x54, item_size = 4, len = 4)]
+    #[register_array(offset = 0x54, item_size = 4, len = 4, write_fn = write_data_in)]
     data_in: [u32; 4],
 
     #[register_array(offset = 0x64, item_size = 4, len = 4)]
     data_out: [u32; 4],
 
-    #[register(offset = 0x74, write_fn = write_ctrl_shadowed)]
-    ctrl_shadowed: ReadWriteRegister<u32>,
+    #[register(offset = 0x74)]
+    ctrl_shadowed: ReadWriteRegister<u32, Ctrl::Register>,
 
     #[register(offset = 0x78)]
     _ctrl_aux_shadowed: ReadWriteRegister<u32>,
@@ -50,24 +95,30 @@ pub struct Aes {
     #[register(offset = 0x7c)]
     _ctrl_aux_regwen: ReadWriteRegister<u32>,
 
-    #[register(offset = 0x80)]
-    trigger: WriteOnlyRegister<u32>,
+    #[register(offset = 0x80, write_fn = write_trigger)]
+    trigger: WriteOnlyRegister<u32, Trigger::Register>,
 
     #[register(offset = 0x84)]
     status: ReadOnlyRegister<u32, Status::Register>,
 
     #[register(offset = 0x88, write_fn = write_ctrl_gcm_shadowed)]
-    ctrl_gcm_shadowed: ReadOnlyRegister<u32>,
+    ctrl_gcm_shadowed: ReadOnlyRegister<u32, GcmCtrl::Register>,
 
-    /// Timer
-    _timer: Timer,
+    aad: Vec<u8>,
+    buffer: Vec<u8>,
+    data_in_written: [bool; 4],
+}
+
+impl Default for Aes {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Aes {
     /// Create a new AES CLP peripheral instance
-    pub fn new(clock: &Clock) -> Self {
+    pub fn new() -> Self {
         Self {
-            _timer: Timer::new(clock),
             key_share0: [0; 8],
             key_share1: [0; 8],
             iv: [0; 4],
@@ -82,14 +133,187 @@ impl Aes {
                     .into(),
             ),
             ctrl_gcm_shadowed: ReadOnlyRegister::new(0),
+            aad: vec![],
+            buffer: vec![],
+            data_in_written: [false; 4],
         }
     }
 
-    fn write_ctrl_shadowed(&mut self, _size: RvSize, _val: RvData) -> Result<(), BusError> {
+    fn write_trigger(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+
+        self.trigger.reg.set(val);
+
+        if self.trigger.reg.is_set(Trigger::KEY_IV_DATA_IN_CLEAR) {
+            rand::thread_rng().fill(&mut self.key_share0[..]);
+            rand::thread_rng().fill(&mut self.key_share1[..]);
+            rand::thread_rng().fill(&mut self.iv[..]);
+            rand::thread_rng().fill(&mut self.data_in[..]);
+            self.data_in_written.fill(false);
+            self.aad.clear();
+            self.buffer.clear();
+        }
+        if self.trigger.reg.is_set(Trigger::DATA_OUT_CLEAR) {
+            rand::thread_rng().fill(&mut self.data_out[..]);
+        } else {
+            self.data_out.fill(0);
+        }
+        self.trigger.reg.set(0);
         Ok(())
     }
 
-    fn write_ctrl_gcm_shadowed(&mut self, _size: RvSize, _val: RvData) -> Result<(), BusError> {
+    fn warm_reset(&mut self) {
+        self.key_share0.fill(0);
+        self.key_share1.fill(0);
+        self.iv.fill(0);
+        self.data_in.fill(0);
+        self.data_out.fill(0);
+        self.ctrl_shadowed.reg.set(0);
+        self._ctrl_aux_shadowed.reg.set(0);
+        self._ctrl_aux_regwen.reg.set(0);
+        self.trigger.reg.set(0);
+        self.status.reg.set(
+            (Status::INPUT_READY.val(1) + Status::OUTPUT_VALID.val(1) + Status::IDLE.val(1)).into(),
+        );
+        self.ctrl_gcm_shadowed.reg.set(0);
+        self.aad.clear();
+        self.buffer.clear();
+        self.data_in_written.fill(false);
+    }
+
+    fn write_ctrl_gcm_shadowed(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+
+        self.ctrl_gcm_shadowed.reg.set(val);
+
+        match self.gcm_phase() {
+            GcmCtrl::PHASE::Value::INIT => {
+                self.buffer.clear();
+                self.aad.clear();
+                self.data_in_written.fill(false);
+                self.data_in.fill(0);
+                self.data_out.fill(0);
+            }
+            GcmCtrl::PHASE::Value::RESTORE => todo!(),
+            GcmCtrl::PHASE::Value::AAD => {}
+            GcmCtrl::PHASE::Value::TEXT => {}
+            GcmCtrl::PHASE::Value::SAVE => todo!(),
+            GcmCtrl::PHASE::Value::TAG => {}
+        }
+        Ok(())
+    }
+
+    fn gcm_phase(&self) -> GcmCtrl::PHASE::Value {
+        self.ctrl_gcm_shadowed
+            .reg
+            .read_as_enum(GcmCtrl::PHASE)
+            .unwrap_or(GcmCtrl::PHASE::Value::INIT)
+    }
+
+    fn is_encrypt(&self) -> bool {
+        self.ctrl_shadowed
+            .reg
+            .read_as_enum(Ctrl::OP)
+            .unwrap_or(Ctrl::OP::Value::ENCRYPT)
+            == Ctrl::OP::Value::ENCRYPT
+    }
+
+    fn key(&self) -> [u8; 32] {
+        let mut key = [0u8; 32];
+        for i in 0..8 {
+            let word = (self.key_share0[i] ^ self.key_share1[i]).to_le_bytes();
+            key[i * 4..(i + 1) * 4].copy_from_slice(&word);
+        }
+        key
+    }
+
+    fn iv(&self) -> [u8; 12] {
+        let mut iv = [0u8; 12];
+        for i in 0..3 {
+            let word = self.iv[i].to_le_bytes();
+            iv[i * 4..(i + 1) * 4].copy_from_slice(&word);
+        }
+        iv
+    }
+
+    fn update_data_out(&mut self) {
+        // populate the data_out register
+        // TODO: use a proper streaming AES implementation
+        let key = self.key();
+        let iv = self.iv();
+
+        match self.gcm_phase() {
+            GcmCtrl::PHASE::Value::TEXT => {
+                // in GCM encryption and decryption result in the same output
+                let (_, output, _) =
+                    Aes256Gcm::encrypt(&key, Some(&iv), &self.aad, &self.buffer).unwrap();
+                let len = output.len();
+                self.data_out[0] =
+                    u32::from_le_bytes(output[len - 16..len - 12].try_into().unwrap());
+                self.data_out[1] =
+                    u32::from_le_bytes(output[len - 12..len - 8].try_into().unwrap());
+                self.data_out[2] = u32::from_le_bytes(output[len - 8..len - 4].try_into().unwrap());
+                self.data_out[3] = u32::from_le_bytes(output[len - 4..].try_into().unwrap());
+            }
+            GcmCtrl::PHASE::Value::TAG => {
+                let tag = if self.is_encrypt() {
+                    let (_, _, tag) =
+                        Aes256Gcm::encrypt(&key, Some(&iv), &self.aad, &self.buffer).unwrap();
+                    tag
+                } else {
+                    // the hardware doesn't care if the tag is correct, but returns what it would be
+                    // so "encrypt" the ciphertext to get the plaintext
+                    let (_, plaintext, _) =
+                        Aes256Gcm::encrypt(&key, Some(&iv), &self.aad, &self.buffer).unwrap();
+                    // now encrypt again to get the correct tag
+                    let (_, _, tag) =
+                        Aes256Gcm::encrypt(&key, Some(&iv), &self.aad, &plaintext).unwrap();
+                    tag
+                };
+                self.data_out[0] = u32::from_le_bytes(tag[0..4].try_into().unwrap());
+                self.data_out[1] = u32::from_le_bytes(tag[4..8].try_into().unwrap());
+                self.data_out[2] = u32::from_le_bytes(tag[8..12].try_into().unwrap());
+                self.data_out[3] = u32::from_le_bytes(tag[12..16].try_into().unwrap());
+            }
+            _ => {}
+        }
+    }
+
+    fn write_data_in(&mut self, size: RvSize, idx: usize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+
+        self.data_in[idx] = val;
+        self.data_in_written[idx] = true;
+        // All data_in registers have been written
+        if self.data_in_written.iter().copied().all(|x| x) {
+            self.data_in_written = [false; 4];
+            // copy to the buffer
+            match self.gcm_phase() {
+                GcmCtrl::PHASE::Value::AAD => {
+                    for i in 0..4 {
+                        self.aad
+                            .extend_from_slice(&self.data_in[i].to_le_bytes()[..]);
+                    }
+                }
+                GcmCtrl::PHASE::Value::TEXT => {
+                    for i in 0..4 {
+                        self.buffer
+                            .extend_from_slice(&self.data_in[i].to_le_bytes()[..]);
+                    }
+                }
+                _ => {}
+            }
+            self.update_data_out();
+        }
         Ok(())
     }
 

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -356,7 +356,7 @@ impl CaliptraRootBus {
 
         Self {
             rom,
-            aes: Aes::new(clock),
+            aes: Aes::new(),
             aes_clp: AesClp::new(clock, key_vault.clone()),
             doe: Doe::new(clock, key_vault.clone(), soc_reg.clone()),
             ecc384: AsymEcc384::new(clock, key_vault.clone(), sha512.clone()),


### PR DESCRIPTION
I wrote a KAT for the AES driver from the FIPS GCM test suite and validated that it passes on an FPGA.

I then wrote the emulator AES peripheral to match that behavior.

This doesn't yet support streaming mode, which is necessary for the mailbox commands, but that will be next.

To support the AES KAT, I had to add the driver to the ROM as well. It might be possible to avoid this, but it is a bit difficult even with feature flags due to feature flag unification (which tends to turn on the AES driver in the KAT when compiling even if only requested in the runtime).