### PR TITLE
[Fix] Restore FMC & RT Firmware Versions on Warm Reset

### DIFF
--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -1,15 +1,20 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::SocManager;
-use caliptra_builder::firmware::FMC_WITH_UART;
-use caliptra_builder::firmware::{APP_WITH_UART, ROM_WITH_UART};
-use caliptra_builder::ImageOptions;
-use caliptra_common::mailbox_api::CommandId;
-use caliptra_common::RomBootStatus::*;
+use caliptra_api::{
+    mailbox::{FipsVersionResp, MailboxReqHeader, MailboxRespHeader},
+    SocManager,
+};
+use caliptra_builder::{
+    firmware::{APP_WITH_UART, FMC_WITH_UART, ROM_WITH_UART},
+    version, ImageOptions,
+};
+use caliptra_common::{fips::FipsVersionCmd, mailbox_api::CommandId, RomBootStatus::*};
 use caliptra_drivers::CaliptraError;
-use caliptra_hw_model::DeviceLifecycle;
-use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
+use caliptra_hw_model::{
+    BootParams, DefaultHwModel, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState,
+};
 use caliptra_test::image_pk_desc_hash;
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::helpers;
 
@@ -221,4 +226,132 @@ fn test_warm_reset_during_update_reset() {
             u32::from(CaliptraError::ROM_WARM_RESET_UNSUCCESSFUL_PREVIOUS_UPDATE_RESET)
         );
     }
+}
+
+const HW_REV_ID: u32 = 0x102;
+
+fn test_version(
+    hw: &mut DefaultHwModel,
+    hw_rev: u32,
+    rom_version: u32,
+    fmc_version: u32,
+    app_version: u32,
+) {
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::VERSION), &[]),
+    };
+
+    let response = hw
+        .mailbox_execute(CommandId::VERSION.into(), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+
+    let version_resp = FipsVersionResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+    // Verify response checksum
+    assert!(caliptra_common::checksum::verify_checksum(
+        version_resp.hdr.chksum,
+        0x0,
+        &version_resp.as_bytes()[core::mem::size_of_val(&version_resp.hdr.chksum)..],
+    ));
+
+    // Verify FIPS status
+    assert_eq!(
+        version_resp.hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    // Verify Version Info
+    assert_eq!(version_resp.mode, FipsVersionCmd::MODE);
+
+    // fips_rev[0] is hw_rev_id
+    // fips_rev[1] is FMC version at 31:16 and ROM version at 15:0
+    // fips_rev[2] is app (fw) version
+    let received_hw_rev = version_resp.fips_rev[0];
+    let received_rom_version = version_resp.fips_rev[1] & 0x0000FFFF;
+    let received_fmc_version = (version_resp.fips_rev[1] & 0xFFFF0000) >> 16;
+    let received_app_version = version_resp.fips_rev[2];
+
+    assert_eq!(received_hw_rev, hw_rev);
+    assert_eq!(received_rom_version, rom_version);
+    assert_eq!(received_fmc_version, fmc_version);
+    assert_eq!(received_app_version, app_version);
+    let name = &version_resp.name[..];
+    assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
+}
+
+#[test]
+fn test_warm_reset_version() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let fmc_version = 3;
+    let app_version = 5;
+
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions {
+            fmc_version,
+            app_version,
+            fw_svn: 9,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let (vendor_pk_desc_hash, owner_pk_hash) = image_pk_desc_hash(&image.manifest);
+
+    let binding = image.to_bytes().unwrap();
+    let boot_params = BootParams {
+        fuses: Fuses {
+            vendor_pk_hash: vendor_pk_desc_hash,
+            owner_pk_hash,
+            fw_svn: [0x7F, 0, 0, 0], // Equals 7
+            ..Default::default()
+        },
+        fw_image: Some(&binding),
+        ..Default::default()
+    };
+
+    let mut hw = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            security_state,
+            ..Default::default()
+        },
+        boot_params.clone(),
+    )
+    .unwrap();
+
+    // Wait for boot
+    while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {
+        hw.step();
+    }
+
+    test_version(
+        &mut hw,
+        HW_REV_ID,
+        version::get_rom_version().into(),
+        fmc_version.into(),
+        app_version,
+    );
+
+    // Perform warm reset
+    hw.warm_reset_flow(&boot_params).unwrap();
+
+    // Wait for boot
+    while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {
+        hw.step();
+    }
+
+    test_version(
+        &mut hw,
+        HW_REV_ID,
+        version::get_rom_version().into(),
+        fmc_version.into(),
+        app_version,
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -74,6 +74,7 @@ fn test_fw_version() {
 #[test]
 fn test_update() {
     let image_options = ImageOptions {
+        fmc_version: DEFAULT_FMC_VERSION,
         app_version: 0xaabbccdd,
         pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()


### PR DESCRIPTION
During a warm reset, the cptra_fw_rev_id registers are cleared, causing RT commands such as VERSION to return a firmware version of 0. This update re-applies the FMC and RT firmware versions during RT initialization by reading them from the manifest stored in DCCM.

This is a temporary workaround until the hardware update planned for version 2.2 addresses the issue more robustly.