### PR TITLE
[jtag] make DMI reg enum values hashable and comparable

### DIFF
--- a/hw-model/src/jtag.rs
+++ b/hw-model/src/jtag.rs
@@ -13,7 +13,7 @@ pub trait JtagAccessibleReg {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum CaliptraCoreReg {
     MboxDlen = 0x50,


### PR DESCRIPTION
This enables adding them to a HashSet that can be interated over in a test to test accessing each register.