### PR TITLE
rom: Add subsystem-only ROM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,7 @@ rustflags = [
   "-C", "target-feature=+zbc",
   "-C", "target-feature=+zbs",
 ]
+
+# Some tests don't fit the default stack size
+[env]
+RUST_MIN_STACK="16777216" # 16MB

--- a/builder/bin/image_gen.rs
+++ b/builder/bin/image_gen.rs
@@ -7,7 +7,7 @@ use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_image_types::ImageHeader;
 use caliptra_image_types::ImageManifest;
 use caliptra_image_types::ImageSignatures;
-use clap::{arg, value_parser, Command};
+use clap::{arg, value_parser, ArgAction, Command};
 use memoffset::{offset_of, span_of};
 use serde_json::{json, to_string_pretty};
 use sha2::{Digest, Sha384};
@@ -48,26 +48,45 @@ fn main() {
             arg!(--"pqc-key-type" [integer] "PQC key type to use (MLDSA: 1, LMS: 3)")
                 .value_parser(value_parser!(i32)),
         )
-        .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given TOML file").value_parser(value_parser!(PathBuf)));
+        .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given TOML file").value_parser(value_parser!(PathBuf)))
+        .arg(arg!(--"subsystem" "Build ROM with subsystem support").action(ArgAction::SetTrue))
+        .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given toml file").value_parser(value_parser!(PathBuf)));
     let args = cmd.get_matches_mut();
 
     // Print help if the provided args did not create anything.
     let mut valid_cmd = false;
 
+    let use_subsystem = args.get_flag("subsystem");
+
     if let Some(path) = args.get_one::<PathBuf>("rom-no-log") {
-        let rom = caliptra_builder::build_firmware_rom(&firmware::ROM).unwrap();
         valid_cmd = true;
+        let rom_variant = if use_subsystem {
+            &firmware::ROM_SS
+        } else {
+            &firmware::ROM
+        };
+        let rom = caliptra_builder::build_firmware_rom(rom_variant).unwrap();
         std::fs::write(path, rom).unwrap();
     }
 
     if let Some(path) = args.get_one::<PathBuf>("rom-with-log") {
-        let rom = caliptra_builder::build_firmware_rom(&firmware::ROM_WITH_UART).unwrap();
         valid_cmd = true;
+        let rom_variant = if use_subsystem {
+            &firmware::ROM_WITH_UART_SS
+        } else {
+            &firmware::ROM_WITH_UART
+        };
+        let rom = caliptra_builder::build_firmware_rom(rom_variant).unwrap();
         std::fs::write(path, rom).unwrap();
     }
     if let Some(path) = args.get_one::<PathBuf>("fake-rom") {
-        let rom = caliptra_builder::build_firmware_rom(&firmware::ROM_FAKE_WITH_UART).unwrap();
         valid_cmd = true;
+        let rom_variant = if use_subsystem {
+            &firmware::ROM_FAKE_WITH_UART_SS
+        } else {
+            &firmware::ROM_FAKE_WITH_UART
+        };
+        let rom = caliptra_builder::build_firmware_rom(rom_variant).unwrap();
         std::fs::write(path, rom).unwrap();
     }
 

--- a/builder/bin/image_gen.rs
+++ b/builder/bin/image_gen.rs
@@ -49,8 +49,7 @@ fn main() {
                 .value_parser(value_parser!(i32)),
         )
         .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given TOML file").value_parser(value_parser!(PathBuf)))
-        .arg(arg!(--"subsystem" "Build ROM with subsystem support").action(ArgAction::SetTrue))
-        .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given toml file").value_parser(value_parser!(PathBuf)));
+        .arg(arg!(--"subsystem" "Build ROM with subsystem support").action(ArgAction::SetTrue));
     let args = cmd.get_matches_mut();
 
     // Print help if the provided args did not create anything.

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -15,6 +15,17 @@ pub fn rom_from_env() -> &'static FwId<'static> {
     }
 }
 
+// Without uart messages there is enough space in
+pub fn ss_rom_from_env() -> &'static FwId<'static> {
+    match std::env::var("CPTRA_ROM_TYPE").as_ref().map(|s| s.as_str()) {
+        Ok("ROM") => &ROM_FPGA_WITH_UART_SS,
+        Ok("ROM_WITHOUT_UART") => &ROM_SS,
+        Ok("ROM_WITH_UART") => &ROM_FPGA_WITH_UART_SS,
+        Ok(s) => panic!("unexpected CPRTA_TEST_ROM env-var value: {s:?}"),
+        Err(_) => &ROM_FPGA_WITH_UART_SS,
+    }
+}
+
 pub const ROM: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
@@ -39,11 +50,41 @@ pub const ROM_WITH_FIPS_TEST_HOOKS: FwId = FwId {
     features: &["fips-test-hooks"],
 };
 
+pub const ROM_SS: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["subsystem"],
+};
+
+pub const ROM_WITH_UART_SS: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["emu", "subsystem"],
+};
+
+pub const ROM_FAKE_WITH_UART_SS: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["emu", "fake-rom", "subsystem"],
+};
+
+pub const ROM_WITH_FIPS_TEST_HOOKS_SS: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["fips-test-hooks", "subsystem"],
+};
+
 // TODO: delete this when AXI DMA is fixed in the FPGA
 pub const ROM_FPGA_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
     features: &["emu", "fpga_realtime"],
