### PR TITLE
Add MLDSA wycheproof test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,12 +3420,12 @@ dependencies = [
 
 [[package]]
 name = "wycheproof"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71039afb8a94cba8b3fbcd400af2d259eb0ecd833fca548130f9e7681ef2c53a"
+version = "0.6.0"
+source = "git+https://github.com/randombit/wycheproof-rs?rev=5120390a605bb6fd950048928981dc7a52937379#5120390a605bb6fd950048928981dc7a52937379"
 dependencies = [
  "data-encoding",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ ureg = { path = "ureg" }
 ureg-codegen = { path = "ureg/lib/codegen" }
 ureg-schema = { path = "ureg/lib/schema" }
 ureg-systemrdl = { path = "ureg/lib/systemrdl" }
-wycheproof = "0.5.1"
+wycheproof = { git = "https://github.com/randombit/wycheproof-rs", rev = "5120390a605bb6fd950048928981dc7a52937379" }
 x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
 x509-parser = "0.15.0"
 zerocopy = { version = "0.8.17", features = ["derive"] }

--- a/runtime/tests/runtime_integration_tests/test_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa.rs
@@ -122,3 +122,130 @@ fn test_mldsa_verify_bad_chksum() {
         resp,
     );
 }
+
+// This file includes some tests from Wycheproof to testing specific common
+// MLDSA problems.
+// In the long term, this file should just run the entire Wycheproof test
+// vector file wycheproof/testvectors_v1/mldsa_verify_schema.json
+
+#[test]
+fn mldsa_cmd_run_wycheproof() {
+    // This test is too slow to run as part of the verilator nightly.
+    #![cfg_attr(all(not(feature = "slow_tests"), feature = "verilator"), ignore)]
+
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read()
+            == <RtBootStatus as Into<u32>>::into(RtBootStatus::RtReadyForCommands)
+    });
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct WycheproofResults {
+        id: usize,
+        comment: String,
+    }
+    // Collect all the errors and print at the end
+    let mut wyche_fail: Vec<WycheproofResults> = Vec::new();
+    let mut wyche_ran: Vec<WycheproofResults> = Vec::new();
+
+    // Load MLDSA87 verify test set
+    let test_set =
+        wycheproof::mldsa_verify::TestSet::load(wycheproof::mldsa_verify::TestName::MlDsa87Verify)
+            .unwrap();
+
+    for test_group in &test_set.test_groups {
+        for test in &test_group.tests {
+            // Skip tests with context since Caliptra MLDSA doesn't support context
+            if test.ctx.is_some() {
+                continue;
+            }
+
+            // Check that public key is exactly the right size
+            if test_group.pubkey.as_slice().len() != 2592 {
+                continue;
+            }
+
+            // Check that signature is the right size
+            // MLDSA signatures are 4627 bytes, but get padded to 4628 for the mailbox
+            // So accept either 4627 or 4628 byte signatures
+            let sig_len = test.sig.as_slice().len();
+            if sig_len != 4627 {
+                continue;
+            }
+
+            // Check that message is not too large
+            if test.msg.as_slice().len() > 4096 {
+                continue;
+            }
+
+            wyche_ran.push(WycheproofResults {
+                id: test.tc_id,
+                comment: test.comment.to_string(),
+            });
+
+            // Create MLDSA verify request
+            let mut cmd = MailboxReq::MldsaVerify(MldsaVerifyReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                pub_key: test_group.pubkey.as_slice()[..].try_into().unwrap(),
+                signature: {
+                    let sig_slice = test.sig.as_slice();
+                    let mut signature = [0u8; 4628]; // MLDSA87_SIGNATURE_BYTE_SIZE
+                                                     // Pad 4627-byte signature to 4628 bytes
+                    signature[..4627].copy_from_slice(sig_slice);
+                    signature
+                },
+                message_size: test.msg.as_slice().len() as u32,
+                message: {
+                    let mut msg_array = [0u8; 4096]; // MAX_CMB_DATA_SIZE
+                    msg_array[..test.msg.as_slice().len()].copy_from_slice(test.msg.as_slice());
+                    msg_array
+                },
+            });
+            cmd.populate_chksum().unwrap();
+
+            let resp = model.mailbox_execute(
+                u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+                cmd.as_bytes().unwrap(),
+            );
+
+            match test.result {
+                wycheproof::TestResult::Valid | wycheproof::TestResult::Acceptable => match resp {
+                    Err(_) | Ok(None) => {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                    Ok(Some(resp)) => {
+                        // Verify the checksum and FIPS status
+                        let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
+                        assert_eq!(
+                            resp_hdr.fips_status,
+                            MailboxRespHeader::FIPS_STATUS_APPROVED
+                        );
+                        // Checksum is just going to be 0 because FIPS_STATUS_APPROVED is 0
+                        assert_eq!(resp_hdr.chksum, 0);
+                    }
+                },
+                wycheproof::TestResult::Invalid => {
+                    if resp.is_ok() {
+                        wyche_fail.push(WycheproofResults {
+                            id: test.tc_id,
+                            comment: test.comment.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+    println!("Executed wycheproof tests:\n{:#?}", wyche_ran);
+    if !wyche_fail.is_empty() {
+        panic!(
+            "Number of failed tests {}:\n{:#?}",
+            wyche_fail.len(),
+            wyche_fail
+        );
+    }
+}


### PR DESCRIPTION
- Update wycheproof dependency to include MLDSA features
- Implement MLDSA-87 wycheproof test following ECDSA pattern
- Filter tests to match Caliptra's MLDSA implementation constraints

This addresses #2754