### PR TITLE
[jtag,openocd] add initial OpenOCD JTAG TAP infra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -587,10 +587,16 @@ dependencies = [
  "caliptra-verilated",
  "libc",
  "nix",
+ "once_cell",
  "rand",
+ "regex",
+ "rustix",
+ "scopeguard",
+ "serde",
  "sha2",
  "sha3",
  "smlang",
+ "thiserror 2.0.16",
  "tock-registers",
  "uio",
  "ureg",
@@ -2652,7 +2658,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2660,6 +2675,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3255,7 +3281,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,8 @@ quote = "1.0"
 rand = "0.8"
 rfc6979 = "0.4.0"
 rusb = "0.9.3"
+rustix = { version = "1", features = ["event", "fs", "net", "process", "stdio", "termios"] }
+scopeguard = "1.2"
 serde = "1.0"
 serde_derive = "1.0.136"
 serde_json = "1.0"
@@ -187,6 +189,7 @@ smlang = "0.8.0"
 spki = { version = "0.7.3", features = ["alloc"] }
 syn = "1.0.107"
 tinytemplate = "1.1"
+thiserror = "2"
 tock-registers = { git = "https://github.com/tock/tock.git", rev = "b128ae817b86706c8c4e39d27fae5c54b98659f1" }
 toml = "0.7.0"
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -28,10 +28,16 @@ caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
 caliptra-registers.workspace = true
 caliptra-verilated = { workspace = true, optional = true }
+once_cell.workspace = true
 rand.workspace = true
+regex.workspace = true
+rustix.workspace = true
+scopeguard.workspace = true
+serde.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 smlang.workspace = true
+thiserror.workspace = true
 uio = { workspace = true, optional = true }
 ureg.workspace = true
 zerocopy.workspace = true

--- a/hw-model/build.rs
+++ b/hw-model/build.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache-2.0 license
+
+fn main() {
+    println!(
+        "cargo:rustc-env=OPENOCD_SYSFSGPIO_ADAPTER_CFG=../../../hw/fpga/openocd_sysfsgpio_adapter.cfg"
+    );
+    println!("cargo:rustc-env=OPENOCD_TAP_CFG=../../../hw/fpga/openocd_ss.cfg");
+}

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -35,6 +35,7 @@ mod bmc;
 mod fpga_regs;
 pub mod mmio;
 mod model_emulated;
+pub mod openocd;
 mod otp_digest;
 mod otp_provision;
 mod recovery;

--- a/hw-model/src/openocd/mod.rs
+++ b/hw-model/src/openocd/mod.rs
@@ -1,0 +1,5 @@
+// Licensed under the Apache-2.0 license
+
+pub mod openocd_jtag_tap;
+pub mod openocd_server;
+pub mod printer;

--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -1,0 +1,100 @@
+// Licensed under the Apache-2.0 license
+//
+// Derived from OpenTitan's opentitanlib with original copyright:
+//
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::openocd::openocd_server::{OpenOcdError, OpenOcdServer};
+
+/// Available JTAG TAPs in Calitpra Subsystem.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
+pub enum JtagTap {
+    /// RISC-V Veer core's TAP for Caliptra Core.
+    CaliptraCoreTap,
+    /// RISC-V Veer core's TAP for Caliptra MCU.
+    CaliptraMcuTap,
+    /// Lifecycle Controller's TAP.
+    LccTap,
+    /// No TAP selected.
+    NoTap,
+}
+
+/// JTAG parameters to pass to OpenOCD server on startup.
+#[derive(Debug, Clone)]
+pub struct JtagParams {
+    /// OpenOCD binary path.
+    pub openocd: PathBuf,
+
+    /// JTAG adapter speed in kHz.
+    pub adapter_speed_khz: u64,
+
+    /// Whether or not to log OpenOCD server messages to stdio.
+    pub log_stdio: bool,
+}
+
+/// A JTAG TAP accessible through an OpenOCD server.
+pub struct OpenOcdJtagTap {
+    /// OpenOCD server instance.
+    openocd: OpenOcdServer,
+    /// JTAG TAP OpenOCD server is connected to.
+    jtag_tap: JtagTap,
+}
+
+impl OpenOcdJtagTap {
+    /// Starts an OpenOCD server and connects to a specified JTAG TAP.
+    pub fn new(params: &JtagParams, tap: JtagTap) -> Result<Box<OpenOcdJtagTap>> {
+        let target_tap = match tap {
+            JtagTap::CaliptraCoreTap => "core",
+            JtagTap::CaliptraMcuTap => "mcu",
+            JtagTap::LccTap => "lcc",
+            // "none" will cause the OpenOCD startup stript to fail.
+            JtagTap::NoTap => "none",
+        };
+        let adapter_cfg = &format!(
+            "{} configure_adapter {}",
+            include_str!(env!("OPENOCD_SYSFSGPIO_ADAPTER_CFG")),
+            target_tap,
+        );
+        let tap_cfg = &format!(
+            "{} configure_tap {}",
+            include_str!(env!("OPENOCD_TAP_CFG")),
+            target_tap,
+        );
+
+        // Spawn the OpenOCD server, configure the adapter, and connect to the TAP.
+        let mut openocd = OpenOcdServer::spawn(&params.openocd, params.log_stdio)?;
+        openocd.execute(adapter_cfg)?;
+        openocd.execute(&format!("adapter speed {}", params.adapter_speed_khz))?;
+        openocd.execute("transport select jtag")?;
+        openocd.execute(tap_cfg)?;
+
+        // Capture outputs during initialization to see if error has occurred during the process.
+        let resp = openocd.execute("capture init")?;
+        println!("Resp: {}", resp);
+        if resp.contains("JTAG scan chain interrogation failed") {
+            bail!(OpenOcdError::InitializeFailure(resp));
+        }
+
+        Ok(Box::new(OpenOcdJtagTap {
+            openocd,
+            jtag_tap: tap,
+        }))
+    }
+
+    /// Stop the OpenOCD server, disconnecting from the TAP in the process.
+    pub fn disconnect(&mut self) -> Result<()> {
+        self.openocd.shutdown()
+    }
+
+    /// Return the TAP we are currently connected to.
+    pub fn tap(&self) -> JtagTap {
+        self.jtag_tap
+    }
+}

--- a/hw-model/src/openocd/openocd_server.rs
+++ b/hw-model/src/openocd/openocd_server.rs
@@ -1,0 +1,226 @@
+// Licensed under the Apache-2.0 license
+//
+// Derived from OpenTitan's opentitanlib with original copyright:
+//
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::openocd::printer;
+
+/// Errors related to the OpenOCD server.
+#[derive(Error, Debug, Deserialize, Serialize)]
+pub enum OpenOcdError {
+    #[error("OpenOCD initialization failed: {0}")]
+    InitializeFailure(String),
+    #[error("OpenOCD server exited prematurely")]
+    PrematureExit,
+    #[error("Generic error {0}")]
+    Generic(String),
+}
+
+/// Represents an OpenOCD server that we can interact with.
+pub struct OpenOcdServer {
+    /// OpenOCD child process.
+    server_process: Child,
+    /// Receiving side of the stream to the telnet interface of OpenOCD.
+    reader: BufReader<TcpStream>,
+    /// Sending side of the stream to the telnet interface of OpenOCD.
+    writer: TcpStream,
+}
+
+impl Drop for OpenOcdServer {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+impl OpenOcdServer {
+    /// Duration to wait for OpenOCD to be ready to accept a Tcl connection.
+    const OPENOCD_TCL_READY_TMO: Duration = Duration::from_secs(5);
+
+    /// Wait until we see a particular message over STDERR.
+    fn wait_until_regex_match<'a>(
+        stderr: &mut impl BufRead,
+        regex: &Regex,
+        timeout: Duration,
+        s: &'a mut String,
+    ) -> Result<regex::Captures<'a>> {
+        let start = Instant::now();
+        loop {
+            // NOTE this read could block indefinitely, but this behavior is desired for test simplicity.
+            let n = stderr.read_line(s)?;
+            if n == 0 {
+                bail!("OpenOCD stopped before being ready?");
+            }
+            print!("OpenOCD::stderr: {}", s);
+            if regex.is_match(s) {
+                // This is not a `if let Some(capture) = regex.captures(s) {}` to to Rust
+                // borrow checker limitations. Can be modified if Polonius lands.
+                return Ok(regex.captures(s).unwrap());
+            }
+            s.clear();
+            if start.elapsed() >= timeout {
+                bail!("OpenOCD did not become ready to accept a Tcl connection");
+            }
+        }
+    }
+
+    /// Spawn an OpenOCD Tcl server with the given OpenOCD binary path.
+    pub fn spawn(path: &Path, log_stdio: bool) -> Result<Self> {
+        // Let OpenOCD choose which port to bind to, in order to never unnecesarily run into
+        // issues due to a particular port already being in use.
+        // We don't use the telnet and GDB ports so disable them.
+        // The configuration will happen through the Tcl interface, so use `noinit` to prevent
+        // OpenOCD from transition to execution mode.
+        let mut cmd = Command::new(path);
+        cmd.arg("-c")
+            .arg("tcl_port 0; telnet_port disabled; gdb_port disabled; noinit;");
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        // SAFETY: prctl is a syscall which is atomic and thus async-signal-safe.
+        unsafe {
+            cmd.pre_exec(|| {
+                // Since we use OpenOCD as a library, make sure it's killed when
+                // the parent process dies. This setting is preserved across execve.
+                rustix::process::set_parent_process_death_signal(Some(
+                    rustix::process::Signal::HUP,
+                ))?;
+                Ok(())
+            });
+        }
+
+        if log_stdio {
+            println!("Spawning OpenOCD with: {cmd:?}");
+        }
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("failed to spawn openocd: {cmd:?}",))?;
+        let stdout = child.stdout.take().unwrap();
+        let mut stderr = BufReader::new(child.stderr.take().unwrap());
+
+        // Wait until we see 'Info : Listening on port XYZ for Tcl connections' before knowing
+        // which port to connect to.
+        if log_stdio {
+            println!("Waiting for OpenOCD to be ready to accept a Tcl connection ...");
+        }
+        static READY_REGEX: Lazy<Regex> = Lazy::new(|| {
+            Regex::new("Info : Listening on port ([0-9]+) for tcl connections").unwrap()
+        });
+        let mut buf = String::new();
+        let regex_captures = Self::wait_until_regex_match(
+            &mut stderr,
+            &READY_REGEX,
+            Self::OPENOCD_TCL_READY_TMO,
+            &mut buf,
+        )
+        .context("OpenOCD was not ready in time to accept a connection")?;
+        let openocd_port: u16 = regex_captures.get(1).unwrap().as_str().parse()?;
+
+        // Print stdout and stderr with log
+        if log_stdio {
+            std::thread::spawn(move || {
+                printer::accumulate(stdout, "OpenOCD::stdout", Default::default())
+            });
+            std::thread::spawn(move || {
+                printer::accumulate(stderr, "OpenOCD::stderr", Default::default())
+            });
+        }
+
+        let kill_guard = scopeguard::guard(child, |mut child| {
+            let _ = child.kill();
+        });
+
+        if log_stdio {
+            println!("Connecting to OpenOCD Tcl interface ...");
+        }
+        let stream = TcpStream::connect(("localhost", openocd_port))
+            .context("failed to connect to OpenOCD socket")?;
+        let connection = Self {
+            server_process: scopeguard::ScopeGuard::into_inner(kill_guard),
+            reader: BufReader::new(stream.try_clone()?),
+            writer: stream,
+        };
+
+        Ok(connection)
+    }
+
+    /// Send a string to the OpenOCD Tcl server.
+    fn send(&mut self, cmd: &str) -> Result<()> {
+        // The protocol is to send the command followed by a `0x1a` byte,
+        // see https://openocd.org/doc/html/Tcl-Scripting-API.html#Tcl-RPC-server
+
+        // Sanity check to ensure that the command string is not malformed.
+        if cmd.contains('\x1A') {
+            bail!("Tcl command string should be contained inside the string to send.");
+        }
+        self.writer
+            .write_all(cmd.as_bytes())
+            .context("failed to send a command to the OpenOCD server")?;
+        self.writer
+            .write_all(&[0x1a])
+            .context("failed to send the command terminator to OpenOCD server")?;
+        self.writer.flush().context("failed to flush stream")?;
+        Ok(())
+    }
+
+    /// Receive a string from the OpenOCD Tcl server.
+    fn recv(&mut self) -> Result<String> {
+        let mut buf = Vec::new();
+        self.reader.read_until(0x1A, &mut buf)?;
+        if !buf.ends_with(b"\x1A") {
+            bail!(OpenOcdError::PrematureExit);
+        }
+        buf.pop();
+        String::from_utf8(buf).context("failed to parse OpenOCD response as UTF-8")
+    }
+
+    /// Execute a Tcl command via the OpenOCD and wait for its response.
+    pub fn execute(&mut self, cmd: &str) -> Result<String> {
+        self.send(cmd)?;
+        self.recv()
+    }
+
+    pub fn shutdown(&mut self) -> Result<()> {
+        self.execute("shutdown")?;
+        self.server_process
+            .wait()
+            .context("failed to wait for OpenOCD server to exit")?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "fpga_subsystem")]
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_openocd_server() {
+        let Ok(mut openocd) = OpenOcdServer::spawn(Path::new("openocd"), /*log_stdio=*/ true)
+        else {
+            panic!("Failed to spawn an openocd subprocess.");
+        };
+        let Ok(version) = openocd.execute("version") else {
+            panic!("Failed to execute an openocd command.");
+        };
+        println!("OpenOCD version: {version}");
+        assert!(openocd.shutdown().is_ok());
+    }
+}

