### PR TITLE
[fix] AXI mbox user warm reset fix

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -316,6 +316,7 @@ fn trace_path_or_env(trace_path: Option<PathBuf>) -> Option<PathBuf> {
     std::env::var("CPTRA_TRACE_PATH").ok().map(PathBuf::from)
 }
 
+#[derive(Clone)]
 pub struct BootParams<'a> {
     pub fuses: Fuses,
     pub fw_image: Option<&'a [u8]>,
@@ -710,11 +711,38 @@ pub trait HwModel: SocManager {
     fn trng_mode(&self) -> TrngMode;
 
     /// Trigger a warm reset and advance the boot
-    fn warm_reset_flow(&mut self, fuses: &Fuses) {
+    fn warm_reset_flow(&mut self, boot_params: &BootParams) -> Result<(), Box<dyn Error>>
+    where
+        Self: Sized,
+    {
         self.warm_reset();
 
-        HwModel::init_fuses(self, fuses);
+        HwModel::init_fuses(self, &boot_params.fuses);
+
+        // Set the registers that were cleared by the warm reset.
+        self.soc_ifc()
+            .cptra_dbg_manuf_service_reg()
+            .write(|_| boot_params.initial_dbg_manuf_service_reg);
+
+        if let Some(reg) = boot_params.initial_repcnt_thresh_reg {
+            self.soc_ifc()
+                .cptra_i_trng_entropy_config_1()
+                .write(|_| reg);
+        }
+
+        if let Some(reg) = boot_params.initial_adaptp_thresh_reg {
+            self.soc_ifc()
+                .cptra_i_trng_entropy_config_0()
+                .write(|_| reg);
+        }
+
+        // Set up the PAUSER as valid for the mailbox (using index 0)
+        self.setup_mailbox_users(boot_params.valid_axi_user.as_slice())
+            .map_err(ModelError::from)?;
+
         self.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
+
+        Ok(())
     }
 
     /// The APB bus from the SoC to Caliptra

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -935,7 +935,7 @@ impl SocRegistersImpl {
             cptra_flow_status: ReadWriteRegister::new(flow_status.get()),
             cptra_reset_reason: ReadOnlyRegister::new(0),
             cptra_security_state: ReadOnlyRegister::new(args.security_state.into()),
-            cptra_mbox_valid_axi_user: Default::default(),
+            cptra_mbox_valid_axi_user: [0xffff_ffff; CPTRA_MBOX_VALID_PAUSER_SIZE / 4],
             cptra_mbox_axi_user_lock: Default::default(),
             cptra_trng_valid_axi_user: ReadWriteRegister::new(0),
             cptra_trng_axi_user_lock: ReadWriteRegister::new(0),
@@ -1469,6 +1469,16 @@ impl SocRegistersImpl {
         self.cptra_flow_status
             .reg
             .write(FlowStatus::READY_FOR_FUSES::SET);
+
+        // Unlock the mailbox axi user lock.
+        for reg in self.cptra_mbox_axi_user_lock.iter_mut() {
+            *reg = 0;
+        }
+
+        // Reset the axi user.
+        for reg in self.cptra_mbox_valid_axi_user.iter_mut() {
+            *reg = 0xffffffff;
+        }
 
         self.reset_common();
     }

--- a/test/tests/caliptra_integration_tests/warm_reset.rs
+++ b/test/tests/caliptra_integration_tests/warm_reset.rs
@@ -29,22 +29,25 @@ fn warm_reset_basic() {
 
     let (vendor_pk_desc_hash, owner_pk_hash) = image_pk_desc_hash(&image.manifest);
 
+    let binding = image.to_bytes().unwrap();
+    let boot_params = BootParams {
+        fuses: Fuses {
+            vendor_pk_hash: vendor_pk_desc_hash,
+            owner_pk_hash,
+            fw_svn: [0x7F, 0, 0, 0], // Equals 7
+            ..Default::default()
+        },
+        fw_image: Some(&binding),
+        ..Default::default()
+    };
+
     let mut hw = caliptra_hw_model::new(
         InitParams {
             rom: &rom,
             security_state,
             ..Default::default()
         },
-        BootParams {
-            fuses: Fuses {
-                vendor_pk_hash: vendor_pk_desc_hash,
-                owner_pk_hash,
-                fw_svn: [0x7F, 0, 0, 0], // Equals 7
-                ..Default::default()
-            },
-            fw_image: Some(&image.to_bytes().unwrap()),
-            ..Default::default()
-        },
+        boot_params.clone(),
     )
     .unwrap();
 
@@ -54,12 +57,7 @@ fn warm_reset_basic() {
     }
 
     // Perform warm reset
-    hw.warm_reset_flow(&Fuses {
-        vendor_pk_hash: vendor_pk_desc_hash,
-        owner_pk_hash,
-        fw_svn: [0x7F, 0, 0, 0], // Equals 7
-        ..Default::default()
-    });
+    hw.warm_reset_flow(&boot_params).unwrap();
 
     // Wait for boot
     while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {
@@ -86,22 +84,24 @@ fn warm_reset_during_fw_load() {
 
     let (vendor_pk_desc_hash, owner_pk_hash) = image_pk_desc_hash(&image.manifest);
 
+    let boot_params = BootParams {
+        fuses: Fuses {
+            vendor_pk_hash: vendor_pk_desc_hash,
+            owner_pk_hash,
+            fw_svn: [0x7F, 0, 0, 0], // Equals 7
+            ..Default::default()
+        },
+        fw_image: None,
+        ..Default::default()
+    };
+
     let mut hw = caliptra_hw_model::new(
         InitParams {
             rom: &rom,
             security_state,
             ..Default::default()
         },
-        BootParams {
-            fuses: Fuses {
-                vendor_pk_hash: vendor_pk_desc_hash,
-                owner_pk_hash,
-                fw_svn: [0x7F, 0, 0, 0], // Equals 7
-                ..Default::default()
-            },
-            fw_image: None,
-            ..Default::default()
-        },
+        boot_params.clone(),
     )
     .unwrap();
 
@@ -122,12 +122,7 @@ fn warm_reset_during_fw_load() {
     hw.soc_mbox().execute().write(|w| w.execute(true));
 
     // Perform warm reset while ROM is executing the firmware load
-    hw.warm_reset_flow(&Fuses {
-        vendor_pk_hash: vendor_pk_desc_hash,
-        owner_pk_hash,
-        fw_svn: [0x7F, 0, 0, 0], // Equals 7
-        ..Default::default()
-    });
+    hw.warm_reset_flow(&boot_params).unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {


### PR DESCRIPTION
This update modifies the emulator to reset the MBOX AXI users and their locks during a warm reset. It also enhances the warm reset integration tests to reprogram the AXI users and their locks afterward.