### PR TITLE
Also check `mailbox_flow_done` before sending an update reset

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -201,7 +201,10 @@ fn test_mbox_idle_during_warm_reset() {
     .unwrap();
 
     // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+    model.step_until(|m| {
+        let status = m.soc_ifc().cptra_flow_status().read();
+        status.ready_for_runtime() && status.mailbox_flow_done()
+    });
 
     // Perform warm reset
     model.warm_reset_flow(&Fuses {


### PR DESCRIPTION
Sometimes this test case flakes on the FPGA, because Caliptra signaled that it was ready for runtime but
it had not yet marked the runtime as inactive.
