### PR TITLE
rom: I3C recovery PROT_CAP needs to set mandatory bits and version

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -402,6 +402,8 @@ impl<'a> DmaRecovery<'a> {
     const RECOVERY_REGISTER_OFFSET: usize = 0x100;
     const INDIRECT_FIFO_DATA_OFFSET: u32 = 0x68;
     const RECOVERY_DMA_BLOCK_SIZE_BYTES: u32 = 256;
+    const PROT_CAP2_DEVICE_ID_SUPPORT: u32 = 0x1; // Bit 0 in agent_caps
+    const PROT_CAP2_DEVICE_STATUS_SUPPORT: u32 = 0x10; // Bit 4 in agent_caps
     const PROT_CAP2_PUSH_C_IMAGE_SUPPORT: u32 = 0x80; // Bit 7 in agent_caps
     const PROT_CAP2_FLASHLESS_BOOT_VALUE: u32 = 0x800; // Bit 11 in agent_caps
     const PROT_CAP2_FIFO_CMS_SUPPORT: u32 = 0x1000; // Bit 12 in agent_caps
@@ -606,15 +608,21 @@ impl<'a> DmaRecovery<'a> {
                 .modify(|val| val.reset(Self::RESET_VAL));
 
             // Set PROT_CAP2.AGENT_CAPS
+            // - Bit0  to 1 ('Device ID support')
+            // - Bit4  to 1 ('Device Status support')
             // - Bit7  to 1 ('Push C-image support')
             // - Bit11 to 1 ('Flashless boot')
             // - Bit12 to 1 ('FIFO CMS support')
+            // Set PROT_CAP2.REC_PROT_VERSION to 0x101 (1.1).
             recovery.prot_cap_2().modify(|val| {
                 val.agent_caps(
-                    Self::PROT_CAP2_FIFO_CMS_SUPPORT
+                    Self::PROT_CAP2_DEVICE_ID_SUPPORT // mandatory
+                        | Self::PROT_CAP2_DEVICE_STATUS_SUPPORT // mandatory
+                        | Self::PROT_CAP2_FIFO_CMS_SUPPORT
                         | Self::PROT_CAP2_FLASHLESS_BOOT_VALUE
                         | Self::PROT_CAP2_PUSH_C_IMAGE_SUPPORT,
                 )
+                .rec_prot_version(0x101) // 1.1
             });
 
             // Set DEVICE_STATUS:Byte0 to 0x3 ('Recovery mode - ready to accept recovery image').

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -646,11 +646,13 @@ There are two modes in which the ROM executes: PASSIVE mode or ACTIVE mode. Foll
 
 Following is the sequence of steps that are performed to download the firmware image into the mailbox in ACTIVE mode.
 
-1. On receiving the RI_DOWNLOAD_FIRMWARE mailbox command, set the RI PROT_CAP2 register, `Agent Capability` field bits:
+1. On receiving the RI_DOWNLOAD_FIRMWARE mailbox command, set the RI PROT_CAP2 register version to 1.1 and the `Agent Capability` field bits:
+    - `Device ID`
+    - `Device Status`
     - `Push C-image support`
     - `Flashless boot`
     - `FIFO CMS support`
-2. Set the RI DEVICE_STATUS_0 register, `Device Status` field  to 0x3 ('Recovery mode - ready to accept recovery image') and 
+2. Set the RI DEVICE_STATUS_0 register, `Device Status` field  to 0x3 ('Recovery mode - ready to accept recovery image') and
 `Recovery Reason Code` field to 0x12 ('Flashless/Streaming Boot (FSB)').
 3. Set the RI RECOVERY_STATUS register, `Device Recovery Status` field to 0x1 ('Awaiting recovery image') and `Recovery Image Index` field to 0 (Firmware Image).
 4. Loop on the `payload_available` bit in the `DMA Status0` register for the firmware image info to be available.
@@ -1141,6 +1143,3 @@ Fake ROM reduces boot time by doing the following:
 - The image builder exposes the argument "fake" that can be used to generate the fake versions
 
 To fully boot to runtime, the fake version of FMC should also be used. Details can be found in the FMC readme.
-
-
-


### PR DESCRIPTION
We thought initially that the hardware would have set the version and the mandatory bits of PROT_CAP, but in hardware, these values are 0 by default.