### PR TITLE
Add CM_DERIVE_STABLE_KEY to runtime mailbox as well

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -63,9 +63,9 @@ impl CommandId {
     pub const GET_FMC_ALIAS_MLDSA87_CERT: Self = Self(0x434D4346); // "CMCF"
     pub const GET_RT_ALIAS_MLDSA87_CERT: Self = Self(0x434D4352); // "CMCR"
     pub const GET_IDEV_MLDSA87_INFO: Self = Self(0x49444D49); // "IDMI"
-    pub const ECDSA384_VERIFY: Self = Self(0x45435632); // "ECV2"
-    pub const LMS_VERIFY: Self = Self(0x4C4D5632); // "LMV2"
-    pub const MLDSA87_VERIFY: Self = Self(0x4d4c5632); // "MLV2"
+    pub const ECDSA384_SIGNATURE_VERIFY: Self = Self(0x45435632); // "ECV2"
+    pub const LMS_SIGNATURE_VERIFY: Self = Self(0x4C4D5632); // "LMV2"
+    pub const MLDSA87_SIGNATURE_VERIFY: Self = Self(0x4d4c5632); // "MLV2"
     pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
     pub const DISABLE_ATTESTATION: Self = Self(0x4453424C); // "DSBL"
@@ -133,9 +133,6 @@ impl CommandId {
     // Image metadata commands
     pub const GET_IMAGE_INFO: Self = Self(0x494D_4530); // "IME0"
 
-    // Stable key derivation command
-    pub const DERIVE_STABLE_KEY: Self = Self(0x44534B45); // "DSKE"
-
     // Device Ownership Transfer command
     pub const INSTALL_OWNER_PK_HASH: Self = Self(0x4F574E50); // "OWNP"
 
@@ -171,6 +168,7 @@ impl CommandId {
     pub const CM_ECDSA_PUBLIC_KEY: Self = Self(0x434D_4550); // "CMEP"
     pub const CM_ECDSA_SIGN: Self = Self(0x434D_4553); // "CMES"
     pub const CM_ECDSA_VERIFY: Self = Self(0x434D_4556); // "CMEV"
+    pub const CM_DERIVE_STABLE_KEY: Self = Self(0x494D_4453); // "CMDS"
 }
 
 impl From<u32> for CommandId {
@@ -303,6 +301,7 @@ pub enum MailboxResp {
     CmMldsaSign(CmMldsaSignResp),
     CmEcdsaPublicKey(CmEcdsaPublicKeyResp),
     CmEcdsaSign(CmEcdsaSignResp),
+    CmDeriveStableKey(CmDeriveStableKeyResp),
     ProductionAuthDebugUnlockChallenge(ProductionAuthDebugUnlockChallenge),
     GetPcrLog(GetPcrLogResp),
 }
@@ -361,6 +360,7 @@ impl MailboxResp {
             MailboxResp::CmMldsaSign(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmEcdsaPublicKey(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmEcdsaSign(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
         }
@@ -417,6 +417,7 @@ impl MailboxResp {
             MailboxResp::CmMldsaSign(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmEcdsaPublicKey(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmEcdsaSign(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
         }
@@ -518,6 +519,7 @@ pub enum MailboxReq {
     CmEcdsaPublicKey(CmEcdsaPublicKeyReq),
     CmEcdsaSign(CmEcdsaSignReq),
     CmEcdsaVerify(CmEcdsaVerifyReq),
+    CmDeriveStableKey(CmDeriveStableKeyReq),
     ProductionAuthDebugUnlockReq(ProductionAuthDebugUnlockReq),
     ProductionAuthDebugUnlockToken(ProductionAuthDebugUnlockToken),
     GetPcrLog(MailboxReqHeader),
@@ -589,6 +591,7 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(req) => Ok(req.as_bytes()),
             MailboxReq::CmEcdsaSign(req) => req.as_bytes_partial(),
             MailboxReq::CmEcdsaVerify(req) => req.as_bytes_partial(),
+            MailboxReq::CmDeriveStableKey(req) => Ok(req.as_bytes()),
             MailboxReq::ProductionAuthDebugUnlockReq(req) => Ok(req.as_bytes()),
             MailboxReq::ProductionAuthDebugUnlockToken(req) => Ok(req.as_bytes()),
             MailboxReq::GetPcrLog(req) => Ok(req.as_bytes()),
@@ -658,6 +661,7 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmEcdsaSign(req) => req.as_bytes_partial_mut(),
             MailboxReq::CmEcdsaVerify(req) => req.as_bytes_partial_mut(),
+            MailboxReq::CmDeriveStableKey(req) => Ok(req.as_mut_bytes()),
             MailboxReq::ProductionAuthDebugUnlockReq(req) => Ok(req.as_mut_bytes()),
             MailboxReq::ProductionAuthDebugUnlockToken(req) => Ok(req.as_mut_bytes()),
             MailboxReq::GetPcrLog(req) => Ok(req.as_mut_bytes()),
@@ -667,9 +671,9 @@ impl MailboxReq {
     pub fn cmd_code(&self) -> CommandId {
         match self {
             MailboxReq::ActivateFirmware(_) => CommandId::ACTIVATE_FIRMWARE,
-            MailboxReq::EcdsaVerify(_) => CommandId::ECDSA384_VERIFY,
-            MailboxReq::LmsVerify(_) => CommandId::LMS_VERIFY,
-            MailboxReq::MldsaVerify(_) => CommandId::MLDSA87_VERIFY,
+            MailboxReq::EcdsaVerify(_) => CommandId::ECDSA384_SIGNATURE_VERIFY,
+            MailboxReq::LmsVerify(_) => CommandId::LMS_SIGNATURE_VERIFY,
+            MailboxReq::MldsaVerify(_) => CommandId::MLDSA87_SIGNATURE_VERIFY,
             MailboxReq::GetLdevEcc384Cert(_) => CommandId::GET_LDEV_ECC384_CERT,
             MailboxReq::GetLdevMldsa87Cert(_) => CommandId::GET_LDEV_MLDSA87_CERT,
             MailboxReq::StashMeasurement(_) => CommandId::STASH_MEASUREMENT,
@@ -727,6 +731,7 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(_) => CommandId::CM_ECDSA_PUBLIC_KEY,
             MailboxReq::CmEcdsaSign(_) => CommandId::CM_ECDSA_SIGN,
             MailboxReq::CmEcdsaVerify(_) => CommandId::CM_ECDSA_VERIFY,
+            MailboxReq::CmDeriveStableKey(_) => CommandId::CM_DERIVE_STABLE_KEY,
             MailboxReq::GetPcrLog(_) => CommandId::GET_PCR_LOG,
             MailboxReq::ProductionAuthDebugUnlockReq(_) => {
                 CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ
@@ -1016,7 +1021,7 @@ pub struct EcdsaVerifyReq {
     pub hash: [u8; 48],
 }
 impl Request for EcdsaVerifyReq {
-    const ID: CommandId = CommandId::ECDSA384_VERIFY;
+    const ID: CommandId = CommandId::ECDSA384_SIGNATURE_VERIFY;
     type Resp = MailboxRespHeader;
 }
 // No command-specific output args
@@ -1037,7 +1042,7 @@ pub struct LmsVerifyReq {
     pub hash: [u8; 48],
 }
 impl Request for LmsVerifyReq {
-    const ID: CommandId = CommandId::LMS_VERIFY;
+    const ID: CommandId = CommandId::LMS_SIGNATURE_VERIFY;
     type Resp = MailboxRespHeader;
 }
 // No command-specific output args
@@ -1131,7 +1136,7 @@ impl Default for MldsaVerifyReq {
 }
 
 impl Request for MldsaVerifyReq {
-    const ID: CommandId = CommandId::MLDSA87_VERIFY;
+    const ID: CommandId = CommandId::MLDSA87_SIGNATURE_VERIFY;
     type Resp = MailboxRespHeader;
 }
 // No command-specific output args
@@ -3281,19 +3286,10 @@ impl Request for CmEcdhFinishReq {
 }
 
 #[repr(C)]
-#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct CmEcdhFinishResp {
     pub hdr: MailboxRespHeader,
-    pub output: [u8; CMK_SIZE_BYTES],
-}
-
-impl Default for CmEcdhFinishResp {
-    fn default() -> Self {
-        Self {
-            hdr: MailboxRespHeader::default(),
-            output: [0u8; CMK_SIZE_BYTES],
-        }
-    }
+    pub output: Cmk,
 }
 
 impl Response for CmEcdhFinishResp {}
@@ -3799,64 +3795,64 @@ impl Request for CmEcdsaVerifyReq {
     type Resp = MailboxRespHeader;
 }
 
-// DERIVE_STABLE_KEY
-pub const STABLE_KEY_INFO_SIZE_BYTES: usize = 32;
+// CM_DERIVE_STABLE_KEY
+pub const CM_STABLE_KEY_INFO_SIZE_BYTES: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StableKeyType {
+pub enum CmStableKeyType {
     Reserved = 0,
     IDevId,
     LDevId,
 }
 
-impl From<u32> for StableKeyType {
+impl From<u32> for CmStableKeyType {
     fn from(val: u32) -> Self {
         match val {
-            1_u32 => StableKeyType::IDevId,
-            2_u32 => StableKeyType::LDevId,
-            _ => StableKeyType::Reserved,
+            1_u32 => CmStableKeyType::IDevId,
+            2_u32 => CmStableKeyType::LDevId,
+            _ => CmStableKeyType::Reserved,
         }
     }
 }
 
-impl From<StableKeyType> for u32 {
-    fn from(val: StableKeyType) -> Self {
+impl From<CmStableKeyType> for u32 {
+    fn from(val: CmStableKeyType) -> Self {
         match val {
-            StableKeyType::IDevId => 1,
-            StableKeyType::LDevId => 2,
-            StableKeyType::Reserved => 0,
+            CmStableKeyType::IDevId => 1,
+            CmStableKeyType::LDevId => 2,
+            CmStableKeyType::Reserved => 0,
         }
     }
 }
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct DeriveStableKeyReq {
+pub struct CmDeriveStableKeyReq {
     pub hdr: MailboxReqHeader,
     pub key_type: u32,
-    pub info: [u8; STABLE_KEY_INFO_SIZE_BYTES],
+    pub info: [u8; CM_STABLE_KEY_INFO_SIZE_BYTES],
 }
-impl Default for DeriveStableKeyReq {
+impl Default for CmDeriveStableKeyReq {
     fn default() -> Self {
         Self {
             hdr: Default::default(),
-            info: [0u8; STABLE_KEY_INFO_SIZE_BYTES],
-            key_type: StableKeyType::Reserved as u32,
+            info: [0u8; CM_STABLE_KEY_INFO_SIZE_BYTES],
+            key_type: CmStableKeyType::Reserved as u32,
         }
     }
 }
-impl Request for DeriveStableKeyReq {
-    const ID: CommandId = CommandId::DERIVE_STABLE_KEY;
-    type Resp = DeriveStableKeyResp;
+impl Request for CmDeriveStableKeyReq {
+    const ID: CommandId = CommandId::CM_DERIVE_STABLE_KEY;
+    type Resp = CmDeriveStableKeyResp;
 }
 
 #[repr(C)]
 #[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct DeriveStableKeyResp {
+pub struct CmDeriveStableKeyResp {
     pub hdr: MailboxRespHeader,
     pub cmk: Cmk,
 }
-impl Response for DeriveStableKeyResp {}
+impl Response for CmDeriveStableKeyResp {}
 
 // INSTALL_OWNER_PK_HASH
 #[repr(C)]

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -644,7 +644,7 @@ pub trait HwModel: SocManager {
                 }
             }
             writeln!(self.output().logger(), "ready_for_fw is high")?;
-            self.cover_fw_mage(fw_image);
+            self.cover_fw_image(fw_image);
             let subsystem_mode = self.soc_ifc().cptra_hw_config().read().subsystem_mode_en();
             writeln!(
                 self.output().logger(),
@@ -875,7 +875,7 @@ pub trait HwModel: SocManager {
         }
     }
 
-    fn cover_fw_mage(&mut self, _image: &[u8]) {}
+    fn cover_fw_image(&mut self, _image: &[u8]) {}
 
     fn tracing_hint(&mut self, enable: bool);
 

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -323,7 +323,7 @@ impl HwModel for ModelEmulated {
         &mut self.output
     }
 
-    fn cover_fw_mage(&mut self, fw_image: &[u8]) {
+    fn cover_fw_image(&mut self, fw_image: &[u8]) {
         let iccm_image = &fw_image[IMAGE_MANIFEST_BYTE_SIZE..];
         self.iccm_image_tag = Some(hash_slice(iccm_image));
     }

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -631,13 +631,17 @@ During this phase, the ROM executes specific mailbox commands. Based on the oper
 
 ROM supports the following set of commands before handling the FW_DOWNLOAD command in PASSIVE mode (described in section 9.6) or RI_DOWNLOAD_FIRMWARE command in ACTIVE mode. Once the FW_DOWNLOAD or RI_DOWNLOAD_FIRMWARE is issued, ROM stops processing any additional mailbox commands.
 
-1. **STASH_MEASUREMENT**: Up to eight measurements can be sent to the ROM for recording. Sending more than eight measurements will result in an FW_PROC_MAILBOX_STASH_MEASUREMENT_MAX_LIMIT fatal error. Format of a measurement is documented at [Stash Measurement command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#stash_measurement).
-2. **VERSION**: Get version info about the module. [Version command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#version).
-3. **SELF_TEST_START**: This command is used to invoke the FIPS Known-Answer-Tests (aka KAT) on demand. [Self Test Start command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#self_test_start).
-4. **SELF_TEST_GET_RESULTS**: This command is used to check if a SELF_TEST command is in progress. [Self Test Get Results command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#self_test_get_results).
-5. **SHUTDOWN**: This command is used clear the hardware crypto blocks including the keyvault. [Shutdown command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#shutdown).
-6. **CAPABILITIES**: This command is used to query the ROM capabilities. Capabilities is a 128-bit value with individual bits indicating a specific capability. Currently, the only capability supported is ROM_BASE (bit 0). [Capabilities command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#capabilities).
-7. **GET_IDEVID_CSR**: This command is used to fetch the IDevID CSR from ROM. [Fetch IDevIDCSR command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#get_idevid_csr).
+1. **STASH_MEASUREMENT**: Up to eight measurements can be sent to the ROM for recording. Sending more than eight measurements will result in an FW_PROC_MAILBOX_STASH_MEASUREMENT_MAX_LIMIT fatal error. Format of a measurement is documented at [Stash Measurement command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#stash_measurement).
+2. **VERSION**: Get version info about the module. [Version command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#version).
+3. **SELF_TEST_START**: This command is used to invoke the FIPS Known-Answer-Tests (aka KAT) on demand. [Self Test Start command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#self_test_start).
+4. **SELF_TEST_GET_RESULTS**: This command is used to check if a SELF_TEST command is in progress. [Self Test Get Results command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#self_test_get_results).
+5. **SHUTDOWN**: This command is used clear the hardware crypto blocks including the keyvault. [Shutdown command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#shutdown).
+6. **CAPABILITIES**: This command is used to query the ROM capabilities. Capabilities is a 128-bit value with individual bits indicating a specific capability. Currently, the only capability supported is ROM_BASE (bit 0). [Capabilities command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#capabilities).
+7. **GET_IDEVID_CSR**: This command is used to fetch the IDevID CSR from ROM. [Fetch IDevIDCSR command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#get_idevid_csr).
+8. **CM_DERIVE_STABLE_KEY**: This command is used to derive a stable key for Device Ownership Transfer or other flows. [CM_DERIVE_STABLE_KEY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#cm_derive_stable_key)
+9. **CM_HMAC**: This command uses derived stable keys for Device Ownership Transfer or other flows. [CM_HMAC](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#cm_hmac)
+10. **ECDSA384_SIGNATURE_VERIFY**: This command verifies ECDSA384 signatures for Device Ownership Transfer or other flows. [ECDSA384_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#ecdsa384_signature_verify)
+11. **MLDSA87_SIGNATURE_VERIFY**: This command verifies MLDSA87 signatures for Device Ownership Transfer or other flows. [MLDSA87_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#mldsa87_signature_verify)
 
 #### Downloading firmware image from mailbox
 

--- a/rom/dev/src/flow/debug_unlock.rs
+++ b/rom/dev/src/flow/debug_unlock.rs
@@ -86,7 +86,7 @@ fn handle_manufacturing(env: &mut RomEnv) -> CaliptraResult<()> {
     let result = (|| {
         let mut request = ManufDebugUnlockTokenReq::default();
         let request_bytes = request.as_mut_bytes();
-        FirmwareProcessor::copy_req_verify_chksum(&mut txn, request_bytes)?;
+        FirmwareProcessor::copy_req_verify_chksum(&mut txn, request_bytes, false)?;
 
         // Hash the token.
         let input_token_digest = env.sha2_512_384.sha512_digest(&request.token)?;
@@ -150,7 +150,7 @@ fn handle_auth_debug_unlock_request(
 
     // Process request and create challenge
     let mut request = ProductionAuthDebugUnlockReq::default();
-    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_mut_bytes())?;
+    FirmwareProcessor::copy_req_verify_chksum(&mut txn, request.as_mut_bytes(), false)?;
 
     // Use common function to create challenge
     let challenge =
@@ -197,7 +197,7 @@ fn handle_auth_debug_unlock_token(
 
     // Copy token from mailbox
     let mut token = ProductionAuthDebugUnlockToken::default();
-    FirmwareProcessor::copy_req_verify_chksum(&mut txn, token.as_mut_bytes())?;
+    FirmwareProcessor::copy_req_verify_chksum(&mut txn, token.as_mut_bytes(), false)?;
 
     // Use common validation function
     let result = debug_unlock::validate_debug_unlock_token(

--- a/rom/dev/tests/rom_integration_tests/test_derive_stable_key.rs
+++ b/rom/dev/tests/rom_integration_tests/test_derive_stable_key.rs
@@ -3,8 +3,8 @@
 use crate::helpers;
 use aes_gcm::{aead::AeadMutInPlace, Key};
 use caliptra_api::mailbox::{
-    CmHashAlgorithm, CmHmacReq, CmHmacResp, DeriveStableKeyReq, DeriveStableKeyResp, StableKeyType,
-    CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE, STABLE_KEY_INFO_SIZE_BYTES,
+    CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmHashAlgorithm, CmHmacReq, CmHmacResp,
+    CmStableKeyType, CMK_SIZE_BYTES, CM_STABLE_KEY_INFO_SIZE_BYTES, MAX_CMB_DATA_SIZE,
 };
 use caliptra_builder::{
     firmware::{self, rom_tests::TEST_FMC_WITH_UART, APP_WITH_UART},
@@ -22,7 +22,7 @@ use rand::{rngs::StdRng, RngCore, SeedableRng};
 use sha2::Sha512;
 use zerocopy::{FromBytes, IntoBytes};
 
-const DOT_KEY_TYPES: [StableKeyType; 2] = [StableKeyType::IDevId, StableKeyType::LDevId];
+const DOT_KEY_TYPES: [CmStableKeyType; 2] = [CmStableKeyType::IDevId, CmStableKeyType::LDevId];
 
 fn decrypt_cmk(key: &[u8], cmk: &EncryptedCmk) -> Option<UnencryptedCmk> {
     use aes_gcm::KeyInit;
@@ -63,21 +63,21 @@ fn test_derive_stable_key() {
         )
         .unwrap();
 
-        let mut request = DeriveStableKeyReq {
+        let mut request = CmDeriveStableKeyReq {
             hdr: MailboxReqHeader { chksum: 0 },
             key_type: (*key_type).into(),
-            info: [0u8; STABLE_KEY_INFO_SIZE_BYTES],
+            info: [0u8; CM_STABLE_KEY_INFO_SIZE_BYTES],
         };
         request.hdr.chksum = caliptra_common::checksum::calc_checksum(
-            u32::from(CommandId::DERIVE_STABLE_KEY),
+            u32::from(CommandId::CM_DERIVE_STABLE_KEY),
             &request.as_bytes()[core::mem::size_of_val(&request.hdr.chksum)..],
         );
         let response = hw
-            .mailbox_execute(CommandId::DERIVE_STABLE_KEY.into(), request.as_bytes())
+            .mailbox_execute(CommandId::CM_DERIVE_STABLE_KEY.into(), request.as_bytes())
             .unwrap()
             .unwrap();
 
-        let resp = DeriveStableKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let resp = CmDeriveStableKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
 
         // Verify response checksum
         assert!(caliptra_common::checksum::verify_checksum(
@@ -141,17 +141,17 @@ fn test_derive_stable_key_invalid_key_type() {
     let (mut hw, _) =
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
 
-    let mut request = DeriveStableKeyReq {
+    let mut request = CmDeriveStableKeyReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        key_type: StableKeyType::Reserved.into(),
-        info: [0u8; STABLE_KEY_INFO_SIZE_BYTES],
+        key_type: CmStableKeyType::Reserved.into(),
+        info: [0u8; CM_STABLE_KEY_INFO_SIZE_BYTES],
     };
     request.hdr.chksum = caliptra_common::checksum::calc_checksum(
-        u32::from(CommandId::DERIVE_STABLE_KEY),
+        u32::from(CommandId::CM_DERIVE_STABLE_KEY),
         &request.as_bytes()[core::mem::size_of_val(&request.hdr.chksum)..],
     );
     assert_eq!(
-        hw.mailbox_execute(CommandId::DERIVE_STABLE_KEY.into(), request.as_bytes()),
+        hw.mailbox_execute(CommandId::CM_DERIVE_STABLE_KEY.into(), request.as_bytes()),
         Err(ModelError::MailboxCmdFailed(
             CaliptraError::DOT_INVALID_KEY_TYPE.into()
         ))

--- a/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
@@ -63,13 +63,16 @@ fn test_ecdsa_verify_cmd() {
 
     // Calculate checksum for bad signature test
     bad_cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
-        u32::from(CommandId::ECDSA384_VERIFY),
+        u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
         &bad_cmd.as_bytes()[core::mem::size_of_val(&bad_cmd.hdr.chksum)..],
     );
 
     // This should fail because the signature is invalid
     let bad_response = hw
-        .mailbox_execute(CommandId::ECDSA384_VERIFY.into(), bad_cmd.as_bytes())
+        .mailbox_execute(
+            CommandId::ECDSA384_SIGNATURE_VERIFY.into(),
+            bad_cmd.as_bytes(),
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -110,12 +113,12 @@ fn test_ecdsa_verify_cmd() {
 
     // Calculate checksum
     cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
-        u32::from(CommandId::ECDSA384_VERIFY),
+        u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
         &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
     );
 
     let response = hw
-        .mailbox_execute(CommandId::ECDSA384_VERIFY.into(), cmd.as_bytes())
+        .mailbox_execute(CommandId::ECDSA384_SIGNATURE_VERIFY.into(), cmd.as_bytes())
         .unwrap()
         .unwrap();
 

--- a/rom/dev/tests/rom_integration_tests/test_mldsa_verify.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mldsa_verify.rs
@@ -50,13 +50,16 @@ fn test_mldsa_verify_cmd() {
 
     // Calculate checksum for bad signature test
     bad_cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
-        u32::from(CommandId::MLDSA87_VERIFY),
+        u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
         &bad_cmd.as_bytes()[core::mem::size_of_val(&bad_cmd.hdr.chksum)..],
     );
 
     // This should fail because the signature is invalid
     let bad_response = hw
-        .mailbox_execute(CommandId::MLDSA87_VERIFY.into(), bad_cmd.as_bytes())
+        .mailbox_execute(
+            CommandId::MLDSA87_SIGNATURE_VERIFY.into(),
+            bad_cmd.as_bytes(),
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -79,12 +82,12 @@ fn test_mldsa_verify_cmd() {
 
     // Calculate checksum
     cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
-        u32::from(CommandId::MLDSA87_VERIFY),
+        u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
         &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
     );
 
     let response = hw
-        .mailbox_execute(CommandId::MLDSA87_VERIFY.into(), cmd.as_bytes())
+        .mailbox_execute(CommandId::MLDSA87_SIGNATURE_VERIFY.into(), cmd.as_bytes())
         .unwrap()
         .unwrap();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -237,11 +237,11 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             GetLdevCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
         CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers, cmd_bytes, resp),
-        CommandId::ECDSA384_VERIFY => {
+        CommandId::ECDSA384_SIGNATURE_VERIFY => {
             caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)
         }
-        CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
-        CommandId::MLDSA87_VERIFY => {
+        CommandId::LMS_SIGNATURE_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
+        CommandId::MLDSA87_SIGNATURE_VERIFY => {
             caliptra_common::verify::MldsaVerifyCmd::execute(&mut drivers.mldsa87, cmd_bytes)
         }
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
@@ -400,6 +400,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         }
         CommandId::CM_ECDSA_VERIFY => {
             cryptographic_mailbox::Commands::ecdsa_verify(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_DERIVE_STABLE_KEY => {
+            cryptographic_mailbox::Commands::derive_stable_key(drivers, cmd_bytes, resp)
         }
         CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ => drivers.debug_unlock.handle_request(
             &mut drivers.trng,

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -2,7 +2,7 @@
 
 use std::collections::VecDeque;
 
-use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
+use crate::common::{assert_error, run_rt_test, start_rt_test_pqc_model, RuntimeTestArgs};
 use aes::Aes256;
 use aes_gcm::{aead::AeadMutInPlace, Key};
 use caliptra_api::mailbox::{
@@ -14,19 +14,21 @@ use caliptra_api::mailbox::{
     CmAesGcmEncryptFinalResp, CmAesGcmEncryptFinalRespHeader, CmAesGcmEncryptInitReq,
     CmAesGcmEncryptInitResp, CmAesGcmEncryptUpdateReq, CmAesGcmEncryptUpdateResp,
     CmAesGcmEncryptUpdateRespHeader, CmAesMode, CmAesResp, CmAesRespHeader, CmDeleteReq,
-    CmEcdhFinishReq, CmEcdhFinishResp, CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq,
-    CmEcdsaPublicKeyResp, CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm,
-    CmHkdfExpandReq, CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq,
+    CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmEcdhFinishReq, CmEcdhFinishResp,
+    CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp,
+    CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm, CmHkdfExpandReq,
+    CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq,
     CmHmacKdfCounterResp, CmHmacReq, CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage,
     CmMldsaPublicKeyReq, CmMldsaPublicKeyResp, CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq,
     CmRandomGenerateReq, CmRandomGenerateResp, CmRandomStirReq, CmShaFinalReq, CmShaFinalResp,
-    CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmStatusResp, Cmk, CommandId, MailboxReq,
-    MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize, ResponseVarSize,
+    CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmStableKeyType, CmStatusResp, Cmk, CommandId,
+    MailboxReq, MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize, ResponseVarSize,
     CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE,
 };
 use caliptra_api::SocManager;
 use caliptra_drivers::AES_BLOCK_SIZE_BYTES;
 use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, TrngMode};
+use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use cbc::cipher::BlockEncryptMut;
 use cipher::{KeyIvInit, StreamCipherCore};
@@ -1530,7 +1532,7 @@ fn test_ecdh() {
         .expect("Should have gotten a response");
 
     let resp = CmEcdhFinishResp::ref_from_bytes(resp_bytes.as_slice()).unwrap();
-    let cmk = Cmk::ref_from_bytes(resp.output.as_slice()).unwrap();
+    let cmk = &resp.output;
 
     // use the CMK shared secret to AES encrypt a known plaintext.
     let plaintext = [0u8; 16];
@@ -2323,4 +2325,125 @@ fn test_ecdsa_sign_verify() {
     }
 }
 
-// #[test]
+#[test]
+fn test_derive_stable_key() {
+    const HMAC_HEADER_SIZE: usize = size_of::<MailboxRespHeaderVarSize>();
+
+    // derive a stable key from ROM
+    let (mut model, fw_image) = start_rt_test_pqc_model(
+        RuntimeTestArgs {
+            stop_at_rom: true,
+            ..Default::default()
+        },
+        FwVerificationPqcKeyType::LMS,
+    );
+    model.step_until(|m| m.ready_for_fw());
+
+    let mut derive_request = MailboxReq::CmDeriveStableKey(CmDeriveStableKeyReq {
+        key_type: CmStableKeyType::IDevId.into(),
+        ..Default::default()
+    });
+
+    derive_request.populate_chksum().unwrap();
+    let response = model
+        .mailbox_execute(
+            CommandId::CM_DERIVE_STABLE_KEY.into(),
+            derive_request.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+
+    let resp = CmDeriveStableKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
+    let rom_stable_cmk = resp.cmk.clone();
+
+    let mut hmac_request = CmHmacReq {
+        cmk: rom_stable_cmk.clone(),
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        data_size: 9,
+        ..Default::default()
+    };
+    hmac_request.data[..9].copy_from_slice(b"test data");
+    let mut request = MailboxReq::CmHmac(hmac_request);
+    request.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(CommandId::CM_HMAC.into(), request.as_bytes().unwrap())
+        .unwrap()
+        .unwrap();
+
+    let mut resp = CmHmacResp {
+        hdr: MailboxRespHeaderVarSize::read_from_bytes(&resp_bytes[..HMAC_HEADER_SIZE]).unwrap(),
+        ..Default::default()
+    };
+    let len = resp.hdr.data_len as usize;
+    assert!(len < MAX_CMB_DATA_SIZE);
+    resp.mac[..len].copy_from_slice(&resp_bytes[HMAC_HEADER_SIZE..HMAC_HEADER_SIZE + len]);
+
+    let rom_hmac: [u8; 48] = resp.mac[..resp.hdr.data_len as usize].try_into().unwrap();
+
+    // now step until runtime
+    model.upload_firmware(&fw_image).unwrap();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // use the ROM key to compute the HMAC and make sure it matches the ROM HMAC
+    let resp_bytes = model
+        .mailbox_execute(CommandId::CM_HMAC.into(), request.as_bytes().unwrap())
+        .unwrap()
+        .unwrap();
+    let mut resp = CmHmacResp {
+        hdr: MailboxRespHeaderVarSize::read_from_bytes(&resp_bytes[..HMAC_HEADER_SIZE]).unwrap(),
+        ..Default::default()
+    };
+    let len = resp.hdr.data_len as usize;
+    assert!(len < MAX_CMB_DATA_SIZE);
+    resp.mac[..len].copy_from_slice(&resp_bytes[HMAC_HEADER_SIZE..HMAC_HEADER_SIZE + len]);
+
+    let fw_hmac_rom_cmk: [u8; 48] = resp.mac[..resp.hdr.data_len as usize].try_into().unwrap();
+    assert_eq!(rom_hmac, fw_hmac_rom_cmk);
+
+    // re-derive the same stable key in runtime
+    let mut derive_request = MailboxReq::CmDeriveStableKey(CmDeriveStableKeyReq {
+        key_type: CmStableKeyType::IDevId.into(),
+        ..Default::default()
+    });
+
+    derive_request.populate_chksum().unwrap();
+    let response = model
+        .mailbox_execute(
+            CommandId::CM_DERIVE_STABLE_KEY.into(),
+            derive_request.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+
+    let resp = CmDeriveStableKeyResp::ref_from_bytes(response.as_bytes()).unwrap();
+    let fw_stable_cmk = resp.cmk.clone();
+
+    // compute the HMAC with the runtime derived key and make sure it matches the ROM HMAC
+    let mut hmac_request = CmHmacReq {
+        cmk: fw_stable_cmk,
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        data_size: 9,
+        ..Default::default()
+    };
+    hmac_request.data[..9].copy_from_slice(b"test data");
+    let mut request = MailboxReq::CmHmac(hmac_request);
+    request.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(CommandId::CM_HMAC.into(), request.as_bytes().unwrap())
+        .unwrap()
+        .unwrap();
+
+    let mut resp = CmHmacResp {
+        hdr: MailboxRespHeaderVarSize::read_from_bytes(&resp_bytes[..HMAC_HEADER_SIZE]).unwrap(),
+        ..Default::default()
+    };
+    let len = resp.hdr.data_len as usize;
+    assert!(len < MAX_CMB_DATA_SIZE);
+    resp.mac[..len].copy_from_slice(&resp_bytes[HMAC_HEADER_SIZE..HMAC_HEADER_SIZE + len]);
+
+    let fw_hmac_fw_cmk: [u8; 48] = resp.mac[..resp.hdr.data_len as usize].try_into().unwrap();
+
+    assert_eq!(rom_hmac, fw_hmac_fw_cmk);
+}

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -105,7 +105,7 @@ fn ecdsa_cmd_run_wycheproof() {
             });
             cmd.populate_chksum().unwrap();
             let resp = model.mailbox_execute(
-                u32::from(CommandId::ECDSA384_VERIFY),
+                u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
                 cmd.as_bytes().unwrap(),
             );
             match test.result {
@@ -204,7 +204,7 @@ fn test_ecdsa_verify_cmd() {
 
     let resp = model
         .mailbox_execute(
-            u32::from(CommandId::ECDSA384_VERIFY),
+            u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
             cmd.as_bytes().unwrap(),
         )
         .unwrap()
@@ -236,7 +236,7 @@ fn test_ecdsa_verify_bad_chksum() {
 
     let resp = model
         .mailbox_execute(
-            u32::from(CommandId::ECDSA384_VERIFY),
+            u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
             cmd.as_bytes().unwrap(),
         )
         .unwrap_err();
@@ -265,7 +265,7 @@ fn test_ecdsa_hw_failure() {
 
     let resp = model
         .mailbox_execute(
-            u32::from(CommandId::ECDSA384_VERIFY),
+            u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
             cmd.as_bytes().unwrap(),
         )
         .unwrap_err();

--- a/runtime/tests/runtime_integration_tests/test_lms.rs
+++ b/runtime/tests/runtime_integration_tests/test_lms.rs
@@ -791,7 +791,10 @@ fn execute_lms_cmd<T: HwModel>(
 
     // Send LMS verify command
     let resp = model
-        .mailbox_execute(u32::from(CommandId::LMS_VERIFY), cmd.as_bytes().unwrap())?
+        .mailbox_execute(
+            u32::from(CommandId::LMS_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )?
         .expect("We should have received a response");
 
     let resp_hdr: &MailboxRespHeader = MailboxRespHeader::ref_from_bytes(resp.as_bytes()).unwrap();

--- a/runtime/tests/runtime_integration_tests/test_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa.rs
@@ -50,7 +50,7 @@ fn test_mldsa_verify_cmd() {
 
     let resp = model
         .mailbox_execute(
-            u32::from(CommandId::MLDSA87_VERIFY),
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
             cmd.as_bytes().unwrap(),
         )
         .unwrap()
@@ -85,7 +85,7 @@ fn test_mldsa_verify_cmd() {
 
     let resp_fail = model
         .mailbox_execute(
-            u32::from(CommandId::MLDSA87_VERIFY),
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
             cmd_fail.as_bytes().unwrap(),
         )
         .unwrap_err();
@@ -111,7 +111,7 @@ fn test_mldsa_verify_bad_chksum() {
 
     let resp = model
         .mailbox_execute(
-            u32::from(CommandId::MLDSA87_VERIFY),
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
             cmd.as_bytes().unwrap(),
         )
         .unwrap_err();

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -290,7 +290,7 @@ pub fn exec_cmd_ecdsa_verify<T: HwModel>(hw: &mut T) {
 
     mbx_send_and_check_resp_hdr::<_, MailboxRespHeader>(
         hw,
-        u32::from(CommandId::ECDSA384_VERIFY),
+        u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
         payload.as_bytes().unwrap(),
     )
     .unwrap();


### PR DESCRIPTION
This does a few other fixups as well:

* Allow the ROM mailbox processor to understand variable-length requests and responses for CM_HMAC (bug fix)
* Make the CM_DERIVE_STABLE_KEY command have the same `CM` prefix as other cryptographic mailbox commands
* Test that the CMK generated by the ROM is usable by the runtime
* Test that HMACs generated by the ROM are consistent with those generated by the runtime
* Test that if we derive the same stable key in runtime that it generates the same HMACs.
* nit: use the same `Cmk` type in all mailbox API commands
* documentation: Update docs for CM_DERIVE_STABLE_KEY and add missing docs for MLDSA87_SIGNATURE_VERIFY. Make the names consistent with the code for ECDSA384_SIGNATURE_VERIFY and MLDSA87_SIGNATURE_VERIFY.

I ran the the new test on the FPGA as well.