### PR TITLE
VCK190 CI Image changes

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -21,6 +21,30 @@ on:
 jobs:
   build_kernel:
     runs-on: [e2-standard-32, vck190-tools]
+    strategy:
+      matrix:
+        image_variant: [core-2.0, core-2.1, subsystem-2.0, subsystem-2.1]
+        include:
+          - bitstream_hash: cb66e3117cab78bf503cfb15a5e1c4c6fc895dc810ad49b78a9de18180837f47
+            image_variant: core-2.0
+          - bitstream_name: 2p0core_5263740.xsa
+            image_variant: core-2.0
+          - bitstream_hash: bdc58b49e2b5c8bd45429c3d9d9a514c7dab7f6dd7b9bdc97a299272a20d10a8
+            image_variant: core-2.1
+          - bitstream_name: 2p1core_a57cc52.xsa
+            image_variant: core-2.1
+          - bitstream_hash: 7df0cd920b4944552f0c25c96d0945821073d82bc9c957c14d471ce2ee80c648
+            image_variant: subsystem-2.0
+          - bitstream_name: ss2p0SS_ea5d803.xsa
+            image_variant: subsystem-2.0
+          - bitstream_hash: 8f3df0309e6187f280b43a954416ea26a7206aac23a325c21817c15fda143515
+            image_variant: subsystem-2.1
+          - bitstream_name: ss2p1SS_e847f4.xsa
+            image_variant: subsystem-2.1
+    env:
+      IMAGE_VARIANT: ${{ matrix.image_variant }}
+      BITSTREAM_NAME: ${{ matrix.bitstream_name }}
+      BITSTREAM_SHA256: ${{ matrix.bitstream_hash }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -39,40 +63,57 @@ jobs:
 
       - name: Build Kernel
         run: |
+          echo "Building kernel for bitstream variant ${IMAGE_VARIANT}"
           source /vck190-tools/petalinux-tool/settings.sh
 
-          sudo scp /vck190-tools/caliptra-bitstreams/20250701/system.xsa /tmp/system.xsa
+          sudo scp /vck190-tools/caliptra-bitstreams/20250815/${BITSTREAM_NAME} /tmp/system.xsa
+
+          if ! (echo "${BITSTREAM_SHA256} /tmp/system.xsa" | sudo sha256sum -c); then
+            echo "Bitstream does not match expected hash."
+            exit 1
+          fi
+
           sudo chown $USER:$GROUP /tmp/system.xsa
 
           pushd hw/fpga
+
+          if [[ "$IMAGE_VARIANT" == "subsystem-2.0" || "$IMAGE_VARIANT" == "subsystem-2.1" ]]; then
+            export BUILD_SS=true
+          fi
+
 
           ./create_boot_bin.sh /tmp/system.xsa
 
           # TODO(clundin): Not all of these artifacts are required.
           tar -C petalinux_project/images/linux -cvzf vck190-kernel.tar.gz BOOT.BIN Image image.ub boot.scr system.dts system.dtb
-          mv vck190-kernel.tar.gz /tmp/vck190-kernel.tar.gz
+          mv vck190-kernel.tar.gz /tmp/vck190-kernel-${IMAGE_VARIANT}.tar.gz
 
           IO_MODULE_PATH=$(find . -name 'io-module.ko')
-          mv $IO_MODULE_PATH /tmp/io-module.ko
+          mv $IO_MODULE_PATH /tmp/io-module-${IMAGE_VARIANT}.ko
           popd
 
       - name: 'Upload kernel artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: vck190-kernel
-          path: /tmp/vck190-kernel.tar.gz
+          name: vck190-kernel-${{ matrix.image_variant}}
+          path: /tmp/vck190-kernel-${{ matrix.image_variant }}.tar.gz
           retention-days: 1
 
       - name: 'Upload kernel module artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: vck190-kernel-module
-          path: /tmp/io-module.ko
+          name: vck190-kernel-module-${{ matrix.image_variant}}
+          path: /tmp/io-module-${{ matrix.image_variant }}.ko
           retention-days: 1
 
   build_sd_image:
     runs-on: ubuntu-22.04
     needs: [build_kernel]
+    strategy:
+      matrix:
+        image_variant: [core-2.0, core-2.1, subsystem-2.0, subsystem-2.1]
+    env:
+      IMAGE_VARIANT: ${{ matrix.image_variant }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -80,13 +121,13 @@ jobs:
       - name: 'Download kernel artifact'
         uses: actions/download-artifact@v4
         with:
-          name: vck190-kernel
+          name: vck190-kernel-${{ matrix.image_variant }}
           path: /tmp/vck190-kernel/
 
       - name: 'Download kernel module artifact'
         uses: actions/download-artifact@v4
         with:
-          name: vck190-kernel-module
+          name: vck190-kernel-module-${{ matrix.image_variant }}
           path: /tmp/vck190-kmod/
 
       - name: Install pre-requisites
@@ -98,11 +139,11 @@ jobs:
       - name: Build SD image
         run: |
           cd ci-tools/fpga-image
-          sudo bash build.sh
+          sudo KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
 
       - name: 'Upload image as artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: caliptra-fpga-image
+          name: caliptra-fpga-image-${{ matrix.image_variant }}
           path: ci-tools/fpga-image/out/image.img
           retention-days: 90

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -5,13 +5,12 @@
 # a zcu104 Zynq FPGA dev board, and be ready to accept GHA runner
 # jitconfig passed in over UART by fpga-boss.
 
-set -e
-set -x
+set -ex
 
 mkdir -p out
 
-mv /tmp/vck190-kernel/vck190-kernel.tar.gz out/system-boot.tar.gz
-mv /tmp/vck190-kmod/io-module.ko  out/
+mv ${KERNEL_ARCHIVE} out/system-boot.tar.gz
+mv ${KERNEL_MODULE_ARCHIVE}  out/io-module.ko
 
 # Build the rootfs
 if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then

--- a/hw/fpga/create_boot_bin.sh
+++ b/hw/fpga/create_boot_bin.sh
@@ -22,8 +22,15 @@ trap '{
   fi  
 }' EXIT
 
-echo "Copying io_module source code"
-cp io_module/io_module.c petalinux_project/project-spec/meta-user/recipes-modules/io-module/files/io-module.c
+echo "BUILD_SS: ${BUILD_SS}"
+
+if [[ -z "${BUILD_SS}" ]]; then
+  echo "Copying io_module source code"
+  cp io_module/io_module.c petalinux_project/project-spec/meta-user/recipes-modules/io-module/files/io-module.c
+else
+  echo "Copying mcu io_module source code"
+  cp io_module/mcu_io_module.c petalinux_project/project-spec/meta-user/recipes-modules/io-module/files/io-module.c
+fi
 
 cd petalinux_project
 

--- a/hw/fpga/io_module/mcu_io_module.c
+++ b/hw/fpga/io_module/mcu_io_module.c
@@ -1,0 +1,138 @@
+// Licensed under the Apache-2.0 license
+
+#include <linux/module.h>
+#include <linux/uio_driver.h>
+
+const char caliptra_dev_name0[] = "caliptra-fpga-uio-dev0";
+const char caliptra_dev_name1[] = "caliptra-fpga-uio-dev1";
+static struct device uio_dev0;
+static struct device uio_dev1;
+static struct uio_info uio_info0;
+static struct uio_info uio_info1;
+
+static void uio_release(struct device *dev)
+{
+    printk("releasing uio-device\n");
+}
+
+int init_module(void)
+{
+    printk("Setting up uio devices\n");
+    // Create UIO devices
+    dev_set_name(&uio_dev0, caliptra_dev_name0);
+    uio_dev0.release = uio_release;
+    if (device_register(&uio_dev0) < 0)
+    {
+        printk("Failing to register uio device 0\n");
+        return -ENODEV;
+    }
+
+    // Create UIO devices
+    dev_set_name(&uio_dev1, caliptra_dev_name1);
+    uio_dev1.release = uio_release;
+    if (device_register(&uio_dev1) < 0)
+    {
+        device_unregister(&uio_dev0); // clean up
+        printk("Failing to register uio device 1\n");
+        return -ENODEV;
+    }
+
+    // Setup Info
+    uio_info0.name = caliptra_dev_name0;
+    uio_info0.version = "1.0.0";
+
+    //  Caliptra FPGA wrapper
+    uio_info0.mem[0].name = "fpga_wrapper";
+    uio_info0.mem[0].addr = 0xA4010000;
+    uio_info0.mem[0].size = 0x00010000;
+    uio_info0.mem[0].memtype = UIO_MEM_PHYS;
+
+    // Caliptra MMIO interface
+    uio_info0.mem[1].name = "caliptra";
+    uio_info0.mem[1].addr = 0xA4100000;
+    uio_info0.mem[1].size = 0x00040000;
+    uio_info0.mem[1].memtype = UIO_MEM_PHYS;
+
+    // Caliptra ROM
+    uio_info0.mem[2].name = "rom";
+    uio_info0.mem[2].addr = 0xB0000000;
+    uio_info0.mem[2].size = 0x00018000;
+    uio_info0.mem[2].memtype = UIO_MEM_PHYS;
+
+    // I3C controller
+    uio_info0.mem[3].name = "i3c_controller";
+    uio_info0.mem[3].addr = 0xA4080000;
+    uio_info0.mem[3].size = 0x00010000;
+    uio_info0.mem[3].memtype = UIO_MEM_PHYS;
+
+    // MCU SRAM
+    uio_info0.mem[4].name = "mcu_sram";
+    uio_info0.mem[4].addr = 0xB0080000;
+    uio_info0.mem[4].size = 0x00080000;
+    uio_info0.mem[4].memtype = UIO_MEM_PHYS;
+
+
+    // Register device
+    if (uio_register_device(&uio_dev0, &uio_info0) < 0)
+    {
+        printk("Failing to register uio device0 \n");
+        return -EIO;
+    }
+
+
+    // Setup Info
+    uio_info1.name = caliptra_dev_name1;
+    uio_info1.version = "1.0.0";
+
+    // LC
+    uio_info1.mem[0].name = "lc";
+    uio_info1.mem[0].addr = 0xA4040000;
+    uio_info1.mem[0].size = 0x00002000;
+    uio_info1.mem[0].memtype = UIO_MEM_PHYS;
+
+    // MCU ROM Backdoor
+    uio_info1.mem[1].name = "mcu_rom";
+    uio_info1.mem[1].addr = 0xB0020000;
+    uio_info1.mem[1].size = 0x00020000;
+    uio_info1.mem[1].memtype = UIO_MEM_PHYS;
+
+    // I3C
+    uio_info1.mem[2].name = "ss_i3c";
+    uio_info1.mem[2].addr = 0xA4030000;
+    uio_info1.mem[2].size = 0x00010000;
+    uio_info1.mem[2].memtype = UIO_MEM_PHYS;
+
+    // MCI
+    uio_info1.mem[3].name = "mci";
+    uio_info1.mem[3].addr = 0xA8000000;
+    uio_info1.mem[3].size = 0x01000000;
+    uio_info1.mem[3].memtype = UIO_MEM_PHYS;
+
+    // OTP
+    uio_info1.mem[4].name = "otp";
+    uio_info1.mem[4].addr = 0xA4060000;
+    uio_info1.mem[4].size = 0x00002000;
+    uio_info1.mem[4].memtype = UIO_MEM_PHYS;
+
+
+    // Register device
+    if (uio_register_device(&uio_dev1, &uio_info1) < 0)
+    {
+        printk("Failing to register uio device1 \n");
+        return -EIO;
+    }
+
+    printk("Initialized uio devices\n");
+    return 0;
+}
+
+void cleanup_module(void)
+{
+    printk("Unregister uio devices\n");
+    uio_unregister_device(&uio_info1);
+    device_unregister(&uio_dev1);
+    uio_unregister_device(&uio_info0);
+    device_unregister(&uio_dev0);
+}
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Linux");


### PR DESCRIPTION
* Create 4 variants of Caliptra that run on the VCK-190
  * core 2.0
  * core 2.1
  * subsystem 2.0
  * subsystem 2.1
* Update bitstreams for each variant.

This resolves https://github.com/chipsalliance/caliptra-sw/pull/2382.