### PR TITLE
drivers: DMA accelerator has to release unlock itself

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -289,7 +289,7 @@ jobs:
               -E 'package(caliptra-auth-man-types)'
               -E 'package(caliptra-cfi-lib)'
               -E 'package(caliptra-coverage)'
-              -E 'package(caliptra-drivers) - test(test_dma_sha384) - test(test_doe_when_debug_locked) - test(test_ecc384_sign_validation_failure)'
+              -E 'package(caliptra-drivers) - test(test_doe_when_debug_locked) - test(test_ecc384_sign_validation_failure)'
               -E 'package(caliptra-error)'
               -E 'package(caliptra-hw-model) - test(tests::test_axi) - test(tests::test_mbox) - test(tests::test_mbox_negative) - binary_id(caliptra-hw-model::model_tests) - test(tests::test_negative_soc_mgr_mbox_users)'
               -E 'package(caliptra-hw-model-types)'

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -252,7 +252,6 @@ jobs:
                        package(caliptra-file-header-fix) |
                        package(compliance-test) |
                        test(test_sign_validation_failure) |
-                       test(test_dma_sha384) |
                        test(test_activate_firmware::test_activate_fw_id_not_in_manifest) |
                        test(test_activate_firmware::test_activate_invalid_fw_id) |
                        test(test_activate_firmware::test_activate_mcu_fw_success) |

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -222,7 +222,7 @@ pub mod driver_tests {
 
     pub const KEYVAULT_FPGA: FwId = FwId {
         bin_name: "keyvault",
-        features: &["fpga_realtime"],
+        features: &["emu", "fpga_realtime"],
         ..BASE_FWID
     };
 
@@ -343,6 +343,13 @@ pub mod driver_tests {
 
     pub const DMA_SHA384: FwId = FwId {
         bin_name: "dma_sha384",
+        ..BASE_FWID
+    };
+
+    // TODO: delete this when AXI DMA is fixed in the FPGA
+    pub const DMA_SHA384_FPGA: FwId = FwId {
+        bin_name: "dma_sha384",
+        features: &["emu", "fpga_subsystem"],
         ..BASE_FWID
     };
 }
@@ -493,6 +500,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::TRNG_DRIVER_RESPONDER,
     &driver_tests::PERSISTENT,
     &driver_tests::DMA_SHA384,
+    &driver_tests::DMA_SHA384_FPGA,
     &rom_tests::ASM_TESTS,
     &rom_tests::TEST_FMC_WITH_UART,
     &rom_tests::FAKE_TEST_FMC_WITH_UART,

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -27,6 +27,11 @@ use ureg::{Mmio, MmioMut, RealMmioMut};
 
 const BLOCK_SIZE: u32 = 256; // Block size for DMA transfers
 pub const MCU_SRAM_OFFSET: u64 = 0xc0_0000;
+// SHA384 of empty stream
+const SHA384_EMPTY: Array4x12 = Array4x12::new([
+    0x38b060a7, 0x51ac9638, 0x4cd9327e, 0xb1b1e36a, 0x21fdb711, 0x14be0743, 0x4c0cc7bf, 0x63f6e1da,
+    0x274edebf, 0xe76f65fb, 0xd51ad2f1, 0x4898b95b,
+]);
 
 pub enum DmaReadTarget {
     Mbox(u32),
@@ -685,7 +690,7 @@ impl<'a> DmaRecovery<'a> {
     }
 
     // TODO: remove this when the FPGA can do fixed burst transfers
-    #[cfg(feature = "fpga_realtime")]
+    #[cfg(any(feature = "fpga_realtime", feature = "fpga_subsystem"))]
     fn exec_dma_read(&self, read_transaction: DmaReadTransaction) -> CaliptraResult<()> {
         // check if this is an I3C DMA
         let i3c = match read_transaction.read_addr {
@@ -712,6 +717,10 @@ impl<'a> DmaRecovery<'a> {
             }
             for j in (0..BLOCK_SIZE).step_by(4) {
                 let i = k + j;
+
+                if i >= read_transaction.length {
+                    break;
+                }
 
                 // translate to single dword transfer
                 match read_transaction.target {
@@ -741,7 +750,7 @@ impl<'a> DmaRecovery<'a> {
         Ok(())
     }
 
-    #[cfg(not(feature = "fpga_realtime"))]
+    #[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
     fn exec_dma_read(&self, read_transaction: DmaReadTransaction) -> CaliptraResult<()> {
         self.dma.flush();
         self.dma.setup_dma_read(read_transaction, BLOCK_SIZE);
@@ -764,6 +773,11 @@ impl<'a> DmaRecovery<'a> {
         source: AxiAddr,
         length: u32,
     ) -> CaliptraResult<Array4x12> {
+        // the hardware does not support hashing an empty stream
+        if length == 0 {
+            return Ok(SHA384_EMPTY);
+        }
+
         // This is tricky, because we need to lock and write to several registers over DMA
         // so that the AXI user is set correctly, but we want the guarantees of the
         // Sha2_512_384Acc without making that too generic.
@@ -777,7 +791,7 @@ impl<'a> DmaRecovery<'a> {
                 return Err(CaliptraError::RUNTIME_INTERNAL);
             }
 
-            // we only use the raw SHA accelerator driver to get the digest at the end and unlock when dropped.
+            // we only use the raw SHA accelerator driver to get the digest at the end.
             let mut acc_op = sha_acc
                 .try_start_operation(ShaAccLockState::AssumedLocked)?
                 .ok_or(CaliptraError::RUNTIME_INTERNAL)?;
@@ -786,7 +800,9 @@ impl<'a> DmaRecovery<'a> {
                 w.endian_toggle(false) // false means swap endianness to match SHA engine
                     .mode(|_| ShaCmdE::ShaStream384)
             });
+
             dma_sha.dlen().write(|_| length);
+
             // Safety: the dma_sha is relative to 0, so we can use it to get the offset of the data in register.
             let write_addr = self.caliptra_base + (dma_sha.datain().ptr as u32 as u64);
 
@@ -804,7 +820,13 @@ impl<'a> DmaRecovery<'a> {
             dma_sha.execute().write(|w| w.execute(true));
 
             let mut digest = Array4x12::default();
+
+            // this is read-only so is safe to do with acc_op
             acc_op.stream_wait_for_done_384(&mut digest)?;
+            drop(acc_op); // this causes acc_op to try to drop the lock, but it will fail
+
+            // we have to release the SHA accelerator lock over DMA for it to take effect
+            dma_sha.lock().write(|w| w.lock(true));
             Ok(digest)
         })?
     }

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -22,7 +22,8 @@ caliptra-cfi-lib = { workspace = true, default-features = false, features = [
 
 [features]
 emu = ["caliptra-test-harness/emu"]
-fpga_realtime = []
+fpga_realtime = ["caliptra-drivers/fpga_realtime"]
+fpga_subsystem = ["caliptra-drivers/fpga_subsystem"]
 
 
 # This feature is used to filter all these binary targets during normal builds

--- a/drivers/test-fw/src/bin/dma_sha384_tests.rs
+++ b/drivers/test-fw/src/bin/dma_sha384_tests.rs
@@ -33,6 +33,7 @@ fn test_dma_sha384_mcu_sram() {
 
     let dma = Dma::default();
     {
+        // the SHA accelerator is locked by default by the uC, so unlock it
         let mut digest = Array4x16::default();
         let mut sha_acc = unsafe { Sha2_512_384Acc::new(Sha512AccCsr::new()) };
         let mut op = sha_acc
@@ -45,6 +46,11 @@ fn test_dma_sha384_mcu_sram() {
     let mut sha2_512_384 = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
 
     let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+
+    // test only runs in subsystem mode
+    if !soc_ifc.subsystem_mode() {
+        return;
+    }
 
     // Generate test data - using a simple pattern for reproducibility
     let mut test_data = [0u32; TEST_DATA_SIZE / 4];
@@ -91,6 +97,11 @@ fn test_dma_sha384_empty_data() {
     let mut sha2_512_384 = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
     let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
 
+    // test only runs in subsystem mode
+    if !soc_ifc.subsystem_mode() {
+        return;
+    }
+
     // Test with empty data (0 length)
     let caliptra_base = AxiAddr::from(soc_ifc.caliptra_base_axi_addr());
     let recovery_base = AxiAddr::from(soc_ifc.recovery_interface_base_addr());
@@ -121,6 +132,11 @@ fn test_dma_sha384_small_data() {
     let mut sha_acc = unsafe { Sha2_512_384Acc::new(Sha512AccCsr::new()) };
     let mut sha2_512_384 = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
     let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+
+    // test only runs in subsystem mode
+    if !soc_ifc.subsystem_mode() {
+        return;
+    }
 
     // Test with small amount of data (32 bytes)
     const SMALL_DATA_SIZE: usize = 32;

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -1174,7 +1174,6 @@ fn test_mailbox_txn_drop() {
 fn test_dma_sha384() {
     if cfg!(feature = "fpga_realtime") {
         // not supported
-        ()
     } else if cfg!(feature = "fpga_subsystem") {
         run_driver_test(&firmware::driver_tests::DMA_SHA384_FPGA);
     } else {

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -1172,5 +1172,12 @@ fn test_mailbox_txn_drop() {
 
 #[test]
 fn test_dma_sha384() {
-    run_driver_test(&firmware::driver_tests::DMA_SHA384);
+    if cfg!(feature = "fpga_realtime") {
+        // not supported
+        ()
+    } else if cfg!(feature = "fpga_subsystem") {
+        run_driver_test(&firmware::driver_tests::DMA_SHA384_FPGA);
+    } else {
+        run_driver_test(&firmware::driver_tests::DMA_SHA384);
+    }
 }


### PR DESCRIPTION
The SHA accelerator hardware does not support calculating the digest of an empty stream, so we workaround that by hardcoding the SHA384("") (still being confirmed by hardware team).

Also fixed a bug where we were feeding the SHA accelerator too much data if the data is not a multiple of 256 bytes.