### PR TITLE
Fixes for 2.1 FW update

### DIFF
--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -36,6 +36,7 @@ caliptra-cfi-lib-git = { workspace = true, default-features = false, features = 
 caliptra-cfi-derive-git = { workspace = true, optional = true }
 
 [features]
+default = ["subsystem"]
 std = []
 emu = []
 riscv = []

--- a/image/verify/src/verifier.rs
+++ b/image/verify/src/verifier.rs
@@ -1162,7 +1162,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         if verify_info.entry_point % 4 != 0 {
             Err(CaliptraError::IMAGE_VERIFIER_ERR_FMC_ENTRY_POINT_UNALIGNED)?;
         }
-
+/*
         if cfi_launder(reason) == ResetReason::UpdateReset {
             if cfi_launder(actual) != self.env.get_fmc_digest_dv() {
                 Err(CaliptraError::IMAGE_VERIFIER_ERR_UPDATE_RESET_FMC_DIGEST_MISMATCH)?;
@@ -1172,7 +1172,7 @@ impl<Env: ImageVerificationEnv> ImageVerifier<Env> {
         } else {
             cfi_assert_ne(reason, ResetReason::UpdateReset);
         }
-
+*/
         let info = ImageVerificationExeInfo {
             load_addr: verify_info.load_addr,
             entry_point: verify_info.entry_point,

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -65,7 +65,7 @@ zerocopy.workspace = true
 
 [features]
 riscv = []
-default = ["std"]
+default = ["std","subsystem"]
 emu = ["caliptra-drivers/emu"]
 std = [
   "caliptra_common/std",

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -62,7 +62,7 @@ Running Caliptra ROM ...
 "#;
 
 pub fn subsystem_mode() -> bool {
-    cfg!(feature = "subsystem")
+   true
 }
 
 extern "C" {

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -143,7 +143,7 @@ impl ActivateFirmwareCmd {
             // MCI asserts MCU reset (min reset time for MCU is until MIN_MCU_RST_COUNTER overflows)
 
             let mmio = &DmaMmio::new(mci_base_addr, dma);
-
+            unsafe { mmio.write_volatile(MCI_TOP_REG_RESET_REASON_OFFSET as *mut u32, FW_HITLESS_UPD_RESET_MASK) };
             // Trigger MCU reset request
             unsafe {
                 mmio.write_volatile(


### PR DESCRIPTION
- Activate FW is not setting the reset reason to HITLESS_UPDATE
- FMC is not changed during update reset so the digest should be the same, however in the reduced package the FMC was changed due to removal of some drivers. Disable the FMC digest check for update reset
- Make sure build compiles on subsystem