### PR TITLE
Adding most recent non-fatal FW error to FW_INFO cmd

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1251,6 +1251,7 @@ pub struct FwInfoResp {
     pub runtime_sha384_digest: [u32; 12],
     pub owner_pub_key_hash: [u32; 12],
     pub authman_sha384_digest: [u32; 12],
+    pub most_recent_fw_error: u32,
 }
 
 // CAPABILITIES

--- a/drivers/src/error_reporter.rs
+++ b/drivers/src/error_reporter.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 use crate::memory_layout::BOOT_STATUS_ORG;
+use crate::PersistentData;
 use caliptra_registers::soc_ifc::SocIfcReg;
 
 /// Report non fatal F/W error
@@ -24,6 +25,32 @@ pub fn report_fw_error_non_fatal(val: u32) {
     soc_ifc.regs_mut().cptra_fw_error_non_fatal().write(|_| val);
 
     update_boot_status(&mut soc_ifc);
+}
+
+/// Get non fatal F/W error
+///
+/// # Arguments
+///
+/// * `val` - F/W error code.
+pub fn get_fw_error_non_fatal() -> u32 {
+    let mut soc_ifc = unsafe { SocIfcReg::new() };
+    soc_ifc.regs_mut().cptra_fw_error_non_fatal().read()
+}
+
+/// Clear non fatal F/W error
+///
+/// /// # Arguments
+///
+/// * `persistent_data` - Persistent data struct so we can track cleared errors.
+pub fn clear_fw_error_non_fatal(persistent_data: &mut PersistentData) {
+    match get_fw_error_non_fatal() {
+        0 => {}
+        val => {
+            // If there is a non-zero error, save it in persistent data before clearing
+            persistent_data.cleared_non_fatal_fw_error = val;
+            report_fw_error_non_fatal(0);
+        }
+    }
 }
 
 /// Report fatal F/W error

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -82,7 +82,10 @@ pub use ecc384::{
     Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Seed, Ecc384Signature,
 };
