### PR TITLE
Allow PL0 to use context slots reserved for PL1

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1090,11 +1090,11 @@ InvokeDpe mailbox command calling the DeriveContext or InitializeContext DPE
 commands. However, a caller could easily exhaust space in DPE's context array
 by repeatedly calling the aforementioned DPE commands with certain flags set.
 
-To prevent this, we establish active context limits for each PAUSER
-privilege level:
+To prevent this, we establish non-inactive (including active and retired) context
+limits based on PAUSER privilege level:
 
-* PL0 - 16 active contexts
-* PL1 - 16 active contexts
+* Total (PL0 + PL1) - 32 non-inactive contexts
+* PL1 - 16 non-inactive contexts
 
 If a DPE command were to activate a new context such that the total number of
 active contexts in a privilege level is above its active context limit, the

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -19,8 +19,8 @@ pub use crate::fips::{fips_self_test_cmd, fips_self_test_cmd::SelfTestStatus};
 
 use crate::{
     dice, CptraDpeTypes, DisableAttestationCmd, DpeCrypto, DpePlatform, Mailbox, DPE_SUPPORT,
-    MAX_CERT_CHAIN_SIZE, PL0_DPE_ACTIVE_CONTEXT_THRESHOLD, PL0_PAUSER_FLAG,
-    PL1_DPE_ACTIVE_CONTEXT_THRESHOLD,
+    MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG,
+    PL1_DPE_ACTIVE_CONTEXT_THRESHOLD, TOTAL_DPE_ACTIVE_CONTEXT_THRESHOLD,
 };
 
 use arrayvec::ArrayVec;
@@ -560,10 +560,12 @@ impl Drivers {
             .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?
             - used_pl0_dpe_context_count;
 
+        let total_used_dpe_context_count = used_pl0_dpe_context_count + used_pl1_dpe_context_count;
+
         match (
             caller_privilege_level,
             used_pl1_dpe_context_count.cmp(&PL1_DPE_ACTIVE_CONTEXT_THRESHOLD),
-            used_pl0_dpe_context_count.cmp(&PL0_DPE_ACTIVE_CONTEXT_THRESHOLD),
+            total_used_dpe_context_count.cmp(&TOTAL_DPE_ACTIVE_CONTEXT_THRESHOLD),
         ) {
             (PauserPrivileges::PL1, Equal, _) => {
                 Err(CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -119,8 +119,8 @@ pub const DPE_SUPPORT: Support = Support::all();
 pub const MAX_CERT_CHAIN_SIZE: usize = 4096;
 
 pub const PL0_PAUSER_FLAG: u32 = 1;
-pub const PL0_DPE_ACTIVE_CONTEXT_THRESHOLD: usize = 16;
 pub const PL1_DPE_ACTIVE_CONTEXT_THRESHOLD: usize = 16;
+pub const TOTAL_DPE_ACTIVE_CONTEXT_THRESHOLD: usize = 32;
 
 const RESERVED_PAUSER: u32 = 0xFFFFFFFF;
 


### PR DESCRIPTION
The original limitation of maximum 16 contexts in each PL already cannot satisfy some complicated SoCs' requirements, which have of a large number of different TCBs in its identity. As a temporary mitigation, this patch allows the PL0 user to take those memory (context array) reserved for PL1 contexts. After this, the PL0 user can have up to (32 - 1) contexts (minus 1 because RT journey always occupies one contexts in PL1). Although this opens the possibility that the PL0 user can deny the DPE service for PL1 users, it is acceptable because PL0 user should be the SoC manager.

This also fixes the inaccurate description in `runtime/README.md`, where the context limit is actually applied to the summation of both active and retired contexts. Even if the user only retains one active context, there could be a lot of retired parent contexts occupying the context array.

Testing: `cargo test` passed.