### PR TITLE
rom/runtime: Re-add reset indirect fifo ctrl before setting next image index

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -818,6 +818,15 @@ impl<'a> DmaRecovery<'a> {
         })
     }
 
+    pub fn reset_indirect_fifo_ctrl(&self) -> CaliptraResult<()> {
+        self.with_regs_mut(|regs_mut| {
+            let recovery = regs_mut.sec_fw_recovery_if();
+            recovery
+                .indirect_fifo_ctrl_0()
+                .modify(|val| val.reset(Self::RESET_VAL));
+        })
+    }
+
     pub fn reset_recovery_ctrl_activate_rec_img(&self) -> CaliptraResult<()> {
         self.with_regs_mut(|regs_mut| {
             let recovery = regs_mut.sec_fw_recovery_if();

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -648,6 +648,8 @@ impl FirmwareProcessor {
 
             // Reset the RECOVERY_CTRL register Activate Recovery Image field by writing 0x1.
             dma_recovery.reset_recovery_ctrl_activate_rec_img()?;
+            // Reset the Indirect FIFO control so that payload_available is reset.
+            dma_recovery.reset_indirect_fifo_ctrl()?;
 
             let (recovery_status, next_image_idx, device_status) = if info.is_err() {
                 (

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -72,6 +72,8 @@ impl RecoveryFlow {
             );
             // Reset the RECOVERY_CTRL register Activate Recovery Image field by writing 0x1.
             dma_recovery.reset_recovery_ctrl_activate_rec_img()?;
+            // Reset the Indirect FIFO control so that payload_available is reset.
+            dma_recovery.reset_indirect_fifo_ctrl()?;
 
             // need to make sure the device status is correct to load the next image
             dma_recovery.set_device_status(


### PR DESCRIPTION
We removed the extra reset of indirect fifo ctrl in #2790 and rely on the BMC to do the reset.

However, it was pointed out in #2967 that this causes another race condition: the payload_available signal does not go low without this reset, and depending on when the BMC sends the reset and when Caliptra FW starts trying to download the next recovery image, Caliptra FW might read the wrong size. This was probably why our FPGA did not have trouble downloading small images without #2966.

This should resolve the race condition by ensuring that the indirect fifo ctrl is always reset before setting the next image index.

The BMC can still send its own indirect fifo data reset, but it should no longer be necessary.

Closes #2969.
Closes #2967.