### PR TITLE
Remove sw-emulator message from DMA code

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -689,7 +689,6 @@ impl<'a> DmaRecovery<'a> {
 
         #[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
         {
-            crate::cprintln!("Wrong Code!");
             let read_transaction = DmaReadTransaction {
                 read_addr: addr,
                 fixed_addr: true,


### PR DESCRIPTION
I used this to identify if fpga tests were accidentally using the sw-emulator codepath and it accidentally crept in a PR.