### PR TITLE
[model] expose default LC token

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -79,6 +79,8 @@ pub use model_fpga_realtime::OpenOcdError;
 pub use model_fpga_subsystem::ModelFpgaSubsystem;
 #[cfg(feature = "fpga_subsystem")]
 pub use model_fpga_subsystem::XI3CWrapper;
+#[cfg(feature = "fpga_subsystem")]
+pub use model_fpga_subsystem::DEFAULT_LIFECYCLE_RAW_TOKEN;
 
 /// Ideally, general-purpose functions would return `impl HwModel` instead of
 /// `DefaultHwModel` to prevent users from calling functions that aren't

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -142,7 +142,7 @@ const I3C_CLK_HZ: u32 = 12_500_000;
 const FPGA_ITRNG_FIFO_SIZE: usize = 1024;
 
 // This is a random number, but should be kept in sync with what is the default value in the FPGA ROM.
-const DEFAULT_LIFECYCLE_RAW_TOKEN: LifecycleToken =
+pub const DEFAULT_LIFECYCLE_RAW_TOKEN: LifecycleToken =
     LifecycleToken(0x05edb8c608fcc830de181732cfd65e57u128.to_le_bytes());
 
 const DEFAULT_LIFECYCLE_RAW_TOKENS: LifecycleRawTokens = LifecycleRawTokens {


### PR DESCRIPTION
This exposes the default LC tokens programmed into OTP so they can be used by downstream FPGA E2E test cases that excercise LC state transitions.