### PR TITLE
Backport MCU integer From implementation

### DIFF
--- a/sw-emulator/lib/bus/src/register.rs
+++ b/sw-emulator/lib/bus/src/register.rs
@@ -266,6 +266,12 @@ where
     }
 }
 
+impl<T: UIntLike, R: RegisterLongName> From<T> for ReadWriteRegister<T, R> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
 /// Write Only Register
 pub struct WriteOnlyRegister<T: UIntLike, R: RegisterLongName = ()> {
     pub reg: InMemoryRegister<T, R>,


### PR DESCRIPTION
This is a useful convenience method and is used all over MCU, so it's useful to have it here as well.