### PR TITLE
Enable subsystem FPGA runtime tests

### DIFF
--- a/rom/dev/Cargo.toml
+++ b/rom/dev/Cargo.toml
@@ -74,6 +74,7 @@ std = [
   "ufmt/std",
 ]
 fpga_realtime = ["caliptra-drivers/fpga_realtime", "caliptra-hw-model/fpga_realtime"]
+fpga_subsystem = ["caliptra-drivers/fpga_subsystem", "caliptra-hw-model/fpga_subsystem"]
 itrng = ["caliptra-hw-model/itrng"]
 verilator = ["caliptra-hw-model/verilator"]
 no-fmc = []


### PR DESCRIPTION
This allows the tests to boot and run to runtime.

I'll enable tests in a separate PR once I have an inventory of what passes, fails, and crashes.