### PR TITLE
Refactor image verification to use enum for mutually exclusive image sources

### DIFF
--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -21,6 +21,14 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use caliptra_drivers::memory_layout::ICCM_RANGE;
 
+/// Image source for verification
+pub enum ImageSource<'a, 'b> {
+    /// Image is in memory (accessible as a byte slice)
+    Memory(&'b [u8]),
+    /// Image is in MCU SRAM (requires DMA access)
+    McuSram(&'a Dma),
+}
+
 /// ROM Verification Environemnt
 pub struct FirmwareImageVerificationEnv<'a, 'b> {
     pub sha256: &'a mut Sha256,
@@ -31,10 +39,8 @@ pub struct FirmwareImageVerificationEnv<'a, 'b> {
     pub mldsa87: &'a mut Mldsa87,
     pub data_vault: &'a DataVault,
     pub pcr_bank: &'a mut PcrBank,
-    pub image: &'b [u8],
-    pub dma: &'a Dma,
+    pub image_source: ImageSource<'a, 'b>,
     pub persistent_data: &'a PersistentData,
-    pub image_in_mcu: bool,
 }
 
 impl FirmwareImageVerificationEnv<'_, '_> {
@@ -52,39 +58,53 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
     /// Calculate 384 digest using SHA2 Engine
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest384> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha384_mcu_sram(self.sha2_512_384_acc, offset, len, dma::AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            let result = self.sha2_512_384.sha384_digest(data)?.0;
-            Ok(result)
+        match &self.image_source {
+            ImageSource::McuSram(dma) => {
+                let dma_recovery =
+                    FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, dma);
+                let result = dma_recovery.sha384_mcu_sram(
+                    self.sha2_512_384_acc,
+                    offset,
+                    len,
+                    dma::AesDmaMode::None,
+                )?;
+                Ok(result.into())
+            }
+            ImageSource::Memory(image) => {
+                let data = image
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                let result = self.sha2_512_384.sha384_digest(data)?.0;
+                Ok(result)
+            }
         }
     }
 
     /// Calculate 512 digest using SHA2 Engine
     fn sha512_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest512> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha512_mcu_sram(self.sha2_512_384_acc, offset, len, AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            Ok(self.sha2_512_384.sha512_digest(data)?.0)
+        match &self.image_source {
+            ImageSource::McuSram(dma) => {
+                let dma_recovery =
+                    FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, dma);
+                let result = dma_recovery.sha512_mcu_sram(
+                    self.sha2_512_384_acc,
+                    offset,
+                    len,
+                    AesDmaMode::None,
+                )?;
+                Ok(result.into())
+            }
+            ImageSource::Memory(image) => {
+                let data = image
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                Ok(self.sha2_512_384.sha512_digest(data)?.0)
+            }
         }
     }
 
@@ -94,23 +114,26 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest384> {
-        if self.image_in_mcu {
-            // For MCU case, use the existing sha384_digest function
-            self.sha384_digest(offset, len).map_err(|_| digest_failure)
-        } else {
-            let mut digest = Array4x12::default();
+        match &self.image_source {
+            ImageSource::McuSram(_) => {
+                // For MCU case, use the existing sha384_digest function
+                self.sha384_digest(offset, len).map_err(|_| digest_failure)
+            }
+            ImageSource::Memory(_) => {
+                let mut digest = Array4x12::default();
 
-            if let Some(mut sha_acc_op) = self
-                .sha2_512_384_acc
-                .try_start_operation(ShaAccLockState::NotAcquired)?
-            {
-                sha_acc_op
-                    .digest_384(len, offset, StreamEndianness::Reorder, &mut digest)
-                    .map_err(|_| digest_failure)?;
-            } else {
-                Err(CaliptraError::DRIVER_SHA2_512_384_ACC_DIGEST_START_OP_FAILURE)?;
-            };
-            Ok(digest.0)
+                if let Some(mut sha_acc_op) = self
+                    .sha2_512_384_acc
+                    .try_start_operation(ShaAccLockState::NotAcquired)?
+                {
+                    sha_acc_op
+                        .digest_384(len, offset, StreamEndianness::Reorder, &mut digest)
+                        .map_err(|_| digest_failure)?;
+                } else {
+                    Err(CaliptraError::DRIVER_SHA2_512_384_ACC_DIGEST_START_OP_FAILURE)?;
+                };
+                Ok(digest.0)
+            }
         }
     }
 
@@ -120,24 +143,27 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest512> {
-        if self.image_in_mcu {
-            // For MCU case, use the existing sha512_digest function
-            self.sha512_digest(offset, len).map_err(|_| digest_failure)
-        } else {
-            let mut digest = Array4x16::default();
+        match &self.image_source {
+            ImageSource::McuSram(_) => {
+                // For MCU case, use the existing sha512_digest function
+                self.sha512_digest(offset, len).map_err(|_| digest_failure)
+            }
+            ImageSource::Memory(_) => {
+                let mut digest = Array4x16::default();
 
-            if let Some(mut sha_acc_op) = self
-                .sha2_512_384_acc
-                .try_start_operation(ShaAccLockState::NotAcquired)?
-            {
-                sha_acc_op
-                    .digest_512(len, offset, StreamEndianness::Reorder, &mut digest)
-                    .map_err(|_| digest_failure)?;
-            } else {
-                Err(CaliptraError::DRIVER_SHA2_512_384_ACC_DIGEST_START_OP_FAILURE)?;
-            };
+                if let Some(mut sha_acc_op) = self
+                    .sha2_512_384_acc
+                    .try_start_operation(ShaAccLockState::NotAcquired)?
+                {
+                    sha_acc_op
+                        .digest_512(len, offset, StreamEndianness::Reorder, &mut digest)
+                        .map_err(|_| digest_failure)?;
+                } else {
+                    Err(CaliptraError::DRIVER_SHA2_512_384_ACC_DIGEST_START_OP_FAILURE)?;
+                };
 
-            Ok(digest.0)
+                Ok(digest.0)
+            }
         }
     }
 


### PR DESCRIPTION
Replace three mutually exclusive fields (image, dma, image_in_mcu) in
FirmwareImageVerificationEnv with a single ImageSource enum. This
enforces mutual exclusivity at the type level, preventing invalid states
where both image sources could be set or the wrong source used with the
wrong flag.

This decreases the rom size by 16 bytes.