### PR TITLE
[hw-model] provision fake default prod debug unlock keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "caliptra-emu-periph",
  "caliptra-emu-types",
  "caliptra-hw-model-types",
+ "caliptra-image-fake-keys",
  "caliptra-image-types",
  "caliptra-registers",
  "caliptra-test-harness-types",

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -29,6 +29,7 @@ caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
 caliptra-registers.workspace = true
+caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }
 once_cell.workspace = true
 rand.workspace = true

--- a/hw-model/src/otp_provision.rs
+++ b/hw-model/src/otp_provision.rs
@@ -2,13 +2,13 @@
 
 #![allow(dead_code)]
 
-use crate::keys::{DEFAULT_PROD_DEBUG_UNLOCK_ECDSA_PUBKEY, DEFAULT_PROD_DEBUG_UNLOCK_MLDSA_PUBKEY};
 use crate::otp_digest::{otp_digest, otp_scramble, otp_unscramble};
+use caliptra_image_fake_keys::{VENDOR_ECC_KEY_0_PUBLIC, VENDOR_MLDSA_KEY_0_PUBLIC};
 
 use anyhow::{bail, Result};
 use sha2::{Digest, Sha384, Sha512};
 use sha3::{digest::ExtendableOutput, digest::Update, CShake128, CShake128Core};
-use zerocopy::{FromBytes, KnownLayout};
+use zerocopy::{FromBytes, IntoBytes, KnownLayout};
 
 /// Unhashed token, suitable for doing lifecycle transitions.
 #[derive(Clone, Copy)]
@@ -715,19 +715,17 @@ pub struct OtpSwManufPartition {
 impl Default for OtpSwManufPartition {
     fn default() -> Self {
         // Compute the SHA2-384 hash of the default ECDSA and ML-DSA public keys.
-        let mut ecdsa_pubkey = [0u8; 96];
-        for (i, word) in DEFAULT_PROD_DEBUG_UNLOCK_ECDSA_PUBKEY.iter().enumerate() {
-            ecdsa_pubkey[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
-        }
-        let mut mldsa_pubkey = [0u8; 2592];
-        for (i, word) in DEFAULT_PROD_DEBUG_UNLOCK_MLDSA_PUBKEY.iter().enumerate() {
-            mldsa_pubkey[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
-        }
+        let mut ecdsa_pubkey = [0u32; 24];
+        ecdsa_pubkey[..12].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.x);
+        ecdsa_pubkey[12..].copy_from_slice(&VENDOR_ECC_KEY_0_PUBLIC.y);
         let mut hasher = Sha384::new();
-        sha2::Digest::update(&mut hasher, ecdsa_pubkey);
-        sha2::Digest::update(&mut hasher, mldsa_pubkey);
-        let default_prod_debug_unlock_pks: [u8; 48] = hasher.finalize().into();
-
+        sha2::Digest::update(&mut hasher, ecdsa_pubkey.as_bytes());
+        sha2::Digest::update(&mut hasher, VENDOR_MLDSA_KEY_0_PUBLIC.0.as_bytes());
+        // Reverse bytes in each words so it matches the hash the ROM computes.
+        let mut default_prod_debug_unlock_pks: [u8; 48] = hasher.finalize().into();
+        for chunk in default_prod_debug_unlock_pks.chunks_mut(4) {
+            chunk.reverse();
+        }
         Self {
             anti_rollback_disable: 0x1,
             idevid_cert_attr: [0; 96],


### PR DESCRIPTION
This updates the HW model to provision default fake ECDSA and MLDSA signing keys in prod debug unlock key hash slots if no other keys are provided.