### PR TITLE
Fixing Runtime LMS command

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -265,11 +265,6 @@ jobs:
                        test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys) |
                        test(test_fe_programming::test_fe_programming_cmd) |
                        test(test_fips::test_fips_shutdown) |
-                       test(test_lms::test_lms_verify_cmd) |
-                       test(test_lms::test_lms_verify_failure) |
-                       test(test_lms::test_lms_verify_invalid_key_lms_type) |
-                       test(test_lms::test_lms_verify_invalid_lmots_type) |
-                       test(test_lms::test_lms_verify_invalid_sig_lms_type) |
                        test(test_rtalias::test_boot_status_reporting) |
                        binary_id(caliptra-test::fips_test_suite) |
                        test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_success) |

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -19,6 +19,7 @@ use caliptra_drivers::{CaliptraError, CaliptraResult, LmsResult};
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
 };
+use core::hint::black_box;
 use zerocopy::{BigEndian, FromBytes, LittleEndian, U32};
 
 pub struct LmsVerifyCmd;
@@ -58,7 +59,7 @@ impl LmsVerifyCmd {
         let lms_pub_key: LmsPublicKey<LMS_N> = LmsPublicKey {
             id: cmd.pub_key_id,
             digest,
-            tree_type: LmsAlgorithmType::new(cmd.pub_key_tree_type),
+            tree_type: black_box(LmsAlgorithmType::new(cmd.pub_key_tree_type)),
             otstype: LmotsAlgorithmType::new(cmd.pub_key_ots_type),
         };
 


### PR DESCRIPTION
This fix resolves the issue where the compiler incorrectly optimizes the read access to cmd.pub_key_tree_type from the LmsVerifyReq struct.