### PR TITLE
Start the subsystem realtime thread after AXI reset

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1826,6 +1826,12 @@ impl HwModel for ModelFpgaSubsystem {
                 .contains(McuBootMilestones::WARM_RESET_FLOW_COMPLETE)
         });
     }
+
+    fn cold_reset(&mut self) {
+        self.set_subsystem_reset(true);
+        std::thread::sleep(std::time::Duration::from_micros(1));
+        self.set_subsystem_reset(false);
+    }
 }
 
 pub struct FpgaRealtimeBus<'a> {


### PR DESCRIPTION
Accessing the wrapper MMIO during AXI reset could cause the AXI bus to hang. This moves starting the iTRNG thread until after the AXI bus reset to guarantee that doesn't happen.

The thread is also joined before resetting on model `drop`.