### PR TITLE
Add x509 template for P-384 ECDH OCP LOCK HPKE Endorsement

### DIFF
--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -251,4 +251,32 @@ fn gen_ocp_lock_endorsement_cert(out_dir: &str) {
         "Caliptra 2.0 MlDsa87 Rt Alias",
     );
     CodeGen::gen_code("OcpLockMlKemCertTbsMlDsa87", template, out_dir);
+
+    let bldr = cert::CertTemplateBuilder::<EcdsaSha384Algo, EcdsaSha384Algo>::new()
+        .add_basic_constraints_ext(false, 0)
+        .add_key_usage_ext(usage)
+        .add_hpke_identifiers_ext(&HPKEIdentifiers::new(
+            HPKEIdentifiers::ECDH_P384_IANA_CODE_POINT,
+            HPKEIdentifiers::HKDF_SHA384_IANA_CODE_POINT,
+            HPKEIdentifiers::AES_256_GCM_IANA_CODE_POINT,
+        ));
+    let template = bldr.tbs_template(
+        "OCP LOCK HPKE Endorsement ECDH P-384",
+        "Caliptra 2.0 Ecc384 Rt Alias",
+    );
+    CodeGen::gen_code("OcpLockEcdh384CertTbsEcc384", template, out_dir);
+
+    let bldr = cert::CertTemplateBuilder::<MlDsa87Algo, EcdsaSha384Algo>::new()
+        .add_basic_constraints_ext(false, 0)
+        .add_key_usage_ext(usage)
+        .add_hpke_identifiers_ext(&HPKEIdentifiers::new(
+            HPKEIdentifiers::ECDH_P384_IANA_CODE_POINT,
+            HPKEIdentifiers::HKDF_SHA384_IANA_CODE_POINT,
+            HPKEIdentifiers::AES_256_GCM_IANA_CODE_POINT,
+        ));
+    let template = bldr.tbs_template(
+        "OCP LOCK HPKE Endorsement ECDH P-384",
+        "Caliptra 2.0 MlDsa87 Rt Alias",
+    );
+    CodeGen::gen_code("OcpLockEcdh384CertTbsMlDsa87", template, out_dir);
 }

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
@@ -1,0 +1,150 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+#[allow(clippy::needless_lifetimes)]
+pub struct OcpLockEcdh384CertTbsEcc384Params<'a> {
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+}
+#[allow(clippy::needless_lifetimes)]
+impl<'a> OcpLockEcdh384CertTbsEcc384Params<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+}
+pub struct OcpLockEcdh384CertTbsEcc384 {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl OcpLockEcdh384CertTbsEcc384 {
+    const PUBLIC_KEY_OFFSET: usize = 342usize;
+    const SUBJECT_SN_OFFSET: usize = 255usize;
+    const ISSUER_SN_OFFSET: usize = 95usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 517usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 550usize;
+    const NOT_BEFORE_OFFSET: usize = 163usize;
+    const NOT_AFTER_OFFSET: usize = 180usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    pub const TBS_TEMPLATE_LEN: usize = 570usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 2u8, 54u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
+        37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 48u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
+        82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
+        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        122u8, 49u8, 45u8, 48u8, 43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8, 79u8, 67u8, 80u8,
+        32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
+        111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8, 68u8, 72u8, 32u8,
+        80u8, 45u8, 51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8,
+        2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8,
+        1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+        15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 27u8, 6u8, 6u8, 103u8, 129u8,
+        5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8, 3u8, 2u8, 1u8, 17u8, 48u8, 3u8, 2u8, 1u8,
+        2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8,
+        20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8,
+        48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &OcpLockEcdh384CertTbsEcc384Params) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &OcpLockEcdh384CertTbsEcc384Params) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 570usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+    }
+}

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
@@ -1,0 +1,150 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+#[allow(clippy::needless_lifetimes)]
+pub struct OcpLockEcdh384CertTbsMlDsa87Params<'a> {
+    pub public_key: &'a [u8; 97usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+}
+#[allow(clippy::needless_lifetimes)]
+impl<'a> OcpLockEcdh384CertTbsMlDsa87Params<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 97usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+}
+pub struct OcpLockEcdh384CertTbsMlDsa87 {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl OcpLockEcdh384CertTbsMlDsa87 {
+    const PUBLIC_KEY_OFFSET: usize = 344usize;
+    const SUBJECT_SN_OFFSET: usize = 257usize;
+    const ISSUER_SN_OFFSET: usize = 97usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 519usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 552usize;
+    const NOT_BEFORE_OFFSET: usize = 165usize;
+    const NOT_AFTER_OFFSET: usize = 182usize;
+    const PUBLIC_KEY_LEN: usize = 97usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    pub const TBS_TEMPLATE_LEN: usize = 572usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 2u8, 56u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
+        49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8,
+        112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 48u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8,
+        56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
+        71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 48u8, 122u8, 49u8, 45u8, 48u8, 43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8,
+        79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+        110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8,
+        68u8, 72u8, 32u8, 80u8, 45u8, 51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
+        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
+        134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8, 48u8, 15u8,
+        6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8,
+        14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8,
+        27u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8, 3u8, 2u8,
+        1u8, 17u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8,
+        29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8,
+        85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &OcpLockEcdh384CertTbsMlDsa87Params) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &OcpLockEcdh384CertTbsMlDsa87Params) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 572usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+    }
+}

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -521,9 +521,7 @@ impl HPKEIdentifiers {
     // TODO(clundin): This will be used in a follow up PR.
     #[allow(dead_code)]
     pub const ML_KEM_EC_P384_IANA_CODE_POINT: KemId = KemId(0x0052);
-    // TODO(clundin): This will be used in a follow up PR.
-    #[allow(dead_code)]
-    pub const EC_P384_IANA_CODE_POINT: KemId = KemId(0x0011);
+    pub const ECDH_P384_IANA_CODE_POINT: KemId = KemId(0x0011);
 
     /// KDF id's
     pub const HKDF_SHA384_IANA_CODE_POINT: KdfId = KdfId(0x0002);

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -46,6 +46,8 @@ pub use rt_alias_cert_ecc_384::{RtAliasCertTbsEcc384, RtAliasCertTbsEcc384Params
 pub use rt_alias_cert_mldsa_87::{RtAliasCertTbsMlDsa87, RtAliasCertTbsMlDsa87Params};
 
 pub use ocp_lock_hpke_certs::{
+    ecdh_384_ecc_348::{OcpLockEcdh384CertTbsEcc384, OcpLockEcdh384CertTbsEcc384Params},
+    ecdh_384_mldsa_87::{OcpLockEcdh384CertTbsMlDsa87, OcpLockEcdh384CertTbsMlDsa87Params},
     ml_kem_ecc_348::{OcpLockMlKemCertTbsEcc384, OcpLockMlKemCertTbsEcc384Params},
     ml_kem_mldsa_87::{OcpLockMlKemCertTbsMlDsa87, OcpLockMlKemCertTbsMlDsa87Params},
 };

--- a/x509/src/ocp_lock_hpke_certs.rs
+++ b/x509/src/ocp_lock_hpke_certs.rs
@@ -320,3 +320,323 @@ pub mod ml_kem_mldsa_87 {
         }
     }
 }
