### PR TITLE
fix `test_invoke_dpe::test_export_cdi_destroyed_root_context`

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -76,7 +76,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db888988
-      CALIPTRA_MCU_COMMIT: d4e5bf93c2d784d4a67442de684aed691e272216
+      CALIPTRA_MCU_COMMIT: e362d273e0775f63bf54414fb1cc5a365d687895
 
     steps:
       - name: Checkout repo
@@ -325,7 +325,7 @@ jobs:
               --binaries-metadata="${TEST_BIN}/target/nextest/binaries-metadata.json"
               --target-dir-remap="${TEST_BIN}/target"
               --workspace-remap=.
-              -E 'package(caliptra-runtime) - test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys) - test(test_debug_unlock::test_dbg_unlock_prod_wrong_cmd) - test(test_pauser_privilege_levels::test_pl0_unset_in_header) - test(test_pauser_privilege_levels::test_pl1_init_ctx_dpe_context_thresholds) - test(test_pauser_privilege_levels::test_user_not_pl0) - test(test_get_idev_csr::test_get_ecc_csr) - test(test_get_idev_csr::test_get_mldsa_csr) - test(test_mailbox::test_reserved_pauser) - test(test_pauser_privilege_levels::test_change_locality) - test(test_certs::test_all_measurement_apis) - test(test_invoke_dpe::test_export_cdi_destroyed_root_context)'
+              -E 'package(caliptra-runtime) - test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys) - test(test_debug_unlock::test_dbg_unlock_prod_wrong_cmd) - test(test_pauser_privilege_levels::test_pl0_unset_in_header) - test(test_pauser_privilege_levels::test_pl1_init_ctx_dpe_context_thresholds) - test(test_pauser_privilege_levels::test_user_not_pl0) - test(test_get_idev_csr::test_get_ecc_csr) - test(test_get_idev_csr::test_get_mldsa_csr) - test(test_mailbox::test_reserved_pauser) - test(test_pauser_privilege_levels::test_change_locality) - test(test_certs::test_all_measurement_apis)'
               -E 'package(caliptra-rom) - test(test_debug_unlock::) - test(test_fmcalias_derivation::test_zero_firmware_size) - test(test_fake_rom::test_fake_rom_production_enabled) - test(test_fake_rom::test_image_verify) - test(test_uds_programming::) - test(test_wdt_activation_and_stoppage::) - test(test_warm_reset::test_warm_reset_during_update_reset) - test(test_warm_reset::test_warm_reset_during_cold_boot_before_image_validation) - test(test_image_validation::cert_test_with_ueid)'
               -E 'package(caliptra-api)'
               -E 'package(caliptra-api-types)'

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -9,7 +9,7 @@ use caliptra_common::mailbox_api::{
     CommandId, FwInfoResp, InvokeDpeReq, MailboxReq, MailboxReqHeader,
 };
 use caliptra_drivers::CaliptraError;
-use caliptra_hw_model::{HwModel, ModelError, SecurityState};
+use caliptra_hw_model::{HwModel, SecurityState};
 use caliptra_runtime::{RtBootStatus, DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
 use cms::{
     cert::x509::der::{Decode, Encode},
@@ -450,14 +450,8 @@ fn test_export_cdi_destroyed_root_context() {
 
     model.warm_reset_flow().unwrap();
 
-    let payload = MailboxReqHeader {
-        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::FW_INFO), &[]),
-    };
-    let resp = model
-        .mailbox_execute(u32::from(CommandId::FW_INFO), payload.as_bytes())
-        .unwrap_err();
-    assert_eq!(
-        resp,
-        ModelError::MailboxCmdFailed(CaliptraError::RUNTIME_UNABLE_TO_FIND_DPE_ROOT_CONTEXT.into())
+    model.step_until_fatal_error(
+        CaliptraError::RUNTIME_UNABLE_TO_FIND_DPE_ROOT_CONTEXT.into(),
+        30_000_000,
     );
 }


### PR DESCRIPTION
This test gets the fatal error while still coming up from warm reset. This needed warm_reset in subsystem to return before the full flow is complete so we can catch the error. This is changed to wait until MCU ROM sets the fuses in warm reset. The `fw_flow_status` error is cleared on warm reset so it shouldn't immediately return from the milestone set during cold reset.

This also overrides the `warm_reset_flow` HwModel function in subsystem because those registers are supposed to be set by MCU ROM instead of the HwModel.