### PR TITLE
Allow DMA access to MCU MBOX SRAMs

### DIFF
--- a/sw-emulator/lib/bus/src/event.rs
+++ b/sw-emulator/lib/bus/src/event.rs
@@ -21,6 +21,8 @@ pub enum Device {
     TestSram,
     ExternalTestSram,
     RecoveryIntf,
+    McuMbox0Sram,
+    McuMbox1Sram,
     External(&'static str),
 }
 

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -23,6 +23,8 @@ use caliptra_emu_bus::{
 };
 use caliptra_emu_types::{RvAddr, RvData, RvSize};
 use const_random::const_random;
+use std::env;
+use std::sync::LazyLock;
 use std::{rc::Rc, sync::mpsc};
 
 pub type AxiAddr = u64;
@@ -55,10 +57,32 @@ impl AxiRootBus {
         const_random!(u64) & 0xffffffff_00000000;
     pub const RECOVERY_REGISTER_INTERFACE_END: AxiAddr =
         Self::RECOVERY_REGISTER_INTERFACE_OFFSET + 0xff;
-    pub const SS_MCI_OFFSET: AxiAddr = const_random!(u64) & 0xffffffff_00000000;
-    pub const SS_MCI_END: AxiAddr = Self::SS_MCI_OFFSET + 0x1454; // 0x1454 is last MCI register offset + size
-    pub const MCU_SRAM_OFFSET: AxiAddr = Self::SS_MCI_OFFSET + 0xc0_0000;
-    pub const MCU_SRAM_END: AxiAddr = Self::MCU_SRAM_OFFSET + 2 * 1024 * 1024 - 1; // the aperture size is 2 MB even though the underlying SRAM may be smaller
+
+    pub fn ss_mci_offset() -> AxiAddr {
+        *SS_MCI_OFFSET
+    }
+
+    pub fn ss_mci_end() -> AxiAddr {
+        *SS_MCI_OFFSET + 0x1454 // 0x1454 is last MCI register offset + size
+    }
+    pub fn mcu_sram_offset() -> AxiAddr {
+        *SS_MCI_OFFSET + 0xc0_0000
+    }
+    pub fn mcu_sram_end() -> AxiAddr {
+        Self::mcu_sram_offset() + 2 * 1024 * 1024 - 1
+    }
+    pub fn mcu_mbox0_sram_offset() -> AxiAddr {
+        *SS_MCI_OFFSET + 0x40_0000
+    }
+    pub fn mcu_mbox0_sram_end() -> AxiAddr {
+        Self::mcu_mbox0_sram_offset() + 0x20_0000 - 1
+    }
+    pub fn mcu_mbox1_sram_offset() -> AxiAddr {
+        *SS_MCI_OFFSET + 0x80_0000
+    }
+    pub fn mcu_mbox1_sram_end() -> AxiAddr {
+        Self::mcu_mbox1_sram_offset() + 0x20_0000 - 1
+    }
 
     pub const OTC_FC_OFFSET: AxiAddr = (const_random!(u64) & 0xffffffff_00000000) + 0x1000;
     pub const OTC_FC_END: AxiAddr = Self::OTC_FC_OFFSET + 0xfff;
@@ -110,22 +134,23 @@ impl AxiRootBus {
 
     pub fn must_schedule(&mut self, addr: AxiAddr) -> bool {
         if self.use_mcu_recovery_interface {
-            (matches!(addr, Self::MCU_SRAM_OFFSET..=Self::MCU_SRAM_END)
+            (addr >= Self::mcu_sram_offset() && addr <= Self::mcu_sram_end())
                 || matches!(
                     addr,
                     Self::EXTERNAL_TEST_SRAM_OFFSET..=Self::EXTERNAL_TEST_SRAM_END
                 )
+                || (addr >= Self::mcu_mbox0_sram_offset() && addr <= Self::mcu_mbox0_sram_end())
+                || (addr >= Self::mcu_mbox1_sram_offset() && addr <= Self::mcu_mbox1_sram_end())
                 || matches!(
                     addr,
                     Self::RECOVERY_REGISTER_INTERFACE_OFFSET
                         ..=Self::RECOVERY_REGISTER_INTERFACE_END
-                ))
+                )
         } else {
-            (matches!(addr, Self::MCU_SRAM_OFFSET..=Self::MCU_SRAM_END)
-                || matches!(
-                    addr,
-                    Self::EXTERNAL_TEST_SRAM_OFFSET..=Self::EXTERNAL_TEST_SRAM_END
-                ))
+            (addr >= Self::mcu_sram_offset() && addr <= Self::mcu_sram_end())
+                || (addr >= Self::mcu_mbox0_sram_offset() && addr <= Self::mcu_mbox0_sram_end())
+                || (addr >= Self::mcu_mbox1_sram_offset() && addr <= Self::mcu_mbox1_sram_end())
+                || (Self::EXTERNAL_TEST_SRAM_OFFSET..=Self::EXTERNAL_TEST_SRAM_END).contains(&addr)
         }
     }
 
@@ -134,58 +159,86 @@ impl AxiRootBus {
             println!("Cannot schedule read if previous DMA result has not been consumed");
             return Err(BusError::LoadAccessFault);
         }
-
-        match addr {
-            Self::MCU_SRAM_OFFSET..=Self::MCU_SRAM_END => {
-                let addr = addr - Self::MCU_SRAM_OFFSET;
-                if let Some(sender) = self.event_sender.as_mut() {
-                    sender
-                        .send(Event::new(
-                            Device::CaliptraCore,
-                            Device::MCU,
-                            EventData::MemoryRead {
-                                start_addr: addr as u32,
-                                len,
-                            },
-                        ))
-                        .unwrap();
-                }
-                Ok(())
+        if (Self::mcu_sram_offset()..=Self::mcu_sram_end()).contains(&addr) {
+            let addr = addr - Self::mcu_sram_offset();
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::MCU,
+                        EventData::MemoryRead {
+                            start_addr: addr as u32,
+                            len,
+                        },
+                    ))
+                    .unwrap();
             }
-            Self::EXTERNAL_TEST_SRAM_OFFSET..=Self::EXTERNAL_TEST_SRAM_END => {
-                let addr = addr - Self::EXTERNAL_TEST_SRAM_OFFSET;
-                println!("Sending read event for ExternalTestSram");
-                if let Some(sender) = self.event_sender.as_mut() {
-                    sender
-                        .send(Event::new(
-                            Device::CaliptraCore,
-                            Device::ExternalTestSram,
-                            EventData::MemoryRead {
-                                start_addr: addr as u32,
-                                len,
-                            },
-                        ))
-                        .unwrap();
-                }
-                Ok(())
+            Ok(())
+        } else if (Self::mcu_mbox0_sram_offset()..=Self::mcu_mbox0_sram_end()).contains(&addr) {
+            let addr = addr - Self::mcu_mbox0_sram_offset();
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::McuMbox0Sram,
+                        EventData::MemoryRead {
+                            start_addr: addr as u32,
+                            len,
+                        },
+                    ))
+                    .unwrap();
             }
