### PR TITLE
Bumping action-gh-release v1->v2 to correct duplicate releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -405,7 +405,7 @@ jobs:
           git push origin ${{ needs.find-latest-release.outputs.new_release_tag }}
 
       - name: Create draft release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.find-latest-release.outputs.new_release_tag }}
           draft: true
@@ -414,7 +414,7 @@ jobs:
             ./release/test_artifacts_${{ needs.find-latest-release.outputs.new_release_tag }}.zip
 
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.find-latest-release.outputs.new_release_tag }}
           draft: false


### PR DESCRIPTION
Separating the draft and publish steps was creating two releases on v1 of this action. v2 seems to correct that issue