### PR TITLE
drivers: Don't restore AES state if no work has been done previously

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -47,7 +47,7 @@ pub use pmp::lock_datavault_region;
 pub const FMC_ORG: u32 = 0x40000000;
 pub const FMC_SIZE: u32 = 32 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 136 * 1024;
+pub const RUNTIME_SIZE: u32 = 140 * 1024;
 
 pub use memory_layout::{DATA_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/drivers/src/aes.rs
+++ b/drivers/src/aes.rs
@@ -1321,71 +1321,8 @@ impl Aes {
         });
     }
 
-    /// Zeroize the GHASH state.
-    /// This can only be done by manually performing a GCM operation
-    /// with an AAD input of [0; 16] to flush the GHASH.
-    fn zeroize_ghash(&mut self) {
-        self.with_aes(|aes, _| {
-            wait_for_idle(&aes);
-            for _ in 0..2 {
-                aes.ctrl_shadowed().write(|w| {
-                    w.key_len(AesKeyLen::_256 as u32)
-                        .mode(AesMode::Gcm as u32)
-                        .operation(AesOperation::Encrypt as u32)
-                        .manual_operation(false)
-                        .sideload(false)
-                });
-            }
-
-            wait_for_idle(&aes);
-
-            for _ in 0..2 {
-                aes.ctrl_gcm_shadowed()
-                    .write(|w| w.phase(GcmPhase::Init as u32).num_valid_bytes(16));
-            }
-
-            wait_for_idle(&aes);
-
-            // Load the 0 key.
-            for i in 0..8 {
-                aes.key_share0().at(i).write(|_| 0);
-                aes.key_share1().at(i).write(|_| 0);
-            }
-
-            wait_for_idle(&aes);
-
-            // Program the IV.
-            aes.iv().at(0).write(|_| 0);
-            aes.iv().at(1).write(|_| 0);
-            aes.iv().at(2).write(|_| 0);
-            aes.iv().at(3).write(|_| 0);
-
-            wait_for_idle(&aes);
-
-            // Load the AAD of 0
-            // set the mode and valid length
-            for _ in 0..2 {
-                aes.ctrl_gcm_shadowed()
-                    .write(|w| w.phase(GcmPhase::Aad as u32).num_valid_bytes(16_u32));
-            }
-
-            wait_for_idle(&aes);
-
-            while !aes.status().read().input_ready() {}
-            aes.data_in().at(0).write(|_| 0);
-            aes.data_in().at(1).write(|_| 0);
-            aes.data_in().at(2).write(|_| 0);
-            aes.data_in().at(3).write(|_| 0);
-
-            wait_for_idle(&aes);
-            // GHASH should now be zero (except for internal hardware masking).
-        });
-    }
-
     /// Zeroize the hardware registers.
     fn zeroize_internal(&mut self) {
-        self.zeroize_iv_data();
-        self.zeroize_ghash();
         self.zeroize_iv_data();
     }
 

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -711,7 +711,6 @@ fn test_aes_gcm_edge_cases() {
 // Check a simple encryption with 4 bytes of data.
 #[test]
 fn test_aes_gcm_simple() {
-    use aes_gcm::KeyInit;
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
@@ -774,14 +773,10 @@ fn test_aes_gcm_simple() {
     let iv = &resp.iv;
     let aad = &[];
     let plaintext = &[1, 1, 1, 1];
-    let key: &Key<aes_gcm::Aes256Gcm> = (&key).into();
-    let mut cipher = aes_gcm::Aes256Gcm::new(key);
-    let mut buffer = plaintext.to_vec();
-    cipher
-        .encrypt_in_place_detached(iv.into(), aad, &mut buffer)
-        .expect("Encryption failed");
+    let (rtag, rciphertext) = rustcrypto_gcm_encrypt(&key, iv, aad, plaintext);
 
-    assert_eq!(ciphertext, &buffer);
+    assert_eq!(ciphertext, &rciphertext);
+    assert_eq!(final_resp.hdr.tag, rtag);
 }
 
 // Random encrypt and decrypt GCM stress test.


### PR DESCRIPTION
If we do an AES GCM init with no AAD, then the GHASH that is output by the hardware when we do a SAVE state does not behave correctly when we subsequently RESTORE it as part of an update or final operation.

This caused mailbox AES GCM operations with no AAD to output incorrect tags (even though the ciphertext was correct).

Luckily there is an easy workaround: we simply do not save or restore the incorrect GHASH intermediate state if there was no AAD during the encrypt or decrypt init. The GHASH will still be correctly initialized to the correct value.

We add some extra logic to zeroize the GHASH state as best we can, since it is not zeroized when the other registers are.

With this fix, all cryptographic mailbox tests pass on the FPGA again.