### PR TITLE
Correctly set the max number of handles in DPE.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,6 @@
+[env]
+ARBITRARY_MAX_HANDLES = "32"
+
 [target.riscv32imc-unknown-none-elf]
 rustflags = [
   "-C", "target-feature=+relax",

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -34,7 +34,6 @@ fn main() {
 
             println!("cargo:rustc-link-arg=-Tlink.x");
             println!("cargo:rerun-if-changed=build.rs");
-            println!("cargo:rustc-env=ARBITRARY_MAX_HANDLES=32");
         }
     }
 }

--- a/test/dpe_verification/transport.go
+++ b/test/dpe_verification/transport.go
@@ -234,7 +234,7 @@ func (s *CptraModel) GetLocality() uint32 {
 
 // GetMaxTciNodes returns the maximum number of TCI nodes supported by the model.
 func (s *CptraModel) GetMaxTciNodes() uint32 {
-	return 24
+	return 32
 }
 
 // GetProfileMajorVersion returns the major version of the DPE profile.


### PR DESCRIPTION
#1891 

Previously the environment variable was not cascading to the DPE crate. The crate was building prior to RT setting the environment variable.

This sets the environment variable in all cargo invocations so DPE detects it. This also adds a line in the GetProfile test to make sure it is set correctly.