### PR TITLE
Disable FPGA tests on push

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -2,8 +2,6 @@
 name: FPGA Build
 
 on:
-  push:
-    branches: ["main-2.x"]
   pull_request:
   workflow_call:
     inputs:


### PR DESCRIPTION
The FPGA tests run on each PR already. To help alleviate the load on the FPGA CI, remove the redundant tests on push.

We can revisit this later if the FPGA CI availability improves.