### PR TITLE
Make OBF key configurable in the HW model.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "caliptra-emu-periph",
  "caliptra-emu-types",
  "caliptra-hw-model",
+ "caliptra-hw-model-types",
  "cbindgen",
 ]
 

--- a/hw-model/c-binding/Cargo.toml
+++ b/hw-model/c-binding/Cargo.toml
@@ -10,6 +10,7 @@ caliptra-emu-bus.workspace = true
 caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model.workspace = true
+caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
 
 [lib]

--- a/hw-model/c-binding/src/caliptra_model.rs
+++ b/hw-model/c-binding/src/caliptra_model.rs
@@ -3,11 +3,12 @@
 use caliptra_api::soc_mgr::SocManager;
 use caliptra_emu_bus::Bus;
 use caliptra_emu_periph::MailboxRequester;
+use caliptra_emu_types::RvSize;
 use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, SecurityState};
+use caliptra_hw_model_types::DEFAULT_CPTRA_OBF_KEY;
+use core::mem::size_of_val;
 use std::ffi::*;
 use std::slice;
-
-use caliptra_emu_types::RvSize;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -30,6 +31,9 @@ pub struct caliptra_model_init_params {
     pub iccm: caliptra_buffer,
     pub security_state: u8,
     pub soc_user: u32,
+
+    // When data is null, DEFAULT_CPTRA_OBF_KEY is used.
+    pub optional_obf_key: caliptra_buffer,
 }
 
 pub const CALIPTRA_SEC_STATE_DBG_UNLOCKED_UNPROVISIONED: c_int = 0b000;
@@ -38,8 +42,12 @@ pub const CALIPTRA_SEC_STATE_DBG_UNLOCKED_PRODUCTION: c_int = 0b011;
 pub const CALIPTRA_SEC_STATE_DBG_LOCKED_PRODUCTION: c_int = 0b111;
 
 pub const CALIPTRA_MODEL_STATUS_OK: c_int = 0;
+pub const CALIPTRA_MODEL_INVALID_OBF_KEY_SIZE: c_int = -1;
 
 /// # Safety
+///
+/// `rom`, `dccm`, and `iccm` in `params` must be non-null. `model` must be
+/// non-null.
 #[no_mangle]
 pub unsafe extern "C" fn caliptra_model_init_default(
     params: caliptra_model_init_params,
@@ -47,6 +55,20 @@ pub unsafe extern "C" fn caliptra_model_init_default(
 ) -> c_int {
     // Parameter check
     assert!(!model.is_null());
+
+    let cptra_obf_key = if params.optional_obf_key.data.is_null() {
+        DEFAULT_CPTRA_OBF_KEY
+    } else if params.optional_obf_key.len != size_of_val(&DEFAULT_CPTRA_OBF_KEY) {
+        return CALIPTRA_MODEL_INVALID_OBF_KEY_SIZE;
+    } else {
+        slice::from_raw_parts(
+            params.optional_obf_key.data as *const u32,
+            params.optional_obf_key.len / 4,
+        )
+        .try_into()
+        .unwrap()
+    };
+
     // Generate Model and cast to caliptra_model
     *model = Box::into_raw(Box::new(
         caliptra_hw_model::new_unbooted(InitParams {
@@ -55,6 +77,7 @@ pub unsafe extern "C" fn caliptra_model_init_default(
             iccm: slice::from_raw_parts(params.iccm.data, params.iccm.len),
             security_state: SecurityState::from(params.security_state as u32),
             soc_user: MailboxRequester::SocUser(params.soc_user),
+            cptra_obf_key,
             ..Default::default()
         })
         .unwrap(),


### PR DESCRIPTION
Some testing with the Caliptra simulator may require changing the obfuscation key. This change makes it possible by adding an optional parameter in the C -> Rust HW model API. All of tests here are still using the DEFAULT_CPTRA_OBF_KEY.