### PR TITLE
rtool: Add branch to artifact download

### DIFF
--- a/ci-tools/github-runner/artifact.go
+++ b/ci-tools/github-runner/artifact.go
@@ -22,14 +22,14 @@ func findArtifact(artifacts *github.ArtifactList, name string) (*github.Artifact
 	return nil, errors.New("could not find artifact")
 }
 
-func DownloadArtifact(ctx context.Context, client *github.Client, workflowFilename string, artifactName string) error {
+func DownloadArtifact(ctx context.Context, client *github.Client, workflowFilename string, artifactName string, branch string) error {
 	repo := "caliptra-sw"
 	workflow, _, err := client.Actions.GetWorkflowByFileName(ctx, githubOrg, repo, workflowFilename)
 	if err != nil {
 		return err
 	}
 	runs, _, err := client.Actions.ListWorkflowRunsByID(ctx, githubOrg, repo, workflow.GetID(), &github.ListWorkflowRunsOptions{
-		Branch: "main",
+		Branch: branch,
 		Status: "completed",
 	})
 	if err != nil {

--- a/ci-tools/github-runner/cmd/rtool/main.go
+++ b/ci-tools/github-runner/cmd/rtool/main.go
@@ -18,7 +18,7 @@ import (
 func usage() {
 	fmt.Println(`Usage: rtool [launch|serve|build_image|cleanup|jitconfig|download_artifact] [...]
 
-  download_artifact <app_id> <installation_id> <workflow_filename> <artifact_name>
+  download_artifact <app_id> <installation_id> <workflow_filename> <artifact_name> <branch>
 
     Download an artifact from Github. A cronjob on the fpga_boss machine
     can use this command to download the latest output of the "Build FPGA SD
@@ -106,7 +106,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = hello.DownloadArtifact(ctx, client, os.Args[4], os.Args[5])
+		err = hello.DownloadArtifact(ctx, client, os.Args[4], os.Args[5], os.Args[6])
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
It's useful to be able to download the artifact from non-main branches
for testing. Additionally, the VCK-190 image build will (most-likely) be
published to a difference branch.
