### PR TITLE
[subsystem] Continue booting after loading fuses.

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db888988
-      CALIPTRA_MCU_COMMIT: ce58b594e8ddb7ee1c374aee742d6dc2b609c3d3
+      CALIPTRA_MCU_COMMIT: b5b242553ce9844eb7e25eea0cee23fa429a6881
 
     steps:
       - name: Checkout repo
@@ -291,7 +291,7 @@ jobs:
               -E 'package(caliptra-coverage)'
               -E 'package(caliptra-drivers) - test(test_doe_when_debug_locked) - test(test_ecc384_sign_validation_failure)'
               -E 'package(caliptra-error)'
-              -E 'package(caliptra-hw-model) - test(tests::test_axi) - test(tests::test_mbox) - test(tests::test_mbox_negative) - binary_id(caliptra-hw-model::model_tests) - test(tests::test_negative_soc_mgr_mbox_users)'
+              -E 'package(caliptra-hw-model) - test(test_iccm_byte_write_nmi_failure) - test(test_iccm_unaligned_write_nmi_failure) - test(test_iccm_write_locked_nmi_failure) - test(test_invalid_instruction_exception_failure) - test(test_write_to_rom)'
               -E 'package(caliptra-hw-model-types)'
               -E 'package(caliptra-image-crypto)'
               -E 'package(caliptra-image-elf)'

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,6 @@ hw/fpga/vivado*.log
 libcaliptra/libcaliptra.a
 
 hw-latest/verilated/out/*
-/cross-target/
+cross-target/
 caliptra-test-binaries.tar.zst
 junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ hw/fpga/vivado*.log
 libcaliptra/libcaliptra.a
 
 hw-latest/verilated/out/*
+/cross-target/
+caliptra-test-binaries.tar.zst
+junit.xml

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -49,6 +49,8 @@ mod model_verilated;
 mod model_fpga_realtime;
 
 #[cfg(feature = "fpga_subsystem")]
+mod mcu_boot_status;
+#[cfg(feature = "fpga_subsystem")]
 mod model_fpga_subsystem;
 
 mod output;

--- a/hw-model/src/mcu_boot_status.rs
+++ b/hw-model/src/mcu_boot_status.rs
@@ -1,0 +1,90 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    boot_status.rs
+
+Abstract:
+
+    MCU ROM boot status codes.
+
+--*/
+
+const ROM_INITIALIZATION_BASE: u32 = 1;
+const LIFECYCLE_MANAGEMENT_BASE: u32 = 65;
+const OTP_FUSE_OPERATIONS_BASE: u32 = 129;
+const CALIPTRA_SETUP_BASE: u32 = 193;
+const FIRMWARE_LOADING_BASE: u32 = 257;
+const FIELD_ENTROPY_BASE: u32 = 321;
+const BOOT_FLOW_BASE: u32 = 385;
+
+/// Status codes used by MCU ROM to log boot progress.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum McuRomBootStatus {
+    // ROM Initialization Statuses
+    RomStarted = ROM_INITIALIZATION_BASE,
+    McuMemoryMapInitialized = ROM_INITIALIZATION_BASE + 1,
+    StrapsLoaded = ROM_INITIALIZATION_BASE + 2,
+    McuRegistersInitialized = ROM_INITIALIZATION_BASE + 3,
+    SocManagerInitialized = ROM_INITIALIZATION_BASE + 4,
+    MciInitialized = ROM_INITIALIZATION_BASE + 5,
+    ResetReasonDetected = ROM_INITIALIZATION_BASE + 6,
+
+    // Lifecycle Management Statuses
+    LifecycleControllerInitialized = LIFECYCLE_MANAGEMENT_BASE,
+    LifecycleTransitionStarted = LIFECYCLE_MANAGEMENT_BASE + 1,
+    LifecycleTransitionComplete = LIFECYCLE_MANAGEMENT_BASE + 2,
+    LifecycleTokenBurningStarted = LIFECYCLE_MANAGEMENT_BASE + 3,
+    LifecycleTokenBurningComplete = LIFECYCLE_MANAGEMENT_BASE + 4,
+
+    // OTP and Fuse Operations
+    OtpControllerInitialized = OTP_FUSE_OPERATIONS_BASE,
+    FusesReadFromOtp = OTP_FUSE_OPERATIONS_BASE + 1,
+    WatchdogConfigured = OTP_FUSE_OPERATIONS_BASE + 2,
+
+    // Caliptra Setup Statuses
+    CaliptraBootGoAsserted = CALIPTRA_SETUP_BASE,
+    I3cInitialized = CALIPTRA_SETUP_BASE + 1,
+    CaliptraReadyForFuses = CALIPTRA_SETUP_BASE + 2,
+    AxiUsersConfigured = CALIPTRA_SETUP_BASE + 3,
+    FusesPopulatedToCaliptra = CALIPTRA_SETUP_BASE + 4,
+    FuseWriteComplete = CALIPTRA_SETUP_BASE + 5,
+    CaliptraReadyForMailbox = CALIPTRA_SETUP_BASE + 6,
+
+    // Firmware Loading Statuses
+    RiDownloadFirmwareCommandSent = FIRMWARE_LOADING_BASE,
+    RiDownloadFirmwareComplete = FIRMWARE_LOADING_BASE + 1,
+    FlashRecoveryFlowStarted = FIRMWARE_LOADING_BASE + 2,
+    FlashRecoveryFlowComplete = FIRMWARE_LOADING_BASE + 3,
+    FirmwareReadyDetected = FIRMWARE_LOADING_BASE + 4,
+    FirmwareValidationComplete = FIRMWARE_LOADING_BASE + 5,
+    CaliptraRuntimeReady = FIRMWARE_LOADING_BASE + 6,
+
+    // Field Entropy Programming
+    FieldEntropyProgrammingStarted = FIELD_ENTROPY_BASE,
+    FieldEntropyPartition0Complete = FIELD_ENTROPY_BASE + 1,
+    FieldEntropyPartition1Complete = FIELD_ENTROPY_BASE + 2,
+    FieldEntropyPartition2Complete = FIELD_ENTROPY_BASE + 3,
+    FieldEntropyPartition3Complete = FIELD_ENTROPY_BASE + 4,
+    FieldEntropyProgrammingComplete = FIELD_ENTROPY_BASE + 5,
+
+    // Boot Flow Completion
+    ColdBootFlowStarted = BOOT_FLOW_BASE,
+    ColdBootFlowComplete = BOOT_FLOW_BASE + 1,
+    WarmResetFlowStarted = BOOT_FLOW_BASE + 2,
+    WarmResetFlowComplete = BOOT_FLOW_BASE + 3,
+    FirmwareUpdateFlowStarted = BOOT_FLOW_BASE + 4,
+    FirmwareUpdateFlowComplete = BOOT_FLOW_BASE + 5,
+    HitlessUpdateFlowStarted = BOOT_FLOW_BASE + 6,
+    HitlessUpdateFlowComplete = BOOT_FLOW_BASE + 7,
+}
+
+impl From<McuRomBootStatus> for u32 {
+    /// Converts to this type from the input type.
+    fn from(status: McuRomBootStatus) -> u32 {
+        status as u32
+    }
+}

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1443,11 +1443,14 @@ impl HwModel for ModelFpgaSubsystem {
 
         self.otp_slice().copy_from_slice(&otp_mem);
 
+        // TODO(zhalvorsen): this should be referencing the other MCI GPIO word.
+        // It looks like the words are backwards in the FPGA wrapper. Update
+        // this when the wrapper is updated.
+
         // Notify MCU ROM it can start loading the fuse registers
-        let gpio1 = self.wrapper.regs().mci_generic_input_wires[1]
-            .extract()
-            .get();
-        self.wrapper.regs().mci_generic_input_wires[0].set(gpio1 | 1 << 30);
+        let gpio = &self.wrapper.regs().mci_generic_input_wires[0];
+        let current = gpio.extract().get();
+        gpio.set(current | 1 << 30);
     }
 
     fn boot(&mut self, boot_params: BootParams) -> Result<(), Box<dyn Error>>

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -6,6 +6,7 @@
 use crate::api_types::{DeviceLifecycle, Fuses};
 use crate::bmc::Bmc;
 use crate::fpga_regs::{Control, FifoData, FifoRegs, FifoStatus, ItrngFifoStatus, WrapperRegs};
