### PR TITLE
[feat] Add LDEV ECC and MLDSA cert retrieval commands to ROM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,6 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitfield",
- "caliptra_common",
  "convert_case",
  "der",
  "hex",
@@ -1060,6 +1059,7 @@ dependencies = [
  "caliptra-image-types",
  "caliptra-image-verify",
  "caliptra-registers",
+ "caliptra-x509",
  "memoffset 0.8.0",
  "riscv",
  "ufmt",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ ufmt.workspace = true
 zerocopy.workspace = true
 zeroize.workspace = true
 riscv.workspace = true
+caliptra-x509 = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]

--- a/common/src/dice.rs
+++ b/common/src/dice.rs
@@ -8,11 +8,181 @@ File Name:
 
 Abstract:
 
-    DICE-related constants.
+    DICE-related
 
 --*/
+
+use caliptra_api::mailbox::{AlgorithmType, GetLdevCertResp, MailboxRespHeader, ResponseVarSize};
+use caliptra_drivers::{
+    CaliptraError, CaliptraResult, Ecc384Signature, Mldsa87Signature, PersistentData,
+};
+use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, MlDsa87CertBuilder};
+
+use crate::hmac_cm::mutrefbytes;
 
 pub const FLAG_BIT_NOT_CONFIGURED: u32 = 1 << 0;
 pub const FLAG_BIT_NOT_SECURE: u32 = 1 << 1;
 pub const FLAG_BIT_DEBUG: u32 = 1 << 3;
 pub const FLAG_BIT_FIXED_WIDTH: u32 = 1 << 31;
+
+/// Return the LDevId ECC cert signature
+///
+/// # Arguments
+///
+/// * `persistent_data` - PersistentData
+///
+/// # Returns
+///
+/// * `Ecc384Signature` - The formed signature
+pub fn ldevid_dice_sign(persistent_data: &PersistentData) -> Ecc384Signature {
+    persistent_data.data_vault.ldev_dice_ecc_signature()
+}
+
+/// Return the LDevId MLDSA87 cert signature
+///
+/// # Arguments
+///
+/// * `persistent_data` - PersistentData
+///
+/// # Returns
+///
+/// * `Mldsa87Signature` - The formed signature
+pub fn ldevid_dice_mldsa87_sign(persistent_data: &PersistentData) -> Mldsa87Signature {
+    persistent_data.data_vault.ldev_dice_mldsa_signature()
+}
+
+pub struct GetLdevCertCmd;
+impl GetLdevCertCmd {
+    #[inline(never)]
+    pub fn execute(
+        persistent_data: &PersistentData,
+        alg_type: AlgorithmType,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let resp = mutrefbytes::<GetLdevCertResp>(resp)?;
+        resp.hdr = MailboxRespHeader::default();
+
+        match alg_type {
+            AlgorithmType::Ecc384 => {
+                resp.data_size = copy_ldevid_ecc384_cert(persistent_data, &mut resp.data)? as u32;
+            }
+            AlgorithmType::Mldsa87 => {
+                resp.data_size = copy_ldevid_mldsa87_cert(persistent_data, &mut resp.data)? as u32;
+            }
+        }
+        resp.partial_len()
+    }
+}
+
+/// Create a certificate from a tbs and a signature and write the output to `cert`
+///
+/// # Arguments
+///
+/// * `tbs` - ToBeSigned portion
+/// * `sig` - Ecc384Signature
+/// * `cert` - Buffer to copy LDevID certificate to
+///
+/// # Returns
+/// * `usize` - The number of bytes written to `cert`
+pub fn ecc384_cert_from_tbs_and_sig(
+    tbs: Option<&[u8]>,
+    sig: &Ecc384Signature,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    let Some(tbs) = tbs else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    // Convert from Ecc384Signature to Ecdsa384Signature
+    let bldr_sig = Ecdsa384Signature {
+        r: sig.r.into(),
+        s: sig.s.into(),
+    };
+    let Some(builder) = Ecdsa384CertBuilder::new(tbs, &bldr_sig) else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    let Some(size) = builder.build(cert) else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    Ok(size)
+}
+
+/// Create a certificate from a tbs and a signature and write the output to `cert`
+///
+/// # Arguments
+///
+/// * `tbs` - ToBeSigned portion
+/// * `sig` - MlDsa87Signature
+/// * `cert` - Buffer to copy LDevID certificate to
+///
+/// # Returns
+/// * `usize` - The number of bytes written to `cert`
+pub fn mldsa87_cert_from_tbs_and_sig(
+    tbs: Option<&[u8]>,
+    sig: &Mldsa87Signature,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    let Some(tbs) = tbs else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    let sig_bytes = <[u8; 4628]>::from(sig)[..4627].try_into().unwrap();
+    let signature = caliptra_x509::MlDsa87Signature { sig: sig_bytes };
+
+    let Some(builder) = MlDsa87CertBuilder::new(tbs, &signature) else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    let Some(size) = builder.build(cert) else {
+        return Err(CaliptraError::CALIPTRA_INTERNAL);
+    };
+
+    Ok(size)
+}
+
+/// Copy ECC LDevID certificate produced by ROM to `cert` buffer
+///
+/// # Arguments
+///
+/// * `persistent_data` - PersistentData
+/// * `cert` - Buffer to copy LDevID certificate to
+///
+/// # Returns
+///
+/// * `usize` - The number of bytes written to `cert`
+#[inline(never)]
+pub fn copy_ldevid_ecc384_cert(
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    let tbs = persistent_data
+        .ecc_ldevid_tbs
+        .get(..persistent_data.fht.ecc_ldevid_tbs_size.into());
+    let sig = ldevid_dice_sign(persistent_data);
+    ecc384_cert_from_tbs_and_sig(tbs, &sig, cert).map_err(|_| CaliptraError::GET_LDEVID_CERT_FAILED)
+}
+
+/// Copy MLDSA LDevID certificate produced by ROM to `cert` buffer
+///
+/// # Arguments
+///
+/// * `persistent_data` - PersistentData
+/// * `cert` - Buffer to copy LDevID certificate to
+///
+/// # Returns
+///
+/// * `usize` - The number of bytes written to `cert`
+#[inline(never)]
+pub fn copy_ldevid_mldsa87_cert(
+    persistent_data: &PersistentData,
+    cert: &mut [u8],
+) -> CaliptraResult<usize> {
+    let tbs = persistent_data
+        .mldsa_ldevid_tbs
+        .get(..persistent_data.fht.mldsa_ldevid_tbs_size.into());
+    let sig = ldevid_dice_mldsa87_sign(persistent_data);
+    mldsa87_cert_from_tbs_and_sig(tbs, &sig, cert)
+        .map_err(|_| CaliptraError::GET_LDEVID_CERT_FAILED)
+}

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -67,6 +67,7 @@ impl CaliptraError {
             0x00010002,
             "Bad datastore register type"
         ),
