### PR TITLE
Add FPGA-specific ROM (no log) to builder

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -83,7 +83,11 @@ slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.nightly.overrides]]
 filter = 'test(test_generate_csr_envelop_stress)'
-slow-timeout = { period = "30s", terminate-after = 140 }
+slow-timeout = { period = "30s", terminate-after = 180 }
+
+[[profile.nightly.overrides]]
+filter = 'test(test_binaries_are_identical)'
+slow-timeout = { period = "30s", terminate-after = 30 }
 
 [[profile.nightly.overrides]]
 filter = 'test(test_stress_update)'

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -21,7 +21,8 @@ pub fn rom_from_env_fpga(fpga: bool) -> &'static FwId<'static> {
         fpga,
     ) {
         (Ok("ROM"), _) => &ROM,
-        (Ok("ROM_WITHOUT_UART"), _) => &ROM,
+        (Ok("ROM_WITHOUT_UART"), true) => &ROM_FPGA,
+        (Ok("ROM_WITHOUT_UART"), false) => &ROM,
         (Ok("ROM_WITH_UART"), true) => &ROM_FPGA_WITH_UART,
         (Ok("ROM_WITH_UART"), false) => &ROM_WITH_UART,
         (Ok(s), _) => panic!("unexpected CPRTA_TEST_ROM env-var value: {s:?}"),
@@ -42,6 +43,12 @@ pub const ROM: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
     features: &[],
+};
+
+pub const ROM_FPGA: FwId = FwId {
+    crate_name: "caliptra-rom",
+    bin_name: "caliptra-rom",
+    features: &["fpga_realtime"],
 };
 
 pub const ROM_WITH_UART: FwId = FwId {
@@ -500,6 +507,7 @@ pub mod runtime_tests {
 
 pub const REGISTERED_FW: &[&FwId] = &[
     &ROM,
+    &ROM_FPGA,
     &ROM_WITH_UART,
     &ROM_FAKE_WITH_UART,
     &ROM_FAKE_WITH_UART_FPGA,


### PR DESCRIPTION
This is needed for the nightly tests. A lot of them override the ROM type to use the UART FPGA ROM, but I think some might use the non-UART log?

This also increases the timeout for the slow tests `test_binaries_are_identical` and `test_generate_csr_envelop_stress`, which were occasionally timing out in nightly.