-            Self::RECOVERY_REGISTER_INTERFACE_OFFSET..=Self::RECOVERY_REGISTER_INTERFACE_END => {
-                let addr = addr - Self::RECOVERY_REGISTER_INTERFACE_OFFSET;
-                if let Some(sender) = self.event_sender.as_mut() {
-                    sender
-                        .send(Event::new(
-                            Device::CaliptraCore,
-                            Device::RecoveryIntf,
-                            EventData::MemoryRead {
-                                start_addr: addr as u32,
-                                len,
-                            },
-                        ))
-                        .unwrap();
-                }
-                Ok(())
+            Ok(())
+        } else if (Self::mcu_mbox1_sram_offset()..=Self::mcu_mbox1_sram_end()).contains(&addr) {
+            let addr = addr - Self::mcu_mbox1_sram_offset();
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::McuMbox1Sram,
+                        EventData::MemoryRead {
+                            start_addr: addr as u32,
+                            len,
+                        },
+                    ))
+                    .unwrap();
             }
-            _ => Err(BusError::LoadAccessFault),
+            Ok(())
+        } else if (Self::EXTERNAL_TEST_SRAM_OFFSET..=Self::EXTERNAL_TEST_SRAM_END).contains(&addr) {
+            let addr = addr - Self::EXTERNAL_TEST_SRAM_OFFSET;
+            println!("Sending read event for ExternalTestSram");
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::ExternalTestSram,
+                        EventData::MemoryRead {
+                            start_addr: addr as u32,
+                            len,
+                        },
+                    ))
+                    .unwrap();
+            }
+            Ok(())
+        } else if (Self::RECOVERY_REGISTER_INTERFACE_OFFSET..=Self::RECOVERY_REGISTER_INTERFACE_END)
+            .contains(&addr)
+        {
+            let addr = addr - Self::RECOVERY_REGISTER_INTERFACE_OFFSET;
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::RecoveryIntf,
+                        EventData::MemoryRead {
+                            start_addr: addr as u32,
+                            len,
+                        },
+                    ))
+                    .unwrap();
+            }
+            Ok(())
+        } else {
+            Err(BusError::LoadAccessFault)
         }
     }
 
