### PR TITLE
Fixes to auth manifest generation app

### DIFF
--- a/auth-manifest/app/src/config.rs
+++ b/auth-manifest/app/src/config.rs
@@ -99,6 +99,11 @@ fn key_config_from_file(
         priv_keys.lms_priv_key = lms_priv_key_from_pem(&priv_key_path)?;
     }
 
+    if let Some(pem_file) = &config.mldsa_priv_key {
+        let priv_key_path = path.join(pem_file);
+        priv_keys.mldsa_priv_key = Crypto::mldsa_priv_key_from_file(&priv_key_path)?;
+    }
+
     Ok(AuthManifestGeneratorKeyConfig {
         pub_keys: AuthManifestPubKeysConfig {
             ecc_pub_key: Crypto::ecc_pub_key_from_pem(&path.join(&config.ecc_pub_key))?,

--- a/auth-manifest/app/src/main.rs
+++ b/auth-manifest/app/src/main.rs
@@ -38,6 +38,11 @@ fn main() {
                 .value_parser(value_parser!(u32)),
         )
         .arg(
+            arg!(--"svn" <U32> "Manifest Security Version Number")
+                .required(true)
+                .value_parser(value_parser!(u32)),
+        )
+        .arg(
             arg!(--"flags" <U32> "Manifest Flags")
                 .required(true)
                 .value_parser(value_parser!(u32)),


### PR DESCRIPTION
Found and fixed 2 bugs when testing generating auth manifests using the app invoked via cargo run (instead of directly calling generate)