### PR TITLE
Fix Caliptra FPGA image to accept larger just-in-time tokens.

### DIFF
--- a/ci-tools/fpga-image/startup-script.sh
+++ b/ci-tools/fpga-image/startup-script.sh
@@ -20,9 +20,8 @@ echo "36668aa492b1c83cdd3ade8466a0153d --- Command input"
 echo Available commands:
 echo "  runner-jitconfig <base64>"
 echo "  login"
-echo -n "> "
+read -e -p "> " cmd
 
-read cmd
 cmd_array=($cmd)
 if [[ "${cmd}" == "login" ]]; then
     login -f root


### PR DESCRIPTION
The read buffer was limited to 4096 bytes. There must have been a change in GitHub token sizes because it is now passing that limit. This change makes it collect characters one-by-one so the buffer doesn't fill.