### PR TITLE
fpga: Support FE programming command test

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -306,6 +306,8 @@ jobs:
               -E 'package(ureg-schema)'
               -E 'package(ureg-systemrdl)'
           )
+          # Disabled due to runtime flakiness
+          # -E 'test(test_fe_programming::test_fe_programming_cmd)'
 
           cargo-nextest nextest list \
               "${COMMON_ARGS[@]}" \

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -264,7 +264,6 @@ jobs:
                        test(test_authorize_and_stash::test_authorize_from_load_address_incorrect_digest) |
                        test(test_authorize_and_stash::test_authorize_from_staging_address) |
                        test(test_authorize_and_stash::test_authorize_from_staging_address_incorrect_digest) |
-                       test(test_fe_programming::test_fe_programming_cmd) |
                        test(test_rtalias::test_boot_status_reporting) |
                        test(test_update_reset::test_update_reset_verify_image_failure) |
                        test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys) |

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -15,6 +15,21 @@ pub fn rom_from_env() -> &'static FwId<'static> {
     }
 }
 
+pub fn rom_from_env_fpga(fpga: bool) -> &'static FwId<'static> {
+    match (
+        std::env::var("CPTRA_ROM_TYPE").as_ref().map(|s| s.as_str()),
+        fpga,
+    ) {
+        (Ok("ROM"), _) => &ROM,
+        (Ok("ROM_WITHOUT_UART"), _) => &ROM,
+        (Ok("ROM_WITH_UART"), true) => &ROM_FPGA_WITH_UART,
+        (Ok("ROM_WITH_UART"), false) => &ROM_WITH_UART,
+        (Ok(s), _) => panic!("unexpected CPRTA_TEST_ROM env-var value: {s:?}"),
+        (Err(_), true) => &ROM_FPGA_WITH_UART,
+        (Err(_), false) => &ROM_WITH_UART,
+    }
+}
+
 pub const ROM: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -379,6 +379,15 @@ pub fn rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
     }
 }
 
+/// Returns the most appropriate ROM for use when testing non-ROM code against
+/// a particular hardware version. DO NOT USE this for ROM-only tests.
+pub fn rom_for_fw_integration_tests_fpga(fpga: bool) -> io::Result<Cow<'static, [u8]>> {
+    let rom_from_env = firmware::rom_from_env_fpga(fpga);
+    match get_ci_rom_version() {
+        CiRomVersion::Latest => Ok(build_firmware_rom(rom_from_env)?.into()),
+    }
+}
+
 pub fn build_firmware_rom(id: &FwId<'static>) -> io::Result<Vec<u8>> {
     let elf_bytes = build_firmware_elf(id)?;
     elf2rom(&elf_bytes)

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -46,6 +46,8 @@ const OTP_MAPPING: (usize, usize) = (1, 4);
 // Offsets in the OTP for fuses.
 const FUSE_VENDOR_PKHASH_OFFSET: usize = 0x3f8;
 const FUSE_PQC_OFFSET: usize = FUSE_VENDOR_PKHASH_OFFSET + 48;
+const FUSE_SVN_OFFSET: usize = 0x390;
+const FUSE_SOC_MAX_SVN_OFFSET: usize = FUSE_SVN_OFFSET + 36;
 const FUSE_LIFECYCLE_TOKENS_OFFSET: usize = 0x2d8;
 const FUSE_LIFECYCLE_STATE_OFFSET: usize = 0xc80;
 
@@ -1484,6 +1486,12 @@ impl HwModel for ModelFpgaSubsystem {
         };
         otp_mem[FUSE_PQC_OFFSET] = val;
 
+        println!(
+            "Burning fuse for SOC MAX SVN {}",
+            fuses.soc_manifest_max_svn
+        );
+        otp_mem[FUSE_SOC_MAX_SVN_OFFSET] = fuses.soc_manifest_max_svn;
+
         self.otp_slice().copy_from_slice(&otp_mem);
 
         // TODO(zhalvorsen): this should be referencing the other MCI GPIO word.
@@ -1635,6 +1643,20 @@ impl HwModel for ModelFpgaSubsystem {
     fn subsystem_mode(&self) -> bool {
         // we only support subsystem mode
         true
+    }
+
+    fn upload_firmware_rri(
+        &mut self,
+        _firmware: &[u8],
+        _soc_manifest: Option<&[u8]>,
+        _mcu_firmware: Option<&[u8]>,
+    ) -> Result<(), ModelError> {
+        // ironically, we don't need to support this
+        Ok(())
+    }
+
+    fn upload_firmware(&mut self, _firmware: &[u8]) -> Result<(), ModelError> {
+        Ok(())
     }
 }
 

--- a/runtime/tests/runtime_integration_tests/test_fe_programming.rs
+++ b/runtime/tests/runtime_integration_tests/test_fe_programming.rs
@@ -10,17 +10,22 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DeviceLifecycle, HwModel, InitParams, ModelError, SecurityState};
 use caliptra_runtime::RtBootStatus;
 
+#[cfg_attr(feature = "fpga_realtime", ignore)] // FE programming is not supported on core FPGA
 #[test]
 fn test_fe_programming_cmd() {
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::rom_for_fw_integration_tests_fpga(cfg!(feature = "fpga_subsystem"))
+        .unwrap();
     let init_params = InitParams {
         rom: &rom,
         security_state: *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Production),
+        enable_mcu_uart_log: true,
+        subsystem_mode: true,
         ..Default::default()
     };
 
     let mut model = run_rt_test(RuntimeTestArgs {
         init_params: Some(init_params),
+        subsystem_mode: true,
         ..Default::default()
     });
 


### PR DESCRIPTION
The test is disabled in the FPGA for now due to flakiness of booting all the way to runtime, but it has been tested as working and is ready for CI whenever that flakiness is resolved.

To support this command (and probably others) we need to pass in SoC manifest and MCU FW when operating in subsystem mode, otherwise the FPGA subsystem boot flow will fail.

We also need to set the SoC Manifest Max SVN in fuses so that these are routed back to the Caliptra fuse registers.