### PR TITLE
kats: Split KATs into initial ROM, initial runtime, all

### DIFF
--- a/kat/Cargo.toml
+++ b/kat/Cargo.toml
@@ -15,3 +15,6 @@ caliptra-registers.workspace = true
 caliptra-lms-types.workspace = true
 zerocopy.workspace = true
 ufmt.workspace = true
+
+[features]
+rom = []

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -41,6 +41,7 @@ pub use aes256ecb_kat::Aes256EcbKat;
 pub use aes256gcm_kat::Aes256GcmKat;
 pub use caliptra_drivers::{CaliptraError, CaliptraResult};
 pub use cmackdf_kat::CmacKdfKat;
+
 pub use ecc384_kat::Ecc384Kat;
 pub use ecdh_kat::EcdhKat;
 pub use hkdf_kat::{Hkdf384Kat, Hkdf512Kat};
@@ -57,14 +58,33 @@ pub use sha512_kat::Sha512Kat;
 
 use caliptra_drivers::cprintln;
 
-/// Execute Known Answer Tests
+/// Execute initial Known Answer Tests for the current environment (ROM or runtime).
 ///
 /// # Arguments
 ///
 /// * `env` - ROM Environment
-pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
+pub fn execute_initial_kats(env: &mut KatsEnv) -> CaliptraResult<()> {
     cprintln!("[kat] ++");
+    if cfg!(feature = "rom") {
+        execute_rom_kats(env)?;
+    } else {
+        execute_runtime_only_kats(env)?;
+    }
+    cprintln!("[kat] --");
+    Ok(())
+}
 
