### PR TITLE
Increase boot timeout

### DIFF
--- a/ci-tools/fpga-boss/src/main.rs
+++ b/ci-tools/fpga-boss/src/main.rs
@@ -414,7 +414,7 @@ fn main_impl() -> anyhow::Result<()> {
                     std::thread::sleep(Duration::from_millis(100));
                 }
 
-                let boot_timeout = Duration::from_secs(60);
+                let boot_timeout = Duration::from_secs(180);
                 let (uart_rx, mut uart_tx) = ftdi_uart::open_blocking(
                     get_zcu104_path()?,
                     ftdi_interface::INTERFACE_B,


### PR DESCRIPTION
https://github.com/chipsalliance/caliptra-sw/pull/2794 add's a sleep to the boot configuration, to allow the NTP service to update. 

Increase boot timeout for now, until a more permanent fix is enabled.