### PR TITLE
[openocd] add functions to interface with LCC

### DIFF
--- a/hw-model/src/lcc.rs
+++ b/hw-model/src/lcc.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache-2.0 license
+
+#[derive(Clone, Copy, Debug)]
+#[repr(u32)]
+pub enum LcCtrlReg {
+    AlertTest = 0x0,
+    Status = 0x4,
+    ClaimTransitionIfRegwen = 0x8,
+    ClaimTransitionIf = 0xC,
+    TransitionRegwen = 0x10,
+    TransitionCmd = 0x14,
+    TransitionCtrl = 0x18,
+    TransitionToken0 = 0x1C,
+    TransitionToken1 = 0x20,
+    TransitionToken2 = 0x24,
+    TransitionToken3 = 0x28,
+    TransitionTarget = 0x2C,
+    OtpVendorTestCtrl = 0x30,
+    OtpVendorTestStatus = 0x34,
+    LcState = 0x38,
+    LcTransitionCnt = 0x3C,
+    LcIdState = 0x40,
+    HwRevision0 = 0x44,
+    HwRevision1 = 0x48,
+    DeviceId0 = 0x4C,
+    DeviceId1 = 0x50,
+    DeviceId2 = 0x54,
+    DeviceId3 = 0x58,
+    DeviceId4 = 0x5C,
+    DeviceId5 = 0x60,
+    DeviceId6 = 0x64,
+    DeviceId7 = 0x68,
+    ManufState0 = 0x6C,
+    ManufState1 = 0x70,
+    ManufState2 = 0x74,
+    ManufState3 = 0x78,
+    ManufState4 = 0x7C,
+    ManufState5 = 0x80,
+    ManufState6 = 0x84,
+    ManufState7 = 0x88,
+}
+
+impl LcCtrlReg {
+    pub fn byte_offset(&self) -> u32 {
+        *self as u32
+    }
+
+    /// Converts the register's byte offset into a word offset for use with DMI.
+    pub fn word_offset(&self) -> u32 {
+        const BYTES_PER_WORD: u32 = std::mem::size_of::<u32>() as u32;
+        assert_eq!(self.byte_offset() % BYTES_PER_WORD, 0);
+        self.byte_offset() / BYTES_PER_WORD
+    }
+}

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -33,6 +33,7 @@ use sha2::Digest;
 
 mod bmc;
 mod fpga_regs;
+pub mod lcc;
 pub mod mmio;
 mod model_emulated;
 pub mod openocd;

--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -6,11 +6,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(dead_code)]
+
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, ensure, Context, Result};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
+use crate::lcc::LcCtrlReg;
 use crate::openocd::openocd_server::{OpenOcdError, OpenOcdServer};
 
 /// Available JTAG TAPs in Calitpra Subsystem.
@@ -37,6 +42,19 @@ pub struct JtagParams {
 
     /// Whether or not to log OpenOCD server messages to stdio.
     pub log_stdio: bool,
+}
+
+/// Errors related to the JTAG interface.
+#[derive(Error, Debug, Deserialize, Serialize)]
+pub enum JtagError {
+    #[error("Operation not valid on selected JTAG TAP: {0:?}")]
+    Tap(JtagTap),
+    #[error("JTAG timeout")]
+    Timeout,
+    #[error("JTAG busy")]
+    Busy,
+    #[error("Generic error {0}")]
+    Generic(String),
 }
 
 /// A JTAG TAP accessible through an OpenOCD server.
@@ -96,5 +114,37 @@ impl OpenOcdJtagTap {
     /// Return the TAP we are currently connected to.
     pub fn tap(&self) -> JtagTap {
         self.jtag_tap
+    }
+
+    pub fn read_lc_ctrl_reg(&mut self, reg: &LcCtrlReg) -> Result<u32> {
+        ensure!(
+            matches!(self.jtag_tap, JtagTap::LccTap),
+            JtagError::Tap(self.jtag_tap)
+        );
+        let reg_offset = reg.word_offset();
+        let cmd = format!("riscv dmi_read 0x{reg_offset:x}");
+        let response = self.openocd.execute(cmd.as_str())?;
+
+        let value = u32::from_str(response.trim()).context(format!(
+            "expected response to be hexadecimal word, got '{response}'"
+        ))?;
+
+        Ok(value)
+    }
+
+    fn write_lc_ctrl_reg(&mut self, reg: &LcCtrlReg, value: u32) -> Result<()> {
+        ensure!(
+            matches!(self.jtag_tap, JtagTap::LccTap),
+            JtagError::Tap(self.jtag_tap)
+        );
+        let reg_offset = reg.word_offset();
+        let cmd = format!("riscv dmi_write 0x{reg_offset:x} 0x{value:x}");
+        let response = self.openocd.execute(cmd.as_str())?;
+
+        if !response.is_empty() {
+            bail!("unexpected response: '{response}'");
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This adds functions to read/write LCC registers over the JTAG/OpenOCD interface. This will be used to write LC transition tests on the FPGA.