@@ -204,10 +257,6 @@ impl AxiRootBus {
                 let addr = (addr - Self::OTC_FC_OFFSET) as RvAddr;
                 return Bus::read(&mut self.otp_fc, size, addr);
             }
-            Self::SS_MCI_OFFSET..=Self::SS_MCI_END => {
-                let addr = (addr - Self::SS_MCI_OFFSET) as RvAddr;
-                return Bus::read(&mut self.mci, size, addr);
-            }
             Self::TEST_SRAM_OFFSET..=Self::TEST_SRAM_END => {
                 if let Some(test_sram) = self.test_sram.as_mut() {
                     let addr = (addr - Self::TEST_SRAM_OFFSET) as RvAddr;
@@ -216,24 +265,30 @@ impl AxiRootBus {
                     return Err(LoadAccessFault);
                 }
             }
-            Self::MCU_SRAM_OFFSET..=Self::MCU_SRAM_END => {
-                let addr = (addr - Self::MCU_SRAM_OFFSET) as RvAddr;
-                return Bus::read(&mut self.mcu_sram, size, addr);
-            }
             _ => {}
         };
+
+        if (Self::mcu_sram_offset()..=Self::mcu_sram_end()).contains(&addr) {
+            let addr = (addr - Self::mcu_sram_offset()) as RvAddr;
+            return Bus::read(&mut self.mcu_sram, size, addr);
+        } else if (*SS_MCI_OFFSET..=Self::mcu_sram_end()).contains(&addr) {
+            let addr = (addr - *SS_MCI_OFFSET) as RvAddr;
+            return Bus::read(&mut self.mci, size, addr);
+        }
 
         Err(LoadAccessFault)
     }
 
     pub fn write(&mut self, size: RvSize, addr: AxiAddr, val: RvData) -> Result<(), BusError> {
         match addr {
-            Self::SHA512_ACC_OFFSET..=Self::SHA512_ACC_END => self.sha512_acc.write(
-                size,
-                ((addr - Self::SHA512_ACC_OFFSET) & 0xffff_ffff) as u32,
-                val,
-            ),
-            Self::TEST_REG_OFFSET => Register::write(&mut self.reg, size, val),
+            Self::SHA512_ACC_OFFSET..=Self::SHA512_ACC_END => {
+                return self.sha512_acc.write(
+                    size,
+                    ((addr - Self::SHA512_ACC_OFFSET) & 0xffff_ffff) as u32,
+                    val,
+                )
+            }
+            Self::TEST_REG_OFFSET => return Register::write(&mut self.reg, size, val),
             Self::RECOVERY_REGISTER_INTERFACE_OFFSET..=Self::RECOVERY_REGISTER_INTERFACE_END => {
                 if self.use_mcu_recovery_interface {
                     if let Some(sender) = self.event_sender.as_mut() {
@@ -249,52 +304,85 @@ impl AxiRootBus {
                             ))
                             .unwrap();
                     }
-                    Ok(())
+                    return Ok(());
                 } else {
                     let addr = (addr - Self::RECOVERY_REGISTER_INTERFACE_OFFSET) as RvAddr;
-                    Bus::write(&mut self.recovery, size, addr, val)
-                }
-            }
-            Self::MCU_SRAM_OFFSET..=Self::MCU_SRAM_END => {
-                if let Some(sender) = self.event_sender.as_mut() {
-                    sender
-                        .send(Event::new(
-                            Device::CaliptraCore,
-                            Device::MCU,
-                            EventData::MemoryWrite {
-                                start_addr: (addr - Self::MCU_SRAM_OFFSET) as u32,
-                                data: val.to_le_bytes().to_vec(),
-                            },
-                        ))
-                        .unwrap();
-                }
-                // There is nothing responding to this events but we still want to see them happen.
-                // This is why we do both and event and a Bus::write
-                if !self.use_mcu_recovery_interface {
-                    let addr = (addr - Self::MCU_SRAM_OFFSET) as RvAddr;
-                    Bus::write(&mut self.mcu_sram, size, addr, val)
-                } else {
-                    Ok(())
+                    return Bus::write(&mut self.recovery, size, addr, val);
                 }
             }
             Self::OTC_FC_OFFSET..=Self::OTC_FC_END => {
                 let addr = (addr - Self::OTC_FC_OFFSET) as RvAddr;
-                Bus::write(&mut self.otp_fc, size, addr, val)
-            }
-            Self::SS_MCI_OFFSET..=Self::SS_MCI_END => {
-                let addr = (addr - Self::SS_MCI_OFFSET) as RvAddr;
-                Bus::write(&mut self.mci, size, addr, val)
+                return Bus::write(&mut self.otp_fc, size, addr, val);
             }
             Self::TEST_SRAM_OFFSET..=Self::TEST_SRAM_END => {
                 if let Some(test_sram) = self.test_sram.as_mut() {
                     let addr = (addr - Self::TEST_SRAM_OFFSET) as RvAddr;
-                    Bus::write(test_sram, size, addr, val)
+                    return Bus::write(test_sram, size, addr, val);
                 } else {
-                    Err(StoreAccessFault)
+                    return Err(StoreAccessFault);
                 }
             }
-            _ => Err(StoreAccessFault),
+            _ => {}
+        };
+        if (Self::mcu_sram_offset()..=Self::mcu_sram_end()).contains(&addr) {
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::MCU,
+                        EventData::MemoryWrite {
+                            start_addr: (addr - Self::mcu_sram_offset()) as u32,
+                            data: val.to_le_bytes().to_vec(),
+                        },
+                    ))
+                    .unwrap();
+            }
+            // There is nothing responding to this events but we still want to see them happen.
+            // This is why we do both and event and a Bus::write
+            if !self.use_mcu_recovery_interface {
+                let addr = (addr - Self::mcu_sram_offset()) as RvAddr;
+                return Bus::write(&mut self.mcu_sram, size, addr, val);
+            } else {
+                return Ok(());
+            }
+        } else if (Self::mcu_mbox0_sram_offset()..=Self::mcu_mbox0_sram_end()).contains(&addr) {
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::McuMbox0Sram,
+                        EventData::MemoryWrite {
+                            start_addr: (addr - Self::mcu_mbox0_sram_offset()) as u32,
+                            data: val.to_le_bytes().to_vec(),
+                        },
+                    ))
+                    .unwrap();
+            }
+            // There is nothing responding to this events but we still want to see them happen.
+            // This is why we do both and event and a Bus::write
+            return Ok(());
+        } else if (Self::mcu_mbox1_sram_offset()..=Self::mcu_mbox1_sram_end()).contains(&addr) {
+            if let Some(sender) = self.event_sender.as_mut() {
+                sender
+                    .send(Event::new(
+                        Device::CaliptraCore,
+                        Device::McuMbox1Sram,
+                        EventData::MemoryWrite {
+                            start_addr: (addr - Self::mcu_mbox1_sram_offset()) as u32,
+                            data: val.to_le_bytes().to_vec(),
+                        },
+                    ))
+                    .unwrap();
+            }
+            // There is nothing responding to this events but we still want to see them happen.
+            // This is why we do both and event and a Bus::write
+            return Ok(());
+        } else if (*SS_MCI_OFFSET..=Self::mcu_sram_end()).contains(&addr) {
+            let addr = (addr - *SS_MCI_OFFSET) as RvAddr;
+            return Bus::write(&mut self.mci, size, addr, val);
         }
