### PR TITLE
Rom rework mbox processing

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -485,6 +485,25 @@ impl Default for MailboxResp {
 
 #[cfg_attr(test, derive(PartialEq, Debug, Eq))]
 #[allow(clippy::large_enum_variant)]
+pub enum RomMailboxResp {
+    Header(MailboxRespHeader),
+    FipsVersion(FipsVersionResp),
+    Capabilities(CapabilitiesResp),
+    StashMeasurement(StashMeasurementResp),
+    GetIdevCsr(GetIdevCsrResp),
+    CmDeriveStableKey(CmDeriveStableKeyResp),
+    CmRandomGenerate(CmRandomGenerateResp),
+    CmHmac(CmHmacResp),
+    ReportHekMetaData(ReportHekMetadataReq),
+    InstallOwnerPkHash(InstallOwnerPkHashResp),
+    GetLdevCert(GetLdevCertResp),
+    ZeroizeUdsFe(ZeroizeUdsFeResp),
+}
+
+pub const MAX_ROM_RESP_SIZE: usize = size_of::<RomMailboxResp>();
+
+#[cfg_attr(test, derive(PartialEq, Debug, Eq))]
+#[allow(clippy::large_enum_variant)]
 pub enum MailboxReq {
     ActivateFirmware(ActivateFirmwareReq),
     EcdsaVerify(EcdsaVerifyReq),

--- a/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
@@ -13,18 +13,23 @@ Abstract:
 --*/
 
 use caliptra_common::capabilities::Capabilities;
-use caliptra_common::mailbox_api::{CapabilitiesResp, MailboxRespHeader, Response};
-use caliptra_drivers::{CaliptraResult, SocIfc};
-use zerocopy::IntoBytes;
+use caliptra_common::mailbox_api::{
+    CapabilitiesResp, MailboxReqHeader, MailboxRespHeader, Response,
+};
+use caliptra_drivers::{CaliptraError, CaliptraResult, SocIfc};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct CapabilitiesCmd;
 impl CapabilitiesCmd {
     #[inline(always)]
     pub(crate) fn execute(
-        _cmd_bytes: &[u8],
+        cmd_bytes: &[u8],
         soc_ifc: &mut SocIfc,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let mut capabilities = Capabilities::default();
         capabilities |= Capabilities::ROM_BASE;
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
@@ -1,0 +1,45 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    capabilities.rs
+
+Abstract:
+
+    File contains CAPABILITIES mailbox command.
+
+--*/
+
+use caliptra_common::capabilities::Capabilities;
+use caliptra_common::mailbox_api::{CapabilitiesResp, MailboxRespHeader, Response};
+use caliptra_drivers::{CaliptraResult, SocIfc};
+use zerocopy::IntoBytes;
+
+pub struct CapabilitiesCmd;
+impl CapabilitiesCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        soc_ifc: &mut SocIfc,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let mut capabilities = Capabilities::default();
+        capabilities |= Capabilities::ROM_BASE;
+
+        if soc_ifc.ocp_lock_enabled() {
+            capabilities |= Capabilities::ROM_OCP_LOCK;
+        }
+
+        let mut capabilities_resp = CapabilitiesResp {
+            hdr: MailboxRespHeader::default(),
+            capabilities: capabilities.to_bytes(),
+        };
+        capabilities_resp.populate_chksum();
+
+        let resp_bytes = capabilities_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
@@ -13,9 +13,7 @@ Abstract:
 --*/
 
 use caliptra_common::capabilities::Capabilities;
-use caliptra_common::mailbox_api::{
-    CapabilitiesResp, MailboxReqHeader, MailboxRespHeader, Response,
-};
+use caliptra_common::mailbox_api::{CapabilitiesResp, MailboxReqHeader, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -48,8 +46,6 @@ impl CapabilitiesCmd {
 
         capabilities_resp.hdr = MailboxRespHeader::default();
         capabilities_resp.capabilities = capabilities.to_bytes();
-        capabilities_resp.populate_chksum();
-
         let resp_bytes = capabilities_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_derive_stable_key.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_derive_stable_key.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::{CmDeriveStableKeyReq, CmDeriveStableKeyResp};
-use caliptra_common::mailbox_api::Response;
+
 use caliptra_drivers::{Aes, CaliptraResult, Hmac, PersistentData, Trng};
 use zerocopy::{transmute, FromBytes, IntoBytes};
 
@@ -46,8 +46,6 @@ impl CmDeriveStableKeyCmd {
             .map_err(|_| caliptra_drivers::CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
         derive_resp.cmk = transmute!(encrypted_cmk);
-        derive_resp.populate_chksum();
-
         let resp_bytes = derive_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_derive_stable_key.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_derive_stable_key.rs
@@ -1,0 +1,49 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    cm_derive_stable_key.rs
+
+Abstract:
+
+    File contains CM_DERIVE_STABLE_KEY mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::{CmDeriveStableKeyReq, CmDeriveStableKeyResp};
+use caliptra_common::mailbox_api::Response;
+use caliptra_drivers::{Aes, CaliptraResult, Hmac, PersistentData, Trng};
+use zerocopy::{transmute, FromBytes, IntoBytes};
+
+use super::FirmwareProcessor;
+
+pub struct CmDeriveStableKeyCmd;
+impl CmDeriveStableKeyCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        aes: &mut Aes,
+        hmac: &mut Hmac,
+        trng: &mut Trng,
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let request = CmDeriveStableKeyReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| caliptra_drivers::CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        let encrypted_cmk =
+            FirmwareProcessor::derive_stable_key(aes, hmac, trng, persistent_data, request)?;
+
+        let mut derive_resp = CmDeriveStableKeyResp {
+            cmk: transmute!(encrypted_cmk),
+            ..Default::default()
+        };
+        derive_resp.populate_chksum();
+
+        let resp_bytes = derive_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
@@ -15,7 +15,7 @@ Abstract:
 use caliptra_api::mailbox::CmHmacResp;
 use caliptra_common::crypto::Crypto;
 use caliptra_common::hmac_cm::hmac;
-use caliptra_common::mailbox_api::{Response, ResponseVarSize};
+use caliptra_common::mailbox_api::ResponseVarSize;
 use caliptra_drivers::{Aes, CaliptraError, CaliptraResult, Hmac, PersistentData, Trng};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -48,7 +48,6 @@ impl CmHmacCmd {
             hmac_resp.as_mut_bytes(),
         )?;
 
-        hmac_resp.populate_chksum();
         let resp_bytes = hmac_resp.as_bytes_partial()?;
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
@@ -1,0 +1,48 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    cm_hmac.rs
+
+Abstract:
+
+    File contains CM_HMAC mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::CmHmacResp;
+use caliptra_common::crypto::Crypto;
+use caliptra_common::hmac_cm::hmac;
+use caliptra_common::mailbox_api::{Response, ResponseVarSize};
+use caliptra_drivers::{Aes, CaliptraResult, Hmac, PersistentData, Trng};
+use zerocopy::IntoBytes;
+
+pub struct CmHmacCmd;
+impl CmHmacCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        aes: &mut Aes,
+        hmac_engine: &mut Hmac,
+        trng: &mut Trng,
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let mut hmac_resp = CmHmacResp::default();
+        hmac(
+            hmac_engine,
+            aes,
+            trng,
+            Crypto::get_cmb_aes_key(persistent_data),
+            cmd_bytes,
+            hmac_resp.as_mut_bytes(),
+        )?;
+
+        hmac_resp.populate_chksum();
+        let resp_bytes = hmac_resp.as_bytes_partial()?;
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_hmac.rs
@@ -16,8 +16,8 @@ use caliptra_api::mailbox::CmHmacResp;
 use caliptra_common::crypto::Crypto;
 use caliptra_common::hmac_cm::hmac;
 use caliptra_common::mailbox_api::{Response, ResponseVarSize};
-use caliptra_drivers::{Aes, CaliptraResult, Hmac, PersistentData, Trng};
-use zerocopy::IntoBytes;
+use caliptra_drivers::{Aes, CaliptraError, CaliptraResult, Hmac, PersistentData, Trng};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct CmHmacCmd;
 impl CmHmacCmd {
@@ -30,7 +30,15 @@ impl CmHmacCmd {
         persistent_data: &mut PersistentData,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        let mut hmac_resp = CmHmacResp::default();
+        // Use the response buffer directly as CmHmacResp.
+        // The buffer is zeroized at the start of the loop
+        let resp_buffer_size = core::mem::size_of::<CmHmacResp>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let hmac_resp = CmHmacResp::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         hmac(
             hmac_engine,
             aes,
@@ -42,7 +50,6 @@ impl CmHmacCmd {
 
         hmac_resp.populate_chksum();
         let resp_bytes = hmac_resp.as_bytes_partial()?;
-        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
         Ok(resp_bytes.len())
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_random_generate.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_random_generate.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::{CmRandomGenerateReq, CmRandomGenerateResp};
-use caliptra_common::mailbox_api::{Response, ResponseVarSize};
+use caliptra_common::mailbox_api::ResponseVarSize;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Trng;
 use zerocopy::FromBytes;
@@ -56,8 +56,6 @@ impl CmRandomGenerateCmd {
         }
 
         rand_resp.hdr.data_len = size as u32;
-        rand_resp.populate_chksum();
-
         let resp_bytes = rand_resp.as_bytes_partial()?;
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_random_generate.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_random_generate.rs
@@ -1,0 +1,57 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    cm_random_generate.rs
+
+Abstract:
+
+    File contains CM_RANDOM_GENERATE mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::{CmRandomGenerateReq, CmRandomGenerateResp};
+use caliptra_common::mailbox_api::{Response, ResponseVarSize};
+use caliptra_drivers::CaliptraResult;
+use caliptra_drivers::Trng;
+use zerocopy::FromBytes;
+
+pub struct CmRandomGenerateCmd;
+impl CmRandomGenerateCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        trng: &mut Trng,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let request = CmRandomGenerateReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| caliptra_drivers::CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        let size = request.size as usize;
+        let mut rand_resp = CmRandomGenerateResp::default();
+
+        if size > rand_resp.data.len() {
+            // Return 0 to indicate failure
+            return Ok(0);
+        }
+
+        for i in (0..size).step_by(48) {
+            let rand: [u8; 48] = trng.generate()?.into();
+            let len = rand.len().min(rand_resp.data.len() - i);
+            // check to prevent panic even though this is impossible
+            if i > rand_resp.data.len() {
+                break;
+            }
+            rand_resp.data[i..i + len].copy_from_slice(&rand[..len]);
+        }
+
+        rand_resp.hdr.data_len = size as u32;
+        rand_resp.populate_chksum();
+
+        let resp_bytes = rand_resp.as_bytes_partial()?;
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Ecc384};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -36,8 +36,6 @@ impl EcdsaVerifyCmd {
                     .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
                 let verify_resp = MailboxRespHeader::mut_from_bytes(resp)
                     .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-                verify_resp.populate_chksum();
 
                 let resp_bytes = verify_resp.as_bytes();
                 Ok(resp_bytes.len())

--- a/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
@@ -13,8 +13,8 @@ Abstract:
 --*/
 
 use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
-use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Ecc384};
-use zerocopy::IntoBytes;
+use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Ecc384};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
@@ -28,11 +28,18 @@ impl EcdsaVerifyCmd {
 
         match result {
             Ok(_) => {
-                let mut verify_resp = MailboxRespHeader::default();
+                // Use the response buffer directly as MailboxRespHeader.
+                // The buffer is zeroized at the start of the loop
+                let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
+                let resp = resp
+                    .get_mut(..resp_buffer_size)
+                    .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+                let verify_resp = MailboxRespHeader::mut_from_bytes(resp)
+                    .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
                 verify_resp.populate_chksum();
 
                 let resp_bytes = verify_resp.as_bytes();
-                resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
                 Ok(resp_bytes.len())
             }
             Err(e) => {

--- a/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
@@ -1,0 +1,45 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    ecdsa_verify.rs
+
+Abstract:
+
+    File contains ECDSA384_SIGNATURE_VERIFY mailbox command.
+
+--*/
+
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Ecc384};
+use zerocopy::IntoBytes;
+
+pub struct EcdsaVerifyCmd;
+impl EcdsaVerifyCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        ecc384: &mut Ecc384,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let result = caliptra_common::verify::EcdsaVerifyCmd::execute(ecc384, cmd_bytes);
+
+        match result {
+            Ok(_) => {
+                let mut verify_resp = MailboxRespHeader::default();
+                verify_resp.populate_chksum();
+
+                let resp_bytes = verify_resp.as_bytes();
+                resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+                Ok(resp_bytes.len())
+            }
+            Err(e) => {
+                report_fw_error_non_fatal(e.into());
+                // Return 0 to indicate failure
+                Ok(0)
+            }
+        }
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
@@ -12,17 +12,21 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{GetIdevCsrResp, Response, ResponseVarSize};
+use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxReqHeader, Response, ResponseVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
+use zerocopy::FromBytes;
 
 pub struct GetIdevEcc384CsrCmd;
 impl GetIdevEcc384CsrCmd {
     #[inline(always)]
     pub(crate) fn execute(
-        _cmd_bytes: &[u8],
+        cmd_bytes: &[u8],
         persistent_data: &mut PersistentData,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let csr_persistent_mem = &persistent_data.idevid_csr_envelop.ecc_csr;
         let mut csr_resp = GetIdevCsrResp::default();
 
@@ -50,10 +54,13 @@ pub struct GetIdevMldsa87CsrCmd;
 impl GetIdevMldsa87CsrCmd {
     #[inline(always)]
     pub(crate) fn execute(
-        _cmd_bytes: &[u8],
+        cmd_bytes: &[u8],
         persistent_data: &mut PersistentData,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let csr_persistent_mem = &persistent_data.idevid_csr_envelop.mldsa_csr;
         let mut csr_resp = GetIdevCsrResp::default();
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
@@ -1,0 +1,78 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    get_idev_csr.rs
+
+Abstract:
+
+    File contains GET_IDEV_ECC384_CSR and GET_IDEV_MLDSA87_CSR mailbox commands.
+
+--*/
+
+use caliptra_common::mailbox_api::{GetIdevCsrResp, Response, ResponseVarSize};
+use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
+
+pub struct GetIdevEcc384CsrCmd;
+impl GetIdevEcc384CsrCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let csr_persistent_mem = &persistent_data.idevid_csr_envelop.ecc_csr;
+        let mut csr_resp = GetIdevCsrResp::default();
+
+        if csr_persistent_mem.is_unprovisioned() {
+            // CSR was never written to DCCM. This means the gen_idev_id_csr
+            // manufacturing flag was not set before booting into ROM.
+            return Err(CaliptraError::FW_PROC_MAILBOX_GET_IDEV_CSR_UNPROVISIONED_CSR);
+        }
+
+        let csr = csr_persistent_mem
+            .get()
+            .ok_or(CaliptraError::ROM_IDEVID_INVALID_CSR)?;
+
+        csr_resp.data_size = csr_persistent_mem.get_csr_len();
+        csr_resp.data[..csr_resp.data_size as usize].copy_from_slice(csr);
+
+        csr_resp.populate_chksum();
+        let resp_bytes = csr_resp.as_bytes_partial()?;
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}
+
+pub struct GetIdevMldsa87CsrCmd;
+impl GetIdevMldsa87CsrCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let csr_persistent_mem = &persistent_data.idevid_csr_envelop.mldsa_csr;
+        let mut csr_resp = GetIdevCsrResp::default();
+
+        if csr_persistent_mem.is_unprovisioned() {
+            // CSR was never written to DCCM. This means the gen_idev_id_csr
+            // manufacturing flag was not set before booting into ROM.
+            return Err(CaliptraError::FW_PROC_MAILBOX_GET_IDEV_CSR_UNPROVISIONED_CSR);
+        }
+
+        let csr = csr_persistent_mem
+            .get()
+            .ok_or(CaliptraError::ROM_IDEVID_INVALID_CSR)?;
+
+        csr_resp.data_size = csr_persistent_mem.get_csr_len();
+        csr_resp.data[..csr_resp.data_size as usize].copy_from_slice(csr);
+
+        csr_resp.populate_chksum();
+        let resp_bytes = csr_resp.as_bytes_partial()?;
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
@@ -27,8 +27,16 @@ impl GetIdevEcc384CsrCmd {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
+        // Use the response buffer directly as GetIdevCsrResp.
+        // The buffer is zeroized at the start of the loop
+        let resp_buffer_size = core::mem::size_of::<GetIdevCsrResp>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let csr_resp = GetIdevCsrResp::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let csr_persistent_mem = &persistent_data.idevid_csr_envelop.ecc_csr;
-        let mut csr_resp = GetIdevCsrResp::default();
 
         if csr_persistent_mem.is_unprovisioned() {
             // CSR was never written to DCCM. This means the gen_idev_id_csr
@@ -45,7 +53,6 @@ impl GetIdevEcc384CsrCmd {
 
         csr_resp.populate_chksum();
         let resp_bytes = csr_resp.as_bytes_partial()?;
-        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
         Ok(resp_bytes.len())
     }
 }
@@ -61,8 +68,16 @@ impl GetIdevMldsa87CsrCmd {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
+        // Use the response buffer directly as GetIdevCsrResp.
+        // The buffer is zeroized at the start of the loop
+        let resp_buffer_size = core::mem::size_of::<GetIdevCsrResp>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let csr_resp = GetIdevCsrResp::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let csr_persistent_mem = &persistent_data.idevid_csr_envelop.mldsa_csr;
-        let mut csr_resp = GetIdevCsrResp::default();
 
         if csr_persistent_mem.is_unprovisioned() {
             // CSR was never written to DCCM. This means the gen_idev_id_csr
@@ -79,7 +94,6 @@ impl GetIdevMldsa87CsrCmd {
 
         csr_resp.populate_chksum();
         let resp_bytes = csr_resp.as_bytes_partial()?;
-        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
         Ok(resp_bytes.len())
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_idev_csr.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxReqHeader, Response, ResponseVarSize};
+use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxReqHeader, ResponseVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
 use zerocopy::FromBytes;
 
@@ -51,7 +51,6 @@ impl GetIdevEcc384CsrCmd {
         csr_resp.data_size = csr_persistent_mem.get_csr_len();
         csr_resp.data[..csr_resp.data_size as usize].copy_from_slice(csr);
 
-        csr_resp.populate_chksum();
         let resp_bytes = csr_resp.as_bytes_partial()?;
         Ok(resp_bytes.len())
     }
@@ -92,7 +91,6 @@ impl GetIdevMldsa87CsrCmd {
         csr_resp.data_size = csr_persistent_mem.get_csr_len();
         csr_resp.data[..csr_resp.data_size as usize].copy_from_slice(csr);
 
-        csr_resp.populate_chksum();
         let resp_bytes = csr_resp.as_bytes_partial()?;
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
@@ -14,19 +14,22 @@ Abstract:
 
 use caliptra_api::mailbox::{AlgorithmType, GetLdevCertResp};
 use caliptra_common::dice::GetLdevCertCmd as CommonGetLdevCertCmd;
-use caliptra_common::mailbox_api::{Response, ResponseVarSize};
-use caliptra_drivers::{CaliptraResult, PersistentData};
-use zerocopy::IntoBytes;
+use caliptra_common::mailbox_api::{MailboxReqHeader, Response, ResponseVarSize};
+use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct GetLdevCertCmd;
 impl GetLdevCertCmd {
     #[inline(always)]
     pub(crate) fn execute(
-        _cmd_bytes: &[u8],
+        cmd_bytes: &[u8],
         persistent_data: &mut PersistentData,
         algorithm_type: AlgorithmType,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let mut ldev_resp = GetLdevCertResp::default();
         CommonGetLdevCertCmd::execute(persistent_data, algorithm_type, ldev_resp.as_mut_bytes())?;
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
@@ -1,0 +1,38 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    get_ldev_cert.rs
+
+Abstract:
+
+    File contains GET_LDEV_ECC384_CERT and GET_LDEV_MLDSA87_CERT mailbox commands.
+
+--*/
+
+use caliptra_api::mailbox::{AlgorithmType, GetLdevCertResp};
+use caliptra_common::dice::GetLdevCertCmd as CommonGetLdevCertCmd;
+use caliptra_common::mailbox_api::{Response, ResponseVarSize};
+use caliptra_drivers::{CaliptraResult, PersistentData};
+use zerocopy::IntoBytes;
+
+pub struct GetLdevCertCmd;
+impl GetLdevCertCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        persistent_data: &mut PersistentData,
+        algorithm_type: AlgorithmType,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let mut ldev_resp = GetLdevCertResp::default();
+        CommonGetLdevCertCmd::execute(persistent_data, algorithm_type, ldev_resp.as_mut_bytes())?;
+
+        ldev_resp.populate_chksum();
+        let resp_bytes = ldev_resp.as_bytes_partial()?;
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/get_ldev_cert.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use caliptra_api::mailbox::{AlgorithmType, GetLdevCertResp};
 use caliptra_common::dice::GetLdevCertCmd as CommonGetLdevCertCmd;
-use caliptra_common::mailbox_api::{MailboxReqHeader, Response, ResponseVarSize};
+use caliptra_common::mailbox_api::{MailboxReqHeader, ResponseVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -41,7 +41,6 @@ impl GetLdevCertCmd {
 
         CommonGetLdevCertCmd::execute(persistent_data, algorithm_type, ldev_resp.as_mut_bytes())?;
 
-        ldev_resp.populate_chksum();
         let resp_bytes = ldev_resp.as_bytes_partial()?;
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
@@ -1,0 +1,49 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    install_owner_pk_hash.rs
+
+Abstract:
+
+    File contains INSTALL_OWNER_PK_HASH mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::{InstallOwnerPkHashReq, InstallOwnerPkHashResp};
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct InstallOwnerPkHashCmd;
+impl InstallOwnerPkHashCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let request = InstallOwnerPkHashReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        // Save the owner public key hash in persistent data.
+        persistent_data
+            .dot_owner_pk_hash
+            .owner_pk_hash
+            .copy_from_slice(&request.digest);
+        persistent_data.dot_owner_pk_hash.valid = true;
+
+        // Generate and send response (with FIPS approved status)
+        let mut install_resp = InstallOwnerPkHashResp {
+            hdr: MailboxRespHeader::default(),
+            dpe_result: 0, // DPE_STATUS_SUCCESS
+        };
+        install_resp.populate_chksum();
+
+        let resp_bytes = install_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
@@ -13,9 +13,8 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::{InstallOwnerPkHashReq, InstallOwnerPkHashResp};
-use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
 pub struct InstallOwnerPkHashCmd;
 impl InstallOwnerPkHashCmd {
@@ -23,7 +22,7 @@ impl InstallOwnerPkHashCmd {
     pub(crate) fn execute(
         cmd_bytes: &[u8],
         persistent_data: &mut PersistentData,
-        resp: &mut [u8],
+        _resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let request = InstallOwnerPkHashReq::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
@@ -35,18 +34,7 @@ impl InstallOwnerPkHashCmd {
             .copy_from_slice(&request.digest);
         persistent_data.dot_owner_pk_hash.valid = true;
 
-        // Use the response buffer directly as InstallOwnerPkHashResp.
-        // The buffer is zeroized at the start of the loop
-        let resp_buffer_size = core::mem::size_of::<InstallOwnerPkHashResp>();
-        let resp = resp
-            .get_mut(..resp_buffer_size)
-            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-        let install_resp = InstallOwnerPkHashResp::mut_from_bytes(resp)
-            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-        install_resp.hdr = MailboxRespHeader::default();
-        install_resp.dpe_result = 0; // DPE_STATUS_SUCCESS
-        let resp_bytes = install_resp.as_bytes();
-        Ok(resp_bytes.len())
+        // Zero value of response buffer is good
+        Ok(core::mem::size_of::<InstallOwnerPkHashResp>())
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/install_owner_pk_hash.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::{InstallOwnerPkHashReq, InstallOwnerPkHashResp};
-use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -46,8 +46,6 @@ impl InstallOwnerPkHashCmd {
 
         install_resp.hdr = MailboxRespHeader::default();
         install_resp.dpe_result = 0; // DPE_STATUS_SUCCESS
-        install_resp.populate_chksum();
-
         let resp_bytes = install_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Mldsa87};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -36,8 +36,6 @@ impl MldsaVerifyCmd {
                     .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
                 let verify_resp = MailboxRespHeader::mut_from_bytes(resp)
                     .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-                verify_resp.populate_chksum();
 
                 let resp_bytes = verify_resp.as_bytes();
                 Ok(resp_bytes.len())

--- a/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
@@ -13,8 +13,7 @@ Abstract:
 --*/
 
 use caliptra_common::mailbox_api::MailboxRespHeader;
-use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Mldsa87};
-use zerocopy::{FromBytes, IntoBytes};
+use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Mldsa87};
 
 pub struct MldsaVerifyCmd;
 impl MldsaVerifyCmd {
@@ -22,23 +21,14 @@ impl MldsaVerifyCmd {
     pub(crate) fn execute(
         cmd_bytes: &[u8],
         mldsa87: &mut Mldsa87,
-        resp: &mut [u8],
+        _resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let result = caliptra_common::verify::MldsaVerifyCmd::execute(mldsa87, cmd_bytes);
 
         match result {
             Ok(_) => {
-                // Use the response buffer directly as MailboxRespHeader.
-                // The buffer is zeroized at the start of the loop
-                let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
-                let resp = resp
-                    .get_mut(..resp_buffer_size)
-                    .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-                let verify_resp = MailboxRespHeader::mut_from_bytes(resp)
-                    .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-                let resp_bytes = verify_resp.as_bytes();
-                Ok(resp_bytes.len())
+                // Zero value of response buffer is good
+                Ok(core::mem::size_of::<MailboxRespHeader>())
             }
             Err(e) => {
                 report_fw_error_non_fatal(e.into());

--- a/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
@@ -1,0 +1,45 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    mldsa_verify.rs
+
+Abstract:
+
+    File contains MLDSA87_SIGNATURE_VERIFY mailbox command.
+
+--*/
+
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Mldsa87};
+use zerocopy::IntoBytes;
+
+pub struct MldsaVerifyCmd;
+impl MldsaVerifyCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        mldsa87: &mut Mldsa87,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let result = caliptra_common::verify::MldsaVerifyCmd::execute(mldsa87, cmd_bytes);
+
+        match result {
+            Ok(_) => {
+                let mut verify_resp = MailboxRespHeader::default();
+                verify_resp.populate_chksum();
+
+                let resp_bytes = verify_resp.as_bytes();
+                resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+                Ok(resp_bytes.len())
+            }
+            Err(e) => {
+                report_fw_error_non_fatal(e.into());
+                // Return 0 to indicate failure
+                Ok(0)
+            }
+        }
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -351,7 +351,10 @@ impl FirmwareProcessor {
                 // Response buffer
                 let resp = &mut [0u8; caliptra_common::mailbox_api::MAX_ROM_RESP_SIZE][..];
 
-                let resp_len = match CommandId::from(txn.cmd()) {
+                // Don't read CMD again in the same loop execution is it might already have changed
+                // to the next CMD
+                let cmd = txn.cmd();
+                let resp_len = match CommandId::from(cmd) {
                     CommandId::VERSION => VersionCmd::execute(cmd_bytes, soc_ifc, resp)?,
                     CommandId::SELF_TEST_START => {
                         let (in_progress, len) =
@@ -460,7 +463,7 @@ impl FirmwareProcessor {
                     txn.complete(false)?;
                 }
 
-                match CommandId::from(txn.cmd()) {
+                match CommandId::from(cmd) {
                     // ZEROIZE_UDS_FE sends both a response as well as an error after that.
                     // Shutdown after zeroization as UDS and/or FE values and its derived keys are no longer valid.
                     CommandId::ZEROIZE_UDS_FE => {

--- a/rom/dev/src/flow/cold_reset/fw_processor/report_hek_metadata.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/report_hek_metadata.rs
@@ -1,0 +1,50 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    report_hek_metadata.rs
+
+Abstract:
+
+    File contains REPORT_HEK_METADATA mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::ReportHekMetadataReq;
+use caliptra_common::mailbox_api::Response;
+use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData, SocIfc};
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::flow::cold_reset::ocp_lock;
+
+pub struct ReportHekMetadataCmd;
+impl ReportHekMetadataCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        soc_ifc: &mut SocIfc,
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let request = ReportHekMetadataReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        if !soc_ifc.ocp_lock_enabled() {
+            Err(CaliptraError::FW_PROC_OCP_LOCK_UNSUPPORTED)?;
+        }
+
+        let mut hek_resp = ocp_lock::handle_report_hek_metadata(
+            soc_ifc.lifecycle(),
+            persistent_data,
+            request,
+            &soc_ifc.fuse_bank().ocp_hek_seed(),
+        )?;
+
+        hek_resp.populate_chksum();
+        let resp_bytes = hek_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/report_hek_metadata.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/report_hek_metadata.rs
@@ -13,7 +13,6 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::ReportHekMetadataReq;
-use caliptra_common::mailbox_api::Response;
 use caliptra_drivers::{CaliptraError, CaliptraResult, PersistentData, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -54,8 +53,6 @@ impl ReportHekMetadataCmd {
         // Copy the data from the response
         hek_resp.flags = hek_resp_data.flags;
         hek_resp.hdr = hek_resp_data.hdr;
-        hek_resp.populate_chksum();
-
         let resp_bytes = hek_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/ri_download_firmware.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ri_download_firmware.rs
@@ -1,0 +1,54 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    ri_download_firmware.rs
+
+Abstract:
+
+    File contains RI_DOWNLOAD_FIRMWARE mailbox command.
+
+--*/
+
+use caliptra_common::RomBootStatus::FwProcessorDownloadImageComplete;
+use caliptra_drivers::{
+    cprintln, report_boot_status, CaliptraResult, Dma, Mailbox, MailboxRecvTxn, SocIfc,
+};
+use core::mem::ManuallyDrop;
+
+use super::FirmwareProcessor;
+
+pub struct RiDownloadFirmwareCmd;
+impl RiDownloadFirmwareCmd {
+    #[inline(always)]
+    pub(crate) fn execute<'a>(
+        mbox: &'a mut Mailbox,
+        dma: &mut Dma,
+        soc_ifc: &mut SocIfc,
+        subsystem_mode: bool,
+    ) -> CaliptraResult<(ManuallyDrop<MailboxRecvTxn<'a>>, u32)> {
+        // Create a transaction to facilitate the download of the firmware image
+        // from the recovery interface. This dummy transaction is necessary to
+        // obtain and subsequently release the lock required to gain exclusive
+        // access to the mailbox sram by the DMA engine, enabling it to write the
+        // firmware image into the mailbox sram.
+        let txn = ManuallyDrop::new(mbox.recovery_recv_txn());
+
+        // Download the firmware image from the recovery interface.
+        let image_size_bytes = if subsystem_mode {
+            cprintln!("[fwproc] Downloading image from RRI to MCU SRAM");
+            FirmwareProcessor::retrieve_image_from_recovery_interface_to_mcu(dma, soc_ifc)?
+        } else {
+            cprintln!("[fwproc] Downloading image from RRI to MBOX SRAM");
+            FirmwareProcessor::retrieve_image_from_recovery_interface(dma, soc_ifc)?
+        };
+        cprintln!(
+            "[fwproc] Received image from the Recovery Interface of size {} bytes",
+            image_size_bytes
+        );
+        report_boot_status(FwProcessorDownloadImageComplete.into());
+        Ok((txn, image_size_bytes))
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use caliptra_kat::KatsEnv;
 use zerocopy::{FromBytes, IntoBytes};
@@ -46,8 +46,6 @@ impl SelfTestStartCmd {
             let test_resp = MailboxRespHeader::mut_from_bytes(resp)
                 .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
-            test_resp.populate_chksum();
-
             let resp_bytes = test_resp.as_bytes();
             Ok((true, resp_bytes.len()))
         }
@@ -78,8 +76,6 @@ impl SelfTestGetResultsCmd {
                 .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
             let test_resp = MailboxRespHeader::mut_from_bytes(resp)
                 .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-            test_resp.populate_chksum();
 
             let resp_bytes = test_resp.as_bytes();
             Ok((false, resp_bytes.len()))

--- a/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
@@ -37,11 +37,18 @@ impl SelfTestStartCmd {
             Ok((false, 0))
         } else {
             run_fips_tests(env)?;
-            let mut test_resp = MailboxRespHeader::default();
+            // Use the response buffer directly as MailboxRespHeader.
+            // The buffer is zeroized at the start of the loop
+            let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
+            let resp = resp
+                .get_mut(..resp_buffer_size)
+                .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+            let test_resp = MailboxRespHeader::mut_from_bytes(resp)
+                .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
             test_resp.populate_chksum();
 
             let resp_bytes = test_resp.as_bytes();
-            resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
             Ok((true, resp_bytes.len()))
         }
     }
@@ -63,11 +70,18 @@ impl SelfTestGetResultsCmd {
             // Return 0 for response length, will cause txn.complete(false)
             Ok((false, 0))
         } else {
-            let mut test_resp = MailboxRespHeader::default();
+            // Use the response buffer directly as MailboxRespHeader.
+            // The buffer is zeroized at the start of the loop
+            let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
+            let resp = resp
+                .get_mut(..resp_buffer_size)
+                .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+            let test_resp = MailboxRespHeader::mut_from_bytes(resp)
+                .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
             test_resp.populate_chksum();
 
             let resp_bytes = test_resp.as_bytes();
-            resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
             Ok((false, resp_bytes.len()))
         }
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
@@ -1,0 +1,68 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    self_test.rs
+
+Abstract:
+
+    File contains SELF_TEST_START and SELF_TEST_GET_RESULTS mailbox commands.
+
+--*/
+
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_drivers::CaliptraResult;
+use caliptra_kat::KatsEnv;
+use zerocopy::IntoBytes;
+
+use crate::run_fips_tests;
+
+pub struct SelfTestStartCmd;
+impl SelfTestStartCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        env: &mut KatsEnv,
+        self_test_in_progress: bool,
+        resp: &mut [u8],
+    ) -> CaliptraResult<(bool, usize)> {
+        if self_test_in_progress {
+            // TODO: set non-fatal error register?
+            // Return 0 for response length, will cause txn.complete(false)
+            Ok((false, 0))
+        } else {
+            run_fips_tests(env)?;
+            let mut test_resp = MailboxRespHeader::default();
+            test_resp.populate_chksum();
+
+            let resp_bytes = test_resp.as_bytes();
+            resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+            Ok((true, resp_bytes.len()))
+        }
+    }
+}
+
+pub struct SelfTestGetResultsCmd;
+impl SelfTestGetResultsCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        self_test_in_progress: bool,
+        resp: &mut [u8],
+    ) -> CaliptraResult<(bool, usize)> {
+        if !self_test_in_progress {
+            // TODO: set non-fatal error register?
+            // Return 0 for response length, will cause txn.complete(false)
+            Ok((false, 0))
+        } else {
+            let mut test_resp = MailboxRespHeader::default();
+            test_resp.populate_chksum();
+
+            let resp_bytes = test_resp.as_bytes();
+            resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+            Ok((false, resp_bytes.len()))
+        }
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::MailboxReqHeader;
+use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use zerocopy::FromBytes;
 
@@ -24,8 +24,6 @@ impl ShutdownCmd {
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
         // Zero value of response buffer is good
-
-        // Causing a ROM Fatal Error will zeroize the module
-        Err(CaliptraError::RUNTIME_SHUTDOWN)
+        Ok(core::mem::size_of::<MailboxRespHeader>())
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -31,8 +31,6 @@ impl ShutdownCmd {
             .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
         let shutdown_resp = MailboxRespHeader::mut_from_bytes(resp)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-        shutdown_resp.populate_chksum();
 
         let _resp_bytes = shutdown_resp.as_bytes();
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -23,11 +23,18 @@ impl ShutdownCmd {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
-        let mut shutdown_resp = MailboxRespHeader::default();
+        // Use the response buffer directly as MailboxRespHeader.
+        // The buffer is zeroized at the start of the loop
+        let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let shutdown_resp = MailboxRespHeader::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         shutdown_resp.populate_chksum();
 
-        let resp_bytes = shutdown_resp.as_bytes();
-        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        let _resp_bytes = shutdown_resp.as_bytes();
 
         // Causing a ROM Fatal Error will zeroize the module
         Err(CaliptraError::RUNTIME_SHUTDOWN)

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -1,0 +1,32 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    shutdown.rs
+
+Abstract:
+
+    File contains SHUTDOWN mailbox command.
+
+--*/
+
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+use zerocopy::IntoBytes;
+
+pub struct ShutdownCmd;
+impl ShutdownCmd {
+    #[inline(always)]
+    pub(crate) fn execute(_cmd_bytes: &[u8], resp: &mut [u8]) -> CaliptraResult<usize> {
+        let mut shutdown_resp = MailboxRespHeader::default();
+        shutdown_resp.populate_chksum();
+
+        let resp_bytes = shutdown_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+
+        // Causing a ROM Fatal Error will zeroize the module
+        Err(CaliptraError::RUNTIME_SHUTDOWN)
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -12,27 +12,18 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader};
+use caliptra_common::mailbox_api::MailboxReqHeader;
 use caliptra_drivers::{CaliptraError, CaliptraResult};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
 pub struct ShutdownCmd;
 impl ShutdownCmd {
     #[inline(always)]
-    pub(crate) fn execute(cmd_bytes: &[u8], resp: &mut [u8]) -> CaliptraResult<usize> {
+    pub(crate) fn execute(cmd_bytes: &[u8], _resp: &mut [u8]) -> CaliptraResult<usize> {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
-        // Use the response buffer directly as MailboxRespHeader.
-        // The buffer is zeroized at the start of the loop
-        let resp_buffer_size = core::mem::size_of::<MailboxRespHeader>();
-        let resp = resp
-            .get_mut(..resp_buffer_size)
-            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-        let shutdown_resp = MailboxRespHeader::mut_from_bytes(resp)
-            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-        let _resp_bytes = shutdown_resp.as_bytes();
+        // Zero value of response buffer is good
 
         // Causing a ROM Fatal Error will zeroize the module
         Err(CaliptraError::RUNTIME_SHUTDOWN)

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -12,14 +12,17 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxRespHeader, Response};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
-use zerocopy::IntoBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct ShutdownCmd;
 impl ShutdownCmd {
     #[inline(always)]
-    pub(crate) fn execute(_cmd_bytes: &[u8], resp: &mut [u8]) -> CaliptraResult<usize> {
+    pub(crate) fn execute(cmd_bytes: &[u8], resp: &mut [u8]) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let mut shutdown_resp = MailboxRespHeader::default();
         shutdown_resp.populate_chksum();
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use caliptra_common::mailbox_api::{Response, StashMeasurementReq, StashMeasurementResp};
+use caliptra_common::mailbox_api::{StashMeasurementReq, StashMeasurementResp};
 use caliptra_common::pcr::PCR_ID_STASH_MEASUREMENT;
 use caliptra_common::{PcrLogEntry, PcrLogEntryId};
 use caliptra_drivers::pcr_log::MeasurementLogEntry;
@@ -46,8 +46,6 @@ impl StashMeasurementCmd {
 
         stash_resp.hdr = caliptra_common::mailbox_api::MailboxRespHeader::default();
         stash_resp.dpe_result = 0; // DPE_STATUS_SUCCESS
-        stash_resp.populate_chksum();
-
         let resp_bytes = stash_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
@@ -1,0 +1,117 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    stash_measurement.rs
+
+Abstract:
+
+    File contains STASH_MEASUREMENT mailbox command.
+
+--*/
+
+use caliptra_common::mailbox_api::{Response, StashMeasurementReq, StashMeasurementResp};
+use caliptra_common::pcr::PCR_ID_STASH_MEASUREMENT;
+use caliptra_common::{PcrLogEntry, PcrLogEntryId};
+use caliptra_drivers::pcr_log::MeasurementLogEntry;
+use caliptra_drivers::{CaliptraError, CaliptraResult, PcrBank, PersistentData, Sha2_512_384};
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct StashMeasurementCmd;
+impl StashMeasurementCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        pcr_bank: &mut PcrBank,
+        sha2_512_384: &mut Sha2_512_384,
+        persistent_data: &mut PersistentData,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let measurement = StashMeasurementReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        // Extend measurement into PCR31.
+        Self::extend_measurement(pcr_bank, sha2_512_384, persistent_data, measurement)?;
+
+        // Generate and send response (with FIPS approved status)
+        let mut stash_resp = StashMeasurementResp {
+            hdr: caliptra_common::mailbox_api::MailboxRespHeader::default(),
+            dpe_result: 0, // DPE_STATUS_SUCCESS
+        };
+        stash_resp.populate_chksum();
+
+        let resp_bytes = stash_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+
+    /// Extends measurement into PCR31 and logs it to PCR log.
+    ///
+    /// # Arguments
+    /// * `pcr_bank` - PCR Bank
+    /// * `sha2_512_384` - SHA384
+    /// * `persistent_data` - Persistent data
+    /// * `stash_measurement` - Measurement
+    ///
+    /// # Returns
+    /// * `()` - Ok
+    ///    Error code on failure.
+    fn extend_measurement(
+        pcr_bank: &mut PcrBank,
+        sha2: &mut Sha2_512_384,
+        persistent_data: &mut PersistentData,
+        stash_measurement: &StashMeasurementReq,
+    ) -> CaliptraResult<()> {
+        // Extend measurement into PCR31.
+        pcr_bank.extend_pcr(
+            PCR_ID_STASH_MEASUREMENT,
+            sha2,
+            stash_measurement.measurement.as_bytes(),
+        )?;
+
+        // Log measurement to the measurement log.
+        Self::log_measurement(persistent_data, stash_measurement)
+    }
+
+    /// Log measurement data to the Stash Measurement log
+    ///
+    /// # Arguments
+    /// * `persistent_data` - Persistent data
+    /// * `stash_measurement` - Measurement
+    ///
+    /// # Return Value
+    /// * `Ok(())` - Success
+    /// * `Err(GlobalErr::MeasurementLogExhausted)` - Measurement log exhausted
+    ///
+    fn log_measurement(
+        persistent_data: &mut PersistentData,
+        stash_measurement: &StashMeasurementReq,
+    ) -> CaliptraResult<()> {
+        let fht = &mut persistent_data.fht;
+        let Some(dst) = persistent_data
+            .measurement_log
+            .get_mut(fht.meas_log_index as usize)
+        else {
+            return Err(CaliptraError::ROM_GLOBAL_MEASUREMENT_LOG_EXHAUSTED);
+        };
+
+        *dst = MeasurementLogEntry {
+            pcr_entry: PcrLogEntry {
+                id: PcrLogEntryId::StashMeasurement as u16,
+                reserved0: [0u8; 2],
+                pcr_ids: 1 << (PCR_ID_STASH_MEASUREMENT as u8),
+                pcr_data: zerocopy::transmute!(stash_measurement.measurement),
+            },
+            metadata: stash_measurement.metadata,
+            context: zerocopy::transmute!(stash_measurement.context),
+            svn: stash_measurement.svn,
+            reserved0: [0u8; 4],
+        };
+
+        fht.meas_log_index += 1;
+
+        Ok(())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/stash_measurement.rs
@@ -27,7 +27,7 @@ impl StashMeasurementCmd {
         pcr_bank: &mut PcrBank,
         sha2_512_384: &mut Sha2_512_384,
         persistent_data: &mut PersistentData,
-        resp: &mut [u8],
+        _resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let measurement = StashMeasurementReq::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
@@ -35,19 +35,8 @@ impl StashMeasurementCmd {
         // Extend measurement into PCR31.
         Self::extend_measurement(pcr_bank, sha2_512_384, persistent_data, measurement)?;
 
-        // Use the response buffer directly as StashMeasurementResp.
-        // The buffer is zeroized at the start of the loop
-        let resp_buffer_size = core::mem::size_of::<StashMeasurementResp>();
-        let resp = resp
-            .get_mut(..resp_buffer_size)
-            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-        let stash_resp = StashMeasurementResp::mut_from_bytes(resp)
-            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
-
-        stash_resp.hdr = caliptra_common::mailbox_api::MailboxRespHeader::default();
-        stash_resp.dpe_result = 0; // DPE_STATUS_SUCCESS
-        let resp_bytes = stash_resp.as_bytes();
-        Ok(resp_bytes.len())
+        // Zero value of response buffer is good
+        Ok(core::mem::size_of::<StashMeasurementResp>())
     }
 
     /// Extends measurement into PCR31 and logs it to PCR log.

--- a/rom/dev/src/flow/cold_reset/fw_processor/version.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/version.rs
@@ -13,18 +13,21 @@ Abstract:
 --*/
 
 use caliptra_common::fips::FipsVersionCmd;
-use caliptra_common::mailbox_api::Response;
-use caliptra_drivers::{CaliptraResult, SocIfc};
-use zerocopy::IntoBytes;
+use caliptra_common::mailbox_api::{MailboxReqHeader, Response};
+use caliptra_drivers::{CaliptraError, CaliptraResult, SocIfc};
+use zerocopy::{FromBytes, IntoBytes};
 
 pub struct VersionCmd;
 impl VersionCmd {
     #[inline(always)]
     pub(crate) fn execute(
-        _cmd_bytes: &[u8],
+        cmd_bytes: &[u8],
         soc_ifc: &mut SocIfc,
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        MailboxReqHeader::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
         let mut version_resp = FipsVersionCmd::execute(soc_ifc);
         version_resp.populate_chksum();
 

--- a/rom/dev/src/flow/cold_reset/fw_processor/version.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/version.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_common::fips::FipsVersionCmd;
-use caliptra_common::mailbox_api::{MailboxReqHeader, Response};
+use caliptra_common::mailbox_api::{FipsVersionResp, MailboxReqHeader, Response};
 use caliptra_drivers::{CaliptraError, CaliptraResult, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -28,11 +28,23 @@ impl VersionCmd {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
-        let mut version_resp = FipsVersionCmd::execute(soc_ifc);
+        // Use the response buffer directly as FipsVersionResp.
+        // The buffer is zeroized at the start of the loop
+        let resp_buffer_size = core::mem::size_of::<FipsVersionResp>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let version_resp = FipsVersionResp::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        let version_data = FipsVersionCmd::execute(soc_ifc);
+        version_resp.hdr = version_data.hdr;
+        version_resp.mode = version_data.mode;
+        version_resp.fips_rev = version_data.fips_rev;
+        version_resp.name = version_data.name;
         version_resp.populate_chksum();
 
         let resp_bytes = version_resp.as_bytes();
-        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
         Ok(resp_bytes.len())
     }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/version.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/version.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_common::fips::FipsVersionCmd;
-use caliptra_common::mailbox_api::{FipsVersionResp, MailboxReqHeader, Response};
+use caliptra_common::mailbox_api::{FipsVersionResp, MailboxReqHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -42,8 +42,6 @@ impl VersionCmd {
         version_resp.mode = version_data.mode;
         version_resp.fips_rev = version_data.fips_rev;
         version_resp.name = version_data.name;
-        version_resp.populate_chksum();
-
         let resp_bytes = version_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/version.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/version.rs
@@ -1,0 +1,35 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    version.rs
+
+Abstract:
+
+    File contains VERSION mailbox command.
+
+--*/
+
+use caliptra_common::fips::FipsVersionCmd;
+use caliptra_common::mailbox_api::Response;
+use caliptra_drivers::{CaliptraResult, SocIfc};
+use zerocopy::IntoBytes;
+
+pub struct VersionCmd;
+impl VersionCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        _cmd_bytes: &[u8],
+        soc_ifc: &mut SocIfc,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let mut version_resp = FipsVersionCmd::execute(soc_ifc);
+        version_resp.populate_chksum();
+
+        let resp_bytes = version_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
@@ -18,7 +18,7 @@ use caliptra_api::mailbox::{
 };
 use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
 use caliptra_common::uds_fe_programming::UdsFeProgrammingFlow;
-use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Dma, SocIfc};
+use caliptra_drivers::{CaliptraError, CaliptraResult, Dma, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
 
 pub struct ZeroizeUdsFeCmd;

--- a/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
@@ -16,7 +16,7 @@ use caliptra_api::mailbox::{
     ZeroizeUdsFeReq, ZeroizeUdsFeResp, ZEROIZE_FE0_FLAG, ZEROIZE_FE1_FLAG, ZEROIZE_FE2_FLAG,
     ZEROIZE_FE3_FLAG, ZEROIZE_UDS_FLAG,
 };
-use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_common::uds_fe_programming::UdsFeProgrammingFlow;
 use caliptra_drivers::{CaliptraError, CaliptraResult, Dma, SocIfc};
 use zerocopy::{FromBytes, IntoBytes};
@@ -73,8 +73,6 @@ impl ZeroizeUdsFeCmd {
             Ok(()) => 0,   // NoError
             Err(_) => 0x1, // InternalError
         };
-        zeroize_resp.populate_chksum();
-
         let resp_bytes = zeroize_resp.as_bytes();
         Ok(resp_bytes.len())
     }

--- a/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/zeroize_uds_fe.rs
@@ -1,0 +1,77 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    zeroize_uds_fe.rs
+
+Abstract:
+
+    File contains ZEROIZE_UDS_FE mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::{
+    ZeroizeUdsFeReq, ZeroizeUdsFeResp, ZEROIZE_FE0_FLAG, ZEROIZE_FE1_FLAG, ZEROIZE_FE2_FLAG,
+    ZEROIZE_FE3_FLAG, ZEROIZE_UDS_FLAG,
+};
+use caliptra_common::mailbox_api::{MailboxRespHeader, Response};
+use caliptra_common::uds_fe_programming::UdsFeProgrammingFlow;
+use caliptra_drivers::{report_fw_error_non_fatal, CaliptraError, CaliptraResult, Dma, SocIfc};
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct ZeroizeUdsFeCmd;
+impl ZeroizeUdsFeCmd {
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        soc_ifc: &mut SocIfc,
+        dma: &mut Dma,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let request = ZeroizeUdsFeReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        let result = (|| -> CaliptraResult<()> {
+            // Zeroize UDS partition
+            if request.flags & ZEROIZE_UDS_FLAG != 0 {
+                let uds_flow = UdsFeProgrammingFlow::Uds;
+                uds_flow.zeroize(soc_ifc, dma)?;
+            }
+
+            // Zeroize FE partitions (0-3)
+            const FE_FLAGS: [u32; 4] = [
+                ZEROIZE_FE0_FLAG,
+                ZEROIZE_FE1_FLAG,
+                ZEROIZE_FE2_FLAG,
+                ZEROIZE_FE3_FLAG,
+            ];
+            for (partition, &flag) in FE_FLAGS.iter().enumerate() {
+                if request.flags & flag != 0 {
+                    let fe_flow = UdsFeProgrammingFlow::Fe {
+                        partition: partition as u32,
+                    };
+                    fe_flow.zeroize(soc_ifc, dma)?;
+                }
+            }
+
+            Ok(())
+        })();
+
+        // Generate and send response
+        let mut zeroize_resp = ZeroizeUdsFeResp {
+            hdr: MailboxRespHeader::default(),
+            dpe_result: match result {
+                Ok(()) => 0,   // NoError
+                Err(_) => 0x1, // InternalError
+            },
+        };
+        zeroize_resp.populate_chksum();
+
+        let resp_bytes = zeroize_resp.as_bytes();
+        resp[..resp_bytes.len()].copy_from_slice(resp_bytes);
+
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -1085,6 +1085,14 @@ fn test_upload_measurement_limit_plus_one() {
     }
 
     // Upload a 9th measurement, which should fail and raise a fatal error.
+    let checksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::STASH_MEASUREMENT),
+        &measurement.as_bytes()[4..],
+    );
+    let measurement = StashMeasurementReq {
+        hdr: MailboxReqHeader { chksum: checksum },
+        ..measurement
+    };
     let result = hw.upload_measurement(measurement.as_bytes());
     assert!(result.is_err());
     assert!(matches!(

--- a/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
@@ -113,6 +113,14 @@ fn test_mailbox_invalid_req_size_large() {
         context: [0xCD; 48],
         svn: 0xEF01,
     };
+    let checksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CAPABILITIES),
+        &payload.as_bytes()[4..],
+    );
+    let payload = StashMeasurementReq {
+        hdr: MailboxReqHeader { chksum: checksum },
+        ..payload
+    };
 
     // Send too much data (stash measurement is bigger than capabilities)
     assert_eq!(

--- a/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
+++ b/rom/dev/tests/rom_integration_tests/test_mailbox_errors.rs
@@ -18,8 +18,18 @@ fn test_unknown_command_is_fatal() {
         helpers::build_hw_model_and_image_bundle(Fuses::default(), ImageOptions::default());
 
     // This command does not exist
+    // Calculate checksum for unknown command with empty payload (no bytes after header)
+    let checksum = caliptra_common::checksum::calc_checksum(
+        0xabcd_1234,
+        &[], // No payload after header
+    );
+
+    // Create final header with correct checksum
+    let header = MailboxReqHeader { chksum: checksum };
+
+    // This command does not exist
     assert_eq!(
-        hw.mailbox_execute(0xabcd_1234, &[]),
+        hw.mailbox_execute(0xabcd_1234, header.as_bytes()),
         Err(ModelError::MailboxCmdFailed(
             CaliptraError::FW_PROC_MAILBOX_INVALID_COMMAND.into()
         ))
@@ -144,12 +154,21 @@ fn test_mailbox_invalid_req_size_small() {
         context: [0xCD; 48],
         svn: 0xEF01,
     };
+    let payload_size = core::mem::size_of::<StashMeasurementReq>();
+    let checksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::STASH_MEASUREMENT),
+        &payload.as_bytes()[4..payload_size - 4],
+    );
+    let payload = StashMeasurementReq {
+        hdr: MailboxReqHeader { chksum: checksum },
+        ..payload
+    };
 
     // Drop a dword
     assert_eq!(
         hw.mailbox_execute(
             CommandId::STASH_MEASUREMENT.into(),
-            &payload.as_bytes()[4..]
+            &payload.as_bytes()[..payload_size - 4]
         ),
         Err(ModelError::MailboxCmdFailed(
             CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH.into()

--- a/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
+++ b/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
@@ -2,15 +2,13 @@
 
 use caliptra_api::SocManager;
 use caliptra_builder::ImageOptions;
-use caliptra_common::mailbox_api::{
-    CommandId, GetIdevCsrResp, GetIdevMldsaCsrResp, MailboxReqHeader,
-};
+use caliptra_common::mailbox_api::{CommandId, GetIdevCsrResp, MailboxReqHeader};
 use caliptra_drivers::{InitDevIdCsrEnvelope, MfgFlags};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DeviceLifecycle, Fuses, HwModel, ModelError};
 use core::mem::offset_of;
 use openssl::{hash::MessageDigest, memcmp, pkey::PKey, sign::Signer};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::IntoBytes;
 
 use crate::helpers;
 
@@ -190,7 +188,8 @@ fn test_get_mldsa_csr() {
         .unwrap()
         .unwrap();
 
-    let get_idv_csr_resp = GetIdevMldsaCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
+    let mut get_idv_csr_resp = GetIdevCsrResp::default();
+    get_idv_csr_resp.as_mut_bytes()[..response.len()].copy_from_slice(&response);
 
     assert!(caliptra_common::checksum::verify_checksum(
         get_idv_csr_resp.hdr.chksum,


### PR DESCRIPTION
Make the code more similar to runtime with regards to mailbox processing.
- Use zerocopy on the mbox sram rather than copy on the stack
- Use a common output buffer for response
- Always checksum the input
- Move the handler into separate files