### PR TITLE
updated the overlaps function

### DIFF
--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -785,8 +785,10 @@ impl ImageTocEntry {
     }
 
     pub fn overlaps(&self, other: &ImageTocEntry) -> bool {
-        self.load_addr < (other.load_addr + other.image_size())
-            && (self.load_addr + self.image_size()) > other.load_addr
+        // Use saturating_add to prevent integer overflow
+        let self_end = self.load_addr.saturating_add(self.image_size());
+        let other_end = other.load_addr.saturating_add(other.image_size());
+        self.load_addr < other_end && self_end > other.load_addr
     }
 }
 
@@ -900,5 +902,34 @@ mod tests {
         image2.load_addr = 500;
         image2.size = 100;
         assert!(!image1.overlaps(&image2));
+
+        // Case 13: Test overflow protection - load_addr near u32::MAX
+        image1.load_addr = u32::MAX - 50;
+        image1.size = 100;
+        image2.load_addr = 0;
+        image2.size = 100;
+        // With saturating_add, load_addr + size = u32::MAX
+        // This should not overlap with image2 at address 0
+        assert!(!image1.overlaps(&image2));
+
+        // Case 14: Test overflow protection - adjacent regions near u32::MAX
+        image1.load_addr = u32::MAX - 100;
+        image1.size = 50;
+        image2.load_addr = u32::MAX - 49;
+        image2.size = 50;
+        // image1: [u32::MAX-100, u32::MAX-51)
+        // image2: [u32::MAX-49, overflow to u32::MAX]
+        // These should NOT overlap (there's a gap at u32::MAX-50)
+        assert!(!image1.overlaps(&image2));
+
+        // Case 15: Test actual overlap near u32::MAX
+        image1.load_addr = u32::MAX - 100;
+        image1.size = 52; // Now reaches u32::MAX-49
+        image2.load_addr = u32::MAX - 49;
+        image2.size = 50;
+        // image1: [u32::MAX-100, u32::MAX-49)
+        // image2: [u32::MAX-49, overflow to u32::MAX]
+        // These should overlap at u32::MAX-49
+        assert!(image1.overlaps(&image2));
     }
 }


### PR DESCRIPTION
This pull request improves the robustness of the `ImageTocEntry::overlaps` method in `image/types/src/lib.rs` by preventing integer overflow issues when calculating image boundaries. It also adds new unit tests to verify correct behavior near the edge cases of `u32::MAX`.

### Overflow protection and correctness improvements

* Updated the `ImageTocEntry::overlaps` method to use `saturating_add` when calculating the end addresses of image regions, ensuring that integer overflow does not cause incorrect overlap detection.

### Test coverage enhancements

* Added new unit tests to the overlaps logic, specifically targeting scenarios where image addresses and sizes approach or cross the `u32::MAX` boundary, verifying that overflow is handled safely and overlaps are detected correctly.