### PR TITLE
fpga: Update subsystem fuse map offset for Vendor PK hash and PQC type

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db888988
-      CALIPTRA_MCU_COMMIT: 4d150bf2df9b1b321bb975e543158f0e9338f1f5
+      CALIPTRA_MCU_COMMIT: 0be2a9dd179c2b2cb36f203b85b776efffbe394a 
 
     steps:
       - name: Checkout repo

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -224,13 +224,8 @@ impl ModelFpgaRealtime {
                     .read_volatile(),
             );
             val.set_axi_reset(1);
-            self.wrapper
-                .offset(FPGA_WRAPPER_CONTROL_OFFSET)
-                .write_volatile(val.0);
-            val.set_axi_reset(0);
-            self.wrapper
-                .offset(FPGA_WRAPPER_CONTROL_OFFSET)
-                .write_volatile(val.0);
+            // wait a few clock cycles or we can crash the FPGA
+            std::thread::sleep(std::time::Duration::from_micros(1));
         }
     }
 

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -40,10 +40,10 @@ const MCI_MAPPING: (usize, usize) = (1, 3);
 const OTP_MAPPING: (usize, usize) = (1, 4);
 
 // Offsets in the OTP for fuses.
-const FUSE_VENDOR_PKHASH_OFFSET: usize = 0x3f0;
+const FUSE_VENDOR_PKHASH_OFFSET: usize = 0x3f8;
 const FUSE_PQC_OFFSET: usize = FUSE_VENDOR_PKHASH_OFFSET + 48;
-const FUSE_LIFECYCLE_TOKENS_OFFSET: usize = 1184;
-const FUSE_LIFECYCLE_STATE_OFFSET: usize = 4008;
+const FUSE_LIFECYCLE_TOKENS_OFFSET: usize = 0x2d8;
+const FUSE_LIFECYCLE_STATE_OFFSET: usize = 0xc80;
 
 // These are the default physical addresses for the peripherals. The addresses listed in
 // FPGA_MEMORY_MAP are physical addresses specific to the FPGA. These addresses are used over the
@@ -228,7 +228,8 @@ impl ModelFpgaSubsystem {
 
     fn axi_reset(&mut self) {
         self.wrapper.regs().control.modify(Control::AxiReset.val(1));
-        self.wrapper.regs().control.modify(Control::AxiReset.val(0));
+        // wait a few clock cycles or we can crash the FPGA
+        std::thread::sleep(std::time::Duration::from_micros(1));
     }
 
     fn set_subsystem_reset(&mut self, reset: bool) {
@@ -1264,11 +1265,6 @@ impl HwModel for ModelFpgaSubsystem {
             .regs()
             .mcu_reset_vector
             .set(FPGA_MEMORY_MAP.rom_offset);
-        println!("Taking subsystem out of reset");
-        m.set_subsystem_reset(false);
-
-        while !m.i3c_target_configured() {}
-        println!("Done starting MCU");
         Ok(m)
     }
 
@@ -1281,15 +1277,19 @@ impl HwModel for ModelFpgaSubsystem {
     fn init_fuses(&mut self, fuses: &Fuses) {
         let otp_mem = self.otp_slice();
 
-        // TODO: verify endianness of this
-        let vendor_pk_hash: &[u8] = fuses.vendor_pk_hash.as_bytes();
         println!(
             "Setting vendor public key hash to {:x?}",
-            HexSlice(vendor_pk_hash)
+            HexSlice(fuses.vendor_pk_hash.as_bytes())
         );
-        let len = vendor_pk_hash.len();
-        let offset = FUSE_VENDOR_PKHASH_OFFSET;
-        otp_mem[offset..offset + len].copy_from_slice(vendor_pk_hash);
+
+        // Safety: Don't use copy_from_slice because the compiler tries to optimize this to 128-bit
+        // writes which will cause a bus error.
+        unsafe {
+            let ptr = otp_mem.as_mut_ptr().add(FUSE_VENDOR_PKHASH_OFFSET) as *mut u32;
+            for i in 0..fuses.vendor_pk_hash.len() {
+                core::ptr::write_volatile(ptr.add(i), fuses.vendor_pk_hash[i]);
+            }
+        }
 
         let vendor_pqc_type = FwVerificationPqcKeyType::from_u8(fuses.fuse_pqc_key_type as u8)
             .unwrap_or(FwVerificationPqcKeyType::LMS);
@@ -1309,6 +1309,12 @@ impl HwModel for ModelFpgaSubsystem {
         Self: Sized,
     {
         HwModel::init_fuses(self, &boot_params.fuses);
+
+        println!("Taking subsystem out of reset");
+        self.set_subsystem_reset(false);
+
+        while !self.i3c_target_configured() {}
+        println!("Done starting MCU");
 
         // TODO: support passing these into MCU ROM
         // self.soc_ifc()
@@ -1501,9 +1507,6 @@ impl Drop for ModelFpgaSubsystem {
             .store(false, Ordering::Relaxed);
         self.realtime_thread.take().unwrap().join().unwrap();
         self.i3c_controller.off();
-
-        // self.set_generic_input_wires(&[0, 0]);
-        // self.set_mcu_generic_input_wires(&[0, 0]);
 
         self.set_subsystem_reset(true);
 

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1035,6 +1035,28 @@ impl HwModel for ModelFpgaSubsystem {
         self.bmc_step();
     }
 
+    /// Create a model, and boot it to the point where CPU execution can
+    /// occur. This includes programming the fuses, initializing the
+    /// boot_fsm state machine, and (optionally) uploading firmware.
+    fn new(init_params: InitParams, boot_params: BootParams) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let init_params_summary = init_params.summary();
+
+        let mut hw: Self = HwModel::new_unbooted(init_params)?;
+        println!(
+            "Using hardware-model {} trng={:?}",
+            hw.type_name(),
+            hw.trng_mode(),
+        );
+        println!("{init_params_summary:#?}");
+
+        hw.boot(boot_params)?;
+
+        Ok(hw)
+    }
+
     fn new_unbooted(params: InitParams) -> Result<Self, Box<dyn Error>>
     where
         Self: Sized,


### PR DESCRIPTION
This should match the latest FPGA builds.

This is necessary to boot the recovery flow.

The previous value was from caliptra-ss from a few weeks ago.

We have to do a few other fixes:

* Initialize fuses before taking subsystem out of reset, otherwise the controller will cache the values before they are written.
* `copy_from_slice()` on ARM can attempt to lift this to 128-bit writes, which can cause bus errors if the starting address is not 128-bit aligned. So, for copying `vendor_pk_hash`, we have to do it manually with 32-bit volatiles writes.
* Add a small delay after resetting AXI or we can crash the FPGA