### PR TITLE
[feat] DOT_DERIVE_KEY and HMAC mailbox commands

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -133,8 +133,8 @@ impl CommandId {
     // Image metadata commands
     pub const GET_IMAGE_INFO: Self = Self(0x494D_4530); // "IME0"
 
-    // Device Ownership Transfer (DOT) commands
-    pub const DERIVE_DOT_KEY: Self = Self(0x444F544B); // "DOTK"
+    // Stable key derivation command
+    pub const DERIVE_STABLE_KEY: Self = Self(0x44534B45); // "DSKE"
 
     // Cryptographic mailbox commands
     pub const CM_IMPORT: Self = Self(0x434D_494D); // "CMIM"
@@ -3699,64 +3699,64 @@ impl Request for CmEcdsaVerifyReq {
     type Resp = MailboxRespHeader;
 }
 
-// DERIVE_DOT_KEY
-pub const DOT_INFO_SIZE_BYTES: usize = 32;
+// DERIVE_STABLE_KEY
+pub const STABLE_KEY_INFO_SIZE_BYTES: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DotKeyType {
+pub enum StableKeyType {
     Reserved = 0,
     IDevId,
     LDevId,
 }
 
-impl From<u32> for DotKeyType {
+impl From<u32> for StableKeyType {
     fn from(val: u32) -> Self {
         match val {
-            1_u32 => DotKeyType::IDevId,
-            2_u32 => DotKeyType::LDevId,
-            _ => DotKeyType::Reserved,
+            1_u32 => StableKeyType::IDevId,
+            2_u32 => StableKeyType::LDevId,
+            _ => StableKeyType::Reserved,
         }
     }
 }
 
-impl From<DotKeyType> for u32 {
-    fn from(val: DotKeyType) -> Self {
+impl From<StableKeyType> for u32 {
+    fn from(val: StableKeyType) -> Self {
         match val {
-            DotKeyType::IDevId => 1,
-            DotKeyType::LDevId => 2,
-            DotKeyType::Reserved => 0,
+            StableKeyType::IDevId => 1,
+            StableKeyType::LDevId => 2,
+            StableKeyType::Reserved => 0,
         }
     }
 }
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct DeriveDotKeyReq {
+pub struct DeriveStableKeyReq {
     pub hdr: MailboxReqHeader,
     pub key_type: u32,
-    pub info: [u8; DOT_INFO_SIZE_BYTES],
+    pub info: [u8; STABLE_KEY_INFO_SIZE_BYTES],
 }
-impl Default for DeriveDotKeyReq {
+impl Default for DeriveStableKeyReq {
     fn default() -> Self {
         Self {
             hdr: Default::default(),
-            info: [0u8; DOT_INFO_SIZE_BYTES],
-            key_type: DotKeyType::Reserved as u32,
+            info: [0u8; STABLE_KEY_INFO_SIZE_BYTES],
+            key_type: StableKeyType::Reserved as u32,
         }
     }
 }
-impl Request for DeriveDotKeyReq {
-    const ID: CommandId = CommandId::DERIVE_DOT_KEY;
-    type Resp = DeriveDotKeyResp;
+impl Request for DeriveStableKeyReq {
+    const ID: CommandId = CommandId::DERIVE_STABLE_KEY;
+    type Resp = DeriveStableKeyResp;
 }
 
 #[repr(C)]
 #[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct DeriveDotKeyResp {
+pub struct DeriveStableKeyResp {
     pub hdr: MailboxRespHeader,
     pub cmk: Cmk,
 }
-impl Response for DeriveDotKeyResp {}
+impl Response for DeriveStableKeyResp {}
 
 /// Retrieves dlen bytes  from the mailbox.
 pub fn mbox_read_response(

--- a/common/src/crypto.rs
+++ b/common/src/crypto.rs
@@ -13,11 +13,13 @@ Abstract:
 --*/
 use crate::keyids::KEY_ID_TMP;
 use caliptra_drivers::{
-    okmutref, okref, Array4x12, CaliptraResult, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut,
-    Ecc384PubKey, Ecc384Result, Ecc384Signature, Hmac, HmacData, HmacMode, KeyId, KeyReadArgs,
-    KeyUsage, KeyVault, KeyWriteArgs, Mldsa87, Mldsa87PubKey, Mldsa87Result, Mldsa87Seed,
-    Mldsa87SignRnd, Mldsa87Signature, Sha2_512_384, Trng,
+    okmutref, okref, Aes, AesGcmIv, AesKey, Array4x12, CaliptraResult, Ecc384, Ecc384PrivKeyIn,
+    Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Signature, Hmac, HmacData, HmacMode, KeyId,
+    KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs, Mldsa87, Mldsa87PubKey, Mldsa87Result,
+    Mldsa87Seed, Mldsa87SignRnd, Mldsa87Signature, PersistentData, Sha2_512_384, Trng,
 };
+use caliptra_error::CaliptraError;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 /// DICE Layer ECC Key Pair
@@ -46,6 +48,37 @@ pub struct MlDsaKeyPair {
 pub enum PubKey<'a> {
     Ecc(&'a Ecc384PubKey),
     Mldsa(&'a Mldsa87PubKey),
+}
+
+pub const CMK_MAX_KEY_SIZE_BITS: usize = 512;
+pub const UNENCRYPTED_CMK_SIZE_BYTES: usize = 80;
+
+#[repr(C)]
+#[derive(Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+pub struct UnencryptedCmk {
+    pub version: u16,
+    pub length: u16,
+    pub key_usage: u8,
+    pub id: [u8; 3],
+    pub usage_counter: u64,
+    pub key_material: [u8; CMK_MAX_KEY_SIZE_BITS / 8],
+}
+
+impl UnencryptedCmk {
+    #[allow(unused)]
+    pub fn key_id(&self) -> u32 {
+        self.id[0] as u32 | ((self.id[1] as u32) << 8) | ((self.id[2] as u32) << 16)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
+pub struct EncryptedCmk {
+    pub domain: u32,
+    pub domain_metadata: [u8; 16],
+    pub iv: [u8; 12],
+    pub ciphertext: [u8; UNENCRYPTED_CMK_SIZE_BYTES],
+    pub gcm_tag: [u8; 16],
 }
 
 pub struct Crypto {}
@@ -114,10 +147,12 @@ impl Crypto {
             trng,
             KeyWriteArgs::new(
                 output,
+                // [TODO][CAP2] Take usage from caller instead of hardcoding
                 KeyUsage::default()
                     .set_hmac_key_en()
                     .set_ecc_key_gen_seed_en()
-                    .set_mldsa_key_gen_seed_en(),
+                    .set_mldsa_key_gen_seed_en()
+                    .set_aes_key_en(),
             )
             .into(),
             mode,
@@ -393,5 +428,83 @@ impl Crypto {
             &Mldsa87SignRnd::default(),
             trng,
         )
+    }
+
+    pub fn get_cmb_aes_key(pdata: &PersistentData) -> ([u8; 32], [u8; 32]) {
+        (pdata.cmb_aes_key_share0, pdata.cmb_aes_key_share1)
+    }
+
+    /// Encrypt the Cryptographic Mailbox Key (CML) using the Key Encryption Key (KEK)
+    ///
+    /// # Arguments
+    /// * `aes` - AES driver
+    /// * `trng` - TRNG driver
+    /// * `unencrypted_cmk` - Unencrypted CMK to encrypt
+    /// * `kek_iv` - Initialization vector for the KEK
+    /// * `kek` - Key Encrption Key (AES key)
+    ///
+    /// # Returns
+    /// * `EncryptedCmk` - Encrypted CMK
+    ///
+    #[inline(always)]
+    pub fn encrypt_cmk(
+        aes: &mut Aes,
+        trng: &mut Trng,
+        unencrypted_cmk: &UnencryptedCmk,
+        kek_iv: [u8; 12],
+        kek: ([u8; 32], [u8; 32]),
+    ) -> CaliptraResult<EncryptedCmk> {
+        let plaintext = unencrypted_cmk.as_bytes();
+        let mut ciphertext = [0u8; UNENCRYPTED_CMK_SIZE_BYTES];
+        // Encrypt the CMK using the KEK
+        let (iv, gcm_tag) = aes.aes_256_gcm_encrypt(
+            trng,
+            AesGcmIv::Array(&kek_iv),
+            AesKey::Split(&kek.0, &kek.1),
+            &[],
+            plaintext,
+            &mut ciphertext[..],
+            16,
+        )?;
+        Ok(EncryptedCmk {
+            domain: 0,
+            domain_metadata: [0u8; 16],
+            iv,
+            ciphertext,
+            gcm_tag,
+        })
+    }
+
+    /// Decrypt the Cryptographic Mailbox Key (CMK) using the Key Encryption Key (KEK)
+    ///
+    /// # Arguments
+    /// * `aes` - AES driver
+    /// * `trng` - TRNG driver
+    /// * `kek` - Key Encryption Key (AES key)
+    /// * `encrypted_cmk` - Encrypted CMK to decrypt
+    ///
+    /// # Returns
+    /// * `UnencryptedCmk` - Decrypted CMK
+    ///
+    #[inline(always)]
+    pub fn decrypt_cmk(
+        aes: &mut Aes,
+        trng: &mut Trng,
+        kek: ([u8; 32], [u8; 32]),
+        encrypted_cmk: &EncryptedCmk,
+    ) -> CaliptraResult<UnencryptedCmk> {
+        let ciphertext = &encrypted_cmk.ciphertext;
+        let mut plaintext = [0u8; UNENCRYPTED_CMK_SIZE_BYTES];
+        aes.aes_256_gcm_decrypt(
+            trng,
+            &encrypted_cmk.iv,
+            AesKey::Split(&kek.0, &kek.1),
+            &[],
+            ciphertext,
+            &mut plaintext,
+            &encrypted_cmk.gcm_tag,
+        )?;
+        UnencryptedCmk::read_from_bytes(&plaintext)
+            .map_err(|_| CaliptraError::CMB_HMAC_INVALID_DEC_CMK)
     }
 }

--- a/common/src/hmac_cm.rs
+++ b/common/src/hmac_cm.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    crypto.rs
+    hmac_cm.rs
 
 Abstract:
 

--- a/common/src/hmac_cm.rs
+++ b/common/src/hmac_cm.rs
@@ -1,0 +1,129 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    crypto.rs
+
+Abstract:
+
+    HMAC Cryptographic Mailbox command processing.
+
+--*/
+
+use crate::crypto::{Crypto, EncryptedCmk, UnencryptedCmk};
+use caliptra_api::mailbox::{
+    CmHashAlgorithm, CmHmacReq, CmHmacResp, CmKeyUsage, Cmk, MailboxRespHeaderVarSize,
+    ResponseVarSize,
+};
+use caliptra_drivers::{Aes, Array4x12, Array4x16, Hmac, HmacData, HmacMode, Trng};
+use caliptra_error::{CaliptraError, CaliptraResult};
+use caliptra_image_types::{SHA384_DIGEST_BYTE_SIZE, SHA512_DIGEST_BYTE_SIZE};
+use zerocopy::{FromBytes, IntoBytes, KnownLayout};
+
+#[inline(always)]
+pub(crate) fn mutrefbytes<R: FromBytes + IntoBytes + KnownLayout>(
+    resp: &mut [u8],
+) -> CaliptraResult<&mut R> {
+    // the error should be impossible but check to avoid panic
+    let (resp, _) = R::mut_from_prefix(resp).map_err(|_| CaliptraError::RUNTIME_INTERNAL)?;
+    Ok(resp)
+}
+
+pub fn decrypt_hmac_key(
+    aes: &mut Aes,
+    trng: &mut Trng,
+    kek: ([u8; 32], [u8; 32]),
+    cmk: &Cmk,
+) -> CaliptraResult<UnencryptedCmk> {
+    let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmk.0[..])
+        .map_err(|_| CaliptraError::CMB_HMAC_INVALID_ENC_CMK)?;
+
+    let cmk = Crypto::decrypt_cmk(aes, trng, kek, encrypted_cmk)?;
+
+    match (cmk.length, CmKeyUsage::from(cmk.key_usage as u32)) {
+        (48 | 64, CmKeyUsage::Hmac) => Ok(cmk),
+        _ => Err(CaliptraError::CMB_HMAC_INVALID_KEY_USAGE),
+    }
+}
+
+#[inline(always)]
+pub fn hmac(
+    hmac: &mut Hmac,
+    aes: &mut Aes,
+    trng: &mut Trng,
+    kek: ([u8; 32], [u8; 32]),
+    cmd_bytes: &[u8],
+    resp: &mut [u8],
+) -> CaliptraResult<usize> {
+    if cmd_bytes.len() > core::mem::size_of::<CmHmacReq>() {
+        Err(CaliptraError::CMB_HMAC_INVALID_REQ_SIZE)?;
+    }
+    let mut cmd = CmHmacReq::default();
+    cmd.as_mut_bytes()[..cmd_bytes.len()].copy_from_slice(cmd_bytes);
+
+    let cm_hash_algorithm = CmHashAlgorithm::from(cmd.hash_algorithm);
+
+    if cmd.data_size as usize > cmd.data.len() {
+        Err(CaliptraError::CMB_HMAC_INVALID_REQ_SIZE)?;
+    }
+
+    let data = &cmd.data[..cmd.data_size as usize];
+
+    let cmk = decrypt_hmac_key(aes, trng, kek, &cmd.cmk)?;
+    // the hardware will fail if a 384-bit key is used with SHA512
+    if cmk.length == 48 && cm_hash_algorithm != CmHashAlgorithm::Sha384 {
+        Err(CaliptraError::CMB_HMAC_INVALID_KEY_USAGE_AND_SIZE)?;
+    }
+
+    let resp = mutrefbytes::<CmHmacResp>(resp)?;
+    resp.hdr = MailboxRespHeaderVarSize::default();
+    resp.hdr.data_len = match cm_hash_algorithm {
+        CmHashAlgorithm::Sha384 => SHA384_DIGEST_BYTE_SIZE as u32,
+        CmHashAlgorithm::Sha512 => SHA512_DIGEST_BYTE_SIZE as u32,
+        _ => return Err(CaliptraError::CMB_HMAC_UNSUPPORTED_HASH_ALGORITHM)?,
+    };
+
+    match cm_hash_algorithm {
+        CmHashAlgorithm::Sha384 => {
+            let hmac_mode = HmacMode::Hmac384;
+            let arr: [u8; 48] = cmk.key_material[..48].try_into().unwrap();
+            let key: Array4x12 = arr.into();
+            let mut tag = Array4x12::default();
+            hmac.hmac(
+                (&key).into(),
+                HmacData::Slice(data),
+                trng,
+                (&mut tag).into(),
+                hmac_mode,
+            )?;
+            // convert out of HW format
+            tag.0.iter_mut().for_each(|x| {
+                *x = x.swap_bytes();
+            });
+            resp.mac[..tag.as_bytes().len()].copy_from_slice(tag.as_bytes())
+        }
+        CmHashAlgorithm::Sha512 => {
+            let hmac_mode = HmacMode::Hmac512;
+            let arr: [u8; 64] = cmk.key_material[..64].try_into().unwrap();
+            let key: Array4x16 = arr.into();
+            let mut tag = Array4x16::default();
+            hmac.hmac(
+                (&key).into(),
+                HmacData::Slice(data),
+                trng,
+                (&mut tag).into(),
+                hmac_mode,
+            )?;
+            // convert out of HW format
+            tag.0.iter_mut().for_each(|x| {
+                *x = x.swap_bytes();
+            });
+            resp.mac[..tag.as_bytes().len()].copy_from_slice(tag.as_bytes())
+        }
+        _ => return Err(CaliptraError::CMB_HMAC_UNSUPPORTED_HASH_ALGORITHM)?,
+    };
+
+    resp.partial_len()
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod debug_unlock;
 pub mod dice;
 pub mod error_handler;
 pub mod fips;
+pub mod hmac_cm;
 pub mod keyids;
 pub mod macros;
 pub mod pmp;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -20,7 +20,7 @@ mod wait;
 
 mod aes;
 mod bounded_address;
-mod cmac_kdf;
+pub mod cmac_kdf;
 mod csrng;
 mod data_vault;
 mod dma;

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2163,6 +2163,41 @@ impl CaliptraError {
             0xa005_0000,
             "Runtime Error: Signaure mismatch"
         ),
+        (
+            DOT_INVALID_KEY_TYPE,
+            0xa005_5000,
+            "DOT Error: Invalid key type"
+        ),
+        (
+            CMB_HMAC_INVALID_ENC_CMK,
+            0xa005_5020,
+            "Crypto Mailbox Error: Invalid encrypted CMK"
+        ),
+        (
+            CMB_HMAC_INVALID_DEC_CMK,
+            0xa005_5021,
+            "Crypto Mailbox Error: Invalid decrypted CMK"
+        ),
+        (
+            CMB_HMAC_INVALID_KEY_USAGE,
+            0xa005_5022,
+            "Crypto Mailbox Error: Invalid key usage"
+        ),
+        (
+            CMB_HMAC_INVALID_REQ_SIZE,
+            0xa005_5023,
+            "Crypto Mailbox Error: Invalid request size"
+        ),
+        (
+            CMB_HMAC_INVALID_KEY_USAGE_AND_SIZE,
+            0xa005_5024,
+            "Crypto Mailbox Error: Invalid key usage and size"
+        ),
+        (
+            CMB_HMAC_UNSUPPORTED_HASH_ALGORITHM,
+            0xa005_5025,
+            "Crypto Mailbox Error: Unsupported hash algorithm"
+        ),
     ];
 }
 

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -19,28 +19,37 @@ use crate::key_ladder;
 use crate::pcr;
 use crate::rom_env::RomEnv;
 use crate::run_fips_tests;
-use caliptra_api::mailbox::ResponseVarSize;
+use caliptra_api::mailbox::{
+    CmHmacReq, CmHmacResp, CmKeyUsage, DeriveDotKeyReq, DeriveDotKeyResp, DotKeyType,
+    ResponseVarSize, DOT_INFO_SIZE_BYTES,
+};
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert_bool, cfi_assert_ne, CfiCounter};
-use caliptra_common::capabilities::Capabilities;
-use caliptra_common::fips::FipsVersionCmd;
-use caliptra_common::mailbox_api::{
-    CapabilitiesResp, CommandId, GetIdevCsrResp, MailboxReqHeader, MailboxRespHeader, Response,
-    StashMeasurementReq, StashMeasurementResp,
-};
 use caliptra_common::{
-    pcr::PCR_ID_STASH_MEASUREMENT, verifier::FirmwareImageVerificationEnv, FuseLogEntryId,
-    PcrLogEntry, PcrLogEntryId, RomBootStatus::*,
+    capabilities::Capabilities,
+    crypto::{Crypto, EncryptedCmk, UnencryptedCmk},
+    fips::FipsVersionCmd,
+    hmac_cm::hmac,
+    keyids::{KEY_ID_STABLE_IDEV, KEY_ID_STABLE_LDEV},
+    mailbox_api::{
+        CapabilitiesResp, CommandId, GetIdevCsrResp, MailboxReqHeader, MailboxRespHeader, Response,
+        StashMeasurementReq, StashMeasurementResp,
+    },
+    pcr::PCR_ID_STASH_MEASUREMENT,
+    verifier::FirmwareImageVerificationEnv,
+    FuseLogEntryId, PcrLogEntry, PcrLogEntryId,
+    RomBootStatus::*,
 };
 use caliptra_drivers::{pcr_log::MeasurementLogEntry, *};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageManifest, IMAGE_BYTE_SIZE};
-use caliptra_image_verify::MAX_FIRMWARE_SVN;
-use caliptra_image_verify::{ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier};
+use caliptra_image_verify::{
+    ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier, MAX_FIRMWARE_SVN,
+};
 use caliptra_kat::KatsEnv;
 use caliptra_x509::{NotAfter, NotBefore};
 use core::mem::{size_of, ManuallyDrop};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{transmute, FromBytes, IntoBytes};
 use zeroize::Zeroize;
 
 const RESERVED_PAUSER: u32 = 0xFFFFFFFF;
@@ -423,6 +432,41 @@ impl FirmwareProcessor {
                         );
                         report_boot_status(FwProcessorDownloadImageComplete.into());
                         return Ok((txn, image_size_bytes));
+                    }
+                    CommandId::DERIVE_DOT_KEY => {
+                        let mut request = DeriveDotKeyReq::default();
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
+
+                        let encrypted_cmk = Self::derive_dot_key(
+                            env.aes,
+                            env.hmac,
+                            env.trng,
+                            persistent_data,
+                            &request,
+                        )?;
+
+                        let mut resp = DeriveDotKeyResp {
+                            cmk: transmute!(encrypted_cmk),
+                            ..Default::default()
+                        };
+                        resp.populate_chksum();
+                        txn.send_response(resp.as_bytes())?;
+                    }
+                    CommandId::CM_HMAC => {
+                        let mut request = CmHmacReq::default();
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
+                        let mut resp = CmHmacResp::default();
+                        hmac(
+                            env.hmac,
+                            env.aes,
+                            env.trng,
+                            Crypto::get_cmb_aes_key(persistent_data),
+                            request.as_bytes(),
+                            resp.as_mut_bytes(),
+                        )?;
+
+                        resp.populate_chksum();
+                        txn.send_response(resp.as_bytes())?;
                     }
                     _ => {
                         cprintln!("[fwproc] Invalid command received");
@@ -932,5 +976,66 @@ impl FirmwareProcessor {
         const FW_IMAGE_INDEX: u32 = 0x0;
         let dma_recovery = DmaRecovery::new(rri_base_addr, caliptra_base_addr, mci_base_addr, dma);
         dma_recovery.download_image_to_mbox(FW_IMAGE_INDEX)
+    }
+
+    fn derive_dot_key(
+        aes: &mut Aes,
+        hmac: &mut Hmac,
+        trng: &mut Trng,
+        persistent_data: &mut PersistentData,
+        request: &DeriveDotKeyReq,
+    ) -> CaliptraResult<EncryptedCmk> {
+        let key_type: DotKeyType = request.key_type.into();
+
+        let aes_key = match key_type {
+            DotKeyType::IDevId => AesKey::KV(KeyReadArgs::new(KEY_ID_STABLE_IDEV)),
+            DotKeyType::LDevId => AesKey::KV(KeyReadArgs::new(KEY_ID_STABLE_LDEV)),
+            DotKeyType::Reserved => Err(CaliptraError::DOT_INVALID_KEY_TYPE)?,
+        };
+        let k0 = cmac_kdf(aes, aes_key, &request.info, None, 4)?;
+
+        // Prepend "DOT Final" to info and use as label for HMAC KDF
+        const PREFIX: &[u8] = b"DOT Final";
+        let mut data = [0u8; DOT_INFO_SIZE_BYTES + PREFIX.len()];
+        data[..PREFIX.len()].copy_from_slice(PREFIX);
+        data[PREFIX.len()..].copy_from_slice(&request.info);
+
+        let mut tag: Array4x16 = Array4x16::default();
+        hmac_kdf(
+            hmac,
+            HmacKey::Array4x16(&Array4x16::from(k0)),
+            &data[..],
+            None,
+            trng,
+            HmacTag::Array4x16(&mut tag),
+            HmacMode::Hmac512,
+        )?;
+
+        let mut key_material = [0u8; 64];
+        for (i, word) in tag.0.iter().enumerate() {
+            key_material[i * 4..(i + 1) * 4].copy_from_slice(&word.to_le_bytes());
+        }
+
+        // Convert the tag to CMK
+        let unencrypted_cmk = UnencryptedCmk {
+            version: 1,
+            length: key_material.len() as u16,
+            key_usage: CmKeyUsage::Hmac as u32 as u8,
+            id: [0u8; 3],
+            usage_counter: 0,
+            key_material,
+        };
+
+        let random = trng.generate()?;
+        let kek_iv: [u8; 12] = random.0.as_bytes()[..12].try_into().unwrap();
+        let encrypted_cmk = Crypto::encrypt_cmk(
+            aes,
+            trng,
+            &unencrypted_cmk,
+            kek_iv,
+            Crypto::get_cmb_aes_key(persistent_data),
+        )?;
+
+        Ok(encrypted_cmk)
     }
 }

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -7,6 +7,7 @@ mod test_capabilities;
 mod test_cfi;
 mod test_cpu_fault;
 mod test_debug_unlock;
+mod test_derive_dot_key;
 mod test_dice_derivations;
 mod test_fake_rom;
 mod test_fips_hooks;

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -7,7 +7,7 @@ mod test_capabilities;
 mod test_cfi;
 mod test_cpu_fault;
 mod test_debug_unlock;
-mod test_derive_dot_key;
+mod test_derive_stable_key;
 mod test_dice_derivations;
 mod test_fake_rom;
 mod test_fips_hooks;

--- a/rom/dev/tests/rom_integration_tests/test_derive_dot_key.rs
+++ b/rom/dev/tests/rom_integration_tests/test_derive_dot_key.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache-2.0 license
+
+use crate::helpers;
+use caliptra_api::mailbox::{
+    CmHashAlgorithm, CmHmacReq, CmHmacResp, DeriveDotKeyReq, DeriveDotKeyResp, DotKeyType,
+    MailboxRespHeaderVarSize, CMK_SIZE_BYTES, DOT_INFO_SIZE_BYTES, MAX_CMB_DATA_SIZE,
+};
+use caliptra_builder::ImageOptions;
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
+use caliptra_hw_model::{Fuses, HwModel};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use zerocopy::{FromBytes, IntoBytes};
+
+const DOT_KEY_TYPES: [DotKeyType; 2] = [DotKeyType::IDevId, DotKeyType::LDevId];
+
+#[test]
+fn test_derive_dot_key() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
+
+    for key_type in DOT_KEY_TYPES.iter() {
+        let mut request = DeriveDotKeyReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            key_type: (*key_type).into(),
+            info: [0u8; DOT_INFO_SIZE_BYTES],
+        };
+        request.hdr.chksum = caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DERIVE_DOT_KEY),
+            &request.as_bytes()[core::mem::size_of_val(&request.hdr.chksum)..],
+        );
+        let response = hw
+            .mailbox_execute(CommandId::DERIVE_DOT_KEY.into(), request.as_bytes())
+            .unwrap()
+            .unwrap();
+
+        let resp = DeriveDotKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+        // Verify response checksum
+        assert!(caliptra_common::checksum::verify_checksum(
+            resp.hdr.chksum,
+            0x0,
+            &resp.as_bytes()[core::mem::size_of_val(&resp.hdr.chksum)..],
+        ));
+
+        // Verify FIPS status
+        assert_eq!(
+            resp.hdr.fips_status,
+            MailboxRespHeader::FIPS_STATUS_APPROVED
+        );
+
+        assert_ne!(resp.cmk.0, [0u8; CMK_SIZE_BYTES]);
+
+        let seed_bytes = [1u8; 32];
+        let mut seeded_rng = StdRng::from_seed(seed_bytes);
+        let mut data = vec![0u8; MAX_CMB_DATA_SIZE];
+        seeded_rng.fill_bytes(&mut data);
+
+        let mut cm_hmac = CmHmacReq {
+            cmk: resp.cmk.clone(),
+            hash_algorithm: CmHashAlgorithm::Sha512.into(),
+            data_size: MAX_CMB_DATA_SIZE as u32,
+            ..Default::default()
+        };
+        cm_hmac.data[..MAX_CMB_DATA_SIZE].copy_from_slice(&data);
+        cm_hmac.hdr.chksum = caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::CM_HMAC),
+            &cm_hmac.as_bytes()[core::mem::size_of_val(&cm_hmac.hdr.chksum)..],
+        );
+
+        let response = hw
+            .mailbox_execute(CommandId::CM_HMAC.into(), cm_hmac.as_bytes())
+            .unwrap()
+            .unwrap();
+
+        const HMAC_HEADER_SIZE: usize = size_of::<MailboxRespHeaderVarSize>();
+        let _resp = CmHmacResp {
+            hdr: MailboxRespHeaderVarSize::read_from_bytes(&response[..HMAC_HEADER_SIZE]).unwrap(),
+            ..Default::default()
+        };
+
+        // [TODO][CAP2] Get the KEKE, decrypt the CMK to obtain the HMAC key and verify the mac.
+    }
+}

