### PR TITLE
fpga: Reset AXI before and after test

### DIFF
--- a/hw-model/src/fpga_regs.rs
+++ b/hw-model/src/fpga_regs.rs
@@ -17,6 +17,7 @@ register_bitfields! {
         BootfsmBrkpoint OFFSET(6) NUMBITS(1) [],
         SsDebugIntent OFFSET(7) NUMBITS(1) [],
         I3cAxiUserIdFiltering OFFSET(8) NUMBITS(1) [],
+        AxiReset OFFSET(31) NUMBITS(1) [],
     ],
     pub MciError [
         MciErrorFatal OFFSET(0) NUMBITS(1) [],


### PR DESCRIPTION
This makes the FPGA significantly more stable and should remove the need to rebooting the FPGA between runs occasionally.

Cherry-pick of https://github.com/chipsalliance/caliptra-sw/pull/2409