### PR TITLE
 [feat] Device Ownership Transfer: INSTALL_OWNER_PK_HASH Mailbox command implementation

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -136,6 +136,9 @@ impl CommandId {
     // Stable key derivation command
     pub const DERIVE_STABLE_KEY: Self = Self(0x44534B45); // "DSKE"
 
+    // Device Ownership Transfer command
+    pub const INSTALL_OWNER_PK_HASH: Self = Self(0x4F574E50); // "OWNP"
+
     // Cryptographic mailbox commands
     pub const CM_IMPORT: Self = Self(0x434D_494D); // "CMIM"
     pub const CM_DELETE: Self = Self(0x434D_444C); // "CMDL"
@@ -3757,6 +3760,27 @@ pub struct DeriveStableKeyResp {
     pub cmk: Cmk,
 }
 impl Response for DeriveStableKeyResp {}
+
+// INSTALL_OWNER_PK_HASH
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InstallOwnerPkHashReq {
+    pub hdr: MailboxReqHeader,
+    pub digest: [u32; 12],
+}
+
+impl Request for InstallOwnerPkHashReq {
+    const ID: CommandId = CommandId::INSTALL_OWNER_PK_HASH;
+    type Resp = InstallOwnerPkHashResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InstallOwnerPkHashResp {
+    pub hdr: MailboxRespHeader,
+    pub dpe_result: u32,
+}
+impl Response for InstallOwnerPkHashResp {}
 
 /// Retrieves dlen bytes  from the mailbox.
 pub fn mbox_read_response(

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -32,6 +32,7 @@ pub struct FirmwareImageVerificationEnv<'a, 'b> {
     pub pcr_bank: &'a mut PcrBank,
     pub image: &'b [u8],
     pub dma: &'a Dma,
+    pub persistent_data: &'a PersistentData,
 }
 
 impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
@@ -240,5 +241,13 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
             FwVerificationPqcKeyType::from_u8(self.soc_ifc.fuse_bank().pqc_key_type() as u8)
                 .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE)?;
         Ok(pqc_key_type)
+    }
+
+    fn dot_owner_pk_hash(&self) -> Option<&ImageDigest384> {
+        if self.persistent_data.dot_owner_pk_hash.valid {
+            Some(&self.persistent_data.dot_owner_pk_hash.owner_pk_hash)
+        } else {
+            None
+        }
     }
 }

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -253,6 +253,14 @@ pub mod fmc_alias_csr {
 
 #[derive(TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
+pub struct DOT_OWNER_PK_HASH {
+    pub owner_pk_hash: [u32; 12],
+    pub valid: bool,
+    reserved: [u8; 3],
+}
+
+#[derive(TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
+#[repr(C)]
 pub struct PersistentData {
     pub manifest1: ImageManifest,
     reserved0: [u8; MAN1_SIZE as usize - size_of::<ImageManifest>()],
@@ -331,6 +339,8 @@ pub struct PersistentData {
 
     pub cmb_aes_key_share0: [u8; 32],
     pub cmb_aes_key_share1: [u8; 32],
+
+    pub dot_owner_pk_hash: DOT_OWNER_PK_HASH,
 }
 
 impl PersistentData {
@@ -470,6 +480,11 @@ impl PersistentData {
             persistent_data_offset += CMB_AES_KEY_SHARE_SIZE;
             assert_eq!(
                 addr_of!((*P).cmb_aes_key_share1) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+            persistent_data_offset += CMB_AES_KEY_SHARE_SIZE;
+            assert_eq!(
+                addr_of!((*P).dot_owner_pk_hash) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -837,6 +837,11 @@ impl CaliptraError {
             "Image Verifier Error: Activation failed"
         ),
         (
+            IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH,
+            0x000b005e,
+            "Image Verifier Error: DOT owner public key digest mismatch"
+        ),
+        (
             DRIVER_LMS_INVALID_LMS_ALGO_TYPE,
             0x000c0001,
             "Driver Error: LMS invalid LMS algorithm type"

--- a/image/verify/src/lib.rs
+++ b/image/verify/src/lib.rs
@@ -191,4 +191,6 @@ pub trait ImageVerificationEnv {
 
     // Get the PQC Key Type from the fuse.
     fn pqc_key_type_fuse(&self) -> CaliptraResult<FwVerificationPqcKeyType>;
+
+    fn dot_owner_pk_hash(&self) -> Option<&ImageDigest384>;
 }

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -630,6 +630,14 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         let fuses_digest = &self.env.owner_pub_key_digest_fuses();
 
         if fuses_digest == ZERO_DIGEST {
+            if let Some(dot_owner_pk_hash) = self.env.dot_owner_pk_hash() {
+                // If the dot owner public key hash is set, compare it with the actual digest.
+                if dot_owner_pk_hash != actual {
+                    return Err(
+                        CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH,
+                    );
+                }
+            }
             caliptra_cfi_lib::cfi_assert_eq_12_words(fuses_digest, ZERO_DIGEST);
         } else if fuses_digest != actual {
             return Err(CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH);
@@ -2469,5 +2477,9 @@ mod tests {
         }
 
         fn set_fw_extended_error(&mut self, _err: u32) {}
+
+        fn dot_owner_pk_hash(&self) -> Option<&ImageDigest384> {
+            Some(&self.owner_pub_key_digest)
+        }
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -20,8 +20,9 @@ use crate::pcr;
 use crate::rom_env::RomEnv;
 use crate::run_fips_tests;
 use caliptra_api::mailbox::{
-    CmHmacReq, CmHmacResp, CmKeyUsage, DeriveStableKeyReq, DeriveStableKeyResp, ResponseVarSize,
-    StableKeyType, STABLE_KEY_INFO_SIZE_BYTES,
+    CmHmacReq, CmHmacResp, CmKeyUsage, DeriveStableKeyReq, DeriveStableKeyResp,
+    InstallOwnerPkHashReq, InstallOwnerPkHashResp, ResponseVarSize, StableKeyType,
+    STABLE_KEY_INFO_SIZE_BYTES,
 };
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -137,6 +138,7 @@ impl FirmwareProcessor {
             pcr_bank: &mut env.pcr_bank,
             image: txn.raw_mailbox_contents(),
             dma: &mut env.dma,
+            persistent_data: env.persistent_data.get(),
         };
 
         // Verify the image
@@ -465,6 +467,25 @@ impl FirmwareProcessor {
                             resp.as_mut_bytes(),
                         )?;
 
+                        resp.populate_chksum();
+                        txn.send_response(resp.as_bytes())?;
+                    }
+                    CommandId::INSTALL_OWNER_PK_HASH => {
+                        let mut request = InstallOwnerPkHashReq::default();
+                        Self::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
+
+                        // Save the owner public key hash in persistent data.
+                        persistent_data
+                            .dot_owner_pk_hash
+                            .owner_pk_hash
+                            .copy_from_slice(&request.digest);
+                        persistent_data.dot_owner_pk_hash.valid = true;
+
+                        // Generate and send response (with FIPS approved status)
+                        let mut resp = InstallOwnerPkHashResp {
+                            hdr: MailboxRespHeader::default(),
+                            dpe_result: 0, // DPE_STATUS_SUCCESS
+                        };
                         resp.populate_chksum();
                         txn.send_response(resp.as_bytes())?;
                     }

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -406,4 +406,8 @@ impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
                 .ok_or(CaliptraError::IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE)?;
         Ok(pqc_key_type)
     }
+
+    fn dot_owner_pk_hash(&self) -> Option<&ImageDigest384> {
+        None
+    }
 }

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -74,6 +74,7 @@ impl UpdateResetFlow {
                 pcr_bank: &mut env.pcr_bank,
                 image: recv_txn.raw_mailbox_contents(),
                 dma: &env.dma,
+                persistent_data: env.persistent_data.get(),
             };
 
             let info = {

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -119,6 +119,7 @@ pub mod fips_self_test_cmd {
             pcr_bank: &mut env.pcr_bank,
             image: env.mbox.raw_mailbox_contents(),
             dma: &env.dma,
+            persistent_data: &env.persistent_data.get(),
         };
 
         let mut verifier = ImageVerifier::new(&mut venv);


### PR DESCRIPTION
This update introduces the INSTALL_OWNER_PK_HASH mailbox command, enabling the addition of the firmware ownership public key hash to the Caliptra ROM. It also updates the firmware verification flow to utilize this hash when the CPTRA_OWNER_PK_HASH register is set to 0.