### PR TITLE
Update image generator and verifier to use mldsa.sign_var()

### DIFF
--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -140,7 +140,7 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
 
     fn mldsa87_verify(
         &mut self,
-        digest: &ImageDigest512,
+        msg: &[u8],
         pub_key: &ImageMldsaPubKey,
         sig: &ImageMldsaSignature,
     ) -> CaliptraResult<Mldsa87Result> {
@@ -164,10 +164,7 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
             CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_TYPE_CONVERSION_FAILED,
         ))?;
 
-        // digest is received in hw format. No conversion needed.
-        let msg = digest.into();
-
-        self.mldsa87.verify(&pub_key, &msg, &sig)
+        self.mldsa87.verify_var(&pub_key, msg, &sig)
     }
 
     /// Retrieve Vendor Public Key Info Digest

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -757,14 +757,14 @@ impl CaliptraError {
             "Image Verifier Error: MLDSA owner signature read failed"
         ),
         (
-            IMAGE_VERIFIER_ERR_VENDOR_MLDSA_DIGEST_MISSING,
+            IMAGE_VERIFIER_ERR_VENDOR_MLDSA_MSG_MISSING,
             0x000b0052,
-            "Image Verifier Error: Vendor MLDSA digest missing"
+            "Image Verifier Error: Vendor MLDSA message missing"
         ),
         (
-            IMAGE_VERIFIER_ERR_OWNER_MLDSA_DIGEST_MISSING,
+            IMAGE_VERIFIER_ERR_OWNER_MLDSA_MSG_MISSING,
             0x000b0053,
-            "Image Verifier Error: Owner MLDSA digest missing"
+            "Image Verifier Error: Owner MLDSA message missing"
         ),
         (
             IMAGE_VERIFIER_ERR_VENDOR_MLDSA_VERIFY_FAILURE,

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -393,9 +393,9 @@ impl FwVerificationPqcKeyType {
 }
 
 #[derive(Debug)]
-pub struct ImageDigestHolder<'a> {
+pub struct ImageSignData<'a> {
     pub digest_384: &'a ImageDigest384,
-    pub digest_512: Option<&'a ImageDigest512>,
+    pub mldsa_msg: Option<&'a [u8]>,
 }
 
 /// Caliptra Image Bundle

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -142,7 +142,7 @@ pub trait ImageVerificationEnv {
 
     fn mldsa87_verify(
         &mut self,
-        digest: &ImageDigest512,
+        msg: &[u8],
         pub_key: &ImageMldsaPubKey,
         sig: &ImageMldsaSignature,
     ) -> CaliptraResult<Mldsa87Result>;

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -374,16 +374,15 @@ impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
 
     fn mldsa87_verify(
         &mut self,
-        digest: &ImageDigest512,
+        msg: &[u8],
         pub_key: &ImageMldsaPubKey,
         sig: &ImageMldsaSignature,
     ) -> CaliptraResult<Mldsa87Result> {
         if self.soc_ifc.verify_in_fake_mode() {
             let pub_key = Mldsa87PubKey::from(pub_key.0);
             let sig = Mldsa87Signature::from(sig.0);
-            let msg: Mldsa87Msg = Mldsa87Msg::from(digest);
 
-            self.mldsa87.verify(&pub_key, &msg, &sig)
+            self.mldsa87.verify_var(&pub_key, &msg, &sig)
         } else {
             // Mock verify, just always return success
             Ok(Mldsa87Result::Success)

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -26,8 +26,8 @@ use caliptra_image_fake_keys::{
 };
 use caliptra_image_gen::{ImageGenerator, ImageGeneratorConfig, ImageGeneratorVendorConfig};
 use caliptra_image_types::{
-    FwVerificationPqcKeyType, ImageBundle, ImageDigestHolder, ImageEccPubKey, ImageLmsPublicKey,
-    ImageLmsSignature, ImageManifest, ImageMldsaPubKey, ImageMldsaSignature, ImagePqcPubKey,
+    FwVerificationPqcKeyType, ImageBundle, ImageEccPubKey, ImageLmsPublicKey, ImageLmsSignature,
+    ImageManifest, ImageMldsaPubKey, ImageMldsaSignature, ImagePqcPubKey, ImageSignData,
     MLDSA87_SIGNATURE_WORD_SIZE, PQC_PUB_KEY_BYTE_SIZE, VENDOR_ECC_MAX_KEY_COUNT,
     VENDOR_LMS_MAX_KEY_COUNT, VENDOR_MLDSA_MAX_KEY_COUNT,
 };
@@ -2696,23 +2696,19 @@ fn update_header(image_bundle: &mut ImageBundle) {
     let vendor_header_digest_384 = gen
         .vendor_header_digest_384(&image_bundle.manifest.header)
         .unwrap();
-    let vendor_header_digest_512 = gen
-        .vendor_header_digest_512(&image_bundle.manifest.header)
-        .unwrap();
-    let vendor_header_digest_holder = ImageDigestHolder {
+    let vendor_header_bytes = gen.vendor_header_bytes(&image_bundle.manifest.header);
+    let vendor_header_digest_holder = ImageSignData {
         digest_384: &vendor_header_digest_384,
-        digest_512: Some(&vendor_header_digest_512),
+        mldsa_msg: Some(vendor_header_bytes),
     };
 
     let owner_header_digest_384 = gen
         .owner_header_digest_384(&image_bundle.manifest.header)
         .unwrap();
-    let owner_header_digest_512 = gen
-        .owner_header_digest_512(&image_bundle.manifest.header)
-        .unwrap();
-    let owner_header_digest_holder = ImageDigestHolder {
+    let owner_header_bytes = image_bundle.manifest.header.as_bytes();
+    let owner_header_digest_holder = ImageSignData {
         digest_384: &owner_header_digest_384,
-        digest_512: Some(&owner_header_digest_512),
+        mldsa_msg: Some(owner_header_bytes),
     };
 
     image_bundle.manifest.preamble = gen

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -93,6 +93,16 @@ extern "C" fn nmi_handler(exception: &exception::ExceptionRecord) {
         exception.mepc
     );
 
+    {
+        let mut soc_ifc = unsafe { SocIfcReg::new() };
+        let soc_ifc = soc_ifc.regs_mut();
+        let ext_info = soc_ifc.cptra_fw_extended_error_info();
+        ext_info.at(0).write(|_| exception.mcause);
+        ext_info.at(1).write(|_| exception.mscause);
+        ext_info.at(2).write(|_| exception.mepc);
+        ext_info.at(3).write(|_| exception.ra);
+    }
+
     loop {
         unsafe { Mailbox::abort_pending_soc_to_uc_transactions() };
     }

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -19,7 +19,7 @@ use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_elf::ElfExecutable;
 use caliptra_image_gen::{ImageGenerator, ImageGeneratorConfig};
-use caliptra_image_types::{FwVerificationPqcKeyType, ImageDigestHolder};
+use caliptra_image_types::{FwVerificationPqcKeyType, ImageSignData};
 use caliptra_runtime::{
     RtBootStatus, PL0_DPE_ACTIVE_CONTEXT_THRESHOLD, PL1_DPE_ACTIVE_CONTEXT_THRESHOLD,
 };
@@ -736,17 +736,17 @@ fn test_pl0_unset_in_header() {
     let vendor_header_digest_384 = gen
         .vendor_header_digest_384(&image_bundle.manifest.header)
         .unwrap();
-    let vendor_header_digest_holder = ImageDigestHolder {
+    let vendor_header_digest_holder = ImageSignData {
         digest_384: &vendor_header_digest_384,
-        digest_512: None,
+        mldsa_msg: None,
     };
 
     let owner_header_digest_384 = gen
         .owner_header_digest_384(&image_bundle.manifest.header)
         .unwrap();
-    let owner_header_digest_holder = ImageDigestHolder {
+    let owner_header_digest_holder = ImageSignData {
         digest_384: &owner_header_digest_384,
-        digest_512: None,
+        mldsa_msg: None,
     };
 
     let fmc_elf = build_firmware_elf(&FMC_WITH_UART).unwrap();

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -16,7 +16,7 @@ use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_fake_keys::{VENDOR_CONFIG_KEY_0, VENDOR_CONFIG_KEY_1};
 use caliptra_image_gen::{ImageGenerator, ImageGeneratorConfig, ImageGeneratorVendorConfig};
 use caliptra_image_types::{
-    FwVerificationPqcKeyType, ImageBundle, ImageDigestHolder, ImageLmsPublicKey, ImageMldsaPubKey,
+    FwVerificationPqcKeyType, ImageBundle, ImageLmsPublicKey, ImageMldsaPubKey, ImageSignData,
     MLDSA87_PUB_KEY_WORD_SIZE, SHA384_DIGEST_WORD_SIZE, VENDOR_ECC_MAX_KEY_COUNT,
     VENDOR_LMS_MAX_KEY_COUNT, VENDOR_MLDSA_MAX_KEY_COUNT,
 };
@@ -76,23 +76,19 @@ fn update_manifest(image_bundle: &mut ImageBundle, hdr_digest: HdrDigest, toc_di
         let vendor_header_digest_384 = gen
             .vendor_header_digest_384(&image_bundle.manifest.header)
             .unwrap();
-        let vendor_header_digest_512 = gen
-            .vendor_header_digest_512(&image_bundle.manifest.header)
-            .unwrap();
-        let vendor_header_digest_holder = ImageDigestHolder {
+        let vendor_header_bytes = gen.vendor_header_bytes(&image_bundle.manifest.header);
+        let vendor_header_digest_holder = ImageSignData {
             digest_384: &vendor_header_digest_384,
-            digest_512: Some(&vendor_header_digest_512),
+            mldsa_msg: Some(vendor_header_bytes),
         };
 
         let owner_header_digest_384 = gen
             .owner_header_digest_384(&image_bundle.manifest.header)
             .unwrap();
-        let owner_header_digest_512 = gen
-            .owner_header_digest_512(&image_bundle.manifest.header)
-            .unwrap();
-        let owner_header_digest_holder = ImageDigestHolder {
+        let owner_header_bytes = image_bundle.manifest.header.as_bytes();
+        let owner_header_digest_holder = ImageSignData {
             digest_384: &owner_header_digest_384,
-            digest_512: Some(&owner_header_digest_512),
+            mldsa_msg: Some(owner_header_bytes),
         };
 
         // Update preamble


### PR DESCRIPTION
ImageDigestHolder is modified to hold a message instead of a sha512 hash.