### PR TITLE
drivers: AES DMA additional tests

### DIFF
--- a/drivers/src/aes.rs
+++ b/drivers/src/aes.rs
@@ -818,7 +818,7 @@ impl Aes {
         Ok((iv, tag))
     }
 
-    fn compute_tag(
+    pub fn compute_tag(
         &mut self,
         aad_len: usize,
         text_len: usize,


### PR DESCRIPTION
For very large DMA as well as out-of-place.

These were manually confirmed as working on an FPGA with the 2.1 subsystem bitstream (latest). This adds them to CI as well.