### PR TITLE
runtime: Avoid I3C recovery race by not resetting fifo ctrl

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -535,7 +535,7 @@ impl<'a> DmaRecovery<'a> {
         cprintln!("[dma-recovery] Waiting for activation");
         self.wait_for_activation()?;
         // Set the RECOVERY_STATUS register 'Device Recovery Status' field to 0x2 ('Booting recovery image').
-        self.set_recovery_status(Self::RECOVERY_STATUS_BOOTING_RECOVERY_IMAGE, 0)?;
+        self.set_recovery_status(Self::RECOVERY_STATUS_BOOTING_RECOVERY_IMAGE, fw_image_index)?;
         Ok(image_size_bytes)
     }
 
@@ -567,7 +567,7 @@ impl<'a> DmaRecovery<'a> {
         )?;
         self.wait_for_activation()?;
         // Set the RECOVERY_STATUS:Byte0 Bit[3:0] to 0x2 ('Booting recovery image').
-        self.set_recovery_status(Self::RECOVERY_STATUS_BOOTING_RECOVERY_IMAGE, 0)?;
+        self.set_recovery_status(Self::RECOVERY_STATUS_BOOTING_RECOVERY_IMAGE, fw_image_index)?;
         Ok(image_size_bytes)
     }
 
@@ -580,12 +580,6 @@ impl<'a> DmaRecovery<'a> {
 
         self.with_regs_mut(|regs_mut| {
             let recovery = regs_mut.sec_fw_recovery_if();
-
-            // set RESET signal to indirect control to load the next image
-            recovery
-                .indirect_fifo_ctrl_0()
-                .modify(|val| val.reset(Self::RESET_VAL));
-
             // Set PROT_CAP2.AGENT_CAPS
             // - Bit0  to 1 ('Device ID support')
             // - Bit4  to 1 ('Device Status support')

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -689,7 +689,7 @@ impl ModelFpgaSubsystem {
                 }
 
                 let len = ((self.recovery_ctrl_len / 4) as u32).to_le_bytes();
-                let mut ctrl = vec![0, 1];
+                let mut ctrl = vec![0, 1]; // CMS = 0, reset FIFO
                 ctrl.extend_from_slice(&len);
 
                 println!("Writing Indirect fifo ctrl: {:x?}", ctrl);

--- a/sw-emulator/lib/periph/src/dma/recovery.rs
+++ b/sw-emulator/lib/periph/src/dma/recovery.rs
@@ -138,7 +138,7 @@ pub struct RecoveryRegisterInterface {
     pub device_reset: ReadWriteRegister<u32>,
     #[register(offset = 0x3c)]
     pub recovery_ctrl: ReadWriteRegister<u32, RecoveryControl::Register>,
-    #[register(offset = 0x40)]
+    #[register(offset = 0x40, write_fn = recovery_status_write)]
     pub recovery_status: ReadWriteRegister<u32>,
     #[register(offset = 0x44)]
     pub hw_status: ReadWriteRegister<u32>,
@@ -295,43 +295,50 @@ impl RecoveryRegisterInterface {
         }
         let load: ReadWriteRegister<u32, IndirectCtrl0::Register> = ReadWriteRegister::new(val);
         if load.reg.is_set(IndirectCtrl0::RESET) {
-            let image_index = ((self.recovery_status.reg.get() >> 4) & 0xf) as usize;
-            if let Some(image) = self.cms_data.get(image_index) {
-                let cms = load.reg.read(IndirectCtrl0::CMS);
-                if cms != 0 {
-                    self.indirect_fifo_status_0
-                        .reg
-                        .set(IndirectStatus::REGION_TYPE::UnsupportedRegion.value);
-                } else {
-                    let len_dwords = image.len() as u32 / 4;
-                    self.indirect_fifo_ctrl_0
-                        .reg
-                        .modify(IndirectCtrl0::CMS.val(cms));
-                    self.indirect_fifo_ctrl_0
-                        .reg
-                        .modify(IndirectCtrl0::RESET::CLEAR);
-                    self.indirect_fifo_ctrl_image_size.reg.set(len_dwords);
-                    self.indirect_fifo_status_0
-                        .reg
-                        .set(IndirectStatus::REGION_TYPE::CodeSpaceRecovery.value);
-                }
-                self.indirect_fifo_status_1.reg.set(0);
-                self.indirect_fifo_status_2.reg.set(0);
-                self.indirect_fifo_status_0
-                    .reg
-                    .modify(IndirectStatus::FIFO_EMPTY::CLEAR + IndirectStatus::FIFO_FULL::CLEAR);
-            } else {
-                println!(
-                    "No Image in RRI ({} >= {})",
-                    image_index,
-                    self.cms_data.len()
-                );
-                self.indirect_fifo_status_0
-                    .reg
-                    .set(IndirectStatus::REGION_TYPE::UnsupportedRegion.value);
-            }
+            self.load_image();
         }
         Ok(())
+    }
+
+    pub fn recovery_status_write(&mut self, size: RvSize, val: RvData) -> Result<(), BusError> {
+        // Writes have to be Word aligned
+        if size != RvSize::Word {
+            Err(BusError::StoreAccessFault)?
+        }
+        self.recovery_status.reg.set(val);
+        self.load_image();
+        Ok(())
+    }
+
+    fn load_image(&mut self) {
+        let image_index = ((self.recovery_status.reg.get() >> 4) & 0xf) as usize;
+        if let Some(image) = self.cms_data.get(image_index) {
+            let len_dwords = image.len() as u32 / 4;
+            self.indirect_fifo_ctrl_0
+                .reg
+                .modify(IndirectCtrl0::CMS.val(0));
+            self.indirect_fifo_ctrl_0
+                .reg
+                .modify(IndirectCtrl0::RESET::CLEAR);
+            self.indirect_fifo_ctrl_image_size.reg.set(len_dwords);
+            self.indirect_fifo_status_0
+                .reg
+                .set(IndirectStatus::REGION_TYPE::CodeSpaceRecovery.value);
+            self.indirect_fifo_status_1.reg.set(0);
+            self.indirect_fifo_status_2.reg.set(0);
+            self.indirect_fifo_status_0
+                .reg
+                .modify(IndirectStatus::FIFO_EMPTY::CLEAR + IndirectStatus::FIFO_FULL::CLEAR);
+        } else {
+            println!(
+                "No Image in RRI ({} >= {})",
+                image_index,
+                self.cms_data.len()
+            );
+            self.indirect_fifo_status_0
+                .reg
+                .set(IndirectStatus::REGION_TYPE::UnsupportedRegion.value);
+        }
     }
 
     pub fn indirect_fifo_ctrl_image_size_read(&mut self, size: RvSize) -> Result<RvData, BusError> {


### PR DESCRIPTION
We don't need to set the I3C recovery indirect fifo ctrl reset, as this is set by the BMC when setting the recovery image size.

Doing this eliminates a rare race condition that we were occasionally seeing:

* Caliptra sets the recovery status next image index to 1 (SoC manifest)
* BMC reads the recovery status
* BMC writes indirect fifo ctrl to reset and set the next image size
* BMC sends first data block to indirect fifo data
* Caliptra writes indirect fifo ctrl to reset, which drops the first data block

This extra indirect fifo ctrl reset is unnecessary and appears to have been introduced to work around quirks in the fake BMC flow in #2107.

We also change the emulator behavior to load the next image into the recovery registers on writes to the recovery status to clean up these quirks a little.

This addresses one small part of
https://github.com/chipsalliance/caliptra-mcu-sw/issues/572 (but not all of the instability).