### PR TITLE
[hw_model] expose subsystem reset function

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -393,7 +393,7 @@ impl ModelFpgaSubsystem {
         std::thread::sleep(std::time::Duration::from_micros(1));
     }
 
-    fn set_subsystem_reset(&mut self, reset: bool) {
+    pub fn set_subsystem_reset(&mut self, reset: bool) {
         self.wrapper.regs().control.modify(
             Control::CptraSsRstB.val((!reset) as u32) + Control::CptraPwrgood.val((!reset) as u32),
         );


### PR DESCRIPTION
This exposes the subsystem reset actuating function so downstream tests can toggle this as needed. This will be used to put the HW in exactly the right state before attempting to connect to the LCC JTAG TAP to actuate LC transitions.