### PR TITLE
[jtag] fix OpenOCD/JTAG configuration for Caliptra Core TAP

### DIFF
--- a/hw-model/src/jtag.rs
+++ b/hw-model/src/jtag.rs
@@ -52,7 +52,8 @@ pub enum CaliptraCoreReg {
 }
 
 impl JtagAccessibleReg for CaliptraCoreReg {
+    // The offsets above are word offsets.
     fn byte_offset(&self) -> u32 {
-        *self as u32
+        *self as u32 * 4
     }
 }

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -35,7 +35,7 @@ use sha2::Digest;
 
 mod bmc;
 mod fpga_regs;
-mod jtag;
+pub mod jtag;
 pub mod lcc;
 pub mod mmio;
 mod model_emulated;
@@ -191,7 +191,11 @@ pub struct InitParams<'a> {
     // ECC384 and MLDSA87 keypairs (in hardware format i.e. little-endian)
     pub prod_dbg_unlock_keypairs: Vec<(&'a [u8; 96], &'a [u8; 2592])>,
 
+    // Whether or not to set the debug_intent signal.
     pub debug_intent: bool,
+
+    // Whether or not to set the BootFSM break signal.
+    pub bootfsm_break: bool,
 
     // The silicon obfuscation key passed to caliptra_top.
     pub cptra_obf_key: [u32; 8],
@@ -263,6 +267,7 @@ impl Default for InitParams<'_> {
             uds_granularity_64: true,
             prod_dbg_unlock_keypairs: Default::default(),
             debug_intent: false,
+            bootfsm_break: false,
             cptra_obf_key: DEFAULT_CPTRA_OBF_KEY,
             csr_hmac_key: DEFAULT_CSR_HMAC_KEY,
             itrng_nibbles,

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -418,6 +418,20 @@ impl ModelFpgaSubsystem {
         }
     }
 
+    fn set_ss_debug_intent(&mut self, val: bool) {
+        if val {
+            self.wrapper
+                .regs()
+                .control
+                .modify(Control::SsDebugIntent::SET);
+        } else {
+            self.wrapper
+                .regs()
+                .control
+                .modify(Control::SsDebugIntent::CLEAR);
+        }
+    }
+
     fn axi_reset(&mut self) {
         self.wrapper.regs().control.modify(Control::AxiReset.val(1));
         // wait a few clock cycles or we can crash the FPGA
@@ -1430,6 +1444,11 @@ impl HwModel for ModelFpgaSubsystem {
         let mcu_rom_slice =
             unsafe { core::slice::from_raw_parts_mut(m.mcu_rom_backdoor, mcu_rom_size) };
         mcu_rom_slice.copy_from_slice(&mcu_rom_data);
+
+        // Setup debug intent signal if requested.
+        m.set_ss_debug_intent(params.debug_intent);
+        // Set BootFSM break if requested.
+        m.set_bootfsm_break(params.bootfsm_break);
 
         // set the reset vector to point to the ROM backdoor
         println!("Writing MCU reset vector");

--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -94,7 +94,6 @@ impl OpenOcdJtagTap {
 
         // Capture outputs during initialization to see if error has occurred during the process.
         let resp = openocd.execute("capture init")?;
-        println!("Resp: {}", resp);
         if resp.contains("JTAG scan chain interrogation failed") {
             bail!(OpenOcdError::InitializeFailure(resp));
         }

--- a/hw/fpga/openocd_ss.cfg
+++ b/hw/fpga/openocd_ss.cfg
@@ -5,12 +5,14 @@ proc configure_tap {target} {
     if {$target == "core" || $target == "mcu"} {
         set _CHIPNAME riscv
         set _TAPNAME cpu
+        # The IDCODE instruction was removed from Caliptra in
+        # https://github.com/chipsalliance/caliptra-rtl/pull/298, which will
+        # cause OpenOCD to see the following (invalid) IDCODE.
+        set _IDCODE 0xfffffffe
         if {$target == "core"} {
             puts "Connecting to Caliptra Core"
-            set _IDCODE 0x00000001
         } else {
             puts "Connecting to MCU"
-            set _IDCODE 0x00000001
         }
     } elseif {$target == "lcc"} {
         puts "Connecting to LCC"
@@ -34,38 +36,5 @@ proc configure_tap {target} {
     }
 
     gdb_report_data_abort enable
-    init
-
-    if {$target == "core" || $target == "mcu"} {
-        if {$target == "core"} {
-            # Check if we can read/write CPTRA_DBG_MANUF_SERVICE_REG to see if Caliptra JTAG registers are accessible
-            set manuf [riscv dmi_read 0x60]
-            riscv dmi_write 0x60 [expr {0xFFFFFFFF - $manuf}]
-            set manuf_inv [riscv dmi_read 0x60]
-            # Restore original value
-              riscv dmi_write 0x60 [format %08X $manuf]
-            if { $manuf == $manuf_inv } {
-                puts stderr "Caliptra Core not accessible"
-            } else {
-                puts stderr "Caliptra Core accessible"
-            }
-        }
-        set dmstatus [riscv dmi_read 0x11]
-        if {0x0 == $dmstatus} {
-            puts stderr "CPU not accessible"
-        } else {
-            puts stderr "CPU accessible"
-            halt
-        }
-    } else {
-        # Address 0x4 (word address 0x01) is the lc_ctrl STATUS register.
-        set lcc_status [riscv dmi_read 0x01]
-        if {0x0 == $lcc_status} {
-            puts stderr [format "LCC not accessible; STATUS: %x" $lcc_status]
-        } else {
-            puts stderr "LCC accessible"
-        }
-    }
-
     puts stderr "OpenOCD setup finished"
 }


### PR DESCRIPTION
This fixes some configuration errors to enable connecting to the Caliptra Core TAP. This will enable completing the manuf debug unlock test.