+
+        Err(StoreAccessFault)
     }
 
     pub fn send_get_recovery_indirect_fifo_status(&mut self) {
@@ -339,5 +427,21 @@ impl AxiRootBus {
     pub fn register_outgoing_events(&mut self, sender: mpsc::Sender<Event>) {
         self.event_sender = Some(sender.clone());
         self.recovery.register_outgoing_events(sender);
+    }
+}
+
+static SS_MCI_OFFSET: LazyLock<AxiAddr> = LazyLock::new(|| {
+    if let Ok(s) = env::var("CPTRA_EMULATOR_SS_MCI_OFFSET") {
+        parse_u64(&s)
+    } else {
+        const_random!(u64) & 0xffffffff_00000000
+    }
+});
+fn parse_u64(s: &str) -> u64 {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16).unwrap()
+    } else {
+        s.parse::<u64>().unwrap()
     }
 }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -918,7 +918,7 @@ impl SocRegistersImpl {
         let otc_fc_offset = crate::dma::axi_root_bus::AxiRootBus::OTC_FC_OFFSET;
         // To make things easy the fuse bank is part of the fuse bank controller emulation
         let uds_seed_offset = otc_fc_offset + crate::dma::otp_fc::FuseController::FUSE_BANK_OFFSET;
-        let mci_base = crate::dma::axi_root_bus::AxiRootBus::SS_MCI_OFFSET;
+        let mci_base = crate::dma::axi_root_bus::AxiRootBus::ss_mci_offset();
         let ss_prod_dbg_unlock_fuse_offset = crate::mci::MciRegs::SS_MANUF_DBG_UNLOCK_FUSE_OFFSET;
         let ss_prod_dbg_unlock_number_of_fuses =
             crate::mci::MciRegs::SS_MANUF_DBG_UNLOCK_NUMBER_OF_FUSES;


### PR DESCRIPTION
Add MCU MBOX SRAM DMA address ranges in AXI root bus. This allows Caliptra to access MCU MBOX SRAMs through DMA.

Allow MCI_OFFSET base address to be set by an external compiler. Currently the MCI_OFFSET is randomly assigned at compilation. However, in some cases, the MCI_OFFSET should be known before compilation. For example, when creating the authentication manifest, the load_address or staging_address may refer to MCU MBOX SRAM which is some offsets away from the MCI_OFFSET, therefore the MCI offset should be already known before creating the authentication manifest. To allow this, allow the external compiler to pass the desired MCI_OFFSET through an  environment variable. If the environment variable is not set, then the SS_MCI_OFFSET will be assigned randomly.