### PR TITLE
[hw_model] refactor InitParams

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -192,14 +192,6 @@ pub struct InitParams<'a> {
     // ECC384 and MLDSA87 keypairs (in hardware format i.e. little-endian)
     pub prod_dbg_unlock_keypairs: Vec<(&'a [u8; 96], &'a [u8; 2592])>,
 
-    // Number of public key hashes for production debug unlock levels.
-    // Note: does not have to match number of keypairs in prod_dbg_unlock_keypairs above if default
-    // OTP settings are used.
-    pub num_prod_dbg_unlock_pk_hashes: u32,
-
-    // Offset of public key hashes in PROD_DEBUG_UNLOCK_PK_HASH_REG register bank for production debug unlock.
-    pub prod_dbg_unlock_pk_hashes_offset: u32,
-
     // Whether or not to set the debug_intent signal.
     pub debug_intent: bool,
 
@@ -241,11 +233,25 @@ pub struct InitParams<'a> {
     // Initial contents of the test SRAM
     pub test_sram: Option<&'a [u8]>,
 
+    // Subsystem initialization parameters.
+    pub ss_init_params: SubsystemInitParams<'a>,
+}
+
+#[derive(Default)]
+pub struct SubsystemInitParams<'a> {
     // Optionally, provide MCU ROM; otherwise use the pre-built ROM image, if needed
     pub mcu_rom: Option<&'a [u8]>,
 
     // Consume MCU UART log with Caliptra UART log
     pub enable_mcu_uart_log: bool,
+
+    // Number of public key hashes for production debug unlock levels.
+    // Note: does not have to match number of keypairs in prod_dbg_unlock_keypairs above if default
+    // OTP settings are used.
+    pub num_prod_dbg_unlock_pk_hashes: u32,
+
+    // Offset of public key hashes in PROD_DEBUG_UNLOCK_PK_HASH_REG register bank for production debug unlock.
+    pub prod_dbg_unlock_pk_hashes_offset: u32,
 }
 
 impl Default for InitParams<'_> {
@@ -291,12 +297,7 @@ impl Default for InitParams<'_> {
             stack_info: None,
             soc_user: MailboxRequester::SocUser(1u32),
             test_sram: None,
-
-            // Only relevant for SS Model.
-            mcu_rom: None,
-            enable_mcu_uart_log: false,
-            num_prod_dbg_unlock_pk_hashes: 0,
-            prod_dbg_unlock_pk_hashes_offset: 0,
+            ss_init_params: Default::default(),
         }
     }
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1313,7 +1313,7 @@ impl HwModel for ModelFpgaSubsystem {
             return Err("External TRNG mode is not supported in ModelFpgaSubsystem".into());
         }
         let mcu_rom =
