### PR TITLE
[Drivers] - Add AES-256-ECB driver

### DIFF
--- a/kat/src/aes256ecb_kat.rs
+++ b/kat/src/aes256ecb_kat.rs
@@ -1,0 +1,68 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    aes256ecb_kat.rs
+
+Abstract:
+
+    File contains the Known Answer Tests (KAT) for AES-256-ECB cryptography operations.
+
+--*/
+
+use caliptra_drivers::{Aes, AesKey, AesOperation, CaliptraError, CaliptraResult};
+
+// Generated from Python code:
+// >>> from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+// >>> key = b'\x00' * 32
+// >>> pt = b'\x00' * 48
+// >>> cipher = Cipher(algorithms.AES(key), modes.ECB)
+// >>> encryptor = cipher.encryptor()
+// >>> ct = encryptor.update(pt) + encryptor.finalize()
+// >>> print(ct.hex())
+// dc95c078a2408989ad48a21492842087dc95c078a2408989ad48a21492842087dc95c078a2408989ad48a21492842087dc95c078a2408989ad48a21492842087
+
+const KEY: AesKey<'_> = AesKey::Array(&[0u8; 32]);
+const PT: [u8; 48] = [0u8; 48];
+const CT: [u8; 48] = [
+    0xdc, 0x95, 0xc0, 0x78, 0xa2, 0x40, 0x89, 0x89, 0xad, 0x48, 0xa2, 0x14, 0x92, 0x84, 0x20, 0x87,
+    0xdc, 0x95, 0xc0, 0x78, 0xa2, 0x40, 0x89, 0x89, 0xad, 0x48, 0xa2, 0x14, 0x92, 0x84, 0x20, 0x87,
+    0xdc, 0x95, 0xc0, 0x78, 0xa2, 0x40, 0x89, 0x89, 0xad, 0x48, 0xa2, 0x14, 0x92, 0x84, 0x20, 0x87,
+];
+
+#[derive(Default, Debug)]
+pub struct Aes256EcbKat {}
+
+impl Aes256EcbKat {
+    /// This function executes the Known Answer Tests (aka KAT) for AES-256-ECB.
+    ///
+    /// # Arguments
+    ///
+    /// * `aes` - AES driver
+    ///
+    /// # Returns
+    ///
+    /// * `CaliptraResult` - Result denoting the KAT outcome.
+    pub fn execute(&self, aes: &mut Aes) -> CaliptraResult<()> {
+        self.encrypt_decrypt(aes)
+    }
+
+    fn encrypt_decrypt(&self, aes: &mut Aes) -> CaliptraResult<()> {
+        let mut ciphertext: [u8; 48] = [0u8; 48];
+        aes.aes_256_ecb(KEY, AesOperation::Encrypt, &PT[..], &mut ciphertext)?;
+
+        if ciphertext != CT {
+            Err(CaliptraError::KAT_AES_CIPHERTEXT_MISMATCH)?;
+        }
+
+        let mut plaintext: [u8; 48] = [0u8; 48];
+        aes.aes_256_ecb(KEY, AesOperation::Decrypt, &CT[..], &mut plaintext)?;
+        if plaintext != PT {
+            Err(CaliptraError::KAT_AES_PLAINTEXT_MISMATCH)?;
+        }
+
+        Ok(())
+    }
+}

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -17,6 +17,7 @@ Abstract:
 mod aes256cbc_kat;
 mod aes256cmac_kat;
 mod aes256ctr_kat;
+mod aes256ecb_kat;
 mod aes256gcm_kat;
 mod cmackdf_kat;
 mod ecc384_kat;
@@ -35,6 +36,7 @@ mod sha512_kat;
 pub use aes256cbc_kat::Aes256CbcKat;
 pub use aes256cmac_kat::Aes256CmacKat;
 pub use aes256ctr_kat::Aes256CtrKat;
+pub use aes256ecb_kat::Aes256EcbKat;
 pub use aes256gcm_kat::Aes256GcmKat;
 pub use caliptra_drivers::{CaliptraError, CaliptraResult};
 pub use cmackdf_kat::CmacKdfKat;
@@ -102,6 +104,9 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
 
     cprintln!("[kat] MLDSA87");
     Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
+
+    cprintln!("[kat] AES-256-ECB");
+    Aes256EcbKat::default().execute(env.aes)?;
 
     cprintln!("[kat] AES-256-CBC");
     Aes256CbcKat::default().execute(env.aes)?;


### PR DESCRIPTION
This is a building block that will be used in OCP-LOCK.

Not necessary to merge but opening for review.