--- a/hw-model/src/openocd/printer.rs
+++ b/hw-model/src/openocd/printer.rs
@@ -1,0 +1,47 @@
+// Licensed under the Apache-2.0 license
+//
+// Derived from OpenTitan's opentitanlib with original copyright:
+//
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+
+// Accumulates output from a process's `stdout` or `stderr` and redirects to the
+// parent process' `stdout`.
+pub fn accumulate(stdout: impl Read, source: &str, accumulator: Arc<Mutex<String>>) {
+    if let Err(e) = worker(stdout, source, accumulator) {
+        eprintln!("accumulate error: {:?}", e);
+    }
+}
+
+fn worker(mut stdout: impl Read, source: &str, accumulator: Arc<Mutex<String>>) -> Result<()> {
+    let mut s = String::default();
+    loop {
+        read(&mut stdout, &mut s)?;
+        let mut lines = s.split('\n').collect::<Vec<&str>>();
+        let next = if !s.ends_with('\n') {
+            // If we didn't read a complete line at the end, save it for the
+            // next read.
+            lines.pop()
+        } else {
+            None
+        };
+        for line in lines {
+            println!("{}: {}", source, line.trim_end_matches('\r'));
+        }
+        accumulator.lock().unwrap().push_str(&s);
+        s = next.unwrap_or("").to_string();
+    }
+}
+
+fn read(stdout: &mut impl Read, s: &mut String) -> Result<()> {
+    let mut buf = [0u8; 256];
+    let n = stdout.read(&mut buf)?;
+    s.push_str(&String::from_utf8_lossy(&buf[..n]));
+    Ok(())
+}

