### PR TITLE
[OCP LOCK]: Gate OCP LOCK commands behind a single command handler

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -503,14 +503,11 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => {
             ReallocateDpeContextLimitsCmd::execute(drivers, cmd_bytes, resp)
         }
-        // TODO(clundin): Feature flag OCP LOCK commands.
-        CommandId::OCP_LOCK_GET_ALGORITHMS => {
-            ocp_lock::GetAlgorithmsCmd::execute(&mut drivers.ocp_lock_context, resp)
+        ocp_lock_command_id @ CommandId::OCP_LOCK_GET_ALGORITHMS
+        | ocp_lock_command_id @ CommandId::OCP_LOCK_INITIALIZE_MEK_SECRET
+        | ocp_lock_command_id @ CommandId::OCP_LOCK_DERIVE_MEK => {
+            ocp_lock::command_handler(ocp_lock_command_id, drivers, cmd_bytes, resp)
         }
-        CommandId::OCP_LOCK_INITIALIZE_MEK_SECRET => {
-            ocp_lock::InitializeMekSecretCmd::execute(drivers, cmd_bytes, resp)
-        }
-        CommandId::OCP_LOCK_DERIVE_MEK => ocp_lock::DeriveMekCmd::execute(drivers, cmd_bytes, resp),
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     }?;
 

--- a/runtime/src/ocp_lock/derive_mek.rs
+++ b/runtime/src/ocp_lock/derive_mek.rs
@@ -24,10 +24,6 @@ impl DeriveMekCmd {
         let cmd = OcpLockDeriveMekReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
-        if !drivers.ocp_lock_context.available() {
-            Err(CaliptraError::RUNTIME_OCP_LOCK_UNSUPPORTED_COMMAND)?;
-        }
-
         let expected_mek_checksum = MekChecksum(cmd.mek_checksum);
         let checksum = drivers.ocp_lock_context.derive_mek(
             &mut drivers.aes,

--- a/runtime/src/ocp_lock/get_algorithms.rs
+++ b/runtime/src/ocp_lock/get_algorithms.rs
@@ -3,20 +3,15 @@
 use caliptra_api::mailbox::{
     AccessKeySizes, EndorsementAlgorithms, HpkeAlgorithms, OcpLockGetAlgorithmsResp,
 };
-use caliptra_error::{CaliptraError, CaliptraResult};
+use caliptra_error::CaliptraResult;
 
 use crate::mutrefbytes;
-
-use super::OcpLockContext;
 
 pub struct GetAlgorithmsCmd;
 impl GetAlgorithmsCmd {
     #[cfg_attr(not(feature = "no-cfi"), caliptra_cfi_derive_git::cfi_impl_fn)]
     #[inline(never)]
-    pub fn execute(context: &mut OcpLockContext, resp: &mut [u8]) -> CaliptraResult<usize> {
-        if !context.available() {
-            Err(CaliptraError::RUNTIME_OCP_LOCK_UNSUPPORTED_COMMAND)?;
-        }
+    pub fn execute(resp: &mut [u8]) -> CaliptraResult<usize> {
         let resp = mutrefbytes::<OcpLockGetAlgorithmsResp>(resp)?;
         resp.access_key_sizes = AccessKeySizes::LEN_256;
         resp.endorsement_algorithms = EndorsementAlgorithms::all();

--- a/runtime/src/ocp_lock/initialize_mek_secret.rs
+++ b/runtime/src/ocp_lock/initialize_mek_secret.rs
@@ -26,10 +26,6 @@ impl InitializeMekSecretCmd {
         let cmd = OcpLockInitializeMekSecretReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
-        if !drivers.ocp_lock_context.available() {
-            Err(CaliptraError::RUNTIME_OCP_LOCK_UNSUPPORTED_COMMAND)?;
-        }
-
         drivers.ocp_lock_context.create_mek_secret_seed(
             &mut drivers.hmac,
             &mut drivers.trng,


### PR DESCRIPTION
* Ensures all commands check that OCP LOCK is available.
* Ensures that command code is compiled out of the RT firmware if OCP LOCK is not enabled in RT firmware.