### PR TITLE
Add OCP LOCK as a workflow input

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -17,6 +17,9 @@ on:
       fpga-itrng:
         default: true
         type: boolean
+      ocp-lock:
+        default: true
+        type: boolean
       hw-version:
         default: "latest"
         type: string
@@ -177,6 +180,9 @@ jobs:
 
           if [ "${{ inputs.workflow_call }}" ]; then
             FEATURES=fpga_subsystem,${{ inputs.extra-features }}
+            if [ "${{ inputs.ocp-lock }}" == "true" ]; then
+              FEATURES="${FEATURES},ocp-lock"
+            fi
           else
             FEATURES=fpga_subsystem,itrng,ocp-lock
           fi


### PR DESCRIPTION
The nightly job will use this to run tests with and without OCP LOCK enabled in hardware.