### PR TITLE
Add a marker and version to persistent data

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -122,13 +122,15 @@ pub use okref::okref;
 pub use pcr_bank::{PcrBank, PcrId};
 pub use pcr_reset::PcrResetCounter;
 pub use persistent::fmc_alias_csr::FmcAliasCsrs;
+#[cfg(any(feature = "fmc", feature = "runtime"))]
+pub use persistent::FwPersistentData;
 #[cfg(feature = "runtime")]
 pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
 pub use persistent::{
     Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, PcrLogArray,
-    PersistentData, PersistentDataAccessor, StashMeasurementArray, ECC384_MAX_FMC_ALIAS_CSR_SIZE,
-    ECC384_MAX_IDEVID_CSR_SIZE, FUSE_LOG_MAX_COUNT, MEASUREMENT_MAX_COUNT, MLDSA87_MAX_CSR_SIZE,
-    PCR_LOG_MAX_COUNT,
+    PersistentData, PersistentDataAccessor, RomPersistentData, StashMeasurementArray,
+    ECC384_MAX_FMC_ALIAS_CSR_SIZE, ECC384_MAX_IDEVID_CSR_SIZE, FUSE_LOG_MAX_COUNT,
+    MEASUREMENT_MAX_COUNT, MLDSA87_MAX_CSR_SIZE, PCR_LOG_MAX_COUNT,
 };
 pub use pic::{IntSource, Pic};
 pub use sha1::{Sha1, Sha1Digest, Sha1DigestOp};

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1649,6 +1649,26 @@ impl CaliptraError {
             0x000E0079,
             "OCP LOCK Error: Error in derivation caused MEK mismatch"
         ),
