### PR TITLE
Use newer toolchain for installing cross

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -153,7 +153,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools gcc-aarch64-linux-gnu 
           rustup target add aarch64-unknown-linux-gnu
-          cargo install cross --git https://github.com/cross-rs/cross --root /tmp/cross
+          cargo +1.88 install cross --git https://github.com/cross-rs/cross --root /tmp/cross
 
       - name: Build SD images
         run: |


### PR DESCRIPTION
`home` crate requires a newer compiler.

Image build is currently broken due to this.