### PR TITLE
Backport caliptra-mcu-sw CPU and bus improvements

### DIFF
--- a/sw-emulator/lib/bus/src/clock.rs
+++ b/sw-emulator/lib/bus/src/clock.rs
@@ -12,14 +12,15 @@ Abstract:
     execution for peripherals.
 
 --*/
+use crate::Bus;
 use std::{
-    cell::{Cell, RefCell},
     collections::{BTreeSet, HashSet},
     ptr,
-    rc::Rc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, RwLock,
+    },
 };
-
-use crate::Bus;
 
 /// Peripherals that want to use timer-based deferred execution will typically
 /// store a clone of Timer inside themselves, and use it to schedule future
@@ -57,13 +58,13 @@ use crate::Bus;
 /// ```
 #[derive(Clone)]
 pub struct Timer {
-    clock: Rc<ClockImpl>,
+    clock: Arc<ClockImpl>,
 }
 impl Timer {
     /// Constructs a new timer bound to the specified clock.
     pub fn new(clock: &Clock) -> Self {
         Self {
-            clock: Rc::clone(&clock.clock),
+            clock: Arc::clone(&clock.clock),
         }
     }
 
@@ -81,7 +82,7 @@ impl Timer {
         let has_fired = if let Some(ref action) = action {
             debug_assert_eq!(
                 action.0.id.timer_ptr,
-                Rc::as_ptr(&self.clock),
+                Arc::as_ptr(&self.clock),
                 "Supplied action was not created by this timer."
             );
             self.clock.has_fired(action.0.time)
@@ -126,7 +127,7 @@ impl Timer {
 }
 
 pub struct Clock {
-    clock: Rc<ClockImpl>,
+    clock: Arc<ClockImpl>,
 }
 impl Default for Clock {
     fn default() -> Self {
@@ -186,6 +187,7 @@ impl Clock {
                 | TimerAction::SetExtIntVec { .. }
                 | TimerAction::SetGlobalIntEn { .. }
                 | TimerAction::SetExtIntEn { .. }
+                | TimerAction::InternalTimerLocalInterrupt { .. }
                 | TimerAction::Halt => {}
             }
         }
@@ -230,6 +232,10 @@ struct TimerActionId {
     /// An ID assigned by the TimerImpl
     id: u64,
 }
+/// Safety: the *const ClockImpl is Send safe because it is only used for comparisons.
+unsafe impl Send for TimerActionId {}
+/// Safety: the *const ClockImpl is Sync safe because it is only used for comparisons.
+unsafe impl Sync for TimerActionId {}
 impl Default for TimerActionId {
     fn default() -> Self {
         Self {
@@ -250,28 +256,48 @@ pub enum TimerAction {
     SetExtIntVec { addr: u32 },
     SetGlobalIntEn { en: bool },
     SetExtIntEn { en: bool },
+    InternalTimerLocalInterrupt { timer_id: u8 },
     Halt,
 }
 
+impl TimerAction {
+    /// Sort priority based on VeeR EL2 Programmer's Reference Manual Table 14.1.
+    pub fn priority(&self) -> isize {
+        match self {
+            TimerAction::Poll => 0,
+            TimerAction::Halt => 1,
+            TimerAction::SetExtIntVec { .. } => 2,
+            TimerAction::SetNmiVec { .. } => 3,
+            TimerAction::SetGlobalIntEn { .. } => 4,
+            TimerAction::SetExtIntEn { .. } => 5,
+            TimerAction::WarmReset => 6,
+            TimerAction::UpdateReset => 7,
+            TimerAction::Nmi { .. } => 8,
+            TimerAction::ExtInt { .. } => 9,
+            TimerAction::InternalTimerLocalInterrupt { .. } => 10,
+        }
+    }
+}
+
 struct ClockImpl {
-    now: Cell<u64>,
-    next_action_time: Cell<Option<u64>>,
-    next_action_id: Cell<u64>,
-    action_handles: RefCell<BTreeSet<ActionHandleImpl>>,
+    now: AtomicU64,
+    next_action_time: Mutex<Option<u64>>,
+    next_action_id: AtomicU64,
+    action_handles: Arc<RwLock<BTreeSet<ActionHandleImpl>>>,
 }
 impl ClockImpl {
-    fn new() -> Rc<Self> {
-        Rc::new(Self {
-            now: Cell::new(0),
-            next_action_time: Cell::new(None),
-            next_action_id: Cell::new(0),
-            action_handles: RefCell::new(BTreeSet::new()),
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            now: AtomicU64::new(0),
+            next_action_time: Mutex::new(None),
+            next_action_id: AtomicU64::new(0),
+            action_handles: Arc::new(RwLock::new(BTreeSet::new())),
         })
     }
 
     #[inline]
     fn now(&self) -> u64 {
-        self.now.get()
+        self.now.load(Ordering::Relaxed)
     }
 
     #[inline]
@@ -282,17 +308,18 @@ impl ClockImpl {
             "Cannot increment the current time by more than {} clock cycles.",
             (u64::MAX >> 1)
         );
-        self.now.set(self.now.get().wrapping_add(delta));
-        if let Some(next_action_time) = self.next_action_time.get() {
+        self.now.fetch_add(delta, Ordering::Relaxed);
+        let next_action_time = *self.next_action_time.lock().unwrap();
+        if let Some(next_action_time) = next_action_time {
             if self.has_fired(next_action_time) {
                 self.remove_fired_actions(&mut fired_actions);
                 return fired_actions;
             }
-        }
+        };
         fired_actions
     }
 
-    fn schedule_action_at(self: &Rc<Self>, time: u64, action: TimerAction) -> ActionHandle {
+    fn schedule_action_at(self: &Arc<Self>, time: u64, action: TimerAction) -> ActionHandle {
         assert!(
             time.wrapping_sub(self.now()) < (u64::MAX >> 1),
             "Cannot schedule a timer action more than {} clock cycles from now.",
@@ -303,37 +330,35 @@ impl ClockImpl {
             id: self.next_action_id(),
             action,
         };
-        let mut actions = self.action_handles.borrow_mut();
+        let mut actions = self.action_handles.write().unwrap();
         actions.insert(new_action);
         self.recompute_next_action_time(&actions);
         new_action.into()
     }
-    fn cancel(self: &Rc<Self>, action: ActionHandle) {
+    fn cancel(self: &Arc<Self>, action: ActionHandle) {
         let action = ActionHandleImpl::from(action);
         assert_eq!(
-            Rc::as_ptr(self),
+            Arc::as_ptr(self),
             action.id.timer_ptr,
             "Supplied action was not created by this timer."
         );
-        let mut future_actions = self.action_handles.borrow_mut();
+        let mut future_actions = self.action_handles.write().unwrap();
         future_actions.remove(&action);
         self.recompute_next_action_time(&future_actions)
     }
-    fn next_action_id(self: &Rc<Self>) -> TimerActionId {
-        let result = TimerActionId {
-            timer_ptr: Rc::as_ptr(self),
-            id: self.next_action_id.get(),
-        };
-        self.next_action_id
-            .set(self.next_action_id.get().wrapping_add(1));
-        result
+    fn next_action_id(self: &Arc<Self>) -> TimerActionId {
+        let id = self.next_action_id.fetch_add(1, Ordering::Relaxed);
+        TimerActionId {
+            timer_ptr: Arc::as_ptr(self),
+            id,
+        }
     }
     fn has_fired(&self, action_time: u64) -> bool {
         self.now().wrapping_sub(action_time) < (u64::MAX >> 1)
     }
     fn recompute_next_action_time(&self, future_actions: &BTreeSet<ActionHandleImpl>) {
-        self.next_action_time
-            .set(self.find_next_action(future_actions).map(|a| a.time));
+        *self.next_action_time.lock().unwrap() =
+            self.find_next_action(future_actions).map(|a| a.time);
     }
     fn find_next_action<'a>(
         &self,
@@ -353,7 +378,7 @@ impl ClockImpl {
 
     #[cold]
     fn remove_fired_actions(&self, fired_actions: &mut HashSet<TimerAction>) {
-        let mut future_actions = self.action_handles.borrow_mut();
+        let mut future_actions = self.action_handles.write().unwrap();
         while let Some(action) = self.find_next_action(&future_actions) {
             if !self.has_fired(action.time) {
                 break;
@@ -473,7 +498,7 @@ mod tests {
     fn test_timer_schedule_clock_wraparound() {
         for i in (u64::MAX - 120)..=u64::MAX {
             let clock = Clock::new();
-            clock.clock.now.set(i);
+            clock.clock.now.store(i, Ordering::Relaxed);
             test_timer_schedule_with_clock(clock);
         }
     }
@@ -481,7 +506,7 @@ mod tests {
     fn test_timer_schedule_clock_searchback_wraparound() {
         for i in ((u64::MAX >> 1) - 130)..=((u64::MAX >> 1) + 130) {
             let clock = Clock::new();
-            clock.clock.now.set(i);
+            clock.clock.now.store(i, Ordering::Relaxed);
             test_timer_schedule_with_clock(clock);
         }
     }

--- a/sw-emulator/lib/cpu/src/instr/test_macros.rs
+++ b/sw-emulator/lib/cpu/src/instr/test_macros.rs
@@ -1180,12 +1180,18 @@ mod test {
             $data_addr:expr => $data:expr
         ) => {{
             use caliptra_emu_bus::{Clock, DynamicBus, Ram, Rom};
+            use std::rc::Rc;
             use $crate::cpu::Cpu;
+            use $crate::pic::Pic;
+            use $crate::types::CpuArgs;
 
             let text_range = $text_addr..=u32::try_from($text_addr + $text.len() - 1).unwrap();
             let data_range = $data_addr..=u32::try_from($data_addr + $data.len() - 1).unwrap();
 
-            let mut cpu = Cpu::new(DynamicBus::new(), Clock::new());
+            let clock = Rc::new(Clock::new());
+            let pic = Rc::new(Pic::new());
+            let args = CpuArgs::default();
+            let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args);
             let rom = Rom::new($text.clone());
             cpu.bus
                 .attach_dev("ROM", text_range, Box::new(rom))

--- a/sw-emulator/lib/cpu/src/internal_timers.rs
+++ b/sw-emulator/lib/cpu/src/internal_timers.rs
@@ -1,0 +1,223 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    uart.rs
+
+Abstract:
+
+    File contains VeeR Internal Timers implementation.
+
+--*/
+
+use caliptra_emu_bus::{ActionHandle, Clock, Timer, TimerAction};
+use std::rc::Rc;
+
+struct InternalTimer {
+    /// Which timer are we.
+    id: u8,
+    /// Clock.now() when this timer was last written to.
+    last_set_ticks: u64,
+    /// Value this timer was last set to
+    last_set_val: u32,
+    /// Bound to trigger interrupt at.
+    bound: u32,
+    /// The handle for the timer action for the last fired trap.
+    timer_action: Option<ActionHandle>,
+    /// Whether this timer is cascaded (timer 1 only).
+    cascade: bool,
+    /// True if this timer is incremented in pause mode.
+    pause_en: bool,
+    /// True if this timer is incremented in sleep mode.
+    halt_en: bool,
+    /// Whether this timer is enabled.
+    enabled: bool,
+}
+
+impl InternalTimer {
+    fn new(id: u8) -> InternalTimer {
+        InternalTimer {
+            id,
+            last_set_ticks: 0,
+            last_set_val: 0,
+            bound: 0xffff_ffff,
+            timer_action: None,
+            cascade: false,
+            pause_en: false,
+            halt_en: false,
+            enabled: true,
+        }
+    }
+
+    fn read_control(&self) -> u32 {
+        let mut ctl = 0;
+        if self.cascade {
+            ctl |= 1 << 3;
+        }
+        if self.pause_en {
+            ctl |= 1 << 2;
+        }
+        if self.halt_en {
+            ctl |= 1 << 1;
+        }
+        if self.enabled {
+            ctl |= 1;
+        }
+        ctl
+    }
+
+    fn write_control(&mut self, val: u32, timer: &Timer, now: u64) {
+        self.enabled = val & 1 == 1;
+        self.halt_en = val & 2 == 2;
+        self.pause_en = val & 4 == 4;
+        self.cascade = val & 8 == 8;
+        self.arm(timer, now);
+    }
+
+    fn read_time(&self, now: u64) -> u32 {
+        let elapsed = ((now - self.last_set_ticks) & 0xffff_ffff) as u32;
+        self.last_set_val.wrapping_add(elapsed)
+    }
+
+    fn write_time(&mut self, val: u32, timer: &Timer, now: u64) {
+        self.last_set_ticks = now;
+        self.last_set_val = val;
+        self.arm(timer, now);
+    }
+
+    fn write_bound(&mut self, val: u32, timer: &Timer, now: u64) {
+        self.bound = val;
+        self.arm(timer, now);
+    }
+
+    fn interrupt_pending(&self, now: u64) -> bool {
+        self.read_time(now) >= self.bound
+    }
+
+    pub(crate) fn ticks_to_interrupt(&self, now: u64) -> u32 {
+        self.bound.saturating_sub(self.read_time(now)).max(1)
+    }
+
+    fn arm(&mut self, timer: &Timer, now: u64) {
+        if let Some(action) = self.timer_action.take() {
+            timer.cancel(action);
+        }
+        if !self.enabled {
+            return;
+        }
+        // TODO: support cascaded timer
+        let next_interrupt = self.ticks_to_interrupt(now);
+        self.timer_action = Some(timer.schedule_action_in(
+            next_interrupt as u64,
+            TimerAction::InternalTimerLocalInterrupt { timer_id: self.id },
+        ));
+    }
+}
+
+pub struct InternalTimers {
+    clock: Rc<Clock>,
+    clock_timer: Timer,
+    timer0: InternalTimer,
+    timer1: InternalTimer,
+}
+
+impl InternalTimers {
+    pub fn new(clock: Rc<Clock>) -> Self {
+        let clock_timer = clock.timer();
+        Self {
+            clock: clock.clone(),
+            clock_timer,
+            timer0: InternalTimer::new(0),
+            timer1: InternalTimer::new(1),
+        }
+    }
+
+    pub fn read_mitcnt0(&self) -> u32 {
+        self.timer0.read_time(self.clock.now())
+    }
+
+    pub fn read_mitcnt1(&self) -> u32 {
+        self.timer1.read_time(self.clock.now())
+    }
+
+    pub fn write_mitcnt0(&mut self, val: u32) {
+        self.timer0
+            .write_time(val, &self.clock_timer, self.clock.now());
+    }
+
+    pub fn write_mitcnt1(&mut self, val: u32) {
+        self.timer1
+            .write_time(val, &self.clock_timer, self.clock.now());
+    }
+
+    pub fn read_mitb0(&self) -> u32 {
+        self.timer0.bound
+    }
+
+    pub fn read_mitb1(&self) -> u32 {
+        self.timer0.bound
+    }
+
+    pub fn write_mitb0(&mut self, val: u32) {
+        self.timer0
+            .write_bound(val, &self.clock_timer, self.clock.now());
+    }
+
+    pub fn write_mitb1(&mut self, val: u32) {
+        self.timer1
+            .write_bound(val, &self.clock_timer, self.clock.now());
+    }
+
+    pub fn read_mitctl0(&self) -> u32 {
+        self.timer0.read_control()
+    }
+
+    pub fn read_mitctl1(&self) -> u32 {
+        self.timer1.read_control()
+    }
+
+    pub fn write_mitctl0(&mut self, val: u32) {
+        self.timer0
+            .write_control(val, &self.clock_timer, self.clock.now())
+    }
+
+    pub fn write_mitctl1(&mut self, val: u32) {
+        self.timer1
+            .write_control(val, &self.clock_timer, self.clock.now())
+    }
+
+    pub fn interrupts_pending(&self) -> (bool, bool) {
+        (
+            self.timer0.interrupt_pending(self.clock.now()),
+            self.timer1.interrupt_pending(self.clock.now()),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::rc::Rc;
+
+    use super::InternalTimer;
+    use caliptra_emu_bus::Clock;
+
+    #[test]
+    fn test_ticks_to_interrupt() {
+        let clock = Rc::new(Clock::new());
+        let t = clock.timer();
+        let mut itimer = InternalTimer::new(0);
+        itimer.write_bound(300, &t, 100);
+        assert_eq!(200, itimer.ticks_to_interrupt(100));
+    }
+
+    #[test]
+    fn test_ticks_to_interrupt_underflow() {
+        let clock = Rc::new(Clock::new());
+        let t = clock.timer();
+        let mut itimer = InternalTimer::new(0);
+        itimer.write_bound(300, &t, 100);
+        assert_eq!(1, itimer.ticks_to_interrupt(400));
+    }
+}

--- a/sw-emulator/lib/cpu/src/lib.rs
+++ b/sw-emulator/lib/cpu/src/lib.rs
@@ -15,6 +15,7 @@ Abstract:
 pub mod cpu;
 mod csr_file;
 mod instr;
+mod internal_timers;
 mod pic;
 mod types;
 pub mod xreg_file;
@@ -24,5 +25,9 @@ pub use cpu::WatchPtrHit;
 pub use cpu::WatchPtrKind;
 pub use cpu::{CodeRange, CoverageBitmaps, Cpu, ImageInfo, InstrTracer, StackInfo, StackRange};
 pub use csr_file::CsrFile;
+pub use internal_timers::InternalTimers;
 pub use pic::{IntSource, Irq, Pic, PicMmioRegisters};
+pub use types::CpuArgs;
+pub use types::CpuOrgArgs;
 pub use types::RvInstr;
+pub use types::RvInstr32;

--- a/sw-emulator/lib/cpu/src/types.rs
+++ b/sw-emulator/lib/cpu/src/types.rs
@@ -18,6 +18,64 @@ use crate::xreg_file::XReg;
 use bitfield::{bitfield, BitRange, BitRangeMut};
 use caliptra_emu_types::emu_enum;
 
+/// Memory offsets for CPU
+#[derive(Debug, Copy, Clone)]
+pub struct CpuOrgArgs {
+    /// ROM offset
+    pub rom: u32,
+
+    /// ROM size,
+    pub rom_size: u32,
+
+    /// ICCM offset
+    pub iccm: u32,
+
+    /// ICCM size
+    pub iccm_size: u32,
+
+    /// DCCM offset
+    pub dccm: u32,
+
+    /// DCCM size
+    pub dccm_size: u32,
+}
+
+impl CpuOrgArgs {
+    /// Default position of ROM in the memory map
+    pub const DEFAULT_ROM_ORG: u32 = 0x0000_0000;
+    /// Default size of the ROM
+    pub const DEFAULT_ROM_SIZE: u32 = 96 * 1024;
+
+    /// Default position of the ICCM in the memory map
+    pub const DEFAULT_ICCM_ORG: u32 = 0x4000_0000;
+    /// Default size of the ICCM memory
+    pub const DEFAULT_ICCM_SIZE: u32 = 256 * 1024;
+
+    /// Default position of the DCCM in the memory map
+    pub const DEFAULT_DCCM_ORG: u32 = 0x5000_0000;
+    /// Default size of the DCCM memory
+    pub const DEFAULT_DCCM_SIZE: u32 = 256 * 1024;
+}
+
+impl Default for CpuOrgArgs {
+    fn default() -> Self {
+        Self {
+            rom: Self::DEFAULT_ROM_ORG,
+            rom_size: Self::DEFAULT_ROM_SIZE,
+            iccm: Self::DEFAULT_ICCM_ORG,
+            iccm_size: Self::DEFAULT_ICCM_SIZE,
+            dccm: Self::DEFAULT_DCCM_ORG,
+            dccm_size: Self::DEFAULT_DCCM_SIZE,
+        }
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct CpuArgs {
+    /// Memory offsets
+    pub org: CpuOrgArgs,
+}
+
 emu_enum! {
     /// RISCV 32-bit instruction opcodes
     #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
@@ -129,10 +187,13 @@ emu_enum! {
 
         // Bitmanip instructions
         Bitmanip = 0b011_0000,
+
         // OR-Combine byte granule
         Orc = 0b001_0100,
+
         // Bit clear
         Bclr = 0b010_0100,
+
         // Byte reverse
         Rev8 = 0b011_0100,
     };
@@ -185,7 +246,7 @@ emu_enum! {
         Four = 0b100,
 
         /// Function Five
-        Five= 0b101,
+        Five = 0b101,
 
         /// Function Six
         Six = 0b110,

--- a/sw-emulator/lib/derive/src/util/mod.rs
+++ b/sw-emulator/lib/derive/src/util/mod.rs
@@ -12,5 +12,4 @@ Abstract:
 
 --*/
 pub mod literal;
-pub mod sort;
 pub mod token_iter;

--- a/sw-emulator/lib/derive/tests/derive_bus_test.rs
+++ b/sw-emulator/lib/derive/tests/derive_bus_test.rs
@@ -27,34 +27,34 @@ impl From<MyCustomField> for RvData {
 struct MyBus {
     pub log: Log,
 
-    #[peripheral(offset = 0x0000_0000, mask = 0x0fff_ffff)]
+    #[peripheral(offset = 0x0000_0000, len = 0x0fff_ffff)]
     pub rom: Ram,
 
-    #[peripheral(offset = 0x1000_0000, mask = 0x0fff_ffff)]
+    #[peripheral(offset = 0x1000_0000, len = 0x0fff_ffff)]
     pub sram: Ram,
 
-    #[peripheral(offset = 0x2000_0000, mask = 0x0fff_ffff)]
+    #[peripheral(offset = 0x2000_0000, len = 0x0fff_ffff)]
     pub dram: Ram,
 
-    #[peripheral(offset = 0xaa00_0000, mask = 0x0000_ffff)]
+    #[peripheral(offset = 0xaa00_0000, len = 0x80)]
     pub uart0: Ram,
 
-    #[peripheral(offset = 0xaa01_0000, mask = 0x0000_ffff)]
+    #[peripheral(offset = 0xaa01_0000, len = 0x80)]
     pub uart1: Ram,
 
-    #[peripheral(offset = 0xaa02_0000, mask = 0x0000_00ff)]
+    #[peripheral(offset = 0xaa02_0000, len = 0x80)]
     pub i2c0: Ram,
 
-    #[peripheral(offset = 0xaa02_0400, mask = 0x0000_00ff)]
+    #[peripheral(offset = 0xaa02_0400, len = 0x80)]
     pub i2c1: Ram,
 
-    #[peripheral(offset = 0xaa02_0800, mask = 0x0000_00ff)]
+    #[peripheral(offset = 0xaa02_0800, len = 0x80)]
     pub i2c2: Ram,
 
-    #[peripheral(offset = 0xbb42_0000, mask = 0x0000_ffff)]
+    #[peripheral(offset = 0xbb42_0000, len = 0x10000)]
     pub spi0: Ram,
 
-    #[peripheral(offset = 0xaa05_0000, mask = 0x0000_ffff)]
+    #[peripheral(offset = 0xaa05_0000, len = 0x10000)]
     pub fake: FakeBus,
 
     #[register(offset = 0xcafe_f0d0)]
@@ -517,7 +517,7 @@ fn test_write_dispatch() {
 }
 
 #[test]
-fn test_poll_and_dma() {
+fn test_poll() {
     let mut bus = MyBus {
         rom: Ram::new(vec![0u8; 65536]),
         sram: Ram::new(vec![0u8; 65536]),
@@ -547,5 +547,5 @@ fn test_poll_and_dma() {
     };
     Bus::poll(&mut bus);
     assert_eq!(bus.log.take(), "poll; ");
-    assert_eq!(bus.fake.log.take(), "poll()\n");
+    assert_eq!(bus.fake.log.take(), "poll()\n")
 }

--- a/sw-emulator/lib/periph/src/doe.rs
+++ b/sw-emulator/lib/periph/src/doe.rs
@@ -63,7 +63,7 @@ register_bitfields! [
 #[update_reset_fn(update_reset)]
 pub struct Doe {
     /// Initialization Vector
-    #[peripheral(offset = 0x0000_0000, mask = 0x0000_000f)]
+    #[peripheral(offset = 0x0000_0000, len = 0x10)]
     iv: ReadWriteMemory<DOE_IV_SIZE>,
 
     /// Control Register
@@ -215,9 +215,9 @@ mod tests {
     use crate::{CaliptraRootBusArgs, Iccm, KeyUsage, MailboxInternal, MailboxRam};
     use caliptra_api_types::SecurityState;
     use caliptra_emu_bus::Bus;
-    use caliptra_emu_cpu::Pic;
     use caliptra_emu_crypto::EndianessTransform;
     use caliptra_emu_types::RvAddr;
+    use std::rc::Rc;
     use tock_registers::registers::InMemoryRegister;
 
     const OFFSET_IV: RvAddr = 0;
@@ -247,15 +247,13 @@ mod tests {
             0xFB, 0xE5, 0xEF, 0x52, 0x0A, 0x1A,
         ];
 
-        let pic = Pic::new();
-        let clock = Clock::new();
+        let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            &clock,
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
-            &pic,
             CaliptraRootBusArgs {
+                clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
                 ..CaliptraRootBusArgs::default()
             },
@@ -316,15 +314,13 @@ mod tests {
             0xA0, 0x3E, 0xB1, 0xAD, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        let pic = Pic::new();
-        let clock = Clock::new();
+        let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            &clock,
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
-            &pic,
             CaliptraRootBusArgs {
+                clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
                 ..CaliptraRootBusArgs::default()
             },
@@ -385,15 +381,13 @@ mod tests {
         let expected_uds = [0u8; 64];
         let expected_doe_key = [0u8; 32];
         let expected_fe = [0u8; 32];
-        let pic = Pic::new();
-        let clock = Clock::new();
+        let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            &clock,
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
-            &pic,
             CaliptraRootBusArgs {
+                clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
                 ..CaliptraRootBusArgs::default()
             },

--- a/sw-emulator/lib/periph/src/hash_sha256.rs
+++ b/sw-emulator/lib/periph/src/hash_sha256.rs
@@ -90,11 +90,11 @@ pub struct HashSha256 {
     status: ReadOnlyRegister<u32, Status::Register>,
 
     /// SHA256 Block Memory
-    #[peripheral(offset = 0x0000_0080, mask = 0x0000_007f)]
+    #[peripheral(offset = 0x0000_0080, len = 0x40)]
     block: ReadWriteMemory<SHA256_BLOCK_SIZE>,
 
     /// SHA256 Hash Memory
-    #[peripheral(offset = 0x0000_0100, mask = 0x0000_00ff)]
+    #[peripheral(offset = 0x0000_0100, len = 0x20)]
     hash: ReadOnlyMemory<SHA256_HASH_SIZE>,
 
     /// SHA256 engine

--- a/sw-emulator/lib/periph/src/hash_sha512.rs
+++ b/sw-emulator/lib/periph/src/hash_sha512.rs
@@ -164,7 +164,7 @@ pub struct HashSha512Regs {
     block: [u32; SHA512_BLOCK_SIZE_WORDS],
 
     /// SHA512 Hash Memory
-    #[peripheral(offset = 0x0000_0100, mask = 0x0000_00ff)]
+    #[peripheral(offset = 0x0000_0100, len = 0x40)]
     hash: ReadWriteMemory<SHA512_HASH_SIZE>,
 
     /// Block Read Control register

--- a/sw-emulator/lib/periph/src/sha512_acc.rs
+++ b/sw-emulator/lib/periph/src/sha512_acc.rs
@@ -119,10 +119,10 @@ pub struct Sha512AcceleratorRegs {
     status: ReadOnlyRegister<u32, Status::Register>,
 
     /// SHA512 Hash Memory
-    #[peripheral(offset = 0x0000_0020, mask = 0x0000_001F)]
+    #[peripheral(offset = 0x0000_0020, len = 0x20)]
     hash_lower: ReadOnlyMemory<SHA512_HASH_HALF_SIZE>,
 
-    #[peripheral(offset = 0x0000_0040, mask = 0x0000_001F)]
+    #[peripheral(offset = 0x0000_0040, len = 0x20)]
     hash_upper: ReadOnlyMemory<SHA512_HASH_HALF_SIZE>,
 
     /// Control register


### PR DESCRIPTION
This backports major improvements from the Caliptra MCU CPU such as improved timers, IRQ priorities, and other cleanups.

This also gets rid of masks and switches to offsets, work I had done last year in the caliptra-mcu-sw branch but never made it over to the caliptra-sw side.