+};
+
+pub const ROM_FPGA_WITH_UART_SS: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["emu", "fpga_subsystem", "subsystem"],
 };
 
 pub const FMC_WITH_UART: FwId = FwId {
@@ -87,6 +128,12 @@ pub const APP_WITH_UART_FPGA: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
     features: &["emu", "fips_self_test", "fpga_realtime"],
+};
+
+pub const APP_FPGA_WITH_UART_SS: FwId = FwId {
+    crate_name: "caliptra-runtime",
+    bin_name: "caliptra-runtime",
+    features: &["emu", "fips_self_test", "fpga_subsystem"],
 };
 
 pub const APP_ZEROS: FwId = FwId {
@@ -256,13 +303,13 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
-    pub const ML_DSA87_EXTERNAL_MU: FwId = FwId {
-        bin_name: "ml_dsa87_external_mu",
+    pub const ML_KEM: FwId = FwId {
+        bin_name: "ml_kem",
         ..BASE_FWID
     };
 
-    pub const ML_KEM: FwId = FwId {
-        bin_name: "ml_kem",
+    pub const ML_DSA87_EXTERNAL_MU: FwId = FwId {
+        bin_name: "ml_dsa87_external_mu",
         ..BASE_FWID
     };
 
@@ -489,7 +536,12 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &ROM_WITH_UART,
     &ROM_FAKE_WITH_UART,
     &ROM_WITH_FIPS_TEST_HOOKS,
+    &ROM_SS,
+    &ROM_WITH_UART_SS,
+    &ROM_FAKE_WITH_UART_SS,
+    &ROM_WITH_FIPS_TEST_HOOKS_SS,
     &ROM_FPGA_WITH_UART,
+    &ROM_FPGA_WITH_UART_SS,
     &FMC_WITH_UART,
     &FMC_FAKE_WITH_UART,
     &FMC_FPGA_WITH_UART,
@@ -497,6 +549,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &APP_WITH_UART,
     &APP_WITH_UART_FIPS_TEST_HOOKS,
     &APP_WITH_UART_FPGA,
+    &APP_FPGA_WITH_UART_SS,
     &APP_ZEROS,
     &FMC_ZEROS,
     &caliptra_builder_tests::FWID,
@@ -525,8 +578,8 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::MAILBOX_DRIVER_NEGATIVE_TESTS,
     &driver_tests::MBOX_SEND_TXN_DROP,
     &driver_tests::ML_DSA87,
-    &driver_tests::ML_DSA87_EXTERNAL_MU,
     &driver_tests::ML_KEM,
+    &driver_tests::ML_DSA87_EXTERNAL_MU,
     &driver_tests::PCRBANK,
     &driver_tests::PRECONDITIONED_KEYS,
     &driver_tests::SHA1,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -388,6 +388,17 @@ pub fn ss_rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
     }
 }
 
+/// Returns the most appropriate ROM for use when testing non-ROM code against
+/// a particular hardware version and depending on if subsystem mode is enabled.
+/// DO NOT USE this for ROM-only tests.
+pub fn rom_for_fw_integration_tests_mode(subsystem_mode: bool) -> io::Result<Cow<'static, [u8]>> {
+    if subsystem_mode {
+        ss_rom_for_fw_integration_tests()
+    } else {
+        rom_for_fw_integration_tests()
+    }
+}
+
 pub fn build_firmware_rom(id: &FwId<'static>) -> io::Result<Vec<u8>> {
     let elf_bytes = build_firmware_elf(id)?;
     elf2rom(&elf_bytes)

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -379,6 +379,15 @@ pub fn rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
     }
 }
 
