### PR TITLE
chore: Use dpe cargo dependency instead of a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,10 +5,6 @@
 	path = hw/latest/rtl
 	url = https://github.com/chipsalliance/caliptra-rtl
 	branch = main
-[submodule "dpe"]
-	path = dpe
-	url = https://github.com/chipsalliance/caliptra-dpe.git
-	branch = main
 [submodule "hw/latest/i3c-core-rtl"]
 	path = hw/latest/i3c-core-rtl
 	url = https://github.com/chipsalliance/i3c-core.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=runtime-1.2.2#f56f66ef4ada62bd99b5670c8384dc2e97e04e94"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1471,6 +1472,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=runtime-1.2.2#f56f66ef4ada62bd99b5670c8384dc2e97e04e94"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -2318,6 +2320,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=runtime-1.2.2#f56f66ef4ada62bd99b5670c8384dc2e97e04e94"
 dependencies = [
  "arrayvec",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,9 +160,12 @@ convert_case = "0.6.0"
 cms = "0.2.2"
 ctr = "0.9.2"
 der = { version = "0.7.10", features = ["derive", "alloc"] }
-dpe = { path = "dpe/dpe", default-features = false, features = ["dpe_profile_p384_sha384"] }
-crypto = { path = "dpe/crypto", default-features = false }
-platform = { path = "dpe/platform", default-features = false }
+
+# keep these in sync
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "runtime-1.2.2", default-features = false, features = ["dpe_profile_p384_sha384"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "runtime-1.2.2", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "runtime-1.2.2", default-features = false }
+
 elf = "0.7.2"
 fips204 = "0.4.6"
 fslock = "0.2.1"


### PR DESCRIPTION
Submodules are the worst and aren't necessary since Cargo support git dependencies.

This will reduce the potential for problems caused by accidentally reverting or updating the submodule.