### PR TITLE
Add Warm reset test for OCP LOCK HW flow

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -294,6 +294,7 @@ jobs:
               -E 'package(caliptra-hw-model) and test(tests::test_execution)'
               -E 'package(caliptra-drivers) and test(test_dma_aes)'
               -E 'package(caliptra-drivers) and test(test_ocp_lock)'
+              -E 'package(caliptra-drivers) and test(test_ocp_lock_warm_reset)'
               -E 'package(caliptra-rom) and test(test_capabilities::test_capabilities)'
               -E 'package(caliptra-rom) and test(test_ocp_lock::test_hek_seed_states)'
               -E 'package(caliptra-rom) and test(test_ocp_lock::test_invalid_hek_seed_state)'

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -384,6 +384,12 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
+    pub const OCP_LOCK_WARM_RESET: FwId = FwId {
+        bin_name: "ocp_lock_warm_reset",
+        features: &["fpga_realtime"],
+        ..BASE_FWID
+    };
+
     pub const DMA_AES: FwId = FwId {
         bin_name: "dma_aes",
         features: &["emu", "fpga_subsystem"],
@@ -550,6 +556,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::DMA_SHA384,
     &driver_tests::DMA_SHA384_FPGA,
     &driver_tests::OCP_LOCK,
+    &driver_tests::OCP_LOCK_WARM_RESET,
     &driver_tests::DMA_AES,
     &driver_tests::AXI_BYPASS,
     &rom_tests::ASM_TESTS,

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -217,6 +217,11 @@ path = "src/bin/ocp_lock_tests.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "ocp_lock_warm_reset"
+path = "src/bin/ocp_lock_warm_reset_test.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "dma_aes"
 path = "src/bin/dma_aes_tests.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/ocp_lock_warm_reset_test.rs
+++ b/drivers/test-fw/src/bin/ocp_lock_warm_reset_test.rs
@@ -1,0 +1,120 @@
+/*++
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    ocp_lock_warm_reset_test.rs
+
+Abstract:
+
+    File contains test cases for OCP LOCK after a warm reset.
+
+--*/
+
+#![no_std]
+#![no_main]
+
+use caliptra_cfi_lib::CfiCounter;
+use caliptra_drivers::{
+    hmac_kdf, HmacKey, HmacMode, HmacTag, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, ResetReason,
+};
+use caliptra_drivers_test_bin::{
+    kv_release, populate_slot, TestRegisters, ENCRYPTED_MEK, OCP_LOCK_WARM_RESET_MAGIC_BOOT_STATUS,
+};
+use caliptra_registers::soc_ifc::SocIfcReg;
+use caliptra_test_harness::test_suite;
+
+test_suite! {
+    test_ocp_lock_warm_reset,
+}
+
+fn test_ocp_lock_warm_reset() {
+    CfiCounter::reset(&mut || Ok((0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef)));
+    let mut test_regs = TestRegisters::default();
+    assert!(test_regs.soc.ocp_lock_enabled());
+
+    let reason = test_regs.soc.reset_reason();
+    match reason {
+        ResetReason::ColdReset => {
+            cold_reset_flow(&mut test_regs);
+        }
+        ResetReason::WarmReset => {
+            warm_reset_flow(&mut test_regs);
+        }
+        _ => panic!("Unexpected reset reason"),
+    }
+}
+
+fn warm_reset_flow(test_regs: &mut TestRegisters) {
+    assert!(test_regs.soc.ocp_lock_get_lock_in_progress());
+
+    let fuse_bank = test_regs.soc.fuse_bank().ocp_hek_seed();
+    // Check hard coded hek seed from test MCU ROM.
+    assert_eq!(fuse_bank, [0xABDEu32; 8].into());
+
+    // Write lock should be lost on warm reset
+    assert!(!test_regs.kv.key_write_lock(KeyId::KeyId16));
+    assert!(!test_regs.kv.key_write_lock(KeyId::KeyId22));
+
+    // MDK & HEK should still be in KVs.
+    test_regs
+        .aes
+        .aes_256_ecb_decrypt_kv(&ENCRYPTED_MEK)
+        .unwrap();
+    // Check that we still derive the same MEK
+    kv_release(test_regs);
+}
+
+fn cold_reset_flow(test_regs: &mut TestRegisters) -> ! {
+    ocp_lock_flow(test_regs);
+    let mut soc_ifc = unsafe { SocIfcReg::new() };
+
+    // Signal test harness we are ready for reset
+    soc_ifc
+        .regs_mut()
+        .cptra_boot_status()
+        .write(|_| OCP_LOCK_WARM_RESET_MAGIC_BOOT_STATUS);
+
+    loop {}
+}
+
+fn ocp_lock_flow(test_regs: &mut TestRegisters) {
+    let cdi_slot = HmacKey::Key(KeyReadArgs::new(KeyId::KeyId3));
+    let mdk_slot = HmacTag::Key(KeyWriteArgs::from(KeyWriteArgs::new(
+        KeyId::KeyId16,
+        KeyUsage::default().set_aes_key_en(),
+    )));
+
+    populate_slot(
+        &mut test_regs.hmac,
+        &mut test_regs.trng,
+        KeyId::KeyId3, // CDI Slot
+        KeyUsage::default().set_hmac_key_en(),
+    )
+    .unwrap();
+    hmac_kdf(
+        &mut test_regs.hmac,
+        cdi_slot,
+        b"OCP_LOCK_MDK",
+        None,
+        &mut test_regs.trng,
+        mdk_slot,
+        HmacMode::Hmac512,
+    )
+    .unwrap();
+
+    test_regs.kv.set_key_write_lock(KeyId::KeyId16);
+    test_regs.kv.set_key_write_lock(KeyId::KeyId22);
+
+    let fuse_bank = test_regs.soc.fuse_bank().ocp_hek_seed();
+    assert_eq!(fuse_bank, [0xABDEu32; 8].into());
+
+    test_regs.soc.ocp_lock_set_lock_in_progress();
+    assert!(test_regs.soc.ocp_lock_get_lock_in_progress());
+
+    test_regs
+        .aes
+        .aes_256_ecb_decrypt_kv(&ENCRYPTED_MEK)
+        .unwrap();
+    kv_release(test_regs);
+}

--- a/drivers/test-fw/src/lib.rs
+++ b/drivers/test-fw/src/lib.rs
@@ -5,12 +5,12 @@
 use caliptra_drivers::{
     dma::MCU_SRAM_OFFSET, Aes, Array4x16, AxiAddr, DeobfuscationEngine, Dma, DmaWriteOrigin,
     DmaWriteTransaction, Ecc384PubKey, Hmac, HmacData, HmacKey, HmacMode, KeyId, KeyReadArgs,
-    KeyUsage, KeyWriteArgs, SocIfc, Trng,
+    KeyUsage, KeyVault, KeyWriteArgs, SocIfc, Trng,
 };
 use caliptra_kat::CaliptraResult;
 use caliptra_registers::{
     aes::AesReg, aes_clp::AesClpReg, csrng::CsrngReg, doe::DoeReg, entropy_src::EntropySrcReg,
-    hmac::HmacReg, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
+    hmac::HmacReg, kv::KvReg, soc_ifc::SocIfcReg, soc_ifc_trng::SocIfcTrngReg,
 };
 
 /// Code shared between the caliptra-drivers integration_test.rs (running on the
@@ -42,6 +42,8 @@ pub const PLAINTEXT_MEK: [u8; 64] = [
     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
     0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F,
 ];
+
+pub const OCP_LOCK_WARM_RESET_MAGIC_BOOT_STATUS: u32 = 0xFEEB;
 
 #[derive(IntoBytes, KnownLayout, Immutable, Clone, Copy, Default, Eq, PartialEq, FromBytes)]
 #[repr(C)]
@@ -84,6 +86,7 @@ pub struct TestRegisters {
     pub trng: Trng,
     pub dma: Dma,
     pub doe: DeobfuscationEngine,
+    pub kv: KeyVault,
 }
 
 impl Default for TestRegisters {
@@ -103,6 +106,7 @@ impl Default for TestRegisters {
         };
         let dma = Dma::default();
         let doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
+        let kv = unsafe { KeyVault::new(KvReg::new()) };
 
         Self {
             soc,
@@ -111,6 +115,7 @@ impl Default for TestRegisters {
             trng,
             dma,
             doe,
+            kv,
         }
     }
 }


### PR DESCRIPTION
TODO: Build full OCP LOCK key ladder in these tests, to exercise all KV slots.