### PR TITLE
MCI support for MCU Hitless Update

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -26,7 +26,7 @@ use core::{cell::Cell, mem::size_of, ops::Add};
 use ureg::{Mmio, MmioMut, RealMmioMut};
 
 const BLOCK_SIZE: u32 = 256; // Block size for DMA transfers
-const MCU_SRAM_OFFSET: u64 = 0xc0_0000;
+pub const MCU_SRAM_OFFSET: u64 = 0xc0_0000;
 
 pub enum DmaReadTarget {
     Mbox(u32),

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -23,7 +23,7 @@ mod bounded_address;
 pub mod cmac_kdf;
 mod csrng;
 mod data_vault;
-mod dma;
+pub mod dma;
 mod doe;
 mod ecc384;
 mod error_reporter;

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -18,6 +18,7 @@ use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
 use caliptra_auth_man_types::ImageMetadataFlags;
 use caliptra_common::mailbox_api::{ActivateFirmwareReq, ActivateFirmwareResp, MailboxRespHeader};
+use caliptra_drivers::dma::MCU_SRAM_OFFSET;
 use caliptra_drivers::{AxiAddr, CaliptraError, CaliptraResult, DmaMmio, DmaRecovery};
 use ureg::{Mmio, MmioMut};
 
@@ -123,9 +124,15 @@ impl ActivateFirmwareCmd {
 
         let mut temp_bitmap: [u32; 4] = [0; 4];
 
-        // Caliptra clears FW_EXEC_CTRL[2] for all affected images.
+        // Caliptra clears FW_EXEC_CTRL for all affected images
         for i in 0..4 {
             temp_bitmap[i] = go_bitmap[i] & !activate_bitmap[i];
+        }
+
+        // Leave MCU image bit as is, we will set it later after the reset_reason is set to avoid race condition
+        // between Caliptra and MCU
+        if Self::is_bit_set(&go_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize) {
+            Self::set_bit(&mut temp_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize);
         }
 
         drivers.soc_ifc.set_ss_generic_fw_exec_ctrl(&temp_bitmap);
@@ -137,6 +144,18 @@ impl ActivateFirmwareCmd {
             // MCI asserts MCU reset (min reset time for MCU is until MIN_MCU_RST_COUNTER overflows)
 
             let mmio = &DmaMmio::new(mci_base_addr, dma);
+
+            // Caliptra sets RESET_REASON.FW_HITLESS_UPD_RESET
+            unsafe {
+                mmio.write_volatile(
+                    MCI_TOP_REG_RESET_REASON_OFFSET as *mut u32,
+                    FW_HITLESS_UPD_RESET_MASK,
+                )
+            };
+
+            // Clear FW_EXEC_CTRL[2]. This should start the process of resetting MCU.
+            Self::clear_bit(&mut temp_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize);
+            drivers.soc_ifc.set_ss_generic_fw_exec_ctrl(&temp_bitmap);
 
             // Wait for MCU to clear interrupt
             let mut intr_status: u32 = 1;
@@ -156,7 +175,7 @@ impl ActivateFirmwareCmd {
             }
 
             // Caliptra will then have access to MCU SRAM Updatable Execution Region and update the FW image.
-            let (image_load_address, image_staging_address) =
+            let (_, image_staging_address) =
                 Self::get_loading_staging_address(drivers, ActivateFirmwareReq::MCU_IMAGE_ID)?;
             let dma_image = DmaRecovery::new(
                 drivers.soc_ifc.recovery_interface_base_addr().into(),
@@ -164,6 +183,8 @@ impl ActivateFirmwareCmd {
                 drivers.soc_ifc.mci_base_addr().into(),
                 &drivers.dma,
             );
+            let mcu_sram_addr: u64 =
+                ((mci_base_addr.hi as u64) << 32) + (mci_base_addr.lo as u64) + MCU_SRAM_OFFSET;
             dma_image
                 .transfer_payload_to_axi(
                     AxiAddr {
@@ -172,21 +193,13 @@ impl ActivateFirmwareCmd {
                     },
                     mcu_image_size,
                     AxiAddr {
-                        hi: image_load_address.hi,
-                        lo: image_load_address.lo,
+                        hi: (mcu_sram_addr >> 32) as u32,
+                        lo: mcu_sram_addr as u32,
                     },
                     false,
-                    true,
+                    false,
                 )
                 .map_err(|_| ())?;
-
-            // Caliptra sets RESET_REASON.FW_HITLESS_UPD_RESET
-            unsafe {
-                mmio.write_volatile(
-                    MCI_TOP_REG_RESET_REASON_OFFSET as *mut u32,
-                    FW_HITLESS_UPD_RESET_MASK,
-                )
-            };
         }
 
         for i in 0..4 {
@@ -243,6 +256,14 @@ impl ActivateFirmwareCmd {
             let idx = bit / 32;
             let offset = bit % 32;
             bitmap[idx] |= 1 << offset;
+        }
+    }
+
+    fn clear_bit(bitmap: &mut [u32; 4], bit: usize) {
+        if bit < core::mem::size_of_val(bitmap) * 8 {
+            let idx = bit / 32;
+            let offset = bit % 32;
+            bitmap[idx] &= !(1 << offset);
         }
     }
 

--- a/sw-emulator/lib/bus/src/event.rs
+++ b/sw-emulator/lib/bus/src/event.rs
@@ -77,6 +77,9 @@ pub enum EventData {
         descriptor: [u8; 8],
         data: Vec<u8>,
     },
+    MciInterrupt {
+        asserted: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -656,13 +656,14 @@ mod tests {
             ..CaliptraRootBusArgs::default()
         };
         let mailbox_internal = MailboxInternal::new(&clock, mbox_ram.clone());
-        let soc_reg = SocRegistersInternal::new(mailbox_internal, iccm, args);
+        let mci = Mci::new(vec![]);
+        let soc_reg = SocRegistersInternal::new(mailbox_internal, iccm, mci.clone(), args);
         let mut dma = Dma::new(
             &clock,
             mbox_ram.clone(),
             soc_reg,
             Sha512Accelerator::new(&clock, mbox_ram.clone()),
-            Mci::new(vec![]),
+            mci.clone(),
             None,
             false,
         );

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -28,7 +28,7 @@ use std::{rc::Rc, sync::mpsc};
 pub type AxiAddr = u64;
 
 const TEST_SRAM_SIZE: usize = 4 * 1024;
-const EXTERNAL_TEST_SRAM_SIZE: usize = 4 * 1024;
+const EXTERNAL_TEST_SRAM_SIZE: usize = 1024 * 1024;
 
 pub struct AxiRootBus {
     pub reg: u32,

--- a/sw-emulator/lib/periph/src/doe.rs
+++ b/sw-emulator/lib/periph/src/doe.rs
@@ -212,7 +212,7 @@ impl Doe {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CaliptraRootBusArgs, Iccm, KeyUsage, MailboxInternal, MailboxRam};
+    use crate::{CaliptraRootBusArgs, Iccm, KeyUsage, MailboxInternal, MailboxRam, Mci};
     use caliptra_api_types::SecurityState;
     use caliptra_emu_bus::Bus;
     use caliptra_emu_crypto::EndianessTransform;
@@ -249,9 +249,11 @@ mod tests {
 
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
+        let mci = Mci::new(vec![]);
         let soc_reg = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
+            mci.clone(),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
@@ -316,9 +318,11 @@ mod tests {
         ];
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
+        let mci = Mci::new(vec![]);
         let soc_reg = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
+            mci.clone(),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
@@ -383,9 +387,11 @@ mod tests {
         let expected_fe = [0u8; 32];
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
+        let mci = Mci::new(vec![]);
         let soc_reg = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
+            mci.clone(),
             CaliptraRootBusArgs {
                 clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -355,14 +355,14 @@ impl CaliptraRootBus {
         let itrng_nibbles = args.itrng_nibbles.take();
         let test_sram = std::mem::take(&mut args.test_sram);
         let use_mcu_recovery_interface = args.use_mcu_recovery_interface;
-        let soc_reg = SocRegistersInternal::new(mailbox.clone(), iccm.clone(), args);
+        let mci = Mci::new(prod_dbg_unlock_keypairs);
+        let soc_reg = SocRegistersInternal::new(mailbox.clone(), iccm.clone(), mci.clone(), args);
         if !soc_reg.is_debug_locked() {
             // When debug is possible, the key-vault is initialized with a debug value...
             // This is necessary to match the behavior of the RTL.
             key_vault.clear_keys_with_debug_values(false);
         }
         let sha512_acc = Sha512Accelerator::new(clock, mailbox_ram.clone());
-        let mci = Mci::new(prod_dbg_unlock_keypairs);
         let dma = Dma::new(
             clock,
             mailbox_ram.clone(),
@@ -462,7 +462,8 @@ impl CaliptraRootBus {
         self.sha512_acc.register_outgoing_events(sender.clone());
         self.dma.register_outgoing_events(sender.clone());
         self.csrng.register_outgoing_events(sender.clone());
-        self.pic_regs.register_outgoing_events(sender);
+        self.pic_regs.register_outgoing_events(sender.clone());
+        self.mci.register_outgoing_events(sender.clone());
     }
 }
 

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -15,6 +15,7 @@ Abstract:
 use crate::helpers::{bytes_from_words_be, words_from_bytes_be};
 use crate::mailbox::MailboxRequester;
 use crate::root_bus::ReadyForFwCbArgs;
+use crate::Mci;
 use crate::{CaliptraRootBusArgs, Iccm, MailboxInternal};
 use caliptra_emu_bus::BusError::{LoadAccessFault, StoreAccessFault};
 use caliptra_emu_bus::{
@@ -355,9 +356,11 @@ const FUSE_END_ADDR: u32 = 0x340;
 
 impl SocRegistersInternal {
     /// Create an instance of SOC register peripheral
-    pub fn new(mailbox: MailboxInternal, iccm: Iccm, args: CaliptraRootBusArgs) -> Self {
+    pub fn new(mailbox: MailboxInternal, iccm: Iccm, mci: Mci, args: CaliptraRootBusArgs) -> Self {
         Self {
-            regs: Rc::new(RefCell::new(SocRegistersImpl::new(mailbox, iccm, args))),
+            regs: Rc::new(RefCell::new(SocRegistersImpl::new(
+                mailbox, iccm, mci, args,
+            ))),
         }
     }
     pub fn is_debug_locked(&self) -> bool {
@@ -762,7 +765,7 @@ struct SocRegistersImpl {
     #[register_array(offset = 0x5c8)]
     ss_soc_dbg_unlock_level: [u32; 2],
 
-    #[register_array(offset = 0x5d0)]
+    #[register_array(offset = 0x5d0, write_fn = on_write_ss_generic_fw_exec_ctrl)]
     ss_generic_fw_exec_ctrl: [u32; 4],
 
     /// INTERNAL_OBF_KEY Register
@@ -822,6 +825,9 @@ struct SocRegistersImpl {
 
     /// Mailbox
     mailbox: MailboxInternal,
+
+    /// MCU
+    mci: Mci,
 
     /// ICCM
     iccm: Iccm,
@@ -889,7 +895,12 @@ impl SocRegistersImpl {
 
     const CALIPTRA_HW_CONFIG_SUBSYSTEM_MODE: u32 = 1 << 5;
 
-    pub fn new(mailbox: MailboxInternal, iccm: Iccm, mut args: CaliptraRootBusArgs) -> Self {
+    pub fn new(
+        mailbox: MailboxInternal,
+        iccm: Iccm,
+        mci: Mci,
+        mut args: CaliptraRootBusArgs,
+    ) -> Self {
         let clock = &args.clock.clone();
         let pic = &args.pic.clone();
         let flow_status = InMemoryRegister::<u32, FlowStatus::Register>::new(0);
@@ -992,6 +1003,7 @@ impl SocRegistersImpl {
             error_intr_trig_r: ReadWriteRegister::new(0),
             notif_intr_trig_r: ReadWriteRegister::new(0),
             mailbox,
+            mci,
             iccm,
             timer: Timer::new(clock),
             err_irq: pic.register_irq(IntSource::SocIfcErr.into()),
@@ -1314,6 +1326,28 @@ impl SocRegistersImpl {
         Ok(())
     }
 
+    fn on_write_ss_generic_fw_exec_ctrl(
+        &mut self,
+        _size: RvSize,
+        index: usize,
+        val: RvData,
+    ) -> Result<(), BusError> {
+        const MCU_FW_EXEC_CTRL_INDEX: usize = 0;
+        const MCU_FW_EXEC_CTRL_MASK: u32 = 0x4;
+        if index >= self.ss_generic_fw_exec_ctrl.len() {
+            return Err(BusError::StoreAccessFault);
+        }
+        if index == MCU_FW_EXEC_CTRL_INDEX
+            && ((val & MCU_FW_EXEC_CTRL_MASK) == 0)
+            && (self.ss_generic_fw_exec_ctrl[index] & MCU_FW_EXEC_CTRL_MASK) != 0
+        {
+            // If the MCU FW execute bit is cleared, request a reset.
+            self.mci.cptra_request_mcu_reset();
+        }
+        self.ss_generic_fw_exec_ctrl[index] = val;
+        Ok(())
+    }
+
     fn reset_common(&mut self) {
         // Unlock the ICCM.
         self.iccm.unlock();
@@ -1555,8 +1589,13 @@ mod tests {
             clock: clock.clone(),
             ..CaliptraRootBusArgs::default()
         };
-        let mut soc_reg: SocRegistersInternal =
-            SocRegistersInternal::new(mailbox.clone(), Iccm::new(&clock.clone()), args);
+        let mci = Mci::new(vec![]);
+        let mut soc_reg: SocRegistersInternal = SocRegistersInternal::new(
+            mailbox.clone(),
+            Iccm::new(&clock.clone()),
+            mci.clone(),
+            args,
+        );
 
         soc_reg
             .write(RvSize::Word, CPTRA_DBG_MANUF_SERVICE_REG_START, 1)
@@ -1620,8 +1659,13 @@ mod tests {
             clock: clock.clone(),
             ..CaliptraRootBusArgs::default()
         };
-        let mut soc_reg: SocRegistersInternal =
-            SocRegistersInternal::new(mailbox.clone(), Iccm::new(&clock.clone()), args);
+        let mci = Mci::new(vec![]);
+        let mut soc_reg: SocRegistersInternal = SocRegistersInternal::new(
+            mailbox.clone(),
+            Iccm::new(&clock.clone()),
+            mci.clone(),
+            args,
+        );
         soc_reg
             .write(RvSize::Word, CPTRA_DBG_MANUF_SERVICE_REG_START, 2)
             .unwrap();
@@ -1681,8 +1725,9 @@ mod tests {
             tb_services_cb: TbServicesCb::new(move |ch| output2.borrow_mut().push(ch)),
             ..Default::default()
         };
+        let mci = Mci::new(vec![]);
         let mut soc_reg: SocRegistersInternal =
-            SocRegistersInternal::new(mailbox, Iccm::new(&clock), args);
+            SocRegistersInternal::new(mailbox, Iccm::new(&clock), mci.clone(), args);
 
         let _ = soc_reg.write(RvSize::Word, CPTRA_GENERIC_OUTPUT_WIRES_START, b'h'.into());
 
@@ -1697,9 +1742,11 @@ mod tests {
     fn test_secrets_when_debug_not_locked() {
         use caliptra_api_types::SecurityState;
         let clock = Rc::new(Clock::new());
+        let mci = Mci::new(vec![]);
         let soc = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
+            mci,
             CaliptraRootBusArgs {
                 clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(false),
@@ -1716,9 +1763,11 @@ mod tests {
     fn test_secrets_when_debug_locked() {
         use caliptra_api_types::SecurityState;
         let clock = Rc::new(Clock::new());
+        let mci = Mci::new(vec![]);
         let soc = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::new()),
             Iccm::new(&clock),
+            mci,
             CaliptraRootBusArgs {
                 clock: clock.clone(),
                 security_state: *SecurityState::default().set_debug_locked(true),
@@ -1750,8 +1799,9 @@ mod tests {
             clock: clock.clone(),
             ..CaliptraRootBusArgs::default()
         };
+        let mci = Mci::new(vec![]);
         let mut soc_reg: SocRegistersInternal =
-            SocRegistersInternal::new(mailbox, Iccm::new(&clock), args);
+            SocRegistersInternal::new(mailbox, Iccm::new(&clock), mci.clone(), args);
         soc_reg
             .write(RvSize::Word, CPTRA_WDT_TIMER1_TIMEOUT_PERIOD_START, 4)
             .unwrap();


### PR DESCRIPTION
Changes to support MCU Hitless update
(https://github.com/chipsalliance/caliptra-ss/blob/main/docs/CaliptraSSIntegrationSpecification.md#mcu-hitless-fw-update)

1. MCI interrupt When Caliptra clears FW_EXEC_CTRL[2], MCI should be able to generate an interrupt to MCU. Added an outgoing event that will be sent to the MCU to process the MCI interrupt.

2. MCI interrupt registers Added several MCI interrupt registers in the MCI peripheral. Not all are needed for MCU hitless update, but it's added for completeness.

3. External SRAM size increase For non-flash based FW Update, the external test sram is used temporarily for staging area (this can be changed in the future). The firmware is ~512KB in size, so the capacity is bumped up from 4K to 1 MB.

4. Fixes on the ACTIVATE_FIRMWARE mailbox command. a. Since clearing the FW_EXEC_CTRL[2] triggers a reset on MCU, the reset reason should be set first by Caliptra before clearing this field. b. The load address for MCU should always be the MCU SRAM address and need not be taken from the manifest.