### PR TITLE
runtime: Don't return computed tag in GCM decrypt

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -450,6 +450,8 @@ pub enum MailboxReq {
     ProductionAuthDebugUnlockToken(ProductionAuthDebugUnlockToken),
 }
 
+pub const MAX_REQ_SIZE: usize = size_of::<MailboxReq>();
+
 impl MailboxReq {
     pub fn as_bytes(&self) -> CaliptraResult<&[u8]> {
         match self {
@@ -2806,7 +2808,6 @@ pub struct CmAesGcmDecryptFinalResp {
 pub struct CmAesGcmDecryptFinalRespHeader {
     pub hdr: MailboxRespHeader,
     pub tag_verified: u32,
-    pub tag: [u8; 16],
     pub plaintext_size: u32,
 }
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1639,7 +1639,7 @@ Command Code: `0x434D_4446` ("CMDF")
 | --------------- | ------------------- | --------------------------------- |
 | chksum          | u32                 |                                   |
 | context         | AES_GCM_CONTEXT     |                                   |
-| tag size        | u32                 | Can be 0, 1, ..., 16              |
+| tag size        | u32                 | Can be 8, 9, ..., 16              |
 | tag             | u8[16]              | Right-padded with zeroes          |
 | ciphertext size | u32                 | MAY be 0                          |
 | ciphertext      | u8[ciphertext size] | Data to decrypt                   |
@@ -1650,7 +1650,6 @@ Command Code: `0x434D_4446` ("CMDF")
 | chksum         | u32                |                                      |
 | fips_status    | u32                | FIPS approved or an error            |
 | tag verified   | u32                | 1 if tags matched, 0 if they did not |
-| tag            | u8[16]             | Computed tag                         |
 | plaintext size | u32                | MAY be 0                             |
 | plaintext      | u8[plaintext size] |                                      |
 

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -1192,7 +1192,7 @@ impl Commands {
         if cmd.ciphertext_size as usize > MAX_CMB_DATA_SIZE {
             Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
         }
-        if cmd.tag_len as usize > 16 {
+        if cmd.tag_len as usize > 16 || (cmd.tag_len as usize) < 8 {
             Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
         }
 
@@ -1208,14 +1208,13 @@ impl Commands {
             encrypted_context,
         )?;
         let resp = mutrefbytes::<CmAesGcmDecryptFinalResp>(resp)?;
-        let (written, computed_tag, tag_verified) =
+        let (written, _computed_tag, tag_verified) =
             drivers
                 .aes
                 .aes_256_gcm_decrypt_final(context, ciphertext, &mut resp.plaintext, tag)?;
 
         resp.hdr.hdr = MailboxRespHeader::default();
         resp.hdr.tag_verified = tag_verified as u32;
-        resp.hdr.tag = computed_tag;
         resp.hdr.plaintext_size = written as u32;
 
         resp.partial_len()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -49,7 +49,7 @@ mod verify;
 pub mod mailbox;
 use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter};
-use caliptra_common::cfi_check;
+use caliptra_common::{cfi_check, memory_layout};
 pub use drivers::{Drivers, PauserPrivileges};
 use mailbox::Mailbox;
 use zerocopy::{FromBytes, IntoBytes, KnownLayout};
@@ -62,7 +62,9 @@ use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
 pub use caliptra_common::fips::FipsVersionCmd;
-use caliptra_common::mailbox_api::{populate_checksum, FipsVersionResp, MAX_RESP_SIZE};
+use caliptra_common::mailbox_api::{
+    populate_checksum, FipsVersionResp, MAX_REQ_SIZE, MAX_RESP_SIZE,
+};
 pub use dice::{GetFmcAliasCertCmd, GetLdevCertCmd, IDevIdCertCmd};
 pub use disable::DisableAttestationCmd;
 use dpe_crypto::DpeCrypto;
@@ -208,6 +210,13 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     // We can use the second half of the mailbox to stage the response, which we
     // can copy to the first half of the mailbox before sending it. This saves us
     // ~10 KB of stack space.
+
+    // Check that the request and response buffers are small enough to fit in half the mailbox.
+    // If this fails in later versions due to mailbox shrinking, we can simply allocate
+    // the response buffer on the stack, though it will increase stack memory usage.
+    const _: () = assert!(MAX_RESP_SIZE as u32 <= memory_layout::MBOX_SIZE / 2);
+    const _: () = assert!(MAX_REQ_SIZE as u32 <= memory_layout::MBOX_SIZE / 2);
+
     let mbox = Mailbox::raw_mailbox_contents_mut();
     let mbox_len = mbox.len();
     let (_, resp) = mbox.split_at_mut(mbox_len / 2);


### PR DESCRIPTION
Originally I added returning the computed GCM tag on decryption as a flexibility measure.

However, I've given this some further thought, and I think it is a bad idea for a general API to return a GCM tag for arbitrary inputs: a bad actor could request tags for any AAD or ciphertext. If they included no AAD or ciphertext, then they could discover the ECB encryption of the 0 block. Between these, it opens the door to attacks like Invisible Salamanders, which a bad actor could then craft valid tags for arbitrary inputs for any key.

So, I've removed returning the computed GCM tag for decryption and return only whether the input matched or not.

This also means that we need to limit the size of tags we check to be at least 64 bits (8 bytes) long when checking, as otherwise someone could simply brute force compute the GCM tag a byte-at-a-time.

Also, I added a memory check as a follow on to #2144 to ensure that the mailbox requests and responses don't overlap.