--- a/hw/fpga/openocd_ss.cfg
+++ b/hw/fpga/openocd_ss.cfg
@@ -1,0 +1,71 @@
+# Licensed under the Apache-2.0 license
+
+proc configure_tap {target} {
+
+    if {$target == "core" || $target == "mcu"} {
+        set _CHIPNAME riscv
+        set _TAPNAME cpu
+        if {$target == "core"} {
+            puts "Connecting to Caliptra Core"
+            set _IDCODE 0x00000001
+        } else {
+            puts "Connecting to MCU"
+            set _IDCODE 0x00000001
+        }
+    } elseif {$target == "lcc"} {
+        puts "Connecting to LCC"
+        set _CHIPNAME lcc
+        set _TAPNAME tap
+        set _IDCODE 0x00000001
+    } else {
+        puts stderr "Please include -c [target]"
+    }
+
+    set _CHAIN_LENGTH 5
+    set _TARGETNAME $_CHIPNAME.$_TAPNAME
+    jtag newtap $_CHIPNAME $_TAPNAME -irlen $_CHAIN_LENGTH -expected-id $_IDCODE
+    target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos hwthread
+    
+    if {$target == "core" || $target == "mcu"} {
+        $_TARGETNAME configure -work-area-phys 0 -work-area-size 0x8000 -work-area-backup 1
+        # Define custom VEER CSRs. This syntax is for OpenOCD 0.11.0
+        # reg csrxxx
+        $_TARGETNAME riscv expose_csrs 1984,1986,1992,1993,1994,1995,2032,2041,2047,4032
+    }
+
+    gdb_report_data_abort enable
+    init
+
+    if {$target == "core" || $target == "mcu"} {
+        if {$target == "core"} {
+            # Check if we can read/write CPTRA_DBG_MANUF_SERVICE_REG to see if Caliptra JTAG registers are accessible
+            set manuf [riscv dmi_read 0x60]
+            riscv dmi_write 0x60 [expr {0xFFFFFFFF - $manuf}]
+            set manuf_inv [riscv dmi_read 0x60]
+            # Restore original value
+              riscv dmi_write 0x60 [format %08X $manuf]
+            if { $manuf == $manuf_inv } {
+                puts stderr "Caliptra Core not accessible"
+            } else {
+                puts stderr "Caliptra Core accessible"
+            }
+        }
+        set dmstatus [riscv dmi_read 0x11]
+        if {0x0 == $dmstatus} {
+            puts stderr "CPU not accessible"
+        } else {
+            puts stderr "CPU accessible"
+            halt
+        }
+    } else {
+        # Address 0x4 is the lc_ctrl STATUS register.
+        set lcc_status [riscv dmi_read 0x4]
+        if {0x0 == $lcc_status} {
+            puts stderr [format "LCC not accessible; STATUS: %x" $lcc_status]
+        } else {
+            puts stderr "LCC accessible"
+        }
+    }
+
+    puts stderr "OpenOCD setup finished"
+}

