### PR TITLE
builder: Allow caliptra-builder to work on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ dependencies = [
  "caliptra-image-types",
  "clap",
  "elf",
+ "fslock",
  "hex",
  "memoffset 0.8.0",
- "nix",
  "once_cell",
  "serde",
  "serde_derive",
@@ -1540,6 +1540,16 @@ name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ crypto = { path = "dpe/crypto", default-features = false }
 platform = { path = "dpe/platform", default-features = false }
 elf = "0.7.2"
 fips204 = "0.4.6"
+fslock = "0.2.1"
 gdbstub = "0.6.3"
 gdbstub_arch = "0.2.4"
 getrandom = "0.2"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-caliptra-image-elf.workspace= true
+caliptra-image-elf.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
 caliptra-image-crypto.workspace = true
 caliptra-image-types.workspace = true
 clap.workspace = true
 elf.workspace = true
+fslock.workspace = true
 hex.workspace = true
 memoffset.workspace = true
-nix.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_derive.workspace = true


### PR DESCRIPTION
Some teams have wanted to run the emulator on Windows, and this dependency kept coming up as an issue.

It's just as easy to use a  OS-neutral file lock package than it is use a UNIX-specific package.