--- a/rom/dev/tests/rom_integration_tests/test_derive_stable_key.rs
+++ b/rom/dev/tests/rom_integration_tests/test_derive_stable_key.rs
@@ -2,8 +2,9 @@
 
 use crate::helpers;
 use caliptra_api::mailbox::{
-    CmHashAlgorithm, CmHmacReq, CmHmacResp, DeriveDotKeyReq, DeriveDotKeyResp, DotKeyType,
-    MailboxRespHeaderVarSize, CMK_SIZE_BYTES, DOT_INFO_SIZE_BYTES, MAX_CMB_DATA_SIZE,
+    CmHashAlgorithm, CmHmacReq, CmHmacResp, DeriveStableKeyReq, DeriveStableKeyResp,
+    MailboxRespHeaderVarSize, StableKeyType, CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE,
+    STABLE_KEY_INFO_SIZE_BYTES,
 };
 use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
@@ -11,29 +12,29 @@ use caliptra_hw_model::{Fuses, HwModel};
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use zerocopy::{FromBytes, IntoBytes};
 
-const DOT_KEY_TYPES: [DotKeyType; 2] = [DotKeyType::IDevId, DotKeyType::LDevId];
+const DOT_KEY_TYPES: [StableKeyType; 2] = [StableKeyType::IDevId, StableKeyType::LDevId];
 
 #[test]
