### PR TITLE
[aes] use u32 instead of u8 for AES all IVs and tags

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -3454,7 +3454,7 @@ pub struct CmAesGcmDecryptFinalReq {
     pub hdr: MailboxReqHeader,
     pub context: [u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
     pub tag_len: u32,
-    pub tag: [u8; 16],
+    pub tag: [u32; 4],
     pub ciphertext_size: u32,
     pub ciphertext: [u8; MAX_CMB_DATA_SIZE],
 }
@@ -3465,7 +3465,7 @@ impl Default for CmAesGcmDecryptFinalReq {
             hdr: MailboxReqHeader::default(),
             context: [0u8; CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE],
             tag_len: 0,
-            tag: [0u8; 16],
+            tag: [0u32; 4],
             ciphertext_size: 0,
             ciphertext: [0u8; MAX_CMB_DATA_SIZE],
         }

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -1504,7 +1504,8 @@ impl Commands {
             Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
         }
 
-        let tag = &cmd.tag[..cmd.tag_len as usize];
+        let tag_arr: [u8; 16] = transmute!(cmd.tag);
+        let tag = &tag_arr[..cmd.tag_len as usize];
         let ciphertext = &cmd.ciphertext[..cmd.ciphertext_size as usize];
 
         let encrypted_context = EncryptedAesGcmContext::ref_from_bytes(&cmd.context[..])

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -1650,7 +1650,7 @@ fn mailbox_gcm_decrypt(
         hdr: MailboxReqHeader::default(),
         context,
         tag_len: tag.len() as u32,
-        tag: *tag,
+        tag: transmute!(*tag),
         ciphertext_size: ciphertext.len() as u32,
         ciphertext: [0; MAX_CMB_DATA_SIZE],
     };
@@ -1768,7 +1768,7 @@ fn mailbox_spdm_gcm_decrypt(
         hdr: MailboxReqHeader::default(),
         context,
         tag_len: tag.len() as u32,
-        tag: *tag,
+        tag: transmute!(*tag),
         ciphertext_size: ciphertext.len() as u32,
         ciphertext: [0; MAX_CMB_DATA_SIZE],
     };


### PR DESCRIPTION
This was originally attempted in #2710, but a couple instances were missed. I noticed this when trying to rev the caliptra-sw repo version in the caliptra-mcu-sw repo.