### PR TITLE
Update Subsystem Job name

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -219,7 +219,7 @@ jobs:
           path: /tmp/caliptra-test-firmware
           retention-days: 1
 
-  test_artifacts:
+  test_artifacts_subsystem:
     runs-on: vck190-subsystem-2.0
     needs: [check_cache, build_test_binaries]
     timeout-minutes: 120


### PR DESCRIPTION
This prevents clashing with the "core" job.