### PR TITLE
Repurpose fips_status field in FW_INFO

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -662,7 +662,7 @@ Command Code: `0x494E_464F` ("INFO")
 | **Name**               | **Type**       | **Description**
 | --------               | --------       | ---------------
 | chksum                 | u32            | Checksum over other input arguments, computed by the caller. Little endian.
-| fips\_status           | u32            | Indicates if the command is FIPS approved or an error.
+| fips\_status           | u32            | Indicates if Caliptra has been operating in FIPS-approved mode since boot.
 | pl0_pauser             | u32            | PAUSER with PL0 privileges (from image header).
 | runtime_svn            | u32            | Runtime SVN.
 | min_runtime_svn        | u32            | Min Runtime SVN.


### PR DESCRIPTION
By making this field indicate whether Caliptra has been operating in FIPS mode since boot, other mailbox commands shouldn't need to include a fips_status field.