-fn test_derive_dot_key() {
+fn test_derive_stable_key() {
     let (mut hw, _image_bundle) =
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
 
     for key_type in DOT_KEY_TYPES.iter() {
-        let mut request = DeriveDotKeyReq {
+        let mut request = DeriveStableKeyReq {
             hdr: MailboxReqHeader { chksum: 0 },
             key_type: (*key_type).into(),
-            info: [0u8; DOT_INFO_SIZE_BYTES],
+            info: [0u8; STABLE_KEY_INFO_SIZE_BYTES],
         };
         request.hdr.chksum = caliptra_common::checksum::calc_checksum(
-            u32::from(CommandId::DERIVE_DOT_KEY),
+            u32::from(CommandId::DERIVE_STABLE_KEY),
             &request.as_bytes()[core::mem::size_of_val(&request.hdr.chksum)..],
         );
         let response = hw
-            .mailbox_execute(CommandId::DERIVE_DOT_KEY.into(), request.as_bytes())
+            .mailbox_execute(CommandId::DERIVE_STABLE_KEY.into(), request.as_bytes())
             .unwrap()
             .unwrap();
 
-        let resp = DeriveDotKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let resp = DeriveStableKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
 
         // Verify response checksum
         assert!(caliptra_common::checksum::verify_checksum(

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2221,6 +2221,27 @@ The `exported_cdi` can be created by calling `DeriveContext` with the `export-cd
 The `exported_cdi_handle` is no longer usable after calling `REVOKE_EXPORTED_CDI_HANDLE` with it. After the `exported_cdi_handle`
 has been revoked, a new exported CDI can be created by calling `DeriveContext` with the `export-cdi` and `create-certificate` flags.
 
+### DERIVE\_STABLE\_KEY
+
+Derives an exportable HMAC key from either IDEVID or LDEVID. 
+
+Command Code: `0x4453_4B45` ("DSKE")
+
+*Table: `DERIVE_STABLE_KEY` input arguments*
+
+| **Name**      | **Type** | **Description**
+| --------      | -------- | ---------------
+| chksum        | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
+| key_type      | u32      | Source key to derive the stable key from. **0x0000_0001:** IDevId  <br> **0x0000_0002:** LDevId |
+| info          | u8[32]   | Data to use in the key derivation |
+
+*Table: `DERIVE_STABLE_KEY` output arguments*
+| **Name**      | **Type** | **Description**
+| --------      | -------- | ---------------
+| chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
+| cmk           | CMK      | CMK that stores the stable key material |
+
+
 ## Checksum
 
 For every command except for FIRMWARE_LOAD, the request and response feature a checksum. This

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -1568,7 +1568,7 @@ fn test_hmac_cant_use_sha512_on_384_key() {
         .expect_err("Should have failed");
     assert_error(
         &mut model,
-        caliptra_drivers::CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE,
+        caliptra_drivers::CaliptraError::CMB_HMAC_INVALID_KEY_USAGE_AND_SIZE,
         err,
     );
 }


### PR DESCRIPTION
This change implements the DOT_DERIVE_KEY operation in the Caliptra ROM, enabling key derivation functionality to support Device Ownership Transfer (DOT) services. It also enhances the ROM's cryptographic capabilities by adding support for the HMAC mailbox command, allowing the generation of message authentication codes using HMAC operations.