+
+pub mod ecdh_384_ecc_348 {
+
+    #[cfg(feature = "generate_templates")]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs"
+    ));
+    #[cfg(not(feature = "generate_templates"))]
+    include! {"../build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs"}
+
+    #[cfg(all(test, target_family = "unix"))]
+    mod tests {
+        use openssl::ecdsa::EcdsaSig;
+        use openssl::sha::Sha384;
+        use openssl::x509::X509;
+        use x509_parser::nom::Parser;
+        use x509_parser::oid_registry::asn1_rs::oid;
+        use x509_parser::oid_registry::Oid;
+        use x509_parser::prelude::X509CertificateParser;
+        use x509_parser::x509::X509Version;
+
+        use super::*;
+        use crate::test_util::tests::*;
+        use crate::{NotAfter, NotBefore};
+
+        #[test]
+        fn test_cert() {
+            let subject_key = Ecc384AsymKey::default();
+            let issuer_key = Ecc384AsymKey::default();
+            let ec_key = issuer_key.priv_key().ec_key().unwrap();
+            let params = OcpLockEcdh384CertTbsEcc384Params {
+                serial_number: &[0xABu8; OcpLockEcdh384CertTbsEcc384Params::SERIAL_NUMBER_LEN],
+                public_key:
+                    TryInto::<&[u8; OcpLockEcdh384CertTbsEcc384Params::PUBLIC_KEY_LEN]>::try_into(
+                        subject_key.pub_key(),
+                    )
+                    .unwrap(),
+                subject_sn:
+                    &TryInto::<[u8; OcpLockEcdh384CertTbsEcc384Params::SUBJECT_SN_LEN]>::try_into(
+                        subject_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                issuer_sn:
+                    &TryInto::<[u8; OcpLockEcdh384CertTbsEcc384Params::ISSUER_SN_LEN]>::try_into(
+                        issuer_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                subject_key_id: &TryInto::<
+                    [u8; OcpLockEcdh384CertTbsEcc384Params::SUBJECT_KEY_ID_LEN],
+                >::try_into(subject_key.sha1())
+                .unwrap(),
+                authority_key_id: &TryInto::<
+                    [u8; OcpLockEcdh384CertTbsEcc384Params::AUTHORITY_KEY_ID_LEN],
+                >::try_into(issuer_key.sha1())
+                .unwrap(),
+                not_before: &NotBefore::default().value,
+                not_after: &NotAfter::default().value,
+            };
+
+            let cert = OcpLockEcdh384CertTbsEcc384::new(&params);
+
+            let sig = cert
+                .sign(|b| {
+                    let mut sha = Sha384::new();
+                    sha.update(b);
+                    EcdsaSig::sign(&sha.finish(), &ec_key)
+                })
+                .unwrap();
+
+            assert_ne!(cert.tbs(), OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE);
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET
+                    ..OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET
+                        + OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_LEN],
+                params.public_key,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsEcc384::SUBJECT_SN_OFFSET
+                    ..OcpLockEcdh384CertTbsEcc384::SUBJECT_SN_OFFSET
+                        + OcpLockEcdh384CertTbsEcc384::SUBJECT_SN_LEN],
+                params.subject_sn,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsEcc384::ISSUER_SN_OFFSET
+                    ..OcpLockEcdh384CertTbsEcc384::ISSUER_SN_OFFSET
+                        + OcpLockEcdh384CertTbsEcc384::ISSUER_SN_LEN],
+                params.issuer_sn,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                    ..OcpLockEcdh384CertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                        + OcpLockEcdh384CertTbsEcc384::SUBJECT_KEY_ID_LEN],
+                params.subject_key_id,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                    ..OcpLockEcdh384CertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                        + OcpLockEcdh384CertTbsEcc384::AUTHORITY_KEY_ID_LEN],
+                params.authority_key_id,
+            );
+
+            let ecdsa_sig = crate::Ecdsa384Signature {
+                r: TryInto::<[u8; 48]>::try_into(sig.r().to_vec_padded(48).unwrap()).unwrap(),
+                s: TryInto::<[u8; 48]>::try_into(sig.s().to_vec_padded(48).unwrap()).unwrap(),
+            };
+
+            let builder = crate::Ecdsa384CertBuilder::new(cert.tbs(), &ecdsa_sig).unwrap();
+            let mut buf = vec![0u8; builder.len()];
+            builder.build(&mut buf).unwrap();
+
+            let cert: X509 = X509::from_der(&buf).unwrap();
+            assert!(cert.verify(issuer_key.priv_key()).unwrap());
+
+            let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+            let parsed_cert = match parser.parse(&buf) {
+                Ok((_, parsed_cert)) => parsed_cert,
+                Err(e) => panic!("x509 parsing failed: {:?}", e),
+            };
+
+            assert_eq!(parsed_cert.version(), X509Version::V3);
+            let basic_constraints = parsed_cert.basic_constraints().unwrap().unwrap();
+            assert!(basic_constraints.critical);
+            assert!(!basic_constraints.value.ca);
+
+            // Check key usage. OCP LOCK HPKE certs should only allow key encipherment
+            let key_usage = parsed_cert.key_usage().unwrap().unwrap();
+            assert!(key_usage.critical);
+            assert!(key_usage.value.key_encipherment());
+            assert!(!key_usage.value.key_cert_sign());
+            assert!(!key_usage.value.digital_signature());
+
+            // Check that HPKE Identifiers extension is present
+            let ext_map = parsed_cert.extensions_map().unwrap();
+            const HPKE_IDENTIFIERS_OID: Oid = oid!(2.23.133 .21 .1 .1);
+            assert!(!ext_map[&HPKE_IDENTIFIERS_OID].critical);
+        }
+
+        #[test]
+        #[cfg(feature = "generate_templates")]
+        fn test_ocp_lock_ecdh_ecc384_template() {
+            let manual_template = std::fs::read(std::path::Path::new(
+                "./build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs",
+            ))
+            .unwrap();
+            let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+                env!("OUT_DIR"),
+                "/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs"
+            )))
+            .unwrap();
+            if auto_generated_template != manual_template {
+                panic!(
+                "Auto-generated OCP LOCK ECDH P-384 EC Certificate template is not equal to the manual template."
+            )
+            }
+        }
+    }
+}
+
+pub mod ecdh_384_mldsa_87 {
+
+    #[cfg(feature = "generate_templates")]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs"
+    ));
+    #[cfg(not(feature = "generate_templates"))]
+    include! {"../build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs"}
+
+    #[cfg(all(test, target_family = "unix"))]
+    mod tests {
+        use openssl::pkey_ctx::PkeyCtx;
+        use openssl::pkey_ml_dsa::Variant;
+        use openssl::signature::Signature;
+        use openssl::x509::X509;
+        use x509_parser::nom::Parser;
+        use x509_parser::oid_registry::asn1_rs::oid;
+        use x509_parser::oid_registry::Oid;
+        use x509_parser::prelude::X509CertificateParser;
+        use x509_parser::x509::X509Version;
+
+        use super::*;
+        use crate::test_util::tests::*;
+        use crate::{NotAfter, NotBefore};
+
+        #[test]
+        fn test_cert() {
+            let subject_key = Ecc384AsymKey::default();
+            let issuer_key = MlDsa87AsymKey::default();
+            let mldsa_key = issuer_key.priv_key();
+
+            let params = OcpLockEcdh384CertTbsMlDsa87Params {
+                serial_number: &[0xABu8; OcpLockEcdh384CertTbsMlDsa87Params::SERIAL_NUMBER_LEN],
+                public_key:
+                    TryInto::<&[u8; OcpLockEcdh384CertTbsMlDsa87Params::PUBLIC_KEY_LEN]>::try_into(
+                        subject_key.pub_key(),
+                    )
+                    .unwrap(),
+                subject_sn:
+                    &TryInto::<[u8; OcpLockEcdh384CertTbsMlDsa87Params::SUBJECT_SN_LEN]>::try_into(
+                        subject_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                issuer_sn:
+                    &TryInto::<[u8; OcpLockEcdh384CertTbsMlDsa87Params::ISSUER_SN_LEN]>::try_into(
+                        issuer_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                subject_key_id: &TryInto::<
+                    [u8; OcpLockEcdh384CertTbsMlDsa87Params::SUBJECT_KEY_ID_LEN],
+                >::try_into(subject_key.sha1())
+                .unwrap(),
+                authority_key_id: &TryInto::<
+                    [u8; OcpLockEcdh384CertTbsMlDsa87Params::AUTHORITY_KEY_ID_LEN],
+                >::try_into(issuer_key.sha1())
+                .unwrap(),
+                not_before: &NotBefore::default().value,
+                not_after: &NotAfter::default().value,
+            };
+
+            let cert = OcpLockEcdh384CertTbsMlDsa87::new(&params);
+
+            let sig = cert
+                .sign(|b| {
+                    let mut signature = vec![];
+                    let mut ctx = PkeyCtx::new(mldsa_key)?;
+                    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87)?;
+                    ctx.sign_message_init(&mut algo)?;
+                    ctx.sign_to_vec(b, &mut signature)?;
+                    Ok::<Vec<u8>, openssl::error::ErrorStack>(signature)
+                })
+                .unwrap();
+
+            assert_ne!(cert.tbs(), OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE);
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                    ..OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                        + OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_LEN],
+                params.public_key,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsMlDsa87::SUBJECT_SN_OFFSET
+                    ..OcpLockEcdh384CertTbsMlDsa87::SUBJECT_SN_OFFSET
+                        + OcpLockEcdh384CertTbsMlDsa87::SUBJECT_SN_LEN],
+                params.subject_sn,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsMlDsa87::ISSUER_SN_OFFSET
+                    ..OcpLockEcdh384CertTbsMlDsa87::ISSUER_SN_OFFSET
+                        + OcpLockEcdh384CertTbsMlDsa87::ISSUER_SN_LEN],
+                params.issuer_sn,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsMlDsa87::SUBJECT_KEY_ID_OFFSET
+                    ..OcpLockEcdh384CertTbsMlDsa87::SUBJECT_KEY_ID_OFFSET
+                        + OcpLockEcdh384CertTbsMlDsa87::SUBJECT_KEY_ID_LEN],
+                params.subject_key_id,
+            );
+            assert_eq!(
+                &cert.tbs()[OcpLockEcdh384CertTbsMlDsa87::AUTHORITY_KEY_ID_OFFSET
+                    ..OcpLockEcdh384CertTbsMlDsa87::AUTHORITY_KEY_ID_OFFSET
+                        + OcpLockEcdh384CertTbsMlDsa87::AUTHORITY_KEY_ID_LEN],
+                params.authority_key_id,
+            );
+
+            let mldsa_sig = crate::MlDsa87Signature {
+                sig: sig.try_into().unwrap(),
+            };
+
+            let builder = crate::MlDsa87CertBuilder::new(cert.tbs(), &mldsa_sig).unwrap();
+            let mut buf = vec![0u8; builder.len()];
+            builder.build(&mut buf).unwrap();
+
+            let cert: X509 = X509::from_der(&buf).unwrap();
+            assert!(cert.verify(issuer_key.priv_key()).unwrap());
+
+            let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+            let parsed_cert = match parser.parse(&buf) {
+                Ok((_, parsed_cert)) => parsed_cert,
+                Err(e) => panic!("x509 parsing failed: {:?}", e),
+            };
+
+            assert_eq!(parsed_cert.version(), X509Version::V3);
+            let basic_constraints = parsed_cert.basic_constraints().unwrap().unwrap();
+            assert!(basic_constraints.critical);
+            assert!(!basic_constraints.value.ca);
+
+            // Check key usage. OCP LOCK HPKE certs should only allow key encipherment
+            let key_usage = parsed_cert.key_usage().unwrap().unwrap();
+            assert!(key_usage.critical);
+            assert!(key_usage.value.key_encipherment());
+            assert!(!key_usage.value.key_cert_sign());
+            assert!(!key_usage.value.digital_signature());
+
+            // Check that HPKE Identifiers extension is present
+            let ext_map = parsed_cert.extensions_map().unwrap();
+            const HPKE_IDENTIFIERS_OID: Oid = oid!(2.23.133 .21 .1 .1);
+            assert!(!ext_map[&HPKE_IDENTIFIERS_OID].critical);
+        }
+
+        #[test]
+        #[cfg(feature = "generate_templates")]
+        fn test_ocp_lock_ecdh_mldsa87_template() {
+            let manual_template = std::fs::read(std::path::Path::new(
+                "./build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs",
+            ))
+            .unwrap();
+            let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+                env!("OUT_DIR"),
+                "/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs"
+            )))
+            .unwrap();
+            if auto_generated_template != manual_template {
+                panic!(
+                "Auto-generated OCP LOCK ECDH P-384 ML-DSA Certificate template is not equal to the manual template."
+            )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will be used to endorse HPKE public keys used to wrap access keys in OCP LOCK.