+/// Returns the most appropriate ROM for use when testing non-ROM code against
+/// a particular hardware version. DO NOT USE this for ROM-only tests.
+pub fn ss_rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
+    let rom_from_env = firmware::ss_rom_from_env();
+    match get_ci_rom_version() {
+        CiRomVersion::Latest => Ok(build_firmware_rom(rom_from_env)?.into()),
+    }
+}
+
 pub fn build_firmware_rom(id: &FwId<'static>) -> io::Result<Vec<u8>> {
     let elf_bytes = build_firmware_elf(id)?;
     elf2rom(&elf_bytes)

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -47,6 +47,7 @@ itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 no-cfi = []
 fips-test-hooks = []
+subsystem = [] # To hardcode subsystem mode in ROM
 
 [dev-dependencies]
 caliptra-api.workspace = true

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -547,11 +547,15 @@ impl SocIfc {
     }
 
     pub fn subsystem_mode(&self) -> bool {
-        self.soc_ifc
-            .regs()
-            .cptra_hw_config()
-            .read()
-            .subsystem_mode_en()
+        // Only for ROM it makes sense to hardcode this
+        // For Runtime we want runtime images to work on both caliptra-code and subsystem
+        cfg!(feature = "subsystem")
+            || self
+                .soc_ifc
+                .regs()
+                .cptra_hw_config()
+                .read()
+                .subsystem_mode_en()
     }
 
     pub fn ocp_lock_enabled(&self) -> bool {

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -548,7 +548,7 @@ impl SocIfc {
 
     pub fn subsystem_mode(&self) -> bool {
         // Only for ROM it makes sense to hardcode this
-        // For Runtime we want runtime images to work on both caliptra-code and subsystem
+        // For Runtime we want runtime images to work on both caliptra-core and subsystem
         cfg!(feature = "subsystem")
             || self
                 .soc_ifc

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1978,6 +1978,11 @@ impl CaliptraError {
             "ROM Global Error: Measurement log exhausted"
         ),
         (
+            ROM_GLOBAL_SUBSYSTEM_MISMATCH,
+            0x0105000E,
+            "ROM Global Error: Subsystem configuration mismatch"
+        ),
+        (
             ROM_GLOBAL_FIPS_HOOKS_ROM_EXIT,
             0x0105000F,
             "ROM Global Error: FIPS hooks ROM exit"

--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -74,6 +74,7 @@ std = [
   "ufmt/std",
 ]
 fpga_realtime = ["caliptra-drivers/fpga_realtime", "caliptra-hw-model/fpga_realtime"]
+fpga_subsystem = ["caliptra-drivers/fpga_subsystem", "caliptra-hw-model/fpga_subsystem"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 no-fmc = []
@@ -84,6 +85,7 @@ fips-test-hooks = [
   "caliptra-drivers/fips-test-hooks",
   "caliptra-image-verify/fips-test-hooks",
 ]
+subsystem = ["caliptra-drivers/subsystem"]
 
 [[bin]]
 name = "asm_tests"

--- a/rom/dev/Makefile
+++ b/rom/dev/Makefile
@@ -161,6 +161,14 @@ build-rom:
 		--rom-with-log $(TARGET_DIR)/caliptra-rom.bin \
 		--fw /dev/null
 
+build-subsystem-rom:
+	cargo \
+		"--config=$(EXTRA_CARGO_CONFIG)" \
+		run -p caliptra-builder -- \
+		--rom-with-log $(TARGET_DIR)/caliptra-rom-subsystem.bin \
+		--subsystem \
+		--fw /dev/null
+
 run: build-emu build-fw-test-image build-rom
 	cargo \
 		"--config=$(EXTRA_CARGO_CONFIG)" \
@@ -177,7 +185,7 @@ run: build-emu build-fw-test-image build-rom
 			$$(dd if=$(TARGET_DIR)/caliptra-rom-test-fw bs=1 skip=12 count=1736 status=none | sha384sum | cut -d' ' -f1),)
 # See image/types/src/lib.rs ImageManifest for offsets and lenghts of vendor_pub_key_info
 
-run-active: build-emu build-fw-image build-rom
+run-active: build-emu build-fw-image build-subsystem-rom
 	cargo \
 		"--config=$(EXTRA_CARGO_CONFIG)" \
 		run \
@@ -185,7 +193,7 @@ run-active: build-emu build-fw-image build-rom
 		-- \
 		--req-idevid-csr \
 		--idevid-key-id-algo sha1 \
-		--rom $(TARGET_DIR)/caliptra-rom.bin \
+		--rom $(TARGET_DIR)/caliptra-rom-subsystem.bin \
 		--recovery-image-fw $(TARGET_DIR)/caliptra-rom-test-fw \
 		--device-lifecycle $(DEVICE_LIFECYCLE) \
 		--subsystem-mode \

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -61,6 +61,10 @@ const BANNER: &str = r#"
 Running Caliptra ROM ...
 "#;
 
+pub fn subsystem_mode() -> bool {
+    cfg!(feature = "subsystem")
+}
+
 extern "C" {
     static CALIPTRA_ROM_INFO: RomInfo;
 }
@@ -88,6 +92,22 @@ pub extern "C" fn rom_entry() -> ! {
     validate_trng_config(&mut env);
 
     report_boot_status(RomBootStatus::CfiInitialized.into());
+
+    if subsystem_mode() != env.soc_ifc.subsystem_mode() {
+        let mode = |mode| {
+            if mode {
+                "subsystem"
+            } else {
+                "passive"
+            }
+        };
+        cprintln!(
+            "ROM compiled for {} mode, but hardware is in {} mode",
+            mode(subsystem_mode()),
+            mode(env.soc_ifc.subsystem_mode())
+        );
+        handle_fatal_error(CaliptraError::ROM_GLOBAL_SUBSYSTEM_MISMATCH.into())
+    }
 
     let reset_reason = env.soc_ifc.reset_reason();
 

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -40,7 +40,8 @@ pub fn build_hw_model_and_image_bundle(
 }
 
 pub fn build_hw_model(fuses: Fuses) -> DefaultHwModel {
-    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+    let subsystem_mode = cfg!(feature = "fpga_subsystem");
+    let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -116,7 +116,7 @@ pub fn change_dword_endianess(data: &mut [u8]) {
     }
 }
 
-pub fn model_supports_subsystem_mode(subsystem_mode: bool) -> bool {
+pub fn model_supports_subsystem_config(subsystem_mode: bool) -> bool {
     let fpga_subsystem = cfg!(feature = "fpga_subsystem");
     let fpga_realtime = cfg!(feature = "fpga_realtime");
     let fpga = fpga_subsystem || fpga_realtime;

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use caliptra_api::SocManager;
-use caliptra_builder::{firmware, ImageOptions};
+use caliptra_builder::{firmware, FwId, ImageOptions};
 use caliptra_common::{
     memory_layout::{ROM_ORG, ROM_SIZE, ROM_STACK_ORG, ROM_STACK_SIZE, STACK_ORG, STACK_SIZE},
     FMC_ORG, FMC_SIZE, RUNTIME_ORG, RUNTIME_SIZE,
@@ -112,6 +112,14 @@ pub fn change_dword_endianess(data: &mut [u8]) {
     for idx in (0..data.len()).step_by(4) {
         data.swap(idx, idx + 3);
         data.swap(idx + 1, idx + 2);
+    }
+}
+
+pub fn rom_fw_id(subsystem: bool) -> &'static FwId<'static> {
+    if subsystem {
+        firmware::ss_rom_from_env()
+    } else {
+        firmware::rom_from_env()
     }
 }
 

--- a/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
@@ -7,7 +7,7 @@ use caliptra_api::mailbox::{
     ProductionAuthDebugUnlockReq, ProductionAuthDebugUnlockToken,
 };
 use caliptra_api::SocManager;
-use caliptra_builder::firmware::ROM_WITH_UART;
+use caliptra_builder::firmware::{ROM_WITH_UART, ROM_WITH_UART_SS};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
     DbgManufServiceRegReq, DeviceLifecycle, HwModel, ModelError, SecurityState,
@@ -73,13 +73,15 @@ fn test_dbg_unlock_manuf_req_in_passive_mode() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_success() {
+    use caliptra_builder::firmware::ROM_WITH_UART_SS;
+
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_manuf_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -133,13 +135,15 @@ fn test_dbg_unlock_manuf_success() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_wrong_cmd() {
+    use caliptra_builder::firmware::ROM_WITH_UART_SS;
+
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_manuf_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -186,13 +190,15 @@ fn test_dbg_unlock_manuf_wrong_cmd() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_invalid_token() {
+    use caliptra_builder::firmware::ROM_WITH_UART_SS;
+
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_manuf_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -264,6 +270,8 @@ fn u8_to_u32_le(input: &[u8]) -> Vec<u32> {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_prod_success() {
+    use caliptra_builder::firmware::ROM_WITH_UART_SS;
+
     let signing_ecc_key = p384::ecdsa::SigningKey::random(&mut StdRng::from_entropy());
     let verifying_ecc_key = VerifyingKey::from(&signing_ecc_key);
     let ecc_pub_key_bytes = {
@@ -291,7 +299,7 @@ fn test_dbg_unlock_prod_success() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let unlock_level = 5u8;
     let mut prod_dbg_unlock_keypairs: Vec<(&[u8; 96], &[u8; 2592])> =
@@ -463,7 +471,7 @@ fn test_dbg_unlock_prod_invalid_length() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -542,7 +550,7 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -663,7 +671,7 @@ fn test_dbg_unlock_prod_invalid_signature() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -815,7 +823,7 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -933,7 +941,7 @@ fn test_dbg_unlock_prod_wrong_cmd() {
 
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
@@ -1007,7 +1015,7 @@ fn test_dbg_unlock_prod_unlock_levels_success() {
 
         let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-        let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+        let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
         let mut prod_dbg_unlock_keypairs = Vec::new();
         for _ in 0..8 {
@@ -1165,7 +1173,7 @@ fn test_dbg_unlock_prod_unlock_levels_failure() {
 
         let dbg_manuf_service = *DbgManufServiceRegReq::default().set_prod_dbg_unlock_req(true);
 
-        let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+        let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
 
         let mut hw = caliptra_hw_model::new(
             caliptra_hw_model::InitParams {

--- a/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
@@ -73,8 +73,6 @@ fn test_dbg_unlock_manuf_req_in_passive_mode() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_success() {
-    use caliptra_builder::firmware::ROM_WITH_UART_SS;
-
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
@@ -135,8 +133,6 @@ fn test_dbg_unlock_manuf_success() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_wrong_cmd() {
-    use caliptra_builder::firmware::ROM_WITH_UART_SS;
-
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
@@ -190,8 +186,6 @@ fn test_dbg_unlock_manuf_wrong_cmd() {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_manuf_invalid_token() {
-    use caliptra_builder::firmware::ROM_WITH_UART_SS;
-
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Manufacturing);
@@ -270,8 +264,6 @@ fn u8_to_u32_le(input: &[u8]) -> Vec<u32> {
 #[test]
 #[cfg(not(feature = "fpga_realtime"))]
 fn test_dbg_unlock_prod_success() {
-    use caliptra_builder::firmware::ROM_WITH_UART_SS;
-
     let signing_ecc_key = p384::ecdsa::SigningKey::random(&mut StdRng::from_entropy());
     let verifying_ecc_key = VerifyingKey::from(&signing_ecc_key);
     let ecc_pub_key_bytes = {

--- a/rom/dev/tests/rom_integration_tests/test_ocp_lock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ocp_lock.rs
@@ -3,7 +3,7 @@
 use caliptra_api::mailbox::{
     MailboxReq, ReportHekMetadataReq, ReportHekMetadataResp, ReportHekMetadataRespFlags,
 };
-use caliptra_builder::firmware::ROM_FPGA_WITH_UART;
+use caliptra_builder::firmware::ROM_FPGA_WITH_UART_SS;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
 use caliptra_drivers::{CaliptraError, HekSeedState};
 use caliptra_hw_model::{DeviceLifecycle, HwModel, ModelError, SecurityState};
@@ -52,7 +52,7 @@ fn test_hek_seed_states() {
 
 #[test]
 fn test_invalid_hek_seed_state() {
-    let rom = caliptra_builder::build_firmware_rom(&ROM_FPGA_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_FPGA_WITH_UART_SS).unwrap();
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
             rom: &rom,
@@ -94,11 +94,12 @@ fn hek_seed_state_helper(
     seed_states: &[HekSeedState],
     expects_hek_available: bool,
 ) {
-    let rom = caliptra_builder::build_firmware_rom(&ROM_FPGA_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_FPGA_WITH_UART_SS).unwrap();
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
             rom: &rom,
             security_state: *SecurityState::default().set_device_lifecycle(lifecycle),
+            subsystem_mode: true,
             ..Default::default()
         },
         caliptra_hw_model::BootParams::default(),

--- a/rom/dev/tests/rom_integration_tests/test_pmp.rs
+++ b/rom/dev/tests/rom_integration_tests/test_pmp.rs
@@ -1,6 +1,5 @@
 // Licensed under the Apache-2.0 license
 
-use crate::helpers::rom_fw_id;
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{self, rom_tests::TEST_FMC_INTERACTIVE, APP_WITH_UART},
@@ -37,7 +36,7 @@ fn test_datavault_pmp_enforcement_region_start() {
         fuse_pqc_key_type: 1,
         ..Default::default()
     };
-    let rom = caliptra_builder::build_firmware_rom(rom_fw_id(false)).unwrap();
+    let rom = caliptra_builder::rom_for_fw_integration_tests_mode(false).unwrap();
     let image_bundle = caliptra_builder::build_and_sign_image(
         &TEST_FMC_INTERACTIVE,
         &APP_WITH_UART,
@@ -80,7 +79,7 @@ fn test_datavault_pmp_enforcement_region_end() {
         fuse_pqc_key_type: 1,
         ..Default::default()
     };
-    let rom = caliptra_builder::build_firmware_rom(rom_fw_id(false)).unwrap();
+    let rom = caliptra_builder::rom_for_fw_integration_tests_mode(false).unwrap();
     let image_bundle = caliptra_builder::build_and_sign_image(
         &TEST_FMC_INTERACTIVE,
         &APP_WITH_UART,

--- a/rom/dev/tests/rom_integration_tests/test_pmp.rs
+++ b/rom/dev/tests/rom_integration_tests/test_pmp.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use crate::helpers::rom_fw_id;
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{self, rom_tests::TEST_FMC_INTERACTIVE, APP_WITH_UART},
@@ -36,7 +37,7 @@ fn test_datavault_pmp_enforcement_region_start() {
         fuse_pqc_key_type: 1,
         ..Default::default()
     };
-    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(rom_fw_id(false)).unwrap();
     let image_bundle = caliptra_builder::build_and_sign_image(
         &TEST_FMC_INTERACTIVE,
         &APP_WITH_UART,
@@ -79,7 +80,7 @@ fn test_datavault_pmp_enforcement_region_end() {
         fuse_pqc_key_type: 1,
         ..Default::default()
     };
-    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(rom_fw_id(false)).unwrap();
     let image_bundle = caliptra_builder::build_and_sign_image(
         &TEST_FMC_INTERACTIVE,
         &APP_WITH_UART,

--- a/rom/dev/tests/rom_integration_tests/test_uds_programming.rs
+++ b/rom/dev/tests/rom_integration_tests/test_uds_programming.rs
@@ -12,7 +12,7 @@ Abstract:
 --*/
 
 use caliptra_api::SocManager;
-use caliptra_builder::firmware::ROM_WITH_UART;
+use caliptra_builder::firmware::{ROM_WITH_UART, ROM_WITH_UART_SS};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DbgManufServiceRegReq, DeviceLifecycle, HwModel, SecurityState};
 
@@ -51,7 +51,7 @@ fn test_uds_programming_granularity_64bit() {
     let security_state =
         *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing);
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_uds_program_req(true);
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
             rom: &rom,
@@ -81,7 +81,7 @@ fn test_uds_programming_granularity_32bit() {
     let security_state =
         *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing);
     let dbg_manuf_service = *DbgManufServiceRegReq::default().set_uds_program_req(true);
-    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART).unwrap();
+    let rom = caliptra_builder::build_firmware_rom(&ROM_WITH_UART_SS).unwrap();
     let mut hw = caliptra_hw_model::new(
         caliptra_hw_model::InitParams {
             rom: &rom,

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::helpers::{self, rom_fw_id};
+use crate::helpers::{self, model_supports_subsystem_mode};
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{
@@ -27,6 +27,9 @@ const TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD: u32 = 0x1000_000B;
 #[test]
 fn test_update_reset_success() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -36,7 +39,7 @@ fn test_update_reset_success() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -88,6 +91,9 @@ fn test_update_reset_success() {
 #[test]
 fn test_update_reset_no_mailbox_cmd() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -97,7 +103,7 @@ fn test_update_reset_no_mailbox_cmd() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -152,6 +158,9 @@ fn test_update_reset_no_mailbox_cmd() {
 #[test]
 fn test_update_reset_non_fw_load_cmd() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -161,7 +170,7 @@ fn test_update_reset_non_fw_load_cmd() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -223,7 +232,7 @@ fn test_update_reset_verify_image_failure() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -281,6 +290,9 @@ fn test_update_reset_verify_image_failure() {
 #[test]
 fn test_update_reset_boot_status() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -290,7 +302,7 @@ fn test_update_reset_boot_status() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -351,8 +363,11 @@ fn test_update_reset_boot_status() {
 #[test]
 fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let vendor_config_cold_boot = ImageGeneratorVendorConfig {
                 ecc_key_idx: 3,
                 ..VENDOR_CONFIG_KEY_0
@@ -440,7 +455,10 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
 #[test]
 fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
-        let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
+        let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
         let vendor_config_cold_boot = ImageGeneratorVendorConfig {
             pqc_key_idx: 3,
             ..VENDOR_CONFIG_KEY_0
@@ -515,6 +533,9 @@ fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
 #[test]
 fn test_check_rom_update_reset_status_reg() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -524,7 +545,7 @@ fn test_check_rom_update_reset_status_reg() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -627,6 +648,9 @@ fn test_fmc_is_16k() {
 #[test]
 fn test_update_reset_max_fw_image() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
             let image_options = ImageOptions {
                 pqc_key_type: *pqc_key_type,
@@ -636,7 +660,7 @@ fn test_update_reset_max_fw_image() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
+            let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::helpers::{self, model_supports_subsystem_mode};
+use crate::helpers::{self, model_supports_subsystem_config};
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{
@@ -27,7 +27,7 @@ const TEST_FMC_CMD_RESET_FOR_UPDATE_KEEP_MBOX_CMD: u32 = 0x1000_000B;
 #[test]
 fn test_update_reset_success() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -91,7 +91,7 @@ fn test_update_reset_success() {
 #[test]
 fn test_update_reset_no_mailbox_cmd() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -158,7 +158,7 @@ fn test_update_reset_no_mailbox_cmd() {
 #[test]
 fn test_update_reset_non_fw_load_cmd() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -290,7 +290,7 @@ fn test_update_reset_verify_image_failure() {
 #[test]
 fn test_update_reset_boot_status() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -363,7 +363,7 @@ fn test_update_reset_boot_status() {
 #[test]
 fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -455,7 +455,7 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
 #[test]
 fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
@@ -533,7 +533,7 @@ fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
 #[test]
 fn test_check_rom_update_reset_status_reg() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
@@ -648,7 +648,7 @@ fn test_fmc_is_16k() {
 #[test]
 fn test_update_reset_max_fw_image() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {

--- a/rom/dev/tests/rom_integration_tests/test_update_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_update_reset.rs
@@ -1,10 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use crate::helpers;
+use crate::helpers::{self, rom_fw_id};
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{
-        self,
         rom_tests::{
             FAKE_TEST_FMC_INTERACTIVE, FAKE_TEST_FMC_WITH_UART, TEST_FMC_INTERACTIVE,
             TEST_FMC_WITH_UART, TEST_RT_WITH_UART,
@@ -37,7 +36,7 @@ fn test_update_reset_success() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -98,7 +97,7 @@ fn test_update_reset_no_mailbox_cmd() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -162,7 +161,7 @@ fn test_update_reset_non_fw_load_cmd() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -224,7 +223,7 @@ fn test_update_reset_verify_image_failure() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_WITH_UART,
                 &APP_WITH_UART,
@@ -291,7 +290,7 @@ fn test_update_reset_boot_status() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -353,7 +352,7 @@ fn test_update_reset_boot_status() {
 fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
         for pqc_key_type in helpers::PQC_KEY_TYPE.iter() {
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let vendor_config_cold_boot = ImageGeneratorVendorConfig {
                 ecc_key_idx: 3,
                 ..VENDOR_CONFIG_KEY_0
@@ -441,7 +440,7 @@ fn test_update_reset_vendor_ecc_pub_key_idx_dv_mismatch() {
 #[test]
 fn test_update_reset_vendor_lms_pub_key_idx_dv_mismatch() {
     for subsystem_mode in [false, true] {
-        let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+        let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
         let vendor_config_cold_boot = ImageGeneratorVendorConfig {
             pqc_key_idx: 3,
             ..VENDOR_CONFIG_KEY_0
@@ -525,7 +524,7 @@ fn test_check_rom_update_reset_status_reg() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,
@@ -637,7 +636,7 @@ fn test_update_reset_max_fw_image() {
                 fuse_pqc_key_type: *pqc_key_type as u32,
                 ..Default::default()
             };
-            let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env()).unwrap();
+            let rom = caliptra_builder::build_firmware_rom(rom_fw_id(subsystem_mode)).unwrap();
             let image_bundle = caliptra_builder::build_and_sign_image(
                 &TEST_FMC_INTERACTIVE,
                 &APP_WITH_UART,

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -641,3 +641,11 @@ fn assert_same_time(a: &Asn1TimeRef, b: &Asn1TimeRef, label: &str) {
         d.secs
     );
 }
+
+pub fn model_supports_subsystem_mode(subsystem_mode: bool) -> bool {
+    let fpga_subsystem = cfg!(feature = "fpga_subsystem");
+    let fpga_realtime = cfg!(feature = "fpga_realtime");
+    let fpga = fpga_subsystem || fpga_realtime;
+    let emulator = !fpga;
+    emulator || (subsystem_mode && fpga_subsystem) || ((!subsystem_mode) && fpga_realtime)
+}

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -642,7 +642,7 @@ fn assert_same_time(a: &Asn1TimeRef, b: &Asn1TimeRef, label: &str) {
     );
 }
 
-pub fn model_supports_subsystem_mode(subsystem_mode: bool) -> bool {
+pub fn model_supports_subsystem_config(subsystem_mode: bool) -> bool {
     let fpga_subsystem = cfg!(feature = "fpga_subsystem");
     let fpga_realtime = cfg!(feature = "fpga_realtime");
     let fpga = fpga_subsystem || fpga_realtime;

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -104,6 +104,7 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
         Some(auth_manifest),
         &test_sram_contents,
         &images[0].contents,
+        cfg!(feature = "fpga_subsystem"),
     );
 
     #[cfg(feature = "fpga_subsystem")]

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::common::{model_supports_subsystem_mode, run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::{
     create_auth_manifest, create_auth_manifest_with_metadata, AuthManifestBuilderCfg,
 };
@@ -66,11 +66,7 @@ fn set_auth_manifest(
     auth_manifest: Option<AuthorizationManifest>,
     subsystem_mode: bool,
 ) -> DefaultHwModel {
-    let rom = if subsystem_mode {
-        caliptra_builder::ss_rom_for_fw_integration_tests().unwrap()
-    } else {
-        caliptra_builder::rom_for_fw_integration_tests().unwrap()
-    };
+    let rom = caliptra_builder::rom_for_fw_integration_tests_mode(subsystem_mode).unwrap();
 
     let (soc_manifest, mcu_fw) = if subsystem_mode {
         let mut mcu_fw = vec![1, 2, 3, 4]; // FPGA DMA driver needs multiple of 256
@@ -234,6 +230,9 @@ pub fn set_auth_manifest_with_test_sram(
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_deny_authorization_mode(subsystem_mode);
     }
 }
@@ -342,6 +341,9 @@ fn test_authorize_and_stash_cmd_deny_authorization_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_success() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_success_mode(subsystem_mode);
     }
 }
@@ -409,6 +411,9 @@ fn test_authorize_and_stash_cmd_success_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id_mode(subsystem_mode);
     }
 }
@@ -442,6 +447,9 @@ fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id_mode(subsystem_
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash_mode(subsystem_mode);
     }
 }
@@ -476,6 +484,9 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash_mode(subsyst
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_deny_authorization_wrong_hash_mode(subsystem_mode);
     }
 }
@@ -511,6 +522,9 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash_mode(subsystem_mod
 #[test]
 fn test_authorize_and_stash_cmd_success_skip_auth() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_success_skip_auth_mode(subsystem_mode);
     }
 }
@@ -543,6 +557,9 @@ fn test_authorize_and_stash_cmd_success_skip_auth_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_fwid_0() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_fwid_0_mode(subsystem_mode);
     }
 }
@@ -588,6 +605,9 @@ fn test_authorize_and_stash_fwid_0_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_fwid_127() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_fwid_127_mode(subsystem_mode);
     }
 }
@@ -633,6 +653,9 @@ fn test_authorize_and_stash_fwid_127_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_cmd_deny_second_bad_hash_mode(subsystem_mode);
     }
 }
@@ -708,6 +731,9 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash_mode(subsystem_mode: bool) 
 #[test]
 fn test_authorize_and_stash_after_update_reset() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_after_update_reset_mode(subsystem_mode);
     }
 }
@@ -782,6 +808,9 @@ fn test_authorize_and_stash_after_update_reset_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_after_update_reset_unauthorized_fw_id() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_after_update_reset_unauthorized_fw_id_mode(subsystem_mode);
     }
 }
@@ -862,6 +891,9 @@ fn test_authorize_and_stash_after_update_reset_unauthorized_fw_id_mode(subsystem
 #[test]
 fn test_authorize_and_stash_after_update_reset_bad_hash() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_after_update_reset_bad_hash_mode(subsystem_mode);
     }
 }
@@ -942,6 +974,9 @@ fn test_authorize_and_stash_after_update_reset_bad_hash_mode(subsystem_mode: boo
 #[test]
 fn test_authorize_and_stash_after_update_reset_skip_auth() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_after_update_reset_skip_auth_mode(subsystem_mode);
     }
 }
@@ -1002,6 +1037,9 @@ fn test_authorize_and_stash_after_update_reset_skip_auth_mode(subsystem_mode: bo
 #[test]
 fn test_authorize_and_stash_after_update_reset_multiple_set_manifest() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_and_stash_after_update_reset_multiple_set_manifest_mode(subsystem_mode);
     }
 }
@@ -1281,6 +1319,9 @@ fn write_to_test_sram(model: &mut DefaultHwModel, address: Addr64, data: &[u8]) 
 #[test]
 fn test_authorize_from_load_address() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_from_load_address_mode(subsystem_mode);
     }
 }
@@ -1356,6 +1397,9 @@ fn test_authorize_from_load_address_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_from_load_address_incorrect_digest() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_from_load_address_incorrect_digest_mode(subsystem_mode);
     }
 }
@@ -1423,6 +1467,9 @@ fn test_authorize_from_load_address_incorrect_digest_mode(subsystem_mode: bool) 
 #[test]
 fn test_authorize_from_staging_address() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_from_staging_address_mode(subsystem_mode);
     }
 }
@@ -1491,6 +1538,9 @@ fn test_authorize_from_staging_address_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_from_staging_address_incorrect_digest() {
     for subsystem_mode in [false, true] {
+        if !model_supports_subsystem_mode(subsystem_mode) {
+            continue;
+        }
         test_authorize_from_staging_address_incorrect_digest_mode(subsystem_mode);
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{model_supports_subsystem_mode, run_rt_test, RuntimeTestArgs};
+use crate::common::{model_supports_subsystem_config, run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::{
     create_auth_manifest, create_auth_manifest_with_metadata, AuthManifestBuilderCfg,
 };
@@ -230,7 +230,7 @@ pub fn set_auth_manifest_with_test_sram(
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_deny_authorization_mode(subsystem_mode);
@@ -341,7 +341,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_success() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_success_mode(subsystem_mode);
@@ -411,7 +411,7 @@ fn test_authorize_and_stash_cmd_success_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id_mode(subsystem_mode);
@@ -447,7 +447,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_no_hash_or_id_mode(subsystem_
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash_mode(subsystem_mode);
@@ -484,7 +484,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash_mode(subsyst
 #[test]
 fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_deny_authorization_wrong_hash_mode(subsystem_mode);
@@ -522,7 +522,7 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_hash_mode(subsystem_mod
 #[test]
 fn test_authorize_and_stash_cmd_success_skip_auth() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_success_skip_auth_mode(subsystem_mode);
@@ -557,7 +557,7 @@ fn test_authorize_and_stash_cmd_success_skip_auth_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_fwid_0() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_fwid_0_mode(subsystem_mode);
@@ -605,7 +605,7 @@ fn test_authorize_and_stash_fwid_0_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_fwid_127() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_fwid_127_mode(subsystem_mode);
@@ -653,7 +653,7 @@ fn test_authorize_and_stash_fwid_127_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_cmd_deny_second_bad_hash() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_cmd_deny_second_bad_hash_mode(subsystem_mode);
@@ -731,7 +731,7 @@ fn test_authorize_and_stash_cmd_deny_second_bad_hash_mode(subsystem_mode: bool) 
 #[test]
 fn test_authorize_and_stash_after_update_reset() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_after_update_reset_mode(subsystem_mode);
@@ -808,7 +808,7 @@ fn test_authorize_and_stash_after_update_reset_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_and_stash_after_update_reset_unauthorized_fw_id() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_after_update_reset_unauthorized_fw_id_mode(subsystem_mode);
@@ -891,7 +891,7 @@ fn test_authorize_and_stash_after_update_reset_unauthorized_fw_id_mode(subsystem
 #[test]
 fn test_authorize_and_stash_after_update_reset_bad_hash() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_after_update_reset_bad_hash_mode(subsystem_mode);
@@ -974,7 +974,7 @@ fn test_authorize_and_stash_after_update_reset_bad_hash_mode(subsystem_mode: boo
 #[test]
 fn test_authorize_and_stash_after_update_reset_skip_auth() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_after_update_reset_skip_auth_mode(subsystem_mode);
@@ -1037,7 +1037,7 @@ fn test_authorize_and_stash_after_update_reset_skip_auth_mode(subsystem_mode: bo
 #[test]
 fn test_authorize_and_stash_after_update_reset_multiple_set_manifest() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_and_stash_after_update_reset_multiple_set_manifest_mode(subsystem_mode);
@@ -1319,7 +1319,7 @@ fn write_to_test_sram(model: &mut DefaultHwModel, address: Addr64, data: &[u8]) 
 #[test]
 fn test_authorize_from_load_address() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_from_load_address_mode(subsystem_mode);
@@ -1397,7 +1397,7 @@ fn test_authorize_from_load_address_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_from_load_address_incorrect_digest() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_from_load_address_incorrect_digest_mode(subsystem_mode);
@@ -1467,7 +1467,7 @@ fn test_authorize_from_load_address_incorrect_digest_mode(subsystem_mode: bool) 
 #[test]
 fn test_authorize_from_staging_address() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_from_staging_address_mode(subsystem_mode);
@@ -1538,7 +1538,7 @@ fn test_authorize_from_staging_address_mode(subsystem_mode: bool) {
 #[test]
 fn test_authorize_from_staging_address_incorrect_digest() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_authorize_from_staging_address_incorrect_digest_mode(subsystem_mode);

--- a/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
+++ b/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{model_supports_subsystem_mode, run_rt_test, RuntimeTestArgs};
+use crate::common::{model_supports_subsystem_config, run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 
 use caliptra_api::{
@@ -726,7 +726,7 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
 #[test]
 fn test_dbg_unlock_prod_wrong_cmd() {
     for subsystem_mode in [false, true] {
-        if !model_supports_subsystem_mode(subsystem_mode) {
+        if !model_supports_subsystem_config(subsystem_mode) {
             continue;
         }
         test_dbg_unlock_prod_wrong_cmd_mode(subsystem_mode);

--- a/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
+++ b/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
@@ -78,7 +78,7 @@ fn test_dbg_unlock_prod_success() {
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
 
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
@@ -289,7 +289,7 @@ fn test_dbg_unlock_prod_invalid_length() {
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
 
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
@@ -410,7 +410,7 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
 
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
@@ -588,7 +588,7 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
 
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
@@ -750,7 +750,7 @@ fn test_dbg_unlock_prod_wrong_cmd() {
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
 
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     let image_info = vec![
         ImageInfo::new(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
@@ -872,7 +872,7 @@ fn test_dbg_unlock_prod_unlock_levels_success() {
             .set_debug_locked(true)
             .set_device_lifecycle(DeviceLifecycle::Production);
 
-        let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+        let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
         let image_info = vec![
             ImageInfo::new(
                 StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -25,7 +25,9 @@ const RT_READY_FOR_COMMANDS: u32 = 0x600;
 fn test_loads_mcu_fw() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
+    let mut mcu_fw = vec![1, 2, 3, 4];
+    // FPGA ROM requires firmware be a multiple of 256 bytes
+    mcu_fw.resize(256, 0);
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
@@ -40,7 +42,7 @@ fn test_loads_mcu_fw() {
     let soc_manifest = create_auth_manifest_with_metadata(metadata);
     let soc_manifest = soc_manifest.as_bytes();
     let mut args = RuntimeTestArgs::default();
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     args.init_params = Some(InitParams {
         rom: &rom,
         subsystem_mode: true,
@@ -74,8 +76,11 @@ fn test_loads_mcu_fw() {
 fn test_mcu_fw_bad_signature() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
-    let bad_mcu_fw = vec![5, 6, 7, 8];
+    let mut mcu_fw = vec![1, 2, 3, 4];
+    // FPGA ROM requires firmware be a multiple of 256 bytes
+    mcu_fw.resize(256, 0);
+    let mut bad_mcu_fw = vec![5, 6, 7, 8];
+    bad_mcu_fw.resize(256, 0);
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
@@ -91,7 +96,7 @@ fn test_mcu_fw_bad_signature() {
     let soc_manifest = create_auth_manifest_with_metadata(metadata);
     let soc_manifest = soc_manifest.as_bytes();
     let mut args = RuntimeTestArgs::default();
-    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let rom = caliptra_builder::ss_rom_for_fw_integration_tests().unwrap();
     args.init_params = Some(InitParams {
         rom: &rom,
         subsystem_mode: true,

--- a/sw-emulator/lib/periph/src/dma/recovery.rs
+++ b/sw-emulator/lib/periph/src/dma/recovery.rs
@@ -248,6 +248,10 @@ impl RecoveryRegisterInterface {
             self.indirect_fifo_status_0
                 .reg
                 .modify(IndirectStatus::FIFO_EMPTY::SET);
+        } else {
+            self.indirect_fifo_status_0
+                .reg
+                .modify(IndirectStatus::FIFO_FULL::SET);
         }
 
         let address: usize = address.try_into().unwrap();
@@ -319,7 +323,7 @@ impl RecoveryRegisterInterface {
                 self.indirect_fifo_status_2.reg.set(0);
                 self.indirect_fifo_status_0
                     .reg
-                    .modify(IndirectStatus::FIFO_EMPTY::CLEAR + IndirectStatus::FIFO_FULL::CLEAR);
+                    .modify(IndirectStatus::FIFO_EMPTY::CLEAR + IndirectStatus::FIFO_FULL::SET);
             } else {
                 println!(
                     "No Image in RRI ({} >= {})",


### PR DESCRIPTION
Split off from #2679

This will allow us to save space in the ROM since we won't have to support passive-only flows in subsystem mode and vice versa.

The consequence is that we have to plumb the correct ROM into the correct test now, which is a bit of a chore.

This also switches to using the FPGA ROM when doing subsystem tests, which required a small fix to the emulated DMA controller. This fixes many of the test failures that were in #2679.