### PR TITLE
[fix] Don't wait for zeroization to complete for MLDSA in error handler

### DIFF
--- a/common/src/error_handler.rs
+++ b/common/src/error_handler.rs
@@ -19,7 +19,7 @@ pub fn handle_fatal_error(code: u32) -> ! {
         Aes::zeroize();
         Ecc384::zeroize();
         Hmac::zeroize();
-        Mldsa87::zeroize();
+        Mldsa87::zeroize_no_wait();
         Sha256::zeroize();
         Sha2_512_384::zeroize();
         Sha2_512_384Acc::zeroize();

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -587,12 +587,29 @@ impl Mldsa87 {
     ///
     /// This function is safe to call from a trap handler.
     pub unsafe fn zeroize() {
+        Self::zeroize_no_wait();
+
         let mut mldsa_reg = MldsaReg::new();
         let mldsa = mldsa_reg.regs_mut();
-        mldsa.ctrl().write(|f| f.zeroize(true));
 
         // Wait for hardware ready. Ignore errors
         let _ = Mldsa87::wait(mldsa, || mldsa.status().read().ready());
+    }
+
+    /// Zeroize the hardware registers without waiting for readiness.
+    ///
+    /// This is useful to call from a fatal-error-handling routine.
+    ///
+    /// # Safety
+    ///
+    /// The caller must be certain that the results of any pending cryptographic
+    /// operations will not be used after this function is called.
+    ///
+    /// This function is safe to call from a trap handler.
+    pub unsafe fn zeroize_no_wait() {
+        let mut mldsa_reg = MldsaReg::new();
+        let mldsa = mldsa_reg.regs_mut();
+        mldsa.ctrl().write(|f| f.zeroize(true));
     }
 }
 


### PR DESCRIPTION
This is a temporary fix to unblock numerous test timeout failures due to MLDSA zeroization hang in fatal error handler. Once the root cause is investigated, this change should be reverted.