+        (
+            RUNTIME_INVALID_ROM_PERSISTENT_DATA_MARKER,
+            0x000E007A,
+            "Runtime Error: Invalid ROM persistent data marker"
+        ),
+        (
+            RUNTIME_INVALID_ROM_PERSISTENT_DATA_VERSION,
+            0x000E007B,
+            "Runtime Error: Invalid ROM persistent data version"
+        ),
+        (
+            RUNTIME_INVALID_FW_PERSISTENT_DATA_MARKER,
+            0x000E007C,
+            "Runtime Error: Invalid FW persistent data marker"
+        ),
+        (
+            RUNTIME_INVALID_FW_PERSISTENT_DATA_VERSION,
+            0x000E007D,
+            "Runtime Error: Invalid FW persistent data version"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (
@@ -1737,6 +1757,26 @@ impl CaliptraError {
             FMC_RT_ALIAS_MLDSA_TBS_SIZE_EXCEEDED,
             0x000F00014,
             "FMC Error: RT alias MLDSA TBS size exceeded"
+        ),
+        (
+            FMC_INVALID_ROM_PERSISTENT_DATA_MARKER,
+            0x000F00015,
+            "FMC Error: Invalid ROM persistent data marker"
+        ),
+        (
+            FMC_INVALID_ROM_PERSISTENT_DATA_VERSION,
+            0x000F00016,
+            "FMC Error: Invalid ROM persistent data version"
+        ),
+        (
+            FMC_INVALID_FW_PERSISTENT_DATA_MARKER,
+            0x000F00017,
+            "FMC Error: Invalid FW persistent data marker"
+        ),
+        (
+            FMC_INVALID_FW_PERSISTENT_DATA_VERSION,
+            0x000F00018,
+            "FMC Error: Invalid FW persistent data version"
         ),
         (
             DRIVER_TRNG_EXT_TIMEOUT,
@@ -2059,6 +2099,16 @@ impl CaliptraError {
             ROM_GLOBAL_UNSUPPORTED_HW_VERSION,
             0x01050010,
             "ROM Global Error: Unsupported HW version"
+        ),
+        (
+            ROM_INVALID_ROM_PERSISTENT_DATA_MARKER,
+            0x01050011,
+            "ROM Error: Invalid ROM persistent data marker"
+        ),
+        (
+            ROM_INVALID_ROM_PERSISTENT_DATA_VERSION,
+            0x01050012,
+            "ROM Error: Invalid ROM persistent data version"
         ),
         (
             KAT_SHA256_DIGEST_FAILURE,

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -24,7 +24,7 @@ use caliptra_cpu::{log_trap_record, TrapRecord};
 
 use caliptra_drivers::{
     hand_off::{DataStore, HandOffDataHandle},
-    ResetReason,
+    FwPersistentData, ResetReason, RomPersistentData,
 };
 
 mod boot_status;
@@ -71,14 +71,26 @@ pub extern "C" fn entry_point() -> ! {
         cprintln!("[state] CFI Disabled");
     }
 
+    let pdata = env.persistent_data.get();
+    if pdata.rom.marker != RomPersistentData::MAGIC {
+        handle_fatal_error(CaliptraError::FMC_INVALID_ROM_PERSISTENT_DATA_MARKER.into())
+    }
+    if pdata.rom.major_version != RomPersistentData::MAJOR_VERSION {
+        handle_fatal_error(CaliptraError::FMC_INVALID_ROM_PERSISTENT_DATA_VERSION.into())
+    }
     fix_fht(&mut env);
 
     if env.persistent_data.get().rom.fht.is_valid() {
         // Set FHT fields and jump to RT for val-FMC for now
         if cfg!(feature = "fake-fmc") {
-            env.persistent_data.get_mut().rom.fht.rt_cdi_kv_hdl =
+            let pdata = env.persistent_data.get_mut();
+            pdata.rom.minor_version = RomPersistentData::MINOR_VERSION;
+            pdata.fw.marker = FwPersistentData::MAGIC;
+            pdata.fw.version = FwPersistentData::VERSION;
+
+            pdata.rom.fht.rt_cdi_kv_hdl =
                 HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_RT_CDI));
-            env.persistent_data.get_mut().rom.fht.rt_priv_key_kv_hdl =
+            pdata.rom.fht.rt_priv_key_kv_hdl =
                 HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_RT_ECDSA_PRIV_KEY));
             HandOff::to_rt(&env);
         }

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -54,6 +54,11 @@ impl ColdResetFlow {
     pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[cold-reset] ++");
         report_boot_status(ColdResetStarted.into());
+
+        env.persistent_data.get_mut().rom.marker = RomPersistentData::MAGIC;
+        env.persistent_data.get_mut().rom.major_version = RomPersistentData::MAJOR_VERSION;
+        env.persistent_data.get_mut().rom.minor_version = RomPersistentData::MINOR_VERSION;
+
         {
             let data_vault = &mut env.persistent_data.get_mut().rom.data_vault;
 

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -54,6 +54,10 @@ impl FakeRomFlow {
                 cprintln!("[fake-rom-cold-reset] ++");
                 report_boot_status(ColdResetStarted.into());
 
+                env.persistent_data.get_mut().rom.marker = RomPersistentData::MAGIC;
+                env.persistent_data.get_mut().rom.major_version = RomPersistentData::MAJOR_VERSION;
+                env.persistent_data.get_mut().rom.minor_version = RomPersistentData::MINOR_VERSION;
+
                 // Zeroize the key vault in the fake ROM flow
                 unsafe { KeyVault::zeroize() };
 

--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -102,9 +102,7 @@ fn test_warm_reset_during_cold_boot_before_image_validation() {
         helpers::build_hw_model_and_image_bundle(fuses, ImageOptions::default());
 
     // Step till Cold boot starts
-    hw.step_until(|model| {
-        model.soc_ifc().cptra_boot_status().read() >= IDevIdDecryptUdsComplete.into()
-    });
+    hw.step_until(|m| m.ready_for_fw());
 
     // Perform a warm reset
     hw.warm_reset_flow().unwrap();


### PR DESCRIPTION
This will make it easier to evolve in the future and ensure we are interpreting the information correctly on hitless updates.