### PR TITLE
Use Rust stable version 1.70 to match 'rust-toolchain.toml'

### DIFF
--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -79,27 +79,18 @@ jobs:
 
       - name: Update rustup
         run: |
-          rustup toolchain install nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup default nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup target add riscv32imc-unknown-none-elf --toolchain nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup show
-          cargo version
-          ls -la /tmp/
-          df -hi
+          rustup toolchain install 1.70-x86_64-unknown-linux-gnu
+          rustup target add riscv32imc-unknown-none-elf --toolchain 1.70-x86_64-unknown-linux-gnu
+          rustup component add rust-src --toolchain 1.70-x86_64-unknown-linux-gnu
+          rustup component add --toolchain 1.70-x86_64-unknown-linux-gnu rustfmt
+          rustup component add --toolchain 1.70-x86_64-unknown-linux-gnu clippy
+          rustup default 1.70-x86_64-unknown-linux-gnu
       
       - name: Run tests
         run: |
           export CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-unified/
           export CALIPTRA_PREBUILT_ROM_BIN=/tmp/caliptra-unified/caliptra-rom.bin
           export RUST_BACKTRACE=full
-
-          rustup toolchain install nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup default nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup target add riscv32imc-unknown-none-elf --toolchain nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup component add rust-src --toolchain nightly-2023-04-15-x86_64-unknown-linux-gnu
-          rustup show
-          cargo version
 
           if [ "${{ inputs.rom-version }}" != "latest" ]; then
             export CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}"


### PR DESCRIPTION
This fixes the compiler errors in #1907 