### PR TITLE
Add OCP LOCK HEK availability test

### DIFF
--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -34,6 +34,7 @@ const OPCODE_READ_PCR_RESET_COUNTER: u32 = 0xC000_0000;
 const OPCODE_CORRUPT_DPE_ROOT_TCI: u32 = 0xD000_0000;
 const OPCODE_HOLD_COMMAND_BUSY: u32 = 0xE000_0000;
 const OPCODE_READ_KEY_LADDER_MAX_SVN: u32 = 0xF000_0000;
+const OPCODE_OCP_LOCK_HEK_STATE: u32 = 0xF100_0000;
 const OPCODE_READ_KEY_LADDER_DIGEST: u32 = 0x1000_1000;
 const OPCODE_FW_LOAD: u32 = CommandId::FIRMWARE_LOAD.0;
 
@@ -241,6 +242,15 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                         .fw_key_ladder_max_svn
                         .to_le_bytes(),
                 );
+            }
+            CommandId(OPCODE_OCP_LOCK_HEK_STATE) => {
+                let hek_available = drivers
+                    .persistent_data
+                    .get()
+                    .ocp_lock_metadata
+                    .hek_available;
+                let state = U8Bool::new(hek_available);
+                write_response(&mut drivers.mbox, &state.as_bytes());
             }
             // Computes a digest from the key ladder for a given target SVN.
             CommandId(OPCODE_READ_KEY_LADDER_DIGEST) => {

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -23,6 +23,7 @@ mod test_invoke_dpe;
 mod test_lms;
 mod test_mailbox;
 mod test_mldsa;
+mod test_ocp_lock;
 mod test_panic_missing;
 mod test_pauser_privilege_levels;
 mod test_pcr;

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock.rs
@@ -1,0 +1,24 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::firmware::runtime_tests;
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::RtBootStatus;
+use dpe::U8Bool;
+use zerocopy::IntoBytes;
+
+use crate::common::{run_rt_test, RuntimeTestArgs};
+
+#[test]
+fn test_hek_metadata_never_reported() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&runtime_tests::MBOX_FPGA),
+        ..Default::default()
+    });
+
+    model.step_until_boot_status(u32::from(RtBootStatus::RtReadyForCommands), true);
+
+    let expected_val = U8Bool::new(false);
+    // HEK can NEVER be valid if MCU ROM never reported the HEK metadata.
+    let resp = model.mailbox_execute(0xF100_0000, &[]).unwrap().unwrap();
+    assert_eq!(resp.as_bytes(), expected_val.as_bytes());
+}


### PR DESCRIPTION
This a test that proves we can boot into runtime and check the OCP LOCK state.