+/// Execute all Known Answer Tests unconditionally.
+pub fn execute_all_kats(env: &mut KatsEnv) -> CaliptraResult<()> {
+    cprintln!("[kat] ++");
+    execute_rom_kats(env)?;
+    execute_runtime_only_kats(env)?;
+    cprintln!("[kat] --");
+    Ok(())
+}
+
+/// Execute Known Answer Tests for capabilities ROM uses.
+fn execute_rom_kats(env: &mut KatsEnv) -> CaliptraResult<()> {
     cprintln!("[kat] sha1");
     Sha1Kat::default().execute(env.sha1)?;
 
@@ -80,11 +100,70 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
     cprintln!("[kat] SHA2-512-ACC");
     Sha2_512_384AccKat::default().execute(env.sha2_512_384_acc, env.sha_acc_lock_state)?;
 
-    cprintln!("[kat] SHAKE-256");
-    Shake256Kat::default().execute(env.sha3)?;
-
     cprintln!("[kat] ECC-384");
     Ecc384Kat::default().execute(env.ecc384, env.trng)?;
+
+    cprintln!("[kat] HMAC-512Kdf");
+    Hmac512KdfKat::default().execute(env.hmac, env.trng)?;
+
+    // [TODO][CAP2.1]: re-enable all of these
+    // cprintln!("[kat] HKDF-512");
+    // Hkdf512Kat::default().execute(env.hmac, env.trng)?;
+
+    // cprintln!("[kat] KDF-CMAC");
+    // CmacKdfKat::default().execute(env.aes)?;
+
+    cprintln!("[kat] LMS");
+    // cprintln!("[kat] HKDF-512");
+    // Hkdf512Kat::default().execute(env.hmac, env.trng)?;
+
+    // cprintln!("[kat] KDF-CMAC");
+    // CmacKdfKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] MLDSA87");
+    // Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
+
+    // cprintln!("[kat] AES-256-ECB");
+    // Aes256EcbKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CBC");
+    // Aes256CbcKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CMAC");
+    // Aes256CmacKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CTR");
+    // Aes256CtrKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-GCM");
+    // Aes256GcmKat::default().execute(env.aes, env.trng)?;
+    LmsKat::default().execute(env.sha256, env.lms)?;
+
+    // cprintln!("[kat] MLDSA87");
+    // Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
+
+    // cprintln!("[kat] AES-256-ECB");
+    // Aes256EcbKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CBC");
+    // Aes256CbcKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CMAC");
+    // Aes256CmacKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-CTR");
+    // Aes256CtrKat::default().execute(env.aes)?;
+
+    // cprintln!("[kat] AES-256-GCM");
+    // Aes256GcmKat::default().execute(env.aes, env.trng)?;
+
+    Ok(())
+}
+
+/// Execute Known Answer Tests for capabilities only used in runtime.
+fn execute_runtime_only_kats(env: &mut KatsEnv) -> CaliptraResult<()> {
+    cprintln!("[kat] SHAKE-256");
+    Shake256Kat::default().execute(env.sha3)?;
 
     cprintln!("[kat] ECDH");
     EcdhKat::default().execute(env.ecc384, env.trng)?;
@@ -92,40 +171,8 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<()> {
     cprintln!("[kat] HMAC-384Kdf");
     Hmac384KdfKat::default().execute(env.hmac, env.trng)?;
 
-    cprintln!("[kat] HMAC-512Kdf");
-    Hmac512KdfKat::default().execute(env.hmac, env.trng)?;
-
     cprintln!("[kat] HKDF-384");
     Hkdf384Kat::default().execute(env.hmac, env.trng)?;
-
-    cprintln!("[kat] HKDF-512");
-    Hkdf512Kat::default().execute(env.hmac, env.trng)?;
-
-    cprintln!("[kat] KDF-CMAC");
-    CmacKdfKat::default().execute(env.aes)?;
-
-    cprintln!("[kat] LMS");
-    LmsKat::default().execute(env.sha256, env.lms)?;
-
-    cprintln!("[kat] MLDSA87");
-    Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
-
-    cprintln!("[kat] AES-256-ECB");
-    Aes256EcbKat::default().execute(env.aes)?;
-
-    cprintln!("[kat] AES-256-CBC");
-    Aes256CbcKat::default().execute(env.aes)?;
-
-    cprintln!("[kat] AES-256-CMAC");
-    Aes256CmacKat::default().execute(env.aes)?;
-
-    cprintln!("[kat] AES-256-CTR");
-    Aes256CtrKat::default().execute(env.aes)?;
-
-    cprintln!("[kat] AES-256-GCM");
-    Aes256GcmKat::default().execute(env.aes, env.trng)?;
-
-    cprintln!("[kat] --");
 
     Ok(())
 }

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -120,23 +120,6 @@ fn execute_rom_kats(env: &mut KatsEnv) -> CaliptraResult<()> {
     // cprintln!("[kat] KDF-CMAC");
     // CmacKdfKat::default().execute(env.aes)?;
 
-    // cprintln!("[kat] MLDSA87");
-    // Mldsa87Kat::default().execute(env.mldsa87, env.trng)?;
-
-    // cprintln!("[kat] AES-256-ECB");
-    // Aes256EcbKat::default().execute(env.aes)?;
-
-    // cprintln!("[kat] AES-256-CBC");
-    // Aes256CbcKat::default().execute(env.aes)?;
-
-    // cprintln!("[kat] AES-256-CMAC");
-    // Aes256CmacKat::default().execute(env.aes)?;
-
-    // cprintln!("[kat] AES-256-CTR");
-    // Aes256CtrKat::default().execute(env.aes)?;
-
-    // cprintln!("[kat] AES-256-GCM");
-    // Aes256GcmKat::default().execute(env.aes, env.trng)?;
     LmsKat::default().execute(env.sha256, env.lms)?;
 
     // cprintln!("[kat] MLDSA87");

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -20,7 +20,7 @@ caliptra-drivers.workspace = true
 caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false }
 caliptra-image-verify = { workspace = true, default-features = false }
-caliptra-kat.workspace = true
+caliptra-kat = { workspace = true, features = ["rom"] }
 caliptra-lms-types.workspace = true
 caliptra-registers.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -368,10 +368,22 @@ ROM performs the following POST tests to ensure that needed cryptographic module
  - SHA1
  - SHA2-256
  - SHA2-384
- - SHA2-384-ACC
+ - SHA2-512
+ - SHA2-512-ACC
  - ECC-384
- - HMAC-384Kdf
+ - ECDH
+ - HMAC-384Kdf (conditionally, if not ROM feature)
+ - HMAC-512Kdf
+ - HKDF-384 (conditionally, if not ROM feature)
+ - HKDF-512
+ - KDF-CMAC
  - LMS
+ - MLDSA87
+ - AES-256-ECB
+ - AES-256-CBC
+ - AES-256-CMAC
+ - AES-256-CTR
+ - AES-256-GCM
 
 ### DICE Flow
 

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -372,7 +372,7 @@ ROM performs the following POST tests to ensure that needed cryptographic module
  - SHA2-512-ACC
  - SHAKE-256
  - ECC-384
- - ECDH
+ - ECDH (conditionally, if not ROM feature)
  - HMAC-384Kdf (conditionally, if not ROM feature)
  - HMAC-512Kdf
  - HKDF-384 (conditionally, if not ROM feature)

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -370,7 +370,7 @@ ROM performs the following POST tests to ensure that needed cryptographic module
  - SHA2-384
  - SHA2-512
  - SHA2-512-ACC
- - SHAKE-256
+ - SHAKE-256 (conditionally, if not ROM feature)
  - ECC-384
  - ECDH (conditionally, if not ROM feature)
  - HMAC-384Kdf (conditionally, if not ROM feature)

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -370,6 +370,7 @@ ROM performs the following POST tests to ensure that needed cryptographic module
  - SHA2-384
  - SHA2-512
  - SHA2-512-ACC
+ - SHAKE-256
  - ECC-384
  - ECDH
  - HMAC-384Kdf (conditionally, if not ROM feature)

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -247,7 +247,7 @@ fn run_fips_tests(env: &mut KatsEnv) -> CaliptraResult<()> {
     let rom_info = unsafe { &CALIPTRA_ROM_INFO };
     rom_integrity_test(env, &rom_info.sha256_digest)?;
 
-    caliptra_kat::execute_kat(env)?;
+    caliptra_kat::execute_initial_kats(env)?;
 
     report_boot_status(KatComplete.into());
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ use tagging::{GetTaggedTciCmd, TagTciCmd};
 
 use caliptra_common::cprintln;
 
-use caliptra_drivers::{CaliptraError, CaliptraResult, ResetReason};
+use caliptra_drivers::{CaliptraError, CaliptraResult, ResetReason, ShaAccLockState};
 use caliptra_registers::mbox::enums::MboxStatusE;
 pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 use dpe::{
@@ -577,4 +577,54 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         }
     }
     //    Ok(())
+}
+
+pub enum Kats {
+    Initial,
+    All,
+}
+
+pub fn execute_kats(env: &mut Drivers, kats: Kats) -> CaliptraResult<()> {
+    let mut kats_env = caliptra_kat::KatsEnv {
+        // SHA1 Engine
+        sha1: &mut env.sha1,
+
+        // sha256
+        sha256: &mut env.sha256,
+
+        // SHA2-512/384 Engine
+        sha2_512_384: &mut env.sha2_512_384,
+
+        // SHA2-512/384 Accelerator
+        sha2_512_384_acc: &mut env.sha2_512_384_acc,
+
+        // SHA3/SHAKE
+        sha3: &mut env.sha3,
+
+        // Hmac-512/384 Engine
+        hmac: &mut env.hmac,
+
+        // Cryptographically Secure Random Number Generator
+        trng: &mut env.trng,
+
+        // LMS Engine
+        lms: &mut env.lms,
+
+        // MLDSA87 Engine
+        mldsa87: &mut env.mldsa87,
+
+        // Ecc384 Engine
+        ecc384: &mut env.ecc384,
+
+        // AES Engine,
+        aes: &mut env.aes,
+
+        // SHA Acc Lock State
+        sha_acc_lock_state: ShaAccLockState::NotAcquired,
+    };
+
+    match kats {
+        Kats::Initial => caliptra_kat::execute_initial_kats(&mut kats_env),
+        Kats::All => caliptra_kat::execute_all_kats(&mut kats_env),
+    }
 }

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -286,10 +286,21 @@ fn smoke_test() {
                 assert_output_contains(&output, "[kat] SHA2-384");
                 assert_output_contains(&output, "[kat] SHA2-512");
                 assert_output_contains_regex(&output, r"\[kat\] SHA2-(384|512)-ACC");
-                assert_output_contains(&output, "[kat] HMAC-384Kdf");
-                assert_output_contains(&output, "[kat] HMAC-512Kdf");
-                assert_output_contains(&output, "[kat] LMS");
-                assert_output_contains(&output, "[kat] MLDSA87");
+                // [TODO][CAP2.1]: re-enable once KATs are re-enabled
+                // assert_output_contains(&output, "[kat] ECC-384");
+                // assert_output_contains(&output, "[kat] ECDH");
+                // //assert_output_contains(&output, "[kat] HMAC-384Kdf"); // conditional on !rom feature
+                // assert_output_contains(&output, "[kat] HMAC-512Kdf");
+                // //assert_output_contains(&output, "[kat] HKDF-384"); // conditional on !rom feature
+                // assert_output_contains(&output, "[kat] HKDF-512");
+                // assert_output_contains(&output, "[kat] KDF-CMAC");
+                // assert_output_contains(&output, "[kat] LMS");
+                // assert_output_contains(&output, "[kat] MLDSA87");
+                // assert_output_contains(&output, "[kat] AES-256-ECB");
+                // assert_output_contains(&output, "[kat] AES-256-CBC");
+                // assert_output_contains(&output, "[kat] AES-256-CMAC");
+                // assert_output_contains(&output, "[kat] AES-256-CTR");
+                // assert_output_contains(&output, "[kat] AES-256-GCM");
                 assert_output_contains(&output, "[kat] --");
                 assert_output_contains(&output, "Running Caliptra FMC");
                 assert_output_contains(&output, "Caliptra RT");


### PR DESCRIPTION
KATs are split into 3:
* Initial KATs in the ROM (for capabilities ROM uses)
* Initial KATs in the runtime (for capabilities that only runtime uses)
* All KATs (used by FIPS self test command)

This helps save space in the ROM and speed up ROM boot times.

We disable some KATs for now to save some space for upcoming changes (see #2679).

We'll re-enable these in future PRs as we get some space savings.