-pub use error_reporter::{report_fw_error_fatal, report_fw_error_non_fatal};
+pub use error_reporter::{
+    clear_fw_error_non_fatal, get_fw_error_non_fatal, report_fw_error_fatal,
+    report_fw_error_non_fatal,
+};
 pub use exit_ctrl::ExitCtrl;
 #[cfg(feature = "fips-test-hooks")]
 pub use fips_test_hooks::FipsTestHook;

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -331,6 +331,8 @@ pub struct PersistentData {
 
     pub cmb_aes_key_share0: [u8; 32],
     pub cmb_aes_key_share1: [u8; 32],
+
+    pub cleared_non_fatal_fw_error: u32,
 }
 
 impl PersistentData {

--- a/drivers/test-fw/src/bin/error_reporter_tests.rs
+++ b/drivers/test-fw/src/bin/error_reporter_tests.rs
@@ -15,16 +15,51 @@ Abstract:
 #![no_std]
 #![no_main]
 
-use caliptra_drivers::{report_fw_error_fatal, report_fw_error_non_fatal};
+use caliptra_drivers::{
+    clear_fw_error_non_fatal, get_fw_error_non_fatal, report_fw_error_fatal,
+    report_fw_error_non_fatal, PersistentDataAccessor,
+};
 use caliptra_registers::soc_ifc::SocIfcReg;
 
 use caliptra_test_harness::test_suite;
 
 fn test_report_fw_error() {
     let v: u32 = 0xdead0;
-    report_fw_error_non_fatal(0xdead0);
+    report_fw_error_non_fatal(v);
 
     assert_eq!(v, retrieve_fw_error_non_fatal());
+    // Make sure the getter works
+    assert_eq!(v, get_fw_error_non_fatal());
+}
+
+fn test_clear_fw_error_non_fatal() {
+    let err1: u32 = 0xdead1;
+    let err2: u32 = 0xdead2;
+
+    let mut persistent_data_accessor = unsafe { PersistentDataAccessor::new() };
+    let persistent_data = persistent_data_accessor.get_mut();
+
+    report_fw_error_non_fatal(err1);
+    assert_eq!(err1, get_fw_error_non_fatal());
+
+    // Ensure clear function zeros the fw_non_fatal_error and stores it in persistent data correctly
+    clear_fw_error_non_fatal(persistent_data);
+    assert_eq!(0, retrieve_fw_error_non_fatal());
+    assert_eq!(err1, persistent_data.cleared_non_fatal_fw_error);
+
+    // Write a new error
+    report_fw_error_non_fatal(err2);
+    assert_eq!(err2, get_fw_error_non_fatal());
+
+    clear_fw_error_non_fatal(persistent_data);
+    assert_eq!(0, retrieve_fw_error_non_fatal());
+    assert_eq!(err2, persistent_data.cleared_non_fatal_fw_error);
+
+    // Repeatedly clearing should not overwrite the stored previous error when no error is present
+    clear_fw_error_non_fatal(persistent_data);
+    clear_fw_error_non_fatal(persistent_data);
+    assert_eq!(0, retrieve_fw_error_non_fatal());
+    assert_eq!(err2, persistent_data.cleared_non_fatal_fw_error);
 }
 
 fn retrieve_fw_error_non_fatal() -> u32 {
@@ -47,5 +82,6 @@ fn retrieve_fw_error_fatal() -> u32 {
 
 test_suite! {
     test_report_fw_error,
+    test_clear_fw_error_non_fatal,
     test_report_fw_error_fatal,
 }

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -211,6 +211,7 @@ struct caliptra_fw_info_resp
     uint32_t runtime_sha384_digest[12];
     uint32_t owner_pub_key_hash[12];
     uint32_t authman_sha384_digest[12];
+    uint32_t most_recent_fw_error;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -214,7 +214,7 @@ impl FirmwareProcessor {
             CfiCounter::delay();
 
             if let Some(txn) = mbox.peek_recv() {
-                report_fw_error_non_fatal(0);
+                clear_fw_error_non_fatal(persistent_data);
 
                 // Drop all commands for invalid PAUSER
                 if txn.id() == RESERVED_PAUSER {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -954,6 +954,8 @@ Command Code: `0x494E_464F` ("INFO")
 | fmc_sha384_digest      | u32[12]        | Digest of FMC binary.
 | runtime_sha384_digest  | u32[12]        | Digest of runtime binary.
 | owner_pub_key_hash     | u32[12]        | Hash of the owner public keys provided in the image bundle manifest.
+| authman_sha384_digest  | u32[12]        | Hash of the authorization manifest provided by SET_AUTH_MANIFEST.
+| most_recent_fw_error   | u32            | Most recent FW non-fatal error (shows current non-fatal error if non-zero)
 
 ### VERSION
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -16,7 +16,7 @@ use crate::{handoff::RtHandoff, mutrefbytes, Drivers};
 use caliptra_common::mailbox_api::{
     AlgorithmType, FwInfoResp, GetIdevEcc384InfoResp, GetIdevMldsa87InfoResp, MailboxRespHeader,
 };
-use caliptra_drivers::CaliptraResult;
+use caliptra_drivers::{get_fw_error_non_fatal, CaliptraResult};
 
 pub struct FwInfoCmd;
 impl FwInfoCmd {
@@ -46,6 +46,10 @@ impl FwInfoCmd {
         resp.runtime_sha384_digest = pdata.manifest1.runtime.digest;
         resp.owner_pub_key_hash = pdata.data_vault.owner_pk_hash().into();
         resp.authman_sha384_digest = pdata.auth_manifest_digest;
+        resp.most_recent_fw_error = match get_fw_error_non_fatal() {
+            0 => drivers.persistent_data.get().cleared_non_fatal_fw_error,
+            e => e,
+        };
         Ok(core::mem::size_of::<FwInfoResp>())
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -519,7 +519,10 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
                 &mut drivers.soc_ifc,
                 caliptra_common::WdtTimeout::default(),
             );
-            caliptra_drivers::report_fw_error_non_fatal(0);
+
+            // Clear non-fatal error before processing command
+            caliptra_drivers::clear_fw_error_non_fatal(drivers.persistent_data.get_mut());
+
             let command_result = handle_command(drivers);
             cfi_check!(command_result);
             match command_result {

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -105,7 +105,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         if drivers.mbox.is_cmd_ready() {
             drivers.soc_ifc.flow_status_set_mailbox_flow_done(false);
 
-            caliptra_drivers::report_fw_error_non_fatal(0);
+            caliptra_drivers::clear_fw_error_non_fatal(drivers.persistent_data.get_mut());
             match handle_command(drivers) {
                 Ok(status) => {
                     drivers.mbox.set_status(status);

--- a/runtime/test-fw/src/mock_rt_test_interactive.rs
+++ b/runtime/test-fw/src/mock_rt_test_interactive.rs
@@ -61,7 +61,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         }
 
         if drivers.mbox.is_cmd_ready() {
-            caliptra_drivers::report_fw_error_non_fatal(0);
+            caliptra_drivers::clear_fw_error_non_fatal(drivers.persistent_data.get_mut());
             match handle_command(drivers, &persistent_data) {
                 Ok(status) => {
                     drivers.mbox.set_status(status);


### PR DESCRIPTION
FIPS level 3 requires the most recent error to always be available. Because we clear non-fatal errors, this change stores the most recent cleared error in persistent data and exposes it in the FW_INFO command