### PR TITLE
cherry-pick 2.0: Reset RECOVERY_CTRL to inactivate state after the image is authenticated (#2966)

### DIFF
--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -44,7 +44,17 @@ pub const LIFECYCLES_ALL: [DeviceLifecycle; 3] = [
 ];
 
 // Default test MCU firmware used for subsystem mode uploads
-pub static DEFAULT_MCU_FW: [u8; 4] = [0x00, 0x00, 0x00, 0x6f];
+pub static DEFAULT_MCU_FW: [u8; 256] = [
+    0, 0, 0, 0x6f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+];
 
 fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> AuthorizationManifest {
     // generate a default SoC manifest if one is not provided in subsystem mode

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -69,6 +69,9 @@ impl RecoveryFlow {
                 drivers.soc_ifc.mci_base_addr().into(),
                 dma,
             );
+            // Reset the RECOVERY_CTRL register Activate Recovery Image field by writing 0x1.
+            dma_recovery.reset_recovery_ctrl_activate_rec_img()?;
+
             // need to make sure the device status is correct to load the next image
             dma_recovery.set_device_status(
                 DmaRecovery::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE,

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -66,7 +66,7 @@ pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::MLDSA,
 ];
 
-pub const DEFAULT_MCU_FW: &[u8] = &[0x6f; 4];
+pub const DEFAULT_MCU_FW: &[u8] = &[0x6f; 256];
 
 fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> AuthorizationManifest {
     // generate a default SoC manifest if one is not provided in subsystem mode

--- a/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
+++ b/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::common::{run_rt_test, RuntimeTestArgs, DEFAULT_MCU_FW};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 
 use caliptra_api::{
@@ -112,12 +112,11 @@ fn test_dbg_unlock_prod_success() {
         ..Default::default()
     };
 
-    let mcu_fw = vec![1, 2, 3, 4];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
     let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
     let metadata = vec![AuthManifestImageMetadata {
         fw_id: 2,
         flags: flags.0,
@@ -130,7 +129,7 @@ fn test_dbg_unlock_prod_success() {
     let runtime_args = RuntimeTestArgs {
         init_params: Some(init_params),
         soc_manifest: Some(soc_manifest),
-        mcu_fw_image: Some(&mcu_fw),
+        mcu_fw_image: Some(DEFAULT_MCU_FW),
         ..Default::default()
     };
 
@@ -320,12 +319,11 @@ fn test_dbg_unlock_prod_invalid_length() {
         ..Default::default()
     };
 
-    let mcu_fw = vec![1, 2, 3, 4];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
     let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
     let metadata = vec![AuthManifestImageMetadata {
         fw_id: 2,
         flags: flags.0,
@@ -338,7 +336,7 @@ fn test_dbg_unlock_prod_invalid_length() {
     let runtime_args = RuntimeTestArgs {
         init_params: Some(init_params),
         soc_manifest: Some(soc_manifest),
-        mcu_fw_image: Some(&mcu_fw),
+        mcu_fw_image: Some(DEFAULT_MCU_FW),
         ..Default::default()
     };
 
@@ -438,12 +436,11 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
         ..Default::default()
     };
 
-    let mcu_fw = vec![1, 2, 3, 4];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
     let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
     let metadata = vec![AuthManifestImageMetadata {
         fw_id: 2,
         flags: flags.0,
@@ -456,7 +453,7 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
     let runtime_args = RuntimeTestArgs {
         init_params: Some(init_params),
         soc_manifest: Some(soc_manifest),
-        mcu_fw_image: Some(&mcu_fw),
+        mcu_fw_image: Some(DEFAULT_MCU_FW),
         ..Default::default()
     };
 
@@ -613,12 +610,11 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
         ..Default::default()
     };
 
-    let mcu_fw = vec![1, 2, 3, 4];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
     let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
     let metadata = vec![AuthManifestImageMetadata {
         fw_id: 2,
         flags: flags.0,
@@ -631,7 +627,7 @@ fn test_dbg_unlock_prod_wrong_public_keys() {
     let runtime_args = RuntimeTestArgs {
         init_params: Some(init_params),
         soc_manifest: Some(soc_manifest),
-        mcu_fw_image: Some(&mcu_fw),
+        mcu_fw_image: Some(DEFAULT_MCU_FW),
         ..Default::default()
     };
 
@@ -776,12 +772,11 @@ fn test_dbg_unlock_prod_wrong_cmd() {
         ..Default::default()
     };
 
-    let mcu_fw = vec![1, 2, 3, 4];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
     let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
     let metadata = vec![AuthManifestImageMetadata {
         fw_id: 2,
         flags: flags.0,
@@ -794,7 +789,7 @@ fn test_dbg_unlock_prod_wrong_cmd() {
     let runtime_args = RuntimeTestArgs {
         init_params: Some(init_params),
         soc_manifest: Some(soc_manifest),
-        mcu_fw_image: Some(&mcu_fw),
+        mcu_fw_image: Some(DEFAULT_MCU_FW),
         ..Default::default()
     };
 
@@ -894,12 +889,11 @@ fn test_dbg_unlock_prod_unlock_levels_success() {
             ..Default::default()
         };
 
-        let mcu_fw = vec![1, 2, 3, 4];
         const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
         let mut flags = ImageMetadataFlags(0);
         flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
         let crypto = Crypto::default();
-        let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+        let digest = from_hw_format(&crypto.sha384_digest(DEFAULT_MCU_FW).unwrap());
         let metadata = vec![AuthManifestImageMetadata {
             fw_id: 2,
             flags: flags.0,
@@ -912,7 +906,7 @@ fn test_dbg_unlock_prod_unlock_levels_success() {
         let runtime_args = RuntimeTestArgs {
             init_params: Some(init_params),
             soc_manifest: Some(soc_manifest),
-            mcu_fw_image: Some(&mcu_fw),
+            mcu_fw_image: Some(DEFAULT_MCU_FW),
             ..Default::default()
         };
 


### PR DESCRIPTION
* runtime: reset RECOVERY_CTRL to inactivate state

Clear “image_activated” bit by writing to RECOVERY_CTRL register via DMA assist after the image is authenticated.



* Increase size of default MCU FW to 256

* Change other MCU FW to 256 bytes

---------



(cherry picked from commit 2642ced52e624366df4a6c667090e5994b293a08)