### PR TITLE
Split bitstream downloader into a library and CLI

### DIFF
--- a/ci-tools/bitstream-downloader/Cargo.toml
+++ b/ci-tools/bitstream-downloader/Cargo.toml
@@ -1,14 +1,15 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "bitstream-downloader"
+name = "caliptra-bitstream-downloader"
 version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "4.5.48", features = ["derive"] }
 hex = "0.4.3"
-reqwest = { version = "0.12.23", features = ["blocking", "json"] }
+reqwest = { version = "0.12.23", features = ["blocking", "json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.227", features = ["derive"] }
 sha2 = "0.10.9"
 toml = "0.9.7"

--- a/ci-tools/bitstream-downloader/src/lib.rs
+++ b/ci-tools/bitstream-downloader/src/lib.rs
@@ -1,0 +1,61 @@
+// Licensed under the Apache-2.0 license
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Deserialize)]
+pub struct Bitstream {
+    pub name: String,
+    pub url: String,
+    pub hash: String,
+    pub caliptra_variant: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    pub bitstream: Bitstream,
+}
+
+pub fn download_bitstream(manifest_path: &Path) -> Result<PathBuf> {
+    let manifest_content = fs::read_to_string(manifest_path)
+        .context("failed to read manifest file")?;
+    let manifest: Manifest = toml::from_str(&manifest_content)
+        .context("failed to parse manifest TOML")?;
+
+    println!("Downloading bitstream: {}", manifest.bitstream.name);
+    println!("URL: {}", manifest.bitstream.url);
+
+    let response = reqwest::blocking::get(&manifest.bitstream.url)
+        .context("failed to make request")?;
+    let mut content = io::Cursor::new(response.bytes().context("failed to read response bytes")?);
+
+    let mut hasher = Sha256::new();
+    io::copy(&mut content, &mut hasher).context("failed to read content for hashing")?;
+    let calculated_hash = hasher.finalize();
+    let calculated_hash_hex = hex::encode(calculated_hash);
+
+    println!("Expected hash: {}", manifest.bitstream.hash);
+    println!("Calculated hash: {}", calculated_hash_hex);
+
+    if calculated_hash_hex == manifest.bitstream.hash {
+        println!("Hash verification successful!");
+    } else {
+        bail!(
+            "hash mismatch expected: {}, got: {}",
+            manifest.bitstream.hash,
+            calculated_hash_hex
+        );
+    }
+    let output_filename = format!("{}.pdi", manifest.bitstream.caliptra_variant);
+    let output_path = PathBuf::from(&output_filename);
+    let mut file = fs::File::create(&output_path).context("failed to create output file")?;
+    content.set_position(0);
+    io::copy(&mut content, &mut file).context("failed to write output file")?;
+    println!("PDI saved to: {}", output_filename);
+    Ok(output_path)
+}

--- a/ci-tools/bitstream-downloader/src/main.rs
+++ b/ci-tools/bitstream-downloader/src/main.rs
@@ -1,12 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use std::fs;
-use std::io;
 use std::path::PathBuf;
 
+use anyhow::Result;
 use clap::Parser;
-use serde::Deserialize;
-use sha2::{Digest, Sha256};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -16,54 +13,8 @@ struct Cli {
     bitstream_manifest: PathBuf,
 }
 
-#[derive(Debug, Deserialize)]
-struct Bitstream {
-    name: String,
-    url: String,
-    hash: String,
-    caliptra_variant: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct Manifest {
-    bitstream: Bitstream,
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
-
-    let manifest_content = fs::read_to_string(&cli.bitstream_manifest)
-        .map_err(|e| format!("failed to read manifest file: {}", e))?;
-    let manifest: Manifest = toml::from_str(&manifest_content)
-        .map_err(|e| format!("failed to parse manifest TOML: {}", e))?;
-
-    println!("Downloading bitstream: {}", manifest.bitstream.name);
-    println!("URL: {}", manifest.bitstream.url);
-
-    let response = reqwest::blocking::get(&manifest.bitstream.url)?;
-    let mut content = io::Cursor::new(response.bytes()?);
-
-    let mut hasher = Sha256::new();
-    io::copy(&mut content, &mut hasher)?;
-    let calculated_hash = hasher.finalize();
-    let calculated_hash_hex = hex::encode(calculated_hash);
-
-    println!("Expected hash: {}", manifest.bitstream.hash);
-    println!("Calculated hash: {}", calculated_hash_hex);
-
-    if calculated_hash_hex == manifest.bitstream.hash {
-        println!("Hash verification successful!");
-    } else {
-        return Err(format!(
-            "hash mismatch expected: {}, got: {}",
-            manifest.bitstream.hash, calculated_hash_hex
-        )
-        .into());
-    }
-    let output_filename = format!("{}.pdi", manifest.bitstream.caliptra_variant);
-    let mut file = fs::File::create(&output_filename)?;
-    content.set_position(0);
-    io::copy(&mut content, &mut file)?;
-    println!("PDI saved to: {}", output_filename);
+    caliptra_bitstream_downloader::download_bitstream(&cli.bitstream_manifest)?;
     Ok(())
 }


### PR DESCRIPTION
This way the caliptra-bitstream-downloader crate can be used from xtask.