### PR TITLE
feat(hw-model): Add hardware revision support

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -138,6 +138,9 @@ impl TrngMode {
 const EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES: u64 = 40_000_000; // 40 million cycles
 
 pub struct InitParams<'a> {
+    // Hardware revision
+    pub hw_rev: (u8, u8),
+
     // The contents of the boot ROM
     pub rom: &'a [u8],
 
@@ -215,6 +218,7 @@ impl Default for InitParams<'_> {
                 Box::new(RandomEtrngResponses::new_from_stdrng())
             };
         Self {
+            hw_rev: (2, 0),
             rom: Default::default(),
             dccm: Default::default(),
             iccm: Default::default(),

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -164,6 +164,7 @@ impl HwModel for ModelEmulated {
         let output_sink = output.sink().clone();
 
         let bus_args = CaliptraRootBusArgs {
+            hw_rev: params.hw_rev,
             rom: params.rom.into(),
             tb_services_cb: TbServicesCb::new(move |ch| {
                 output_sink.set_now(timer.now());

--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -650,7 +650,7 @@ mod tests {
     #[test]
     fn test_dma_fifo_read_write() {
         let clock = Rc::new(Clock::new());
-        let mbox_ram = MailboxRam::new();
+        let mbox_ram = MailboxRam::default();
         let iccm = Iccm::new(&clock);
         let args = CaliptraRootBusArgs {
             clock: clock.clone(),

--- a/sw-emulator/lib/periph/src/doe.rs
+++ b/sw-emulator/lib/periph/src/doe.rs
@@ -250,7 +250,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            MailboxInternal::new(&clock, MailboxRam::new()),
+            MailboxInternal::new(&clock, MailboxRam::default()),
             Iccm::new(&clock),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
@@ -317,7 +317,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            MailboxInternal::new(&clock, MailboxRam::new()),
+            MailboxInternal::new(&clock, MailboxRam::default()),
             Iccm::new(&clock),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
@@ -384,7 +384,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let soc_reg = SocRegistersInternal::new(
-            MailboxInternal::new(&clock, MailboxRam::new()),
+            MailboxInternal::new(&clock, MailboxRam::default()),
             Iccm::new(&clock),
             CaliptraRootBusArgs {
                 clock: clock.clone(),

--- a/sw-emulator/lib/periph/src/mailbox.rs
+++ b/sw-emulator/lib/periph/src/mailbox.rs
@@ -22,7 +22,8 @@ use tock_registers::interfaces::Writeable;
 use tock_registers::{register_bitfields, LocalRegisterCopy};
 
 /// Maximum mailbox capacity.
-const MAX_MAILBOX_CAPACITY_BYTES: usize = 256 << 10;
+const MAX_MAILBOX_CAPACITY_BYTES_2_0: usize = 256 << 10;
+const MAX_MAILBOX_CAPACITY_BYTES_2_1: usize = 16 << 10;
 
 register_bitfields! [
     u32,
@@ -60,12 +61,14 @@ pub struct MailboxRam {
 }
 
 impl MailboxRam {
-    pub fn new() -> Self {
+    pub fn new(hw_rev: (u8, u8)) -> Self {
+        let mbox_len = match hw_rev {
+            (2, 0) => MAX_MAILBOX_CAPACITY_BYTES_2_0,
+            (2, _) => MAX_MAILBOX_CAPACITY_BYTES_2_1,
+            _ => panic!("Invalid HW revision"),
+        };
         Self {
-            ram: Rc::new(RefCell::new(Ram::new(vec![
-                0u8;
-                MAX_MAILBOX_CAPACITY_BYTES
-            ]))),
+            ram: Rc::new(RefCell::new(Ram::new(vec![0u8; mbox_len]))),
         }
     }
 }
@@ -84,7 +87,7 @@ impl Bus for MailboxRam {
 }
 impl Default for MailboxRam {
     fn default() -> Self {
-        Self::new()
+        Self::new((2, 0))
     }
 }
 
@@ -654,7 +657,7 @@ mod tests {
 
     pub fn get_mailbox() -> MailboxInternal {
         // Acquire lock
-        MailboxInternal::new(&Clock::new(), MailboxRam::new())
+        MailboxInternal::new(&Clock::new(), MailboxRam::default())
     }
 
     #[test]
@@ -721,7 +724,7 @@ mod tests {
 
     #[test]
     fn test_soc_to_caliptra_lock() {
-        let mut caliptra = MailboxInternal::new(&Clock::new(), MailboxRam::new());
+        let mut caliptra = MailboxInternal::new(&Clock::new(), MailboxRam::default());
         let mut soc = caliptra.as_external(MailboxRequester::SocUser(1u32));
         let soc_regs = soc.regs();
 
@@ -738,7 +741,7 @@ mod tests {
     fn test_send_receive() {
         let request_to_send: [u32; 4] = [0x1111_1111, 0x2222_2222, 0x3333_3333, 0x4444_4444];
 
-        let mut caliptra = MailboxInternal::new(&Clock::new(), MailboxRam::new());
+        let mut caliptra = MailboxInternal::new(&Clock::new(), MailboxRam::default());
         let mut soc = caliptra.as_external(MailboxRequester::SocUser(1u32));
         let soc_regs = soc.regs();
         let uc_regs = caliptra.regs();
@@ -900,9 +903,9 @@ mod tests {
         // Write dlen
         uc_regs
             .dlen()
-            .write(|_| (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32);
+            .write(|_| (MAX_MAILBOX_CAPACITY_BYTES_2_0 + 4) as u32);
 
-        for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES).step_by(4) {
+        for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES_2_0).step_by(4) {
             // Write datain
             uc_regs.datain().write(|_| data_in as u32);
         }
@@ -928,10 +931,10 @@ mod tests {
 
         assert_eq!(
             uc_regs.dlen().read(),
-            (MAX_MAILBOX_CAPACITY_BYTES + 4) as u32
+            (MAX_MAILBOX_CAPACITY_BYTES_2_0 + 4) as u32
         );
 
-        for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES).step_by(4) {
+        for data_in in (0..MAX_MAILBOX_CAPACITY_BYTES_2_0).step_by(4) {
             // Read dataout
             let data_out = uc_regs.dataout().read();
             // compare with queued data.

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -209,6 +209,7 @@ impl From<Box<dyn FnMut() + 'static>> for ActionCb {
 
 /// Caliptra Root Bus Arguments
 pub struct CaliptraRootBusArgs<'a> {
+    pub hw_rev: (u8, u8),
     pub pic: Rc<Pic>,
     pub clock: Rc<Clock>,
     pub rom: Vec<u8>,
@@ -244,6 +245,7 @@ pub struct CaliptraRootBusArgs<'a> {
 impl Default for CaliptraRootBusArgs<'_> {
     fn default() -> Self {
         Self {
+            hw_rev: (2, 0),
             clock: Default::default(),
             pic: Default::default(),
             rom: Default::default(),
@@ -344,7 +346,7 @@ impl CaliptraRootBus {
         let clock = &args.clock.clone();
         let pic = &args.pic.clone();
         let mut key_vault = KeyVault::new();
-        let mailbox_ram = MailboxRam::new();
+        let mailbox_ram = MailboxRam::new(args.hw_rev);
         let mailbox = MailboxInternal::new(clock, mailbox_ram.clone());
         let rom = Rom::new(std::mem::take(&mut args.rom));
         let prod_dbg_unlock_keypairs = std::mem::take(&mut args.prod_dbg_unlock_keypairs);

--- a/sw-emulator/lib/periph/src/sha512_acc.rs
+++ b/sw-emulator/lib/periph/src/sha512_acc.rs
@@ -657,7 +657,7 @@ mod tests {
 
     fn test_sha_accelerator(data: &[u8], expected: &[u8], start_address: usize, sha_mode: u32) {
         // Write to the mailbox.
-        let mut mb_ram = MailboxRam::new();
+        let mut mb_ram = MailboxRam::new((2, 0));
         if !data.is_empty() {
             assert!((start_address % 4) == 0);
             let mut data_word_multiples = vec![0u8; ((start_address + data.len() + 3) / 4) * 4];
@@ -1061,7 +1061,7 @@ mod tests {
     #[test]
     fn test_sm_lock() {
         let clock = Clock::new();
-        let mut sha_accl = Sha512Accelerator::new(&clock, MailboxRam::new());
+        let mut sha_accl = Sha512Accelerator::new(&clock, MailboxRam::new((2, 0)));
         assert_eq!(sha_accl.regs.borrow().state_machine.context.locked, 1);
         // Unlock the initial state
         sha_accl.write(RvSize::Word, OFFSET_LOCK, 1).unwrap();
@@ -1093,7 +1093,7 @@ mod tests {
     #[test]
     fn test_sha_acc_check_state() {
         let clock = Clock::new();
-        let mut sha_accl = Sha512Accelerator::new(&clock, MailboxRam::new());
+        let mut sha_accl = Sha512Accelerator::new(&clock, MailboxRam::new((2, 0)));
 
         // Check init state.
         assert_eq!(

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -929,7 +929,9 @@ impl SocRegistersImpl {
             cptra_clk_gating_en: ReadOnlyRegister::new(0),
             cptra_generic_input_wires: Default::default(),
             cptra_generic_output_wires: Default::default(),
-            cptra_hw_rev_id: ReadOnlyRegister::new(0x02), // [3:0] Major, [7:4] Minor, [15:8] Patch
+            cptra_hw_rev_id: ReadOnlyRegister::new(
+                ((args.hw_rev.0 & 0xf) | ((args.hw_rev.1 << 4) & 0xf0)).into(),
+            ), // [3:0] Major, [7:4] Minor, [15:8] Patch
             cptra_fw_rev_id: Default::default(),
             cptra_hw_config: ReadWriteRegister::new(if args.subsystem_mode {
                 Self::CALIPTRA_HW_CONFIG_SUBSYSTEM_MODE
@@ -1544,7 +1546,7 @@ mod tests {
             0x66, 0x65, 0x4a, 0x65, 0x66, 0x65,
         ];
         let clock = Rc::new(Clock::new());
-        let mailbox_ram = MailboxRam::new();
+        let mailbox_ram = MailboxRam::new((2, 0));
         let mut mailbox = MailboxInternal::new(&clock, mailbox_ram);
         let mut log_dir = PathBuf::new();
         log_dir.push("/tmp");
@@ -1609,7 +1611,7 @@ mod tests {
             0x66, 0x65, 0x4a, 0x65, 0x66, 0x65,
         ];
         let clock = Rc::new(Clock::new());
-        let mailbox_ram = MailboxRam::new();
+        let mailbox_ram = MailboxRam::new((2, 0));
         let mut mailbox = MailboxInternal::new(&clock, mailbox_ram);
         let mut log_dir = PathBuf::new();
         log_dir.push("/tmp");
@@ -1672,7 +1674,7 @@ mod tests {
         let output = Rc::new(RefCell::new(vec![]));
         let output2 = output.clone();
 
-        let mailbox_ram = MailboxRam::new();
+        let mailbox_ram = MailboxRam::new((2, 0));
         let mailbox = MailboxInternal::new(&clock, mailbox_ram);
         let args = CaliptraRootBusArgs {
             clock: clock.clone(),
@@ -1696,7 +1698,7 @@ mod tests {
         use caliptra_api_types::SecurityState;
         let clock = Rc::new(Clock::new());
         let soc = SocRegistersInternal::new(
-            MailboxInternal::new(&clock, MailboxRam::new()),
+            MailboxInternal::new(&clock, MailboxRam::new((2, 0))),
             Iccm::new(&clock),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
@@ -1715,7 +1717,7 @@ mod tests {
         use caliptra_api_types::SecurityState;
         let clock = Rc::new(Clock::new());
         let soc = SocRegistersInternal::new(
-            MailboxInternal::new(&clock, MailboxRam::new()),
+            MailboxInternal::new(&clock, MailboxRam::new((2, 0))),
             Iccm::new(&clock),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
@@ -1741,7 +1743,7 @@ mod tests {
     #[test]
     fn test_wdt() {
         let clock = Rc::new(Clock::new());
-        let mailbox_ram = MailboxRam::new();
+        let mailbox_ram = MailboxRam::default();
         let mailbox = MailboxInternal::new(&clock, mailbox_ram);
 
         let args = CaliptraRootBusArgs {


### PR DESCRIPTION
- Added hw_rev field to InitParams
- Updated mailbox RAM sizing based on HW revision
- Exposed HW revision in root bus args
- Updated test cases to use MailboxRam::default()
- Changed mailbox capacity constants for different HW revisions