-            match params.mcu_rom {
+            match params.ss_init_params.mcu_rom {
                 Some(mcu_rom) => mcu_rom,
                 None => &std::fs::read(std::env::var("CPTRA_MCU_ROM").expect(
                     "set the ENV VAR CPTRA_MCU_ROM to the absolute path of caliptra-mcu rom",
@@ -1437,7 +1437,7 @@ impl HwModel for ModelFpgaSubsystem {
             blocks_sent: 0,
             recovery_ctrl_written: false,
             recovery_ctrl_len: 0,
-            enable_mcu_uart_log: params.enable_mcu_uart_log,
+            enable_mcu_uart_log: params.ss_init_params.enable_mcu_uart_log,
         };
 
         println!("AXI reset");
@@ -1519,11 +1519,11 @@ impl HwModel for ModelFpgaSubsystem {
         m.wrapper
             .regs()
             .prod_debug_unlock_auth_pk_hash_reg_bank_offset
-            .set(params.prod_dbg_unlock_pk_hashes_offset);
+            .set(params.ss_init_params.prod_dbg_unlock_pk_hashes_offset);
         m.wrapper
             .regs()
             .num_of_prod_debug_unlock_auth_pk_hashes
-            .set(params.num_prod_dbg_unlock_pk_hashes);
+            .set(params.ss_init_params.num_prod_dbg_unlock_pk_hashes);
 
         // set the reset vector to point to the ROM backdoor
         println!("Writing MCU reset vector");

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -20,7 +20,7 @@ use caliptra_drivers::InitDevIdCsrEnvelope;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
     BootParams, CodeRange, Fuses, HwModel, ImageInfo, InitParams, SecurityState, StackInfo,
-    StackRange,
+    StackRange, SubsystemInitParams,
 };
 use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, ModelError};
 use caliptra_image_crypto::OsslCrypto as Crypto;
@@ -229,7 +229,10 @@ pub fn build_hw_model(fuses: Fuses) -> DefaultHwModel {
             rom: &rom,
             security_state,
             stack_info: Some(StackInfo::new(image_info)),
-            enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
             ..Default::default()
         },
         BootParams {

--- a/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
@@ -10,7 +10,7 @@ use caliptra_api::SocManager;
 use caliptra_builder::firmware::ROM_WITH_UART;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
-    DbgManufServiceRegReq, DeviceLifecycle, HwModel, ModelError, SecurityState,
+    DbgManufServiceRegReq, DeviceLifecycle, HwModel, ModelError, SecurityState, SubsystemInitParams,
 };
 use fips204::traits::{SerDes, Signer};
 use p384::ecdsa::VerifyingKey;
@@ -37,7 +37,10 @@ fn test_dbg_unlock_manuf_req_in_passive_mode() {
             dbg_manuf_service,
             debug_intent: true,
             subsystem_mode: false,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -89,7 +92,10 @@ fn test_dbg_unlock_manuf_success() {
             dbg_manuf_service,
             debug_intent: true,
             subsystem_mode: true,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -150,7 +156,10 @@ fn test_dbg_unlock_manuf_wrong_cmd() {
             dbg_manuf_service,
             debug_intent: true,
             subsystem_mode: true,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -204,7 +213,10 @@ fn test_dbg_unlock_manuf_invalid_token() {
             dbg_manuf_service,
             debug_intent: true,
             subsystem_mode: true,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -313,7 +325,10 @@ fn test_dbg_unlock_prod_success() {
             prod_dbg_unlock_keypairs,
             debug_intent: true,
             subsystem_mode: true,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -560,7 +575,10 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
             )],
             subsystem_mode: true,
             debug_intent: true,
-            enable_mcu_uart_log: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),
@@ -1031,7 +1049,10 @@ fn test_dbg_unlock_prod_unlock_levels_success() {
                 prod_dbg_unlock_keypairs,
                 debug_intent: true,
                 subsystem_mode: true,
-                enable_mcu_uart_log: true,
+                ss_init_params: SubsystemInitParams {
+                    enable_mcu_uart_log: true,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             caliptra_hw_model::BootParams::default(),
@@ -1185,7 +1206,10 @@ fn test_dbg_unlock_prod_unlock_levels_failure() {
                 )],
                 debug_intent: true,
                 subsystem_mode: true,
-                enable_mcu_uart_log: true,
+                ss_init_params: SubsystemInitParams {
+                    enable_mcu_uart_log: true,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             caliptra_hw_model::BootParams::default(),

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -24,7 +24,7 @@ use caliptra_drivers::MfgFlags;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
     BootParams, CodeRange, DefaultHwModel, Fuses, HwModel, ImageInfo, InitParams, ModelError,
-    SecurityState, StackInfo, StackRange,
+    SecurityState, StackInfo, StackRange, SubsystemInitParams,
 };
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
@@ -241,7 +241,10 @@ pub fn start_rt_test_pqc_model(
         test_sram: args.test_sram,
         security_state: args.security_state.unwrap_or_default(),
         subsystem_mode: args.subsystem_mode,
-        enable_mcu_uart_log: args.subsystem_mode,
+        ss_init_params: SubsystemInitParams {
+            enable_mcu_uart_log: args.subsystem_mode,
+            ..Default::default()
+        },
         ..Default::default()
     });
 

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -28,7 +28,7 @@ use caliptra_api::mailbox::{
 };
 use caliptra_api::SocManager;
 use caliptra_drivers::AES_BLOCK_SIZE_BYTES;
-use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, TrngMode};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, SubsystemInitParams, TrngMode};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use cbc::cipher::BlockEncryptMut;
@@ -649,8 +649,11 @@ fn test_random_stir_itrng() {
         init_params: Some(InitParams {
             rom: &rom,
             trng_mode: Some(TrngMode::Internal),
-            enable_mcu_uart_log: subsystem_mode,
             subsystem_mode,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: subsystem_mode,
+                ..Default::default()
+            },
             ..Default::default()
         }),
         ..Default::default()

--- a/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
+++ b/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
@@ -18,7 +18,7 @@ use caliptra_common::{
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{
     CodeRange, DeviceLifecycle, HwModel, ImageInfo, InitParams, ModelError, SecurityState,
-    StackInfo, StackRange,
+    StackInfo, StackRange, SubsystemInitParams,
 };
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
@@ -772,7 +772,10 @@ fn test_dbg_unlock_prod_wrong_cmd() {
         prod_dbg_unlock_keypairs,
         debug_intent: true,
         subsystem_mode: true,
-        enable_mcu_uart_log: true,
+        ss_init_params: SubsystemInitParams {
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        },
         stack_info: Some(StackInfo::new(image_info)),
         ..Default::default()
     };

--- a/runtime/tests/runtime_integration_tests/test_fe_programming.rs
+++ b/runtime/tests/runtime_integration_tests/test_fe_programming.rs
@@ -7,7 +7,9 @@ use caliptra_api::{
 };
 use caliptra_common::mailbox_api::CommandId;
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{DeviceLifecycle, HwModel, InitParams, ModelError, SecurityState};
+use caliptra_hw_model::{
+    DeviceLifecycle, HwModel, InitParams, ModelError, SecurityState, SubsystemInitParams,
+};
 use caliptra_runtime::RtBootStatus;
 
 #[cfg_attr(feature = "fpga_realtime", ignore)] // FE programming is not supported on core FPGA
@@ -18,7 +20,10 @@ fn test_fe_programming_cmd() {
     let init_params = InitParams {
         rom: &rom,
         security_state: *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Production),
-        enable_mcu_uart_log: true,
+        ss_init_params: SubsystemInitParams {
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        },
         subsystem_mode: true,
         ..Default::default()
     };

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -6,7 +6,9 @@ use caliptra_builder::{
     ImageOptions,
 };
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{BootParams, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState};
+use caliptra_hw_model::{
+    BootParams, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState, SubsystemInitParams,
+};
 use caliptra_test::image_pk_desc_hash;
 use dpe::DPE_PROFILE;
 
@@ -49,7 +51,10 @@ fn test_rt_journey_pcr_validation() {
         InitParams {
             rom: &rom,
             security_state,
-            enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
             ..Default::default()
         },
         boot_params.clone(),
@@ -121,7 +126,10 @@ fn test_mbox_busy_during_warm_reset() {
         InitParams {
             rom: &rom,
             security_state,
-            enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
             ..Default::default()
         },
         boot_params.clone(),
@@ -193,7 +201,10 @@ fn test_mbox_idle_during_warm_reset() {
         InitParams {
             rom: &rom,
             security_state,
-            enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
             ..Default::default()
         },
         boot_params.clone(),


### PR DESCRIPTION
This fixes #2650 by refactoring the init params that are specific to Subsystem only into a sub struct to improve readability.