### PR TITLE
[jtag] refactor JTAG TAP code to work with all TAPs

### DIFF
--- a/hw-model/src/jtag.rs
+++ b/hw-model/src/jtag.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache-2.0 license
+
+#![allow(dead_code)]
+
+pub trait JtagAccessibleReg {
+    fn byte_offset(&self) -> u32;
+
+    /// Converts the register's byte offset into a word offset for use with DMI.
+    fn word_offset(&self) -> u32 {
+        const BYTES_PER_WORD: u32 = std::mem::size_of::<u32>() as u32;
+        assert_eq!(self.byte_offset() % BYTES_PER_WORD, 0);
+        self.byte_offset() / BYTES_PER_WORD
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(u32)]
+pub enum CaliptraCoreReg {
+    MboxDlen = 0x50,
+    MboxDout = 0x51,
+    MboxStatus = 0x52,
+    CptraHwErrrorEnc = 0x54,
+    CptraFwErrorEnc = 0x55,
+    SsUdsSeedBaseAddrH = 0x57,
+    HwFatalError = 0x58,
+    FwFatalError = 0x59,
+    HwNonFatalError = 0x5a,
+    FwNonFatalError = 0x5b,
+    CptraDbgManufServiceReg = 0x60,
+    BootfsmGo = 0x61,
+    SsDebugIntent = 0x63,
+    SsCaliptraBaseAddrL = 0x64,
+    SsCaliptraBaseAddrH = 0x65,
+    SsMciBaseAddrL = 0x66,
+    SsMciBaseAddrH = 0x67,
+    SsRecoveryIfcBaseAddrL = 0x68,
+    SsRecoveryIfcBaseAddrH = 0x69,
+    SsOtpFcBaseAddrL = 0x6A,
+    SsOtpFcBaseAddrH = 0x6B,
+    SsStrapGeneric0 = 0x6C,
+    SsStrapGeneric1 = 0x6D,
+    SsStrapGeneric2 = 0x6E,
+    SsStrapGeneric3 = 0x6F,
+    SsDbgManufServiceRegReq = 0x70,
+    SsDbgManufServiceRegRsp = 0x71,
+    SsDbgUnlockLevel0 = 0x72,
+    SsDbgUnlockLevel1 = 0x73,
+    SsStrapCaliptraDmaAxiUser = 0x74,
+    MboxLock = 0x75,
+    MboxCmd = 0x76,
+    MboxExecute = 0x77,
+}
+
+impl JtagAccessibleReg for CaliptraCoreReg {
+    fn byte_offset(&self) -> u32 {
+        *self as u32
+    }
+}

--- a/hw-model/src/lcc.rs
+++ b/hw-model/src/lcc.rs
@@ -2,6 +2,8 @@
 
 use bitflags::bitflags;
 
+use crate::jtag::JtagAccessibleReg;
+
 #[derive(Clone, Copy, Debug)]
 #[repr(u32)]
 pub enum LcCtrlReg {
@@ -42,16 +44,9 @@ pub enum LcCtrlReg {
     ManufState7 = 0x88,
 }
 
-impl LcCtrlReg {
-    pub fn byte_offset(&self) -> u32 {
+impl JtagAccessibleReg for LcCtrlReg {
+    fn byte_offset(&self) -> u32 {
         *self as u32
-    }
-
-    /// Converts the register's byte offset into a word offset for use with DMI.
-    pub fn word_offset(&self) -> u32 {
-        const BYTES_PER_WORD: u32 = std::mem::size_of::<u32>() as u32;
-        assert_eq!(self.byte_offset() % BYTES_PER_WORD, 0);
-        self.byte_offset() / BYTES_PER_WORD
     }
 }
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -33,6 +33,7 @@ use sha2::Digest;
 
 mod bmc;
 mod fpga_regs;
+mod jtag;
 pub mod lcc;
 pub mod mmio;
 mod model_emulated;

--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, ensure, Context, Result};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::lcc::LcCtrlReg;
+use crate::jtag::JtagAccessibleReg;
 use crate::openocd::openocd_server::{OpenOcdError, OpenOcdServer};
 
 /// Available JTAG TAPs in Calitpra Subsystem.
@@ -115,9 +115,9 @@ impl OpenOcdJtagTap {
         self.jtag_tap
     }
 
-    pub fn read_lc_ctrl_reg(&mut self, reg: &LcCtrlReg) -> Result<u32> {
+    pub fn read_reg(&mut self, reg: &dyn JtagAccessibleReg) -> Result<u32> {
         ensure!(
-            matches!(self.jtag_tap, JtagTap::LccTap),
+            self.jtag_tap != JtagTap::NoTap,
             JtagError::Tap(self.jtag_tap)
         );
         let reg_offset = reg.word_offset();
@@ -137,9 +137,9 @@ impl OpenOcdJtagTap {
         Ok(value)
     }
 
-    pub fn write_lc_ctrl_reg(&mut self, reg: &LcCtrlReg, value: u32) -> Result<()> {
+    pub fn write_reg(&mut self, reg: &dyn JtagAccessibleReg, value: u32) -> Result<()> {
         ensure!(
-            matches!(self.jtag_tap, JtagTap::LccTap),
+            self.jtag_tap != JtagTap::NoTap,
             JtagError::Tap(self.jtag_tap)
         );
         let reg_offset = reg.word_offset();


### PR DESCRIPTION
Previously, the JTAG TAP only had functions to read and write LCC registers, i.e. when connected to the LCC TAP. This updates the TAP logic to enable connecting to the Caliptra Core TAP as well.