### PR TITLE
Fixing warm reset flow in test_warm_reset_version to call boot()

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -625,11 +625,53 @@ pub trait HwModel: SocManager {
     fn trng_mode(&self) -> TrngMode;
 
     /// Trigger a warm reset and advance the boot
-    fn warm_reset_flow(&mut self, fuses: &Fuses) {
+    fn warm_reset_flow(&mut self) -> Result<(), Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        // Store non-persistent config regs set at boot
+        let dbg_manuf_service_reg = self.soc_ifc().cptra_dbg_manuf_service_reg().read();
+        let i_trng_entropy_config_1: u32 =
+            self.soc_ifc().cptra_i_trng_entropy_config_1().read().into();
+        let i_trng_entropy_config_0: u32 =
+            self.soc_ifc().cptra_i_trng_entropy_config_0().read().into();
+        // Store mbox pausers
+        let mut valid_pausers: Vec<u32> = Vec::new();
+        for i in 0..caliptra_api::soc_mgr::NUM_PAUSERS {
+            // Only store if locked
+            if self.soc_ifc().cptra_mbox_pauser_lock().at(i).read().lock() {
+                valid_pausers.push(self.soc_ifc().cptra_mbox_pauser_lock().at(i).read().into());
+            }
+        }
+
+        // Perform the warm reset
         self.warm_reset();
 
-        HwModel::init_fuses(self, fuses);
+        // Write back stored values and let boot progress
+        // Fuse values will remain, just re-set fuse done
+        self.soc_ifc().cptra_fuse_wr_done().write(|w| w.done(true));
+
+        self.soc_ifc()
+            .cptra_dbg_manuf_service_reg()
+            .write(|_| dbg_manuf_service_reg);
+        self.soc_ifc()
+            .cptra_i_trng_entropy_config_1()
+            .write(|_| i_trng_entropy_config_1.into());
+        self.soc_ifc()
+            .cptra_i_trng_entropy_config_0()
+            .write(|_| i_trng_entropy_config_0.into());
+
+        // Re-set the valid pausers
+        self.setup_mailbox_users(valid_pausers.as_slice())
+            .map_err(ModelError::from)?;
+
+        // Continue boot
+        writeln!(self.output().logger(), "writing to cptra_bootfsm_go")?;
         self.soc_ifc().cptra_bootfsm_go().write(|w| w.go(true));
+
+        self.step();
+
+        Ok(())
     }
 
     /// The APB bus from the SoC to Caliptra

--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -72,12 +72,7 @@ fn test_warm_reset_success() {
     }
 
     // Perform warm reset
-    hw.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    hw.warm_reset_flow().unwrap();
 
     // Wait for boot
     while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {
@@ -99,7 +94,7 @@ fn test_warm_reset_during_cold_boot_before_image_validation() {
     hw.step_until_boot_status(IDevIdDecryptUdsComplete.into(), true);
 
     // Perform a warm reset
-    hw.warm_reset_flow(&Fuses::default());
+    hw.warm_reset_flow().unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {
@@ -135,7 +130,7 @@ fn test_warm_reset_during_cold_boot_during_image_validation() {
     }
 
     // Perform a warm reset
-    hw.warm_reset_flow(&Fuses::default());
+    hw.warm_reset_flow().unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {
@@ -164,7 +159,7 @@ fn test_warm_reset_during_cold_boot_after_image_validation() {
     hw.step_until_boot_status(FmcAliasDerivationComplete.into(), true);
 
     // Perform a warm reset
-    hw.warm_reset_flow(&Fuses::default());
+    hw.warm_reset_flow().unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {
@@ -210,7 +205,7 @@ fn test_warm_reset_during_update_reset() {
     hw.step_until_boot_status(UpdateResetLoadImageComplete.into(), true);
 
     // Perform a warm reset
-    hw.warm_reset_flow(&Fuses::default());
+    hw.warm_reset_flow().unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {
@@ -302,14 +297,13 @@ fn test_warm_reset_version() {
         bytes_to_be_words_48(&sha384(image.manifest.preamble.owner_pub_keys.as_bytes()));
 
     let binding = image.to_bytes().unwrap();
-    let fuses = Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        runtime_svn: [0x7F, 0, 0, 0], // Equals 7
-        ..Default::default()
-    };
     let boot_params = BootParams {
-        fuses: fuses.clone(),
+        fuses: Fuses {
+            key_manifest_pk_hash: vendor_pk_hash,
+            owner_pk_hash,
+            runtime_svn: [0x7F, 0, 0, 0], // Equals 7
+            ..Default::default()
+        },
         fw_image: Some(&binding),
         ..Default::default()
     };
@@ -338,7 +332,7 @@ fn test_warm_reset_version() {
     );
 
     // Perform warm reset
-    hw.warm_reset_flow(&fuses);
+    hw.warm_reset_flow().unwrap();
 
     // Wait for boot
     while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -72,12 +72,7 @@ fn test_rt_journey_pcr_validation() {
         .unwrap();
 
     // Perform warm reset
-    model.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    model.warm_reset_flow().unwrap();
 
     model.step_until(|m| {
         m.soc_ifc().cptra_fw_error_non_fatal().read()
@@ -145,12 +140,7 @@ fn test_mbox_busy_during_warm_reset() {
         .mailbox_flow_done());
 
     // Perform warm reset
-    model.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    model.warm_reset_flow().unwrap();
 
     // Wait for boot
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().mailbox_flow_done());
@@ -208,12 +198,7 @@ fn test_mbox_idle_during_warm_reset() {
     });
 
     // Perform warm reset
-    model.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    model.warm_reset_flow().unwrap();
 
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().mailbox_flow_done());
 

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1283,6 +1283,11 @@ impl SocRegistersImpl {
             .reg
             .write(FlowStatus::READY_FOR_FUSES::SET);
 
+        self.cptra_mbox_valid_pauser = Default::default();
+        self.cptra_mbox_pauser_lock = Default::default();
+
+        // TODO: All regs on with rst_b reset signal should be reset here
+
         self.reset_common();
     }
 

--- a/test/tests/caliptra_integration_tests/warm_reset.rs
+++ b/test/tests/caliptra_integration_tests/warm_reset.rs
@@ -64,12 +64,7 @@ fn warm_reset_basic() {
     }
 
     // Perform warm reset
-    hw.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    hw.warm_reset_flow().unwrap();
 
     // Wait for boot
     while !hw.soc_ifc().cptra_flow_status().read().ready_for_runtime() {
@@ -134,12 +129,7 @@ fn warm_reset_during_fw_load() {
     hw.soc_mbox().execute().write(|w| w.execute(true));
 
     // Perform warm reset while ROM is executing the firmware load
-    hw.warm_reset_flow(&Fuses {
-        key_manifest_pk_hash: vendor_pk_hash,
-        owner_pk_hash,
-        fmc_key_manifest_svn: 0b1111111,
-        ..Default::default()
-    });
+    hw.warm_reset_flow().unwrap();
 
     // Wait for error
     while hw.soc_ifc().cptra_fw_error_fatal().read() == 0 {


### PR DESCRIPTION
Fixing nightly release failure for test_warm_reset_version on FPGA.

Warm reset flow was not re-setting all config registers set by boot. This was not re-configuring the mailbox pausers and therefore was causing mailbox access to error out.