--- a/hw/fpga/openocd_sysfsgpio_adapter.cfg
+++ b/hw/fpga/openocd_sysfsgpio_adapter.cfg
@@ -1,0 +1,46 @@
+# Licensed under the Apache-2.0 license
+
+proc configure_adapter {target} {
+
+    adapter driver sysfsgpio
+
+    # Get the number of the versal_gpio gpiochip.
+    # This corresponds to the LPD GPIO controller.
+    regexp {.*gpiochip(\d*)/.*} [exec grep -H versal_gpio {*}[glob /sys/class/gpio/*/label]] trash gpionum
+    puts stderr [glob /sys/class/gpio/*/label]
+    puts stderr [exec grep pmc_gpio {*}[glob /sys/class/gpio/*/label]]
+
+    # PL EMIO starts at pin 26
+    # 26-30 -> Caliptra Core JTAG
+    # 31-35 -> MCU JTAG
+    # 36-41 -> LCC JTAG
+    if {$target == "core" || $target == "mcu"} {
+        if {$target == "core"} {
+            set gpionum [expr {$gpionum + 26}]
+            sysfsgpio tdi_num [expr {$gpionum + 1}]
+            sysfsgpio tms_num [expr {$gpionum + 2}]
+        } else {
+            set gpionum [expr {$gpionum + 31}]
+            sysfsgpio tms_num [expr {$gpionum + 1}]
+            sysfsgpio tdi_num [expr {$gpionum + 2}]
+        }
+    } elseif {$target == "lcc"} {
+        set gpionum [expr {$gpionum + 36}]
+        sysfsgpio tms_num [expr {$gpionum + 1}]
+        sysfsgpio tdi_num [expr {$gpionum + 2}]
+    } else {
+        puts stderr "Please include -c [target]"
+    }
+
+    # Define pin numbers for sysfsgpio
+    sysfsgpio tck_num [expr {$gpionum + 0}]
+    # TODO(timothytrippel): use same pin order for all TAPs once #397 merges
+    # sysfsgpio tms_num [expr {$gpionum + 1}]
+    # sysfsgpio tdi_num [expr {$gpionum + 2}]
+    sysfsgpio trst_num [expr {$gpionum + 3}]
+    sysfsgpio tdo_num [expr {$gpionum + 4}]
+
+    reset_config srst_only
+    reset_config srst_nogate
+    reset_config connect_assert_srst
+}


### PR DESCRIPTION
This updates the Subsystem HW model to add the initial OpenOCD/JTAG TAP infrastructure that is required to actuate variouse JTAG TAP interfaces in E2E tests. This simply adds functions to spawn and terminate an OpenOCD server subprocess during a test. In a follow up, additional functionality will be added to implement various TAP operations such as read/write memory/registers.