### PR TITLE
OCP LOCK Rom tests: Reported Valid HEK Metadata

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 # Licensed under the Apache-2.0 license
 [env]
 ARBITRARY_MAX_HANDLES = "32"
+RUST_MIN_STACK="16777216" # 16MB
 
 [target.riscv32imc-unknown-none-elf]
 rustflags = [

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -109,6 +109,8 @@ pub type DefaultHwModel = ModelFpgaSubsystem;
 
 pub const DEFAULT_APB_PAUSER: u32 = 0x01;
 
+pub type ModelCallback = Box<dyn FnOnce(&mut DefaultHwModel)>;
+
 /// Constructs an HwModel based on the cargo features and environment
 /// variables. Most test cases that need to construct a HwModel should use this
 /// function over HwModel::new_unbooted().
@@ -278,6 +280,10 @@ pub struct InitParams<'a> {
 
     // Subsystem initialization parameters.
     pub ss_init_params: SubsystemInitParams<'a>,
+
+    /// ROM Mailbox Handler callback
+    /// Some tests need to access the ROM mailbox, and then continue booting to RT
+    pub rom_callback: Option<ModelCallback>,
 }
 
 impl Default for InitParams<'_> {
@@ -328,6 +334,7 @@ impl Default for InitParams<'_> {
             soc_user: MailboxRequester::SocUser(1u32),
             test_sram: None,
             ss_init_params: Default::default(),
+            rom_callback: None,
         }
     }
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -16,7 +16,9 @@ use crate::otp_provision::{
 };
 use crate::xi3c::XI3cError;
 use crate::SecurityState;
-use crate::{xi3c, BootParams, Error, HwModel, InitParams, ModelError, Output, TrngMode};
+use crate::{
+    xi3c, BootParams, Error, HwModel, InitParams, ModelCallback, ModelError, Output, TrngMode,
+};
 use anyhow::Result;
 use caliptra_api::SocManager;
 use caliptra_emu_bus::{Bus, BusError, BusMmio, Device, Event, EventData, RecoveryCommandCode};
@@ -415,6 +417,7 @@ pub struct ModelFpgaSubsystem {
     pub blocks_sent: usize,
     pub enable_mcu_uart_log: bool,
     pub bootfsm_break: bool,
+    pub rom_callback: Option<ModelCallback>,
 }
 
 impl ModelFpgaSubsystem {
@@ -1586,6 +1589,7 @@ impl HwModel for ModelFpgaSubsystem {
             recovery_ctrl_len: 0,
             enable_mcu_uart_log: params.ss_init_params.enable_mcu_uart_log,
             bootfsm_break: params.bootfsm_break,
+            rom_callback: params.rom_callback,
         };
 
         println!("AXI reset");
@@ -1885,9 +1889,15 @@ impl HwModel for ModelFpgaSubsystem {
         self.step();
         println!("Finished booting");
 
+        // Call ROM callback before informing MCU ROM it can load firmware
+        if let Some(cb) = self.rom_callback.take() {
+            cb(self);
+        }
+
         // Notify MCU ROM it can start loading firmware
         let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
         let current = gpio.extract().get();
+        // MCU ROM will wait after reaching the mailbox for this bit before booting RT
         gpio.set(current | 1 << 31);
 
         // ironically, we don't need to support this

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -102,3 +102,4 @@ fpga_subsystem = [
     "caliptra-hw-model/fpga_subsystem",
 ]
 fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]
+ocp-lock = ["caliptra-hw-model/ocp-lock"]

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock.rs
@@ -1,24 +1,72 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_api::mailbox::{
+    CommandId, MailboxReq, MailboxReqHeader, ReportHekMetadataReq, ReportHekMetadataResp,
+    ReportHekMetadataRespFlags,
+};
 use caliptra_builder::firmware::runtime_tests;
-use caliptra_hw_model::HwModel;
-use caliptra_runtime::RtBootStatus;
+use caliptra_drivers::HekSeedState;
+use caliptra_hw_model::{DefaultHwModel, HwModel};
+use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::U8Bool;
-use zerocopy::IntoBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
+#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_hek_metadata_never_reported() {
     let mut model = run_rt_test(RuntimeTestArgs {
         test_fwid: Some(&runtime_tests::MBOX_FPGA),
+        // This test assumes OCP LOCK is always enabled.
+        ocp_lock_en: true,
+        key_type: Some(FwVerificationPqcKeyType::MLDSA),
         ..Default::default()
     });
 
-    model.step_until_boot_status(u32::from(RtBootStatus::RtReadyForCommands), true);
-
     let expected_val = U8Bool::new(false);
     // HEK can NEVER be valid if MCU ROM never reported the HEK metadata.
+    let resp = model.mailbox_execute(0xF100_0000, &[]).unwrap().unwrap();
+    assert_eq!(resp.as_bytes(), expected_val.as_bytes());
+}
+
+#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
+#[test]
+fn test_hek_available() {
+    let mut cmd = MailboxReq::ReportHekMetadata(ReportHekMetadataReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed_state: HekSeedState::Programmed.into(),
+        ..Default::default()
+    });
+
+    cmd.populate_chksum().unwrap();
+
+    let rom_callback = move |model: &mut DefaultHwModel| {
+        let response = model
+            .mailbox_execute(
+                CommandId::REPORT_HEK_METADATA.into(),
+                cmd.as_bytes().unwrap(),
+            )
+            .unwrap()
+            .unwrap();
+
+        let response = ReportHekMetadataResp::ref_from_bytes(response.as_bytes()).unwrap();
+        assert!(response
+            .flags
+            .contains(ReportHekMetadataRespFlags::HEK_AVAILABLE));
+    };
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&runtime_tests::MBOX_FPGA),
+        // This test assumes OCP LOCK is always enabled.
+        ocp_lock_en: true,
+        key_type: Some(FwVerificationPqcKeyType::MLDSA),
+        rom_callback: Some(Box::new(rom_callback)),
+        ..Default::default()
+    });
+
+    // We reported HEK metadata so it should be available.
+    let expected_val = U8Bool::new(true);
     let resp = model.mailbox_execute(0xF100_0000, &[]).unwrap().unwrap();
     assert_eq!(resp.as_bytes(), expected_val.as_bytes());
 }


### PR DESCRIPTION
This test verifies that HEK is available after reporting a valid HEK seed state.