### PR TITLE
Balance out FPGAs

### DIFF
--- a/ci-tools/host-runner/hostrunners/kir-1.nix
+++ b/ci-tools/host-runner/hostrunners/kir-1.nix
@@ -23,7 +23,7 @@ in
       ftdi = "1-1.3.1.3";
       sdwire = "1-1.3.1.4";
     })
-    (fpga_service.mkVckSubsystemJob "caliptra-kir-vck-1" {
+    (fpga_service.mkVckCoreJob "caliptra-kir-vck-1" {
       ftdi = "1-1.3.1.1";
       sdwire = "1-1.3.1.2";
     })


### PR DESCRIPTION
Currently there are 6 subsystem FPGAs and two core FPGAs

The subsystem job is much slower, but the core FPGAs are starting to bottleneck.

Move 1 subsystem FPGA to core.