### PR TITLE
runtime: warm_reset: Check MCU FW loaded before releasing MCU SRAM

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -52,6 +52,7 @@ pub const FUSE_LOG_MAX_COUNT: usize = 62;
 pub const MEASUREMENT_MAX_COUNT: usize = 8;
 pub const MLDSA_SIGNATURE_SIZE: u32 = 4628;
 pub const CMB_AES_KEY_SHARE_SIZE: u32 = 32;
+pub const DOT_OWNER_PK_HASH_SIZE: u32 = 13 * 4;
 
 #[cfg(feature = "runtime")]
 const DPE_DCCM_STORAGE: usize = size_of::<DpeInstance>()
@@ -343,6 +344,8 @@ pub struct PersistentData {
     pub dot_owner_pk_hash: DOT_OWNER_PK_HASH,
 
     pub cleared_non_fatal_fw_error: u32,
+
+    pub mcu_firmware_loaded: u32,
 }
 
 impl PersistentData {
@@ -487,6 +490,11 @@ impl PersistentData {
             persistent_data_offset += CMB_AES_KEY_SHARE_SIZE;
             assert_eq!(
                 addr_of!((*P).dot_owner_pk_hash) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+            persistent_data_offset += DOT_OWNER_PK_HASH_SIZE;
+            assert_eq!(
+                addr_of!((*P).cleared_non_fatal_fw_error) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1532,6 +1532,16 @@ impl CaliptraError {
             0x000E006F,
             "Runtime Error: FE programming invalid partition number"
         ),
+        (
+            RUNTIME_WARM_RESET_MCU_FW_NOT_LOADED,
+            0x000E0070,
+            "Runtime Error: Warm reset in Subsystem mode, but MCU FW not loaded"
+        ),
+        (
+            RUNTIME_WARM_RESET_MCU_UNSUCCESSFUL_PREVIOUS_UPDATE_RESET,
+            0x000E0071,
+            "Runtime Error: Warm reset in Subsystem mode, but last MCU hitless update failed"
+        ),
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (
             FMC_GLOBAL_EXCEPTION,

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -28,16 +28,19 @@ use crate::{
 use crate::dpe_crypto::{ExportedCdiHandles, EXPORTED_HANDLES_NUM};
 use arrayvec::ArrayVec;
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder};
+use caliptra_cfi_lib_git::{
+    cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_assert_ne, cfi_launder,
+};
 use caliptra_common::cfi_check;
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
-use caliptra_drivers::Dma;
+use caliptra_common::RomBootStatus::{ColdResetComplete, UpdateResetStarted};
 use caliptra_drivers::{
     cprintln, hand_off::DataStore, pcr_log::RT_FW_JOURNEY_PCR, sha2_512_384::Sha2DigestOpTrait,
     Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms, Mldsa87,
     PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha1, Sha256, Sha256Alg, Sha2_512_384,
     Sha2_512_384Acc, SocIfc, Trng,
 };
+use caliptra_drivers::{Dma, DmaMmio};
 use caliptra_image_types::ImageManifest;
 use caliptra_registers::aes::AesReg;
 use caliptra_registers::aes_clp::AesClpReg;
@@ -58,15 +61,45 @@ use dpe::{
     dpe_instance::{DpeEnv, DpeInstance},
     DPE_PROFILE,
 };
+use ureg::MmioMut;
 
 use core::cmp::Ordering::{Equal, Greater};
 use crypto::CryptoBuf;
 use zerocopy::IntoBytes;
 
+pub const MCI_TOP_REG_RESET_REASON_OFFSET: u32 = 0x38;
+
 #[derive(PartialEq, Clone)]
 pub enum PauserPrivileges {
     PL0,
     PL1,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum McuResetReason {
+    ColdReset = 0,
+    FwHitlessUpdReset = 0b1 << 0,
+    FwBootReset = 0b1 << 1,
+    WarmReset = 0b1 << 2,
+}
+
+impl From<McuResetReason> for u32 {
+    fn from(reason: McuResetReason) -> Self {
+        reason as u32
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum McuFwStatus {
+    NotLoaded,
+    Loaded,
+    HitlessUpdateStarted,
+}
+
+impl From<McuFwStatus> for u32 {
+    fn from(status: McuFwStatus) -> Self {
+        status as u32
+    }
 }
 
 pub struct Drivers {
@@ -203,6 +236,9 @@ impl Drivers {
                 Self::validate_context_tags(self)?;
                 Self::check_dpe_rt_journey_unchanged(self)?;
                 Self::update_fw_version(self, true, true);
+                if self.soc_ifc.subsystem_mode() {
+                    Self::release_mcu_sram(self)?;
+                }
             }
             ResetReason::Unknown => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::Unknown);
@@ -241,6 +277,18 @@ impl Drivers {
             return Err(CaliptraError::RUNTIME_UNABLE_TO_FIND_DPE_ROOT_CONTEXT);
         }
         Ok(root_idx)
+    }
+
+    pub fn set_mcu_reset_reason(drivers: &mut Drivers, reason: McuResetReason) {
+        let dma = &drivers.dma;
+        let mci_base_addr = drivers.soc_ifc.mci_base_addr().into();
+        let mmio = &DmaMmio::new(mci_base_addr, dma);
+        unsafe { mmio.write_volatile(MCI_TOP_REG_RESET_REASON_OFFSET as *mut u32, reason.into()) };
+    }
+
+    pub fn request_mcu_reset(drivers: &mut Drivers, reason: McuResetReason) {
+        Self::set_mcu_reset_reason(drivers, reason);
+        drivers.soc_ifc.set_mcu_firmware_ready();
     }
 
     /// Validate DPE and disable attestation if validation fails
@@ -312,6 +360,43 @@ impl Drivers {
                 .soc_ifc
                 .set_rt_fw_rev_id(drivers.persistent_data.get().manifest1.runtime.version);
         }
+    }
+
+    /// Release MCU SRAM if MCU FW was previously loaded correctly
+    fn release_mcu_sram(drivers: &mut Drivers) -> CaliptraResult<()> {
+        // Check if MCU previous Cold-Reset was successful.
+        let persistent_data = drivers.persistent_data.get();
+        if cfi_launder(persistent_data.mcu_firmware_loaded == McuFwStatus::NotLoaded.into()) {
+            cprintln!("[rt-warm-reset] Prev Cold Reset failed");
+            return Err(CaliptraError::RUNTIME_WARM_RESET_MCU_FW_NOT_LOADED);
+        } else {
+            cfi_assert_ne(
+                persistent_data.mcu_firmware_loaded,
+                McuFwStatus::NotLoaded.into(),
+            );
+        }
+
+        // Check if MCU previous Update-Reset, if any,  was successful.
+        let persistent_data = drivers.persistent_data.get();
+        if cfi_launder(
+            persistent_data.mcu_firmware_loaded == McuFwStatus::HitlessUpdateStarted.into(),
+        ) {
+            cprintln!("[rt-warm-reset] Prev Hitless Update Reset failed");
+            return Err(CaliptraError::RUNTIME_WARM_RESET_MCU_UNSUCCESSFUL_PREVIOUS_UPDATE_RESET);
+        } else {
+            cfi_assert_ne(
+                persistent_data.mcu_firmware_loaded,
+                McuFwStatus::HitlessUpdateStarted.into(),
+            );
+        }
+
+        cfi_assert_eq(
+            persistent_data.mcu_firmware_loaded,
+            McuFwStatus::Loaded.into(),
+        );
+        Self::request_mcu_reset(drivers, McuResetReason::FwBootReset);
+
+        Ok(())
     }
 
     /// Check that RT_FW_JOURNEY_PCR == DPE Root Context's TCI measurement

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -13,15 +13,17 @@ Abstract:
 --*/
 
 use crate::{
-    activate_firmware::MCI_TOP_REG_RESET_REASON_OFFSET, authorize_and_stash::AuthorizeAndStashCmd,
-    set_auth_manifest::AuthManifestSource, Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
+    authorize_and_stash::AuthorizeAndStashCmd,
+    drivers::{McuFwStatus, McuResetReason},
+    set_auth_manifest::AuthManifestSource,
+    Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
 };
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::{
     cprintln,
     mailbox_api::{AuthorizeAndStashReq, ImageHashSource},
 };
-use caliptra_drivers::{printer::HexBytes, DmaMmio, DmaRecovery};
+use caliptra_drivers::{printer::HexBytes, AxiAddr, Dma, DmaMmio, DmaRecovery};
 use caliptra_kat::{CaliptraError, CaliptraResult};
 use ureg::MmioMut;
 
@@ -110,21 +112,13 @@ impl RecoveryFlow {
                 return Err(CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH);
             }
 
-            // Caliptra sets RESET_REASON.FW_BOOT_UPD_RESET
-            let mmio = &DmaMmio::new(mci_base_addr, dma);
-            unsafe {
-                mmio.write_volatile(
-                    MCI_TOP_REG_RESET_REASON_OFFSET as *mut u32,
-                    FW_BOOT_UPD_RESET,
-                )
-            };
-
-            // notify MCU that it can boot its firmware
-            drivers.soc_ifc.set_mcu_firmware_ready();
-
             // we're done with recovery
             dma_recovery.set_recovery_status(DmaRecovery::RECOVERY_STATUS_SUCCESSFUL, 0)?;
         }
+
+        // notify MCU that it can boot its firmware
+        drivers.persistent_data.get_mut().mcu_firmware_loaded = McuFwStatus::Loaded.into();
+        Drivers::request_mcu_reset(drivers, McuResetReason::FwBootReset);
 
         Ok(())
     }


### PR DESCRIPTION
Before releasing the MCU SRAM and telling MCU to do the FW boot reset flow, this checks to make sure firmware was loaded successfully during Cold Reset or Update Reset.