+use crate::mcu_boot_status::McuRomBootStatus;
 use crate::openocd::openocd_jtag_tap::{JtagParams, JtagTap, OpenOcdJtagTap};
 use crate::otp_provision::{
     lc_generate_memory, otp_generate_lifecycle_tokens_mem, LifecycleControllerState,
@@ -1400,8 +1401,7 @@ impl HwModel for ModelFpgaSubsystem {
         println!("Taking subsystem out of reset");
         m.set_subsystem_reset(false);
 
-        // Wait for McuRomBootStatus::CaliptraBootGoAsserted
-        while m.mci_flow_status() != 0xC1 {}
+        while m.mci_flow_status() != u32::from(McuRomBootStatus::CaliptraBootGoAsserted) {}
 
         // TODO: This isn't needed in the mcu-sw-model. It should be done by MCU ROM. There must be
         // something out of order that makes this necessary. Without it Caliptra ROM gets stuck in

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -132,7 +132,7 @@ const FPGA_MEMORY_MAP: McuMemoryMap = McuMemoryMap {
 
 // Set to core_clk cycles per ITRNG sample.
 const ITRNG_DIVISOR: u32 = 400;
-const DEFAULT_AXI_PAUSER: u32 = 0xcccc_cccc;
+const DEFAULT_AXI_PAUSER: u32 = 0x1;
 const OTP_SIZE: usize = 16384;
 const AXI_CLK_HZ: u32 = 199_999_000;
 const I3C_CLK_HZ: u32 = 12_500_000;
@@ -1113,6 +1113,12 @@ impl ModelFpgaSubsystem {
         }
     }
 
+    fn set_mci_generic_input_wires(&mut self, value: &[u32; 2]) {
+        for (i, wire) in value.iter().copied().enumerate() {
+            self.wrapper.regs().mci_generic_input_wires[i].set(wire);
+        }
+    }
+
     fn set_itrng_divider(&mut self, divider: u32) {
         self.wrapper.regs().itrng_divisor.set(divider - 1);
     }
@@ -1144,28 +1150,6 @@ impl HwModel for ModelFpgaSubsystem {
     fn step(&mut self) {
         self.handle_log();
         self.bmc_step();
-    }
-
-    /// Create a model, and boot it to the point where CPU execution can
-    /// occur. This includes programming the fuses, initializing the
-    /// boot_fsm state machine, and (optionally) uploading firmware.
-    fn new(init_params: InitParams, boot_params: BootParams) -> Result<Self, Box<dyn Error>>
-    where
-        Self: Sized,
-    {
-        let init_params_summary = init_params.summary();
-
-        let mut hw: Self = HwModel::new_unbooted(init_params)?;
-        println!(
-            "Using hardware-model {} trng={:?}",
-            hw.type_name(),
-            hw.trng_mode(),
-        );
-        println!("{init_params_summary:#?}");
-
-        hw.boot(boot_params)?;
-
-        Ok(hw)
     }
 
     fn new_unbooted(params: InitParams) -> Result<Self, Box<dyn Error>>
@@ -1311,6 +1295,8 @@ impl HwModel for ModelFpgaSubsystem {
         let input_wires = [0, (!params.uds_granularity_64 as u32) << 31];
         m.set_generic_input_wires(&input_wires);
 
+        m.set_mci_generic_input_wires(&[0, 0]);
+
         println!("Set itrng divider");
         // Set divisor for ITRNG throttling
         m.set_itrng_divider(ITRNG_DIVISOR);
@@ -1338,9 +1324,6 @@ impl HwModel for ModelFpgaSubsystem {
 
         // Currently not using strap UDS and FE
         m.set_secrets_valid(false);
-
-        // Clear the generic input wires in case they were left in a non-zero state.
-        m.set_generic_input_wires(&[0, 0]);
 
         println!("Putting subsystem into reset");
         m.set_subsystem_reset(true);
@@ -1413,6 +1396,18 @@ impl HwModel for ModelFpgaSubsystem {
             .regs()
             .mcu_reset_vector
             .set(FPGA_MEMORY_MAP.rom_offset);
+
+        println!("Taking subsystem out of reset");
+        m.set_subsystem_reset(false);
+
+        // Wait for McuRomBootStatus::CaliptraBootGoAsserted
+        while m.mci_flow_status() != 0xC1 {}
+
+        // TODO: This isn't needed in the mcu-sw-model. It should be done by MCU ROM. There must be
+        // something out of order that makes this necessary. Without it Caliptra ROM gets stuck in
+        // the BOOT_WAIT state according to the cptra_flow_status register.
+        println!("writing to cptra_bootfsm_go");
+        m.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
         Ok(m)
     }
 
@@ -1447,6 +1442,12 @@ impl HwModel for ModelFpgaSubsystem {
         otp_mem[FUSE_PQC_OFFSET] = val;
 
         self.otp_slice().copy_from_slice(&otp_mem);
+
+        // Notify MCU ROM it can start loading the fuse registers
+        let gpio1 = self.wrapper.regs().mci_generic_input_wires[1]
+            .extract()
+            .get();
+        self.wrapper.regs().mci_generic_input_wires[0].set(gpio1 | 1 << 30);
     }
 
     fn boot(&mut self, boot_params: BootParams) -> Result<(), Box<dyn Error>>
@@ -1454,9 +1455,6 @@ impl HwModel for ModelFpgaSubsystem {
         Self: Sized,
     {
         HwModel::init_fuses(self, &boot_params.fuses);
-
-        println!("Taking subsystem out of reset");
-        self.set_subsystem_reset(false);
 
         while !self.i3c_target_configured() {}
         println!("Done starting MCU");
@@ -1494,12 +1492,6 @@ impl HwModel for ModelFpgaSubsystem {
         // Set up the PAUSER as valid for the mailbox (using index 0)
         // self.setup_mailbox_users(boot_params.valid_axi_user.as_slice())
         //     .map_err(ModelError::from)?;
-
-        // TODO: This isn't needed in the mcu-sw-model. It should be done by MCU ROM. There must be
-        // something out of order that makes this necessary. Without it Caliptra ROM gets stuck in
-        // the BOOT_WAIT state according to the cptra_flow_status register.
-        println!("writing to cptra_bootfsm_go");
-        self.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
 
         self.step();
 


### PR DESCRIPTION
This will let the MCU test ROM know to go to the next pause point after loading fuse values into the OTP peripheral.

Because this can now release the FPGA from reset during `new_unbooted`, the custom `new` function can also be removed.

This also changes the default AXI user to 0x1 similar to the Core hardware model.

These changes allow us to enable more tests in CI.