### PR TITLE
ci-tools: add nix stateVersion

### DIFF
--- a/ci-tools/host-runner/configuration.nix
+++ b/ci-tools/host-runner/configuration.nix
@@ -69,6 +69,7 @@ in
   imports = [
     ./hardware-configuration.nix
   ];
+  system.stateVersion = "25.05";
 
   # Keep SD card from running out of room
   nix.gc.automatic = true;


### PR DESCRIPTION
While building the SD card image for the Pi I ran into this warning:

```
evaluation warning: system.stateVersion is not set, defaulting to 25.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
```

It seemed reasonable to add, so I did that.