### PR TITLE
[fix] Update fatal error handler cleanup sequence

### DIFF
--- a/common/src/error_handler.rs
+++ b/common/src/error_handler.rs
@@ -6,20 +6,12 @@ use caliptra_drivers::{
 
 #[allow(clippy::empty_loop)]
 pub fn handle_fatal_error(code: u32) -> ! {
-    cprintln!("Fatal Error: 0x{:08X}", code);
-    report_fw_error_fatal(code);
-    // Populate the non-fatal error code too; if there was a
-    // non-fatal error stored here before we don't want somebody
-    // mistakenly thinking that was the reason for their mailbox
-    // command failure.
-    report_fw_error_non_fatal(code);
-
     unsafe {
         // Zeroize the crypto blocks.
         Aes::zeroize();
         Ecc384::zeroize();
         Hmac::zeroize();
-        Mldsa87::zeroize_no_wait();
+        Mldsa87::zeroize();
         Sha256::zeroize();
         Sha2_512_384::zeroize();
         Sha2_512_384Acc::zeroize();
@@ -34,6 +26,14 @@ pub fn handle_fatal_error(code: u32) -> ! {
         // Note: This is an idempotent operation.
         SocIfc::stop_wdt1();
     }
+
+    cprintln!("Fatal Error: 0x{:08X}", code);
+    report_fw_error_fatal(code);
+    // Populate the non-fatal error code too; if there was a
+    // non-fatal error stored here before we don't want somebody
+    // mistakenly thinking that was the reason for their mailbox
+    // command failure.
+    report_fw_error_non_fatal(code);
 
     loop {
         // SoC firmware might be stuck waiting for Caliptra to finish

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -587,29 +587,13 @@ impl Mldsa87 {
     ///
     /// This function is safe to call from a trap handler.
     pub unsafe fn zeroize() {
-        Self::zeroize_no_wait();
-
         let mut mldsa_reg = MldsaReg::new();
         let mldsa = mldsa_reg.regs_mut();
+
+        mldsa.ctrl().write(|f| f.zeroize(true));
 
         // Wait for hardware ready. Ignore errors
         let _ = Mldsa87::wait(mldsa, || mldsa.status().read().ready());
-    }
-
-    /// Zeroize the hardware registers without waiting for readiness.
-    ///
-    /// This is useful to call from a fatal-error-handling routine.
-    ///
-    /// # Safety
-    ///
-    /// The caller must be certain that the results of any pending cryptographic
-    /// operations will not be used after this function is called.
-    ///
-    /// This function is safe to call from a trap handler.
-    pub unsafe fn zeroize_no_wait() {
-        let mut mldsa_reg = MldsaReg::new();
-        let mldsa = mldsa_reg.regs_mut();
-        mldsa.ctrl().write(|f| f.zeroize(true));
     }
 }
 


### PR DESCRIPTION
This change moves the zeroization of the peripherals before setting the fatal/no-fatal error registers.