### PR TITLE
Use OCP lock compatible bit stream in CI

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Build Kernel
         run: |
           source /vck190-tools/petalinux-tool/settings.sh
+          BIT_STREAM=/vck190-tools/caliptra-bitstreams/ocp-lock/20250721/system.xsa
 
-          sudo scp /vck190-tools/caliptra-bitstreams/20250701/system.xsa /tmp/system.xsa
+          sudo scp ${BIT_STREAM} /tmp/system.xsa
           sudo chown $USER:$GROUP /tmp/system.xsa
 
           pushd hw/fpga


### PR DESCRIPTION
NOTE: I am not sure if we will want to treat the "OCP LOCK" bitstream separately, so it may be unnecessary to place it in a separate path.