### PR TITLE
[fix] MLDSA driver fix

### DIFF
--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -152,12 +152,6 @@ impl Mldsa87 {
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
 
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
         // Copy seed to the hardware
         match seed {
             Mldsa87Seed::Array4x8(arr) => arr.write_to_reg(mldsa.seed()),
@@ -222,12 +216,6 @@ impl Mldsa87 {
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
 
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
         // Copy seed or the private key to the hardware
         match seed {
             Mldsa87Seed::Array4x8(arr) => arr.write_to_reg(mldsa.seed()),
@@ -268,7 +256,9 @@ impl Mldsa87 {
         // Copy signature
         let signature = Mldsa87Signature::read_from_reg(mldsa.signature());
 
-        // No need to zeroize here, as the hardware will be zeroized by verify.
+        // Clear the hardware.
+        mldsa.ctrl().write(|w| w.zeroize(true));
+
         let result = self.verify(pub_key, msg, &signature)?;
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
@@ -336,12 +326,6 @@ impl Mldsa87 {
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
 
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
         // Sign RND.
         sign_rnd.write_to_reg(mldsa.sign_rnd());
 
@@ -380,7 +364,9 @@ impl Mldsa87 {
         // Copy signature
         let signature = Mldsa87Signature::read_from_reg(mldsa.signature());
 
-        // No need to zeroize here, as the hardware will be zeroized by verify.
+        // Clear the hardware.
+        mldsa.ctrl().write(|w| w.zeroize(true));
+
         let result = self.verify_var(pub_key, msg, &signature)?;
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
@@ -390,42 +376,51 @@ impl Mldsa87 {
         }
     }
 
-    /// Verify the signature with specified public key and message.
-    ///
-    /// # Arguments
-    ///
-    /// * `pub_key` - Public key.
-    /// * `msg` - Message to verify.
-    /// * `signature` - Signature to verify.
-    ///
-    /// # Result
-    ///
-    /// *  `Mldsa87Result` - Mldsa87Result::Success if the signature verification passed else an error code.
-    fn verify_res(
+    /// Common setup for verification functions
+    /// Returns the truncated signature for later comparison
+    fn verify_common_setup(
         &mut self,
         pub_key: &Mldsa87PubKey,
-        msg: &Mldsa87Msg,
         signature: &Mldsa87Signature,
-    ) -> CaliptraResult<Mldsa87VerifyRes> {
+    ) -> CaliptraResult<[u32; MLDSA87_VERIFY_RES_WORD_LEN]> {
+        #[cfg(feature = "fips-test-hooks")]
+        unsafe {
+            crate::FipsTestHook::error_if_hook_set(crate::FipsTestHook::MLDSA_VERIFY_FAILURE)?
+        }
+
+        let truncated_signature = &signature.0[..MLDSA87_VERIFY_RES_WORD_LEN];
+        let empty_verify_res = [0; MLDSA87_VERIFY_RES_WORD_LEN];
+        if truncated_signature == empty_verify_res {
+            Err(CaliptraError::DRIVER_MLDSA87_UNSUPPORTED_SIGNATURE)?;
+        }
+        cfi_assert_ne_16_words(truncated_signature.try_into().unwrap(), &empty_verify_res);
+
         let mldsa = self.mldsa87.regs_mut();
 
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
-        // Copy digest
-        msg.write_to_reg(mldsa.msg());
 
         // Copy pubkey
         pub_key.write_to_reg(mldsa.pubkey());
 
         // Copy signature
         signature.write_to_reg(mldsa.signature());
+
+        Ok(truncated_signature.try_into().unwrap())
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    pub fn verify(
+        &mut self,
+        pub_key: &Mldsa87PubKey,
+        msg: &Mldsa87Msg,
+        signature: &Mldsa87Signature,
+    ) -> CaliptraResult<Mldsa87Result> {
+        let truncated_signature = self.verify_common_setup(pub_key, signature)?;
+        let mldsa = self.mldsa87.regs_mut();
+
+        // Copy the message
+        msg.write_to_reg(mldsa.msg());
 
         // Program the command register for signature verification
         mldsa.ctrl().write(|w| w.ctrl(|w| w.verifying()));
@@ -439,32 +434,8 @@ impl Mldsa87 {
         // Clear the hardware when done
         mldsa.ctrl().write(|w| w.zeroize(true));
 
-        Ok(verify_res)
-    }
-
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn verify(
-        &mut self,
-        pub_key: &Mldsa87PubKey,
-        msg: &Mldsa87Msg,
-        signature: &Mldsa87Signature,
-    ) -> CaliptraResult<Mldsa87Result> {
-        #[cfg(feature = "fips-test-hooks")]
-        unsafe {
-            crate::FipsTestHook::error_if_hook_set(crate::FipsTestHook::MLDSA_VERIFY_FAILURE)?
-        }
-
-        let truncated_signature = &signature.0[..MLDSA87_VERIFY_RES_WORD_LEN];
-        let empty_verify_res = [0; MLDSA87_VERIFY_RES_WORD_LEN];
-        if truncated_signature == empty_verify_res {
-            Err(CaliptraError::DRIVER_MLDSA87_UNSUPPORTED_SIGNATURE)?;
-        }
-        cfi_assert_ne_16_words(truncated_signature.try_into().unwrap(), &empty_verify_res);
-
-        let verify_res = self.verify_res(pub_key, msg, signature)?;
-
         let result = if verify_res.0 == truncated_signature {
-            cfi_assert_eq_16_words(&verify_res.0, &truncated_signature.try_into().unwrap());
+            cfi_assert_eq_16_words(&verify_res.0, &truncated_signature);
             Mldsa87Result::Success
         } else {
             Mldsa87Result::SigVerifyFailed
@@ -480,34 +451,8 @@ impl Mldsa87 {
         msg: &[u8],
         signature: &Mldsa87Signature,
     ) -> CaliptraResult<Mldsa87Result> {
-        #[cfg(feature = "fips-test-hooks")]
-        unsafe {
-            crate::FipsTestHook::error_if_hook_set(crate::FipsTestHook::MLDSA_VERIFY_FAILURE)?
-        }
-
-        let truncated_signature = &signature.0[..MLDSA87_VERIFY_RES_WORD_LEN];
-        let empty_verify_res = [0; MLDSA87_VERIFY_RES_WORD_LEN];
-        if truncated_signature == empty_verify_res {
-            Err(CaliptraError::DRIVER_MLDSA87_UNSUPPORTED_SIGNATURE)?;
-        }
-        cfi_assert_ne_16_words(truncated_signature.try_into().unwrap(), &empty_verify_res);
-
+        let truncated_signature = self.verify_common_setup(pub_key, signature)?;
         let mldsa = self.mldsa87.regs_mut();
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
-        // Copy pubkey
-        pub_key.write_to_reg(mldsa.pubkey());
-
-        // Copy signature
-        signature.write_to_reg(mldsa.signature());
 
         // Program the command register for signature verification with streaming
         mldsa
@@ -524,7 +469,7 @@ impl Mldsa87 {
         mldsa.ctrl().write(|w| w.zeroize(true));
 
         let result = if verify_res.0 == truncated_signature {
-            cfi_assert_eq_16_words(&verify_res.0, &truncated_signature.try_into().unwrap());
+            cfi_assert_eq_16_words(&verify_res.0, &truncated_signature);
             Mldsa87Result::Success
         } else {
             Mldsa87Result::SigVerifyFailed
@@ -546,12 +491,6 @@ impl Mldsa87 {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn pcr_sign_flow(&mut self, trng: &mut Trng) -> CaliptraResult<Mldsa87Signature> {
         let mldsa = self.mldsa87.regs_mut();
-
-        // Wait for hardware ready
-        Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;
-
-        // Clear the hardware before start
-        mldsa.ctrl().write(|w| w.zeroize(true));
 
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.status().read().ready())?;

--- a/sw-emulator/lib/periph/src/ml_dsa87.rs
+++ b/sw-emulator/lib/periph/src/ml_dsa87.rs
@@ -307,7 +307,7 @@ impl Mldsa87 {
             privkey_out: [0; ML_DSA87_PRIVKEY_SIZE / 4],
             privkey_in: [0; ML_DSA87_PRIVKEY_SIZE / 4],
             kv_rd_seed_ctrl: ReadWriteRegister::new(0),
-            kv_rd_seed_status: ReadOnlyRegister::new(0),
+            kv_rd_seed_status: ReadOnlyRegister::new(KvRdSeedStatus::READY::SET.value),
             error_global_intr: ReadOnlyRegister::new(0),
             error_internal_intr: ReadOnlyRegister::new(0),
             private_key: [0; ML_DSA87_PRIVKEY_SIZE],


### PR DESCRIPTION
An update to the MLDSA peripheral requires it to be zeroized after each cryptographic operation—key generation, signing, and verification. To comply with this change, the MLDSA driver must perform a zeroize operation immediately after signing, before proceeding to signature verification.