### PR TITLE
Disable FPGA tests that uses test SRAM

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -119,6 +119,11 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
     model
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_activate_mcu_fw_success() {
     let mcu_image = Image {
@@ -153,6 +158,11 @@ fn test_activate_mcu_fw_success() {
         .expect("We should have received a response");
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {
@@ -196,6 +206,11 @@ fn test_activate_mcu_soc_fw_success() {
         .expect("We should have received a response");
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_activate_soc_fw_success() {
     let soc_image = Image {
@@ -230,6 +245,11 @@ fn test_activate_soc_fw_success() {
         .expect("We should have received a response");
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_activate_invalid_fw_id() {
     let soc_image = Image {
@@ -263,6 +283,11 @@ fn test_activate_invalid_fw_id() {
         .is_err());
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_activate_fw_id_not_in_manifest() {
     let soc_image = Image {
@@ -296,6 +321,11 @@ fn test_activate_fw_id_not_in_manifest() {
         .is_err());
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_invalid_exec_bit_in_manifest() {
     let soc_image = Image {

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -996,6 +996,11 @@ fn test_authorize_and_stash_after_update_reset_multiple_set_manifest() {
     );
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_authorize_from_load_address() {
     let mut flags = ImageMetadataFlags(0);
@@ -1044,6 +1049,11 @@ fn test_authorize_from_load_address() {
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_authorize_from_load_address_incorrect_digest() {
     let mut flags = ImageMetadataFlags(0);
@@ -1091,6 +1101,11 @@ fn test_authorize_from_load_address_incorrect_digest() {
     );
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_authorize_from_staging_address() {
     let mut flags = ImageMetadataFlags(0);
@@ -1139,6 +1154,11 @@ fn test_authorize_from_staging_address() {
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }
 
+#[cfg(all(
+    not(feature = "verilator"),
+    not(feature = "fpga_realtime"),
+    not(feature = "fpga_subsystem")
+))]
 #[test]
 fn test_authorize_from_staging_address_incorrect_digest() {
     let mut flags = ImageMetadataFlags(0);


### PR DESCRIPTION

Some integration tests uses test SRAM that does not exist in actual HW
which causes FPGA tests to fail.

Disable these tests for now until we find a way to use an actual SRAM
that can be accessed from the integration test.