### PR TITLE
Re-enable subsystem FPGA runtime tests (#2658)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,6 +27,7 @@ package(ureg-systemrdl)
 failure-output = "immediate-final"
 fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 6 }
+retries = 2 # the fpga subsystem is a bit flacky with typically 1 test randomly failing out of 100-200
 
 [profile.fpga-subsystem.junit]
 path = "/tmp/junit.xml"

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1632,22 +1632,6 @@ impl HwModel for ModelFpgaSubsystem {
             }
         };
 
-        println!("Setting recovery images to BMC");
-        self.bmc
-            .push_recovery_image(boot_params.fw_image.map(|s| s.to_vec()).unwrap_or_default());
-        self.bmc.push_recovery_image(
-            boot_params
-                .soc_manifest
-                .map(|s| s.to_vec())
-                .unwrap_or_default(),
-        );
-        self.bmc.push_recovery_image(mcu_fw_image);
-
-        while !self.i3c_target_configured() {
-            self.step();
-        }
-        println!("Done starting MCU");
-
         // TODO: support passing these into MCU ROM
         // self.soc_ifc()
         //     .cptra_wdt_cfg()
@@ -1682,12 +1666,12 @@ impl HwModel for ModelFpgaSubsystem {
         // self.setup_mailbox_users(boot_params.valid_axi_user.as_slice())
         //     .map_err(ModelError::from)?;
 
-        self.i3c_controller.configure();
-        println!("Starting recovery flow (BMC)");
-        self.start_recovery_bmc();
-        self.step();
-
-        println!("Finished booting");
+        self.upload_firmware_rri(
+            boot_params.fw_image.unwrap(),
+            boot_params.soc_manifest,
+            Some(&mcu_fw_image),
+        )
+        .unwrap();
 
         Ok(())
     }
@@ -1740,10 +1724,29 @@ impl HwModel for ModelFpgaSubsystem {
 
     fn upload_firmware_rri(
         &mut self,
-        _firmware: &[u8],
-        _soc_manifest: Option<&[u8]>,
-        _mcu_firmware: Option<&[u8]>,
+        firmware: &[u8],
+        soc_manifest: Option<&[u8]>,
+        mcu_firmware: Option<&[u8]>,
     ) -> Result<(), ModelError> {
+        println!("Setting recovery images to BMC");
+        // First add image to BMC
+        self.bmc.push_recovery_image(firmware.to_vec());
+        self.bmc
+            .push_recovery_image(soc_manifest.unwrap_or_default().to_vec());
+        self.bmc
+            .push_recovery_image(mcu_firmware.unwrap_or_default().to_vec());
+
+        while !self.i3c_target_configured() {
+            self.step();
+        }
+        println!("Done starting MCU");
+
+        self.i3c_controller.configure();
+        println!("Starting recovery flow (BMC)");
+        self.start_recovery_bmc();
+        self.step();
+        println!("Finished booting");
+
         // Notify MCU ROM it can start loading firmware
         let gpio = &self.wrapper.regs().mci_generic_input_wires[0];
         let current = gpio.extract().get();

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -86,7 +86,7 @@ fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> Aut
     create_auth_manifest_with_metadata_with_svn(metadata, pqc_key_type, svn)
 }
 
-fn default_soc_manifest_bytes(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> Vec<u8> {
+pub fn default_soc_manifest_bytes(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> Vec<u8> {
     let manifest = default_soc_manifest(pqc_key_type, svn);
     let manifest_bytes = manifest.as_bytes();
     let len = manifest_bytes.len();

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -11,10 +11,7 @@ use caliptra_auth_man_types::{
     Addr64, AuthManifestFlags, AuthManifestImageMetadata, AuthorizationManifest, ImageMetadataFlags,
 };
 use caliptra_builder::firmware::APP_WITH_UART;
-use caliptra_builder::{
-    firmware::{self, FMC_WITH_UART},
-    ImageOptions,
-};
+use caliptra_builder::{firmware::FMC_WITH_UART, ImageOptions};
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
     MailboxReqHeader, SetAuthManifestReq,
@@ -205,7 +202,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     };
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
-        &firmware::runtime_tests::MBOX,
+        crate::test_update_reset::mbox_test_image(),
         image_options,
     )
     .unwrap()
@@ -265,7 +262,7 @@ fn test_authorize_and_stash_cmd_success() {
     };
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
-        &firmware::runtime_tests::MBOX,
+        crate::test_update_reset::mbox_test_image(),
         image_options,
     )
     .unwrap()

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -2,7 +2,7 @@
 
 use caliptra_api::SocManager;
 use caliptra_builder::{
-    firmware::{self, APP_WITH_UART, FMC_WITH_UART},
+    firmware::{APP_WITH_UART, FMC_WITH_UART},
     ImageOptions,
 };
 use caliptra_common::mailbox_api::{
@@ -59,7 +59,7 @@ fn test_stash_measurement() {
 
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
-        &firmware::runtime_tests::MBOX,
+        crate::test_update_reset::mbox_test_image(),
         image_options,
     )
     .unwrap()
@@ -95,7 +95,7 @@ fn test_pcr31_extended_upon_stash_measurement() {
         ..Default::default()
     };
     let runtime_test_args = RuntimeTestArgs {
-        test_fwid: Some(&firmware::runtime_tests::MBOX),
+        test_fwid: Some(crate::test_update_reset::mbox_test_image()),
         test_image_options: Some(image_options.clone()),
         ..Default::default()
     };
@@ -140,7 +140,7 @@ fn test_pcr31_extended_upon_stash_measurement() {
     // update reset back to mbox responder
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
-        &firmware::runtime_tests::MBOX,
+        crate::test_update_reset::mbox_test_image(),
         image_options.clone(),
     )
     .unwrap()
@@ -152,7 +152,7 @@ fn test_pcr31_extended_upon_stash_measurement() {
 
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
-        &firmware::runtime_tests::MBOX,
+        crate::test_update_reset::mbox_test_image(),
         image_options,
     )
     .unwrap()

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -41,8 +41,8 @@ pub fn update_fw(model: &mut DefaultHwModel, rt_fw: &FwId<'static>, image_opts: 
         .unwrap();
 }
 
-fn mbox_test_image() -> &'static FwId<'static> {
-    if cfg!(all(feature = "fpga_realtime", feature = "fpga_subsystem")) {
+pub fn mbox_test_image() -> &'static FwId<'static> {
+    if cfg!(any(feature = "fpga_realtime", feature = "fpga_subsystem")) {
         &MBOX_FPGA
     } else {
         &MBOX


### PR DESCRIPTION
* fpga_subsystem: Implement loading images when not part of BootParams



* Fix subsystem CI file

The newline made it invalid.

- Update the list of tests
- Update the MCU ROM for warm reset




* test(fpga-subsystem): Add retries for flaky tests

Configure nextest to retry failing tests up to 2 times for the fpga-subsystem profile, as the FPGA subsystem exhibits flaky behavior with typically 1 test randomly failing out of 100-200.



* move some configs back to `boot`

* Remove flaky test(test_lms::test_lms_verify_invalid_lmots_type)

* filter a couple more LMS tests

---------