### PR TITLE
Fix nightly EMU tests on main-2.x

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -86,7 +86,7 @@ slow-timeout = { period = "30s", terminate-after = 140 }
 
 [[profile.nightly.overrides]]
 filter = 'test(test_stress_update)'
-slow-timeout = { period = "30s", terminate-after = 17 }
+slow-timeout = { period = "30s", terminate-after = 50 }
 
 [profile.nightly.junit]
 path = "/tmp/junit.xml"

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -133,11 +133,7 @@ fn test_generate_csr_envelop_stress() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let num_tests = if cfg!(feature = "slow_tests") {
-            1000
-        } else {
-            1
-        };
+        let num_tests = if cfg!(feature = "slow_tests") { 250 } else { 1 };
 
         for _ in 0..num_tests {
             let mut fuses = fuses_with_random_uds();


### PR DESCRIPTION
* The CSR generation is 3x slower on main-2.x, so reduce iterations by 75%.
* Increase timeout for boot stress test