### PR TITLE
Fix SHA ACC driver to initialize DLEN

### DIFF
--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1454,6 +1454,11 @@ int caliptra_start_sha_stream(int mode, uint8_t* in_data, uint32_t data_len) {
     if (error) {
         return REG_ACCESS_ERROR;
     }
+    // Clear and initialize DLEN used in the previous process
+    error = caliptra_write_u32(CALIPTRA_TOP_REG_SHA512_ACC_CSR_DLEN, 0);
+    if (error) {
+        return REG_ACCESS_ERROR;
+    }
 
     return caliptra_update_sha_stream(in_data, data_len);
 }


### PR DESCRIPTION
DLEN must be cleared and initialized to zero before use.
First SHA process after reset has no issue, but second SHA process reflects previous DLEN.
SHA ACC emulator seems to clear DLEN after finishing each process, but HW(used own FPGA) doesn't clear DLEN and it requires to clear DLEN everytime.
While I suspect this is an issue with the emulator implementation, it would be good to double-check if the described behavior is actually the intended operation in the HW