### PR TITLE
[cherry-pick] size history Fix

### DIFF
--- a/ci-tools/size-history/src/http.rs
+++ b/ci-tools/size-history/src/http.rs
@@ -3,6 +3,7 @@
 use std::str::FromStr;
 use std::{borrow::Cow, io, process::Command};
 
+use crate::util::expect_line_with_prefix_ignore_case;
 use crate::{
     process::run_cmd_stdout,
     util::{expect_line_with_prefix, other_err},
@@ -30,6 +31,7 @@ impl<'a> Content<'a> {
 pub struct HttpResponse {
     pub status: u32,
     pub content_type: String,
+    pub location: Option<String>,
     pub data: Vec<u8>,
 }
 impl HttpResponse {
@@ -46,19 +48,26 @@ impl HttpResponse {
         let status = u32::from_str(&status_str[..3])
             .map_err(|_| other_err(format!("Bad HTTP status code: {line:?}")))?;
         let mut content_type = String::new();
+        let mut location = None;
         loop {
             let mut line = String::new();
             raw.read_line(&mut line)?;
             if line == "\r\n" {
                 break;
             }
-            if let Ok(header_val) = expect_line_with_prefix("Content-Type: ", Some(&line)) {
+            if let Ok(header_val) =
+                expect_line_with_prefix_ignore_case("Content-Type: ", Some(&line))
+            {
                 content_type = header_val.trim().into();
+            }
+            if let Ok(header_val) = expect_line_with_prefix_ignore_case("Location: ", Some(&line)) {
+                location = Some(header_val.trim().into());
             }
         }
         Ok(HttpResponse {
             status,
             content_type,
+            location,
             data: raw.into(),
         })
     }
@@ -68,6 +77,7 @@ impl std::fmt::Debug for HttpResponse {
         f.debug_struct("HttpResponse")
             .field("status", &self.status)
             .field("content_type", &self.content_type)
+            .field("location", &self.location)
             .field("data", &String::from_utf8_lossy(&self.data))
             .finish()
     }
@@ -84,6 +94,15 @@ pub fn raw_get(url: &str) -> io::Result<HttpResponse> {
         Command::new("curl").arg("-sSi").arg(url),
         None,
     )?)
+}
+pub fn raw_get_ok(url: &str) -> io::Result<HttpResponse> {
+    let response = raw_get(url)?;
+    if !status_ok(response.status) {
+        return Err(other_err(format!(
+            "HTTP request to {url} failed: {response:?}"
+        )));
+    }
+    Ok(response)
 }
 
 pub fn api_post(url: &str, content: Option<&Content>) -> io::Result<HttpResponse> {
@@ -105,26 +124,45 @@ pub fn api_post(url: &str, content: Option<&Content>) -> io::Result<HttpResponse
     }
 }
 
-pub fn api_patch(url: &str, offset: u64, content: &Content) -> io::Result<HttpResponse> {
+pub fn api_post_ok(url: &str, content: Option<&Content>) -> io::Result<HttpResponse> {
+    let response = api_post(url, content)?;
+    if !status_ok(response.status) {
+        return Err(other_err(format!(
+            "HTTP request to {url} failed: {response:?}"
+        )));
+    }
+    Ok(response)
+}
+
+pub fn api_put(url: &str, content: &Content) -> io::Result<HttpResponse> {
     HttpResponse::parse(run_cmd_stdout(
         Command::new("curl")
             .arg("-sSi")
             .arg("-H")
             .arg(format!("Content-Type: {}", content.mime_type))
             .arg("-H")
-            .arg(format!(
-                "Content-Range: bytes {offset}-{}/*",
-                offset + (content.data.len() as u64)
-            ))
+            .arg("x-ms-blob-type: BlockBlob")
             .arg("-H")
-            .arg("Accept: application/json;api-version=6.0-preview.1")
-            .arg("-H")
-            .arg(auth_header()?)
+            .arg("x-ms-version: 2025-05-05")
             .arg("-X")
-            .arg("PATCH")
+            .arg("PUT")
             .arg("--data-binary")
             .arg("@-")
             .arg(url),
         Some(&content.data),
     )?)
+}
+
+pub fn api_put_ok(url: &str, content: &Content) -> io::Result<HttpResponse> {
+    let response = api_put(url, content)?;
+    if !status_ok(response.status) {
+        return Err(other_err(format!(
+            "HTTP request to {url} failed: {response:?}"
+        )));
+    }
+    Ok(response)
+}
+
+fn status_ok(status: u32) -> bool {
+    matches!(status, 200..=299)
 }

--- a/ci-tools/size-history/src/util.rs
+++ b/ci-tools/size-history/src/util.rs
@@ -26,6 +26,23 @@ pub fn expect_line_with_prefix<'a>(prefix: &str, line: Option<&'a str>) -> io::R
     ))
 }
 
+pub fn expect_line_with_prefix_ignore_case<'a>(
+    prefix: &str,
+    line: Option<&'a str>,
+) -> io::Result<&'a str> {
+    if let Some(line) = line {
+        if let Some(line_prefix) = line.get(..prefix.len()) {
+            if line_prefix.eq_ignore_ascii_case(prefix) {
+                return Ok(&line[prefix.len()..]);
+            }
+        }
+    };
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        format!("Expected line with prefix {prefix:?}; was {line:?}"),
+    ))
+}
+
 pub fn hex(bytes: &[u8]) -> String {
     use std::fmt::Write;
 


### PR DESCRIPTION
* URL path started with '//twirp'; should be '/twirp'
  * HTTP status codes were being ignored
  * The reason for an HTTP failure wasn't being reported in the error message.
  * HTTP 2.0 headers weren't being parsed correctly.
  * Remove authentication tokens from Azure blob storage requests
  * Add required x-msft* headers to Azure blob storage requests

With these changes, the size-history cache should start working again.