### PR TITLE
Peek DPE command status before parsing response

### DIFF
--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -23,8 +23,8 @@ use caliptra_hw_model::{
 use dpe::{
     commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags},
     response::{
-        CertifyKeyResp, DeriveContextExportedCdiResp, DeriveContextResp, GetCertificateChainResp,
-        GetProfileResp, NewHandleResp, Response, ResponseHdr, SignResp,
+        CertifyKeyResp, DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode,
+        GetCertificateChainResp, GetProfileResp, NewHandleResp, Response, ResponseHdr, SignResp,
     },
 };
 use openssl::{
@@ -181,7 +181,20 @@ fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
     }
 }
 
+fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
+    if let Ok(&ResponseHdr { status, .. }) =
+        ResponseHdr::ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
+    {
+        if status != expected_status.get_error_code() {
+            panic!("Unexpected DPE Status: 0x{:X}", status);
+        }
+    }
+}
+
 fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
+    // Peek response header so we can panic with an error code in case the command failed.
+    check_dpe_status(resp_bytes, DpeErrorCode::NoError);
+
     match dpe_cmd {
         Command::CertifyKey(_) => {
             Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())


### PR DESCRIPTION
This makes it easier to debug test failures where we expected
`DpeResult::Success` but had a failure.
