### PR TITLE
Fix FPGA workflow

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -260,7 +260,6 @@ jobs:
               "${COMMON_ARGS[@]}" \
               --test-threads=1 \
               --no-fail-fast \
-              --no-capture \
               --profile=nightly
 
       - name: 'Upload test results'


### PR DESCRIPTION
cargo nextest does not support the '--no-capture' flag when `--test-threads` is specified.