### PR TITLE
Create a owners subdirectory for /rom/dev/tests.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 #             Code Ownership
 ##########################################
 /rom/dev/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson
+/rom/dev/tests/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @jhand2 @zhalvorsen
 /kat/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson
 /drivers/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @rusty1968 @swenson
 /image/ @mhatrevi @ajisaxena @vsonims @korran @swenson @vsonims @jhand2 @zhalvorsen


### PR DESCRIPTION
This will be used to enable fixing the tests in https://github.com/chipsalliance/caliptra-sw/pull/2380. The owners are everyone in /rom/dev/ with the addition of @jhand2 and @zhalvorsen.