+        (CALIPTRA_INTERNAL, 0x00010003, "Internal error"),
         (
             DRIVER_SHA256_INVALID_STATE,
             0x00020001,
@@ -1173,9 +1174,9 @@ impl CaliptraError {
             "Runtime Error: DPE command deserialization failed"
         ),
         (
-            RUNTIME_GET_LDEVID_CERT_FAILED,
+            GET_LDEVID_CERT_FAILED,
             0x000E0028,
-            "Runtime Error: Get LDevID cert failed"
+            "Caliptra Error: Get LDevID cert failed"
         ),
         (
             RUNTIME_GET_FMC_ALIAS_CERT_FAILED,

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -15,6 +15,7 @@ mod test_fips_hooks;
 mod test_fmcalias_derivation;
 mod test_idevid_derivation;
 mod test_image_validation;
+mod test_ldev_cert_cmd;
 mod test_mailbox_errors;
 mod test_mldsa_verify;
 mod test_panic_missing;

--- a/rom/dev/tests/rom_integration_tests/test_ldev_cert_cmd.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ldev_cert_cmd.rs
@@ -1,0 +1,129 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::mailbox::GetLdevCertResp;
+use caliptra_api::SocManager;
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
+use caliptra_hw_model::{DefaultHwModel, Fuses, HwModel};
+use caliptra_image_types::FwVerificationPqcKeyType;
+use openssl::x509::X509;
+use zerocopy::IntoBytes;
+
+use crate::helpers;
+
+const RT_READY_FOR_COMMANDS: u32 = 0x600;
+
+fn get_ldev_ecc_cert(model: &mut DefaultHwModel) -> GetLdevCertResp {
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::GET_LDEV_ECC384_CERT),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::GET_LDEV_ECC384_CERT),
+            payload.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
+    let mut ldev_resp = GetLdevCertResp::default();
+    ldev_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+    ldev_resp
+}
+
+fn get_ldev_mldsa_cert(model: &mut DefaultHwModel) -> GetLdevCertResp {
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::GET_LDEV_MLDSA87_CERT),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::GET_LDEV_MLDSA87_CERT),
+            payload.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    assert!(resp.len() <= std::mem::size_of::<GetLdevCertResp>());
+    let mut ldev_resp = GetLdevCertResp::default();
+    ldev_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+    ldev_resp
+}
+
+#[test]
+fn test_ldev_ecc384_cert() {
+    let (mut hw, image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Step till we are ready for mailbox processing
+    hw.step_until(|m| {
+        m.soc_ifc()
+            .cptra_flow_status()
+            .read()
+            .ready_for_mb_processing()
+    });
+
+    // Get LDev ECC384 cert from ROM
+    let ldev_resp = get_ldev_ecc_cert(&mut hw);
+    let ldev_cert_rom: X509 =
+        X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
+
+    // Step till RT is ready for commands
+    helpers::test_upload_firmware(
+        &mut hw,
+        &image_bundle.to_bytes().unwrap(),
+        FwVerificationPqcKeyType::MLDSA,
+    );
+    hw.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    // Get the LDev ECC384 cert from RT
+    let ldev_resp = get_ldev_ecc_cert(&mut hw);
+    let ldev_cert_rt: X509 =
+        X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
+
+    // Compare the two certs
+    assert_eq!(
+        ldev_cert_rom.to_der().unwrap(),
+        ldev_cert_rt.to_der().unwrap()
+    );
+}
+
+#[test]
+fn test_ldev_mldsa87_cert() {
+    let (mut hw, image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Step till we are ready for mailbox processing
+    hw.step_until(|m| {
+        m.soc_ifc()
+            .cptra_flow_status()
+            .read()
+            .ready_for_mb_processing()
+    });
+
+    // Get LDev MLDSA87 cert from ROM
+    let ldev_resp = get_ldev_mldsa_cert(&mut hw);
+    let ldev_cert_rom: X509 =
+        X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
+
+    // Step till RT is ready for commands
+    helpers::test_upload_firmware(
+        &mut hw,
+        &image_bundle.to_bytes().unwrap(),
+        FwVerificationPqcKeyType::MLDSA,
+    );
+    hw.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    // Get the LDev MLDSA87 cert from RT
+    let ldev_resp = get_ldev_mldsa_cert(&mut hw);
+    let ldev_cert_rt: X509 =
+        X509::from_der(&ldev_resp.data[..ldev_resp.data_size as usize]).unwrap();
+
+    // Compare the two certs
+    assert_eq!(
+        ldev_cert_rom.to_der().unwrap(),
+        ldev_cert_rt.to_der().unwrap()
+    );
+}

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -30,6 +30,7 @@ use arrayvec::ArrayVec;
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder};
 use caliptra_common::cfi_check;
+use caliptra_common::dice::{copy_ldevid_ecc384_cert, copy_ldevid_mldsa87_cert};
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
 use caliptra_drivers::{
     cprintln, hand_off::DataStore, pcr_log::RT_FW_JOURNEY_PCR, sha2_512_384::Sha2DigestOpTrait,
@@ -595,10 +596,8 @@ impl Drivers {
         }
 
         // Write ldev_id cert to cert chain.
-        let ldevid_cert_size = dice::copy_ldevid_ecc384_cert(
-            persistent_data.get(),
-            drivers.ecc_cert_chain.as_mut_slice(),
-        )?;
+        let ldevid_cert_size =
+            copy_ldevid_ecc384_cert(persistent_data.get(), drivers.ecc_cert_chain.as_mut_slice())?;
         if ldevid_cert_size > drivers.ecc_cert_chain.len() {
             return Err(CaliptraError::RUNTIME_LDEV_ID_CERT_TOO_BIG);
         }
@@ -642,7 +641,7 @@ impl Drivers {
         }
 
         // Write ldev_id cert to cert chain.
-        let ldevid_cert_size = dice::copy_ldevid_mldsa87_cert(
+        let ldevid_cert_size = copy_ldevid_mldsa87_cert(
             persistent_data.get(),
             drivers.mldsa_cert_chain.as_mut_slice(),
         )?;

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -305,7 +305,7 @@ pub fn generate_test_x509_cert(private_key: &PKey<Private>) -> X509 {
     cert_builder
         .set_serial_number(&Asn1Integer::from_bn(&BigNum::from_u32(1).unwrap()).unwrap())
         .unwrap();
-    let mut subj_name_builder = X509Name::builder().unwrap();
+    let mut subj_name_builder: X509NameBuilder = X509Name::builder().unwrap();
     subj_name_builder
         .append_entry_by_text("CN", "example.com")
         .unwrap();

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -15,7 +15,6 @@ zeroize.workspace = true
 [build-dependencies]
 asn1 = { workspace = true, optional = true }
 bitfield = { workspace = true, optional = true }
-caliptra_common = { workspace = true, optional = true, features = ["std"] }
 convert_case = { workspace = true, optional = true }
 der = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
@@ -33,4 +32,4 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 std = []
-generate_templates = ["dep:asn1", "dep:bitfield", "dep:caliptra_common", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn", "dep:rand"]
+generate_templates = ["dep:asn1", "dep:bitfield", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn", "dep:rand"]

--- a/x509/build/cert.rs
+++ b/x509/build/cert.rs
@@ -13,9 +13,8 @@ Abstract:
 
 --*/
 
-use crate::tbs::{init_param, sanitize, TbsParam, TbsTemplate};
+use crate::tbs::{get_tbs, init_param, sanitize, TbsParam, TbsTemplate};
 use crate::x509::{self, AsymKey, FwidParam, KeyUsage, SigningAlgorithm};
-use caliptra_common::x509::get_tbs;
 use openssl::asn1::Asn1Time;
 use openssl::bn::BigNum;
 use openssl::stack::Stack;

--- a/x509/build/csr.rs
+++ b/x509/build/csr.rs
@@ -13,9 +13,8 @@ Abstract:
 
 --*/
 
-use crate::tbs::{init_param, sanitize, TbsParam, TbsTemplate};
+use crate::tbs::{get_tbs, init_param, sanitize, TbsParam, TbsTemplate};
 use crate::x509::{self, AsymKey, KeyUsage, SigningAlgorithm};
-use caliptra_common::x509::get_tbs;
 use openssl::stack::Stack;
 use openssl::x509::{X509Extension, X509NameBuilder, X509ReqBuilder};
 

--- a/x509/build/tbs.rs
+++ b/x509/build/tbs.rs
@@ -89,3 +89,40 @@ pub fn sanitize(param: TbsParam, buf: &mut [u8]) -> TbsParam {
     }
     param
 }
+
+/// Retrieve the TBS from DER encoded vector
+///
+/// Note: Rust OpenSSL binding is missing the extensions to retrieve TBS portion of the X509
+/// artifact
+#[cfg(feature = "std")]
+pub fn get_tbs(der: Vec<u8>) -> Vec<u8> {
+    if der[0] != 0x30 {
+        panic!("Invalid DER start tag");
+    }
+
+    let der_len_offset = 1;
+
+    let tbs_offset = match der[der_len_offset] {
+        0..=0x7F => der_len_offset + 1,
+        0x81 => der_len_offset + 2,
+        0x82 => der_len_offset + 3,
+        _ => panic!("Unsupported DER Length"),
+    };
+
+    if der[tbs_offset] != 0x30 {
+        panic!("Invalid TBS start tag");
+    }
+
+    let tbs_len_offset = tbs_offset + 1;
+    let tbs_len = match der[tbs_len_offset] {
+        0..=0x7F => der[tbs_len_offset] as usize + 2,
+        0x81 => (der[tbs_len_offset + 1]) as usize + 3,
+        0x82 => {
+            (((der[tbs_len_offset + 1]) as usize) << u8::BITS)
+                | (((der[tbs_len_offset + 2]) as usize) + 4)
+        }
+        _ => panic!("Invalid DER Length"),
+    };
+
+    der[tbs_offset..tbs_offset + tbs_len].to_vec()
+}

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -12,8 +12,6 @@ Abstract:
 
 --*/
 
-use caliptra_common::dice;
-
 use openssl::asn1::{Asn1Object, Asn1OctetString};
 use openssl::bn::BigNumContext;
 use openssl::ec::EcGroup;
@@ -33,10 +31,13 @@ use openssl::x509::X509Extension;
 use openssl::x509::X509v3Context;
 use rand::Rng;
 
-const FLAG_MASK: u32 = dice::FLAG_BIT_NOT_CONFIGURED
-    | dice::FLAG_BIT_NOT_SECURE
-    | dice::FLAG_BIT_DEBUG
-    | dice::FLAG_BIT_FIXED_WIDTH;
+const FLAG_BIT_NOT_CONFIGURED: u32 = 1 << 0;
+const FLAG_BIT_NOT_SECURE: u32 = 1 << 1;
+const FLAG_BIT_DEBUG: u32 = 1 << 3;
+const FLAG_BIT_FIXED_WIDTH: u32 = 1 << 31;
+
+const FLAG_MASK: u32 =
+    FLAG_BIT_NOT_CONFIGURED | FLAG_BIT_NOT_SECURE | FLAG_BIT_DEBUG | FLAG_BIT_FIXED_WIDTH;
 
 const AUTH_KEY_ID_OID: &str = "2.5.29.35";
 const TCG_UEID_OID: &str = "2.23.133.5.4.4";


### PR DESCRIPTION
This change adds the GET_LDEV_ECC384_CERT and GET_LDEV_MLDSA87_CERT mailbox command support to ROM. These certificates are needed in manufacturing flows where Runtime availability is not always possible.