### PR TITLE
Pull DPE persistent info into a struct

### DIFF
--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -57,7 +57,7 @@ impl CertifyKeyExtendedCmd {
             &mut pdata.fht.rt_dice_ecc_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
-            &mut pdata.exported_cdi_slots,
+            &mut pdata.dpe.exported_cdi_slots,
         );
         let pl0_pauser = pdata.manifest1.header.pl0_pauser;
         let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
@@ -83,7 +83,7 @@ impl CertifyKeyExtendedCmd {
             ),
         };
 
-        let dpe = &mut pdata.dpe;
+        let dpe = &mut pdata.dpe.dpe;
         let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..]).or(Err(
             CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
         ))?;

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -31,7 +31,7 @@ impl DisableAttestationCmd {
         Self::zero_cdi(drivers, key_id_rt_cdi)?;
         Self::zero_cdi(drivers, KEY_ID_EXPORTED_DPE_CDI)?;
         Self::generate_dice_key(drivers)?;
-        drivers.persistent_data.get_mut().attestation_disabled = U8Bool::new(true);
+        drivers.persistent_data.get_mut().dpe.attestation_disabled = U8Bool::new(true);
         Ok(0)
     }
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -216,7 +216,7 @@ impl Drivers {
         Self::create_cert_chain(self)?;
         self.cryptographic_mailbox
             .init(&self.persistent_data, &mut self.trng)?;
-        if self.persistent_data.get().attestation_disabled.get() {
+        if self.persistent_data.get().dpe.attestation_disabled.get() {
             DisableAttestationCmd::execute(self)
                 .map_err(|_| CaliptraError::RUNTIME_GLOBAL_EXCEPTION)?;
         }
@@ -299,7 +299,7 @@ impl Drivers {
 
     /// Validate DPE and disable attestation if validation fails
     fn validate_dpe_structure(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &mut drivers.persistent_data.get_mut().dpe;
+        let dpe = &mut drivers.persistent_data.get_mut().dpe.dpe;
         let dpe_validator = DpeValidator { dpe };
         let validation_result = dpe_validator.validate_dpe();
         if let Err(e) = validation_result {
@@ -346,7 +346,7 @@ impl Drivers {
     /// Update DPE root context's TCI measurement with RT_FW_JOURNEY_PCR
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn update_dpe_rt_journey(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &mut drivers.persistent_data.get_mut().dpe;
+        let dpe = &mut drivers.persistent_data.get_mut().dpe.dpe;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
         let latest_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR));
         dpe.contexts[root_idx].tci.tci_current = TciMeasurement(latest_pcr);
@@ -393,7 +393,7 @@ impl Drivers {
 
     /// Check that RT_FW_JOURNEY_PCR == DPE Root Context's TCI measurement
     fn check_dpe_rt_journey_unchanged(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &drivers.persistent_data.get().dpe;
+        let dpe = &drivers.persistent_data.get().dpe.dpe;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
         let latest_tci = Array4x12::from(&dpe.contexts[root_idx].tci.tci_current.0);
         let latest_pcr = drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR);
@@ -427,9 +427,9 @@ impl Drivers {
     /// Check that inactive DPE contexts do not have context tags set
     fn validate_context_tags(drivers: &mut Drivers) -> CaliptraResult<()> {
         let pdata = drivers.persistent_data.get();
-        let context_has_tag = &pdata.context_has_tag;
-        let context_tags = &pdata.context_tags;
-        let dpe = &pdata.dpe;
+        let context_has_tag = &pdata.dpe.context_has_tag;
+        let context_tags = &pdata.dpe.context_tags;
+        let dpe = &pdata.dpe.dpe;
 
         for i in 0..MAX_HANDLES {
             if dpe.contexts[i].state == ContextState::Inactive {
@@ -463,12 +463,12 @@ impl Drivers {
         let privilege_level = drivers.caller_privilege_level();
 
         // Set context limits in persistent data as we init DPE
-        drivers.persistent_data.get_mut().dpe_pl0_context_limit =
+        drivers.persistent_data.get_mut().dpe.pl0_context_limit =
             PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD as u8;
-        drivers.persistent_data.get_mut().dpe_pl1_context_limit =
+        drivers.persistent_data.get_mut().dpe.pl1_context_limit =
             PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD as u8;
-        let pl0_context_limit = drivers.persistent_data.get().dpe_pl0_context_limit;
-        let pl1_context_limit = drivers.persistent_data.get().dpe_pl1_context_limit;
+        let pl0_context_limit = drivers.persistent_data.get().dpe.pl0_context_limit;
+        let pl1_context_limit = drivers.persistent_data.get().dpe.pl1_context_limit;
 
         // create a hash of all the mailbox valid pausers
         const PAUSER_COUNT: usize = 5;
@@ -495,7 +495,7 @@ impl Drivers {
             &mut pdata.fht.rt_dice_ecc_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
-            &mut pdata.exported_cdi_slots,
+            &mut pdata.dpe.exported_cdi_slots,
         );
 
         let (nb, nf) = Self::get_cert_validity_info(&pdata.manifest1);
@@ -589,7 +589,7 @@ impl Drivers {
         }
 
         // Write DPE to persistent data.
-        pdata.dpe = dpe;
+        pdata.dpe.dpe = dpe;
         Ok(())
     }
 
@@ -696,7 +696,7 @@ impl Drivers {
     pub fn dpe_get_used_context_counts(&self) -> CaliptraResult<(usize, usize)> {
         Self::dpe_get_used_context_counts_helper(
             self.persistent_data.get().manifest1.header.pl0_pauser,
-            &self.persistent_data.get().dpe,
+            &self.persistent_data.get().dpe.dpe,
         )
     }
 
@@ -728,12 +728,13 @@ impl Drivers {
         &self,
         context_privilege_level: PauserPrivileges,
     ) -> CaliptraResult<()> {
+        let dpe_data = &self.persistent_data.get().dpe;
         Self::is_dpe_context_threshold_exceeded_helper(
             self.persistent_data.get().manifest1.header.pl0_pauser,
             context_privilege_level,
-            &self.persistent_data.get().dpe,
-            self.persistent_data.get().dpe_pl0_context_limit as usize,
-            self.persistent_data.get().dpe_pl1_context_limit as usize,
+            &dpe_data.dpe,
+            dpe_data.pl0_context_limit as usize,
+            dpe_data.pl1_context_limit as usize,
         )
     }
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -37,7 +37,7 @@ impl FwInfoCmd {
         resp.fw_svn = handoff.fw_svn();
         resp.min_fw_svn = handoff.fw_min_svn();
         resp.cold_boot_fw_svn = handoff.cold_boot_fw_svn();
-        resp.attestation_disabled = pdata.attestation_disabled.get().into();
+        resp.attestation_disabled = pdata.dpe.attestation_disabled.get().into();
         resp.rom_revision = rom_info.revision;
         resp.fmc_revision = pdata.manifest1.fmc.revision;
         resp.runtime_revision = pdata.manifest1.runtime.revision;

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -72,7 +72,7 @@ impl InvokeDpeCmd {
                 &mut pdata.fht.rt_dice_ecc_pub_key,
                 key_id_rt_cdi,
                 key_id_rt_priv_key,
-                &mut pdata.exported_cdi_slots,
+                &mut pdata.dpe.exported_cdi_slots,
             );
             let pl0_pauser = pdata.manifest1.header.pl0_pauser;
             let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
@@ -91,9 +91,9 @@ impl InvokeDpeCmd {
             };
 
             let locality = drivers.mbox.id();
-            let dpe = &mut pdata.dpe;
-            let context_has_tag = &mut pdata.context_has_tag;
-            let context_tags = &mut pdata.context_tags;
+            let dpe = &mut pdata.dpe.dpe;
+            let context_has_tag = &mut pdata.dpe.context_has_tag;
+            let context_tags = &mut pdata.dpe.context_tags;
             let resp = match command {
                 Command::GetProfile => Ok(Response::GetProfile(
                     dpe.get_profile(&mut env.platform)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -653,7 +653,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
     caliptra_drivers::report_boot_status(RtBootStatus::RtReadyForCommands.into());
 
     // Disable attestation if in the middle of executing an mbox cmd during warm reset
-    let command_was_running = drivers.persistent_data.get().runtime_cmd_active.get();
+    let command_was_running = drivers.persistent_data.get().dpe.runtime_cmd_active.get();
     if command_was_running {
         let reset_reason = drivers.soc_ifc.reset_reason();
         if reset_reason == ResetReason::WarmReset {
@@ -686,7 +686,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
 
         // No command is executing, set the mailbox flow done to true before beginning idle.
         drivers.soc_ifc.flow_status_set_mailbox_flow_done(true);
-        drivers.persistent_data.get_mut().runtime_cmd_active = U8Bool::new(false);
+        drivers.persistent_data.get_mut().dpe.runtime_cmd_active = U8Bool::new(false);
 
         enter_idle(drivers);
 
@@ -702,7 +702,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
             // We have woken from idle and have a command ready, set the mailbox flow done to false until we return to
             // idle.
             drivers.soc_ifc.flow_status_set_mailbox_flow_done(false);
-            drivers.persistent_data.get_mut().runtime_cmd_active = U8Bool::new(true);
+            drivers.persistent_data.get_mut().dpe.runtime_cmd_active = U8Bool::new(true);
 
             // Acknowledge the interrupt so we go back to sleep after
             // processing the mailbox. After this point, if the mailbox is

--- a/runtime/src/reallocate_dpe_context_limits.rs
+++ b/runtime/src/reallocate_dpe_context_limits.rs
@@ -65,15 +65,15 @@ impl ReallocateDpeContextLimitsCmd {
         }
 
         // Update limits in persistent data now that error checking has passed
-        drivers.persistent_data.get_mut().dpe_pl0_context_limit = cmd.pl0_context_limit as u8;
-        drivers.persistent_data.get_mut().dpe_pl1_context_limit = pl1_context_limit as u8;
+        drivers.persistent_data.get_mut().dpe.pl0_context_limit = cmd.pl0_context_limit as u8;
+        drivers.persistent_data.get_mut().dpe.pl1_context_limit = pl1_context_limit as u8;
 
         // Populate response
         let resp = mutrefbytes::<ReallocateDpeContextLimitsResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
 
-        resp.new_pl0_context_limit = drivers.persistent_data.get().dpe_pl0_context_limit as u32;
-        resp.new_pl1_context_limit = drivers.persistent_data.get().dpe_pl1_context_limit as u32;
+        resp.new_pl0_context_limit = drivers.persistent_data.get().dpe.pl0_context_limit as u32;
+        resp.new_pl1_context_limit = drivers.persistent_data.get().dpe.pl1_context_limit as u32;
 
         Ok(core::mem::size_of::<ReallocateDpeContextLimitsResp>())
     }

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -35,6 +35,7 @@ impl RevokeExportedCdiHandleCmd {
         for slot in drivers
             .persistent_data
             .get_mut()
+            .dpe
             .exported_cdi_slots
             .entries
             .iter_mut()

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -81,7 +81,7 @@ impl SignWithExportedEcdsaCmd {
             &mut pdata.fht.rt_dice_ecc_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
-            &mut pdata.exported_cdi_slots,
+            &mut pdata.dpe.exported_cdi_slots,
         );
 
         let digest = Digest::new(&cmd.tbs)

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -62,7 +62,7 @@ impl StashMeasurementCmd {
                 &mut pdata.fht.rt_dice_ecc_pub_key,
                 key_id_rt_cdi,
                 key_id_rt_priv_key,
-                &mut pdata.exported_cdi_slots,
+                &mut pdata.dpe.exported_cdi_slots,
             );
             let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
             let mut env = DpeEnv::<CptraDpeTypes> {
@@ -90,7 +90,7 @@ impl StashMeasurementCmd {
                 tci_type: u32::from_ne_bytes(*metadata),
                 target_locality: locality,
             }
-            .execute(&mut pdata.dpe, &mut env, locality);
+            .execute(&mut pdata.dpe.dpe, &mut env, locality);
 
             match derive_context_resp {
                 Ok(_) => DpeErrorCode::NoError,

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -29,9 +29,9 @@ impl TagTciCmd {
         let cmd = TagTciReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let pdata_mut = drivers.persistent_data.get_mut();
-        let dpe = &mut pdata_mut.dpe;
-        let context_has_tag = &mut pdata_mut.context_has_tag;
-        let context_tags = &mut pdata_mut.context_tags;
+        let dpe = &mut pdata_mut.dpe.dpe;
+        let context_has_tag = &mut pdata_mut.dpe.context_has_tag;
+        let context_tags = &mut pdata_mut.dpe.context_tags;
 
         // Make sure the tag isn't used by any other contexts.
         if (0..MAX_HANDLES).any(|i| {
@@ -72,8 +72,8 @@ impl GetTaggedTciCmd {
         let cmd = GetTaggedTciReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let persistent_data = drivers.persistent_data.get();
-        let context_has_tag = &persistent_data.context_has_tag;
-        let context_tags = &persistent_data.context_tags;
+        let context_has_tag = &persistent_data.dpe.context_has_tag;
+        let context_tags = &persistent_data.dpe.context_tags;
         let idx = (0..MAX_HANDLES)
             .find(|i| {
                 *i < context_has_tag.len()
@@ -82,10 +82,10 @@ impl GetTaggedTciCmd {
                     && context_tags[*i] == cmd.tag
             })
             .ok_or(CaliptraError::RUNTIME_TAGGING_FAILURE)?;
-        if idx >= persistent_data.dpe.contexts.len() {
+        if idx >= persistent_data.dpe.dpe.contexts.len() {
             return Err(CaliptraError::RUNTIME_TAGGING_FAILURE);
         }
-        let context = persistent_data.dpe.contexts[idx];
+        let context = persistent_data.dpe.dpe.contexts[idx];
 
         let resp = mutrefbytes::<GetTaggedTciResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();


### PR DESCRIPTION
We decided to separate the persistent data into ROM and non-ROM partitions. This change pulls all DPE related information into its own struct which helps to keep this information self contained and will make it easier to move around in following PRs.

The final persistent data will look something like this from @clundin25 's comment below:

```
persistent_data
├── rom
└── runtime
    └── dpe
```