### PR TITLE
fpga: Cold reset test can be too fast sometimes

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -2007,7 +2007,7 @@ mod tests {
         );
         println!("{init_params_summary:#?}");
 
-        // The Caliptra ROM boots so quickly that sometimes it is done while before we finish returning from booting the MCU
+        // While in boot(), sometimes the test Caliptra ROM has written to the output before we can set the search term in step_until_output().
         // So set the search term manually before calling boot().
         model.output().set_search_term("hii");
         model.boot(BootParams::default()).unwrap();


### PR DESCRIPTION
Since we step the hw-model to get the MCU booted and the cold reset ROM is so fast, sometimes the output has already been processed before we set up the search term.

We refactor the test to call new_unbooted() and boot() manually so that we can set the search term before boot() so that it will always be captured.