### PR TITLE
Reduce CSR stress iteration count

### DIFF
--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -113,7 +113,7 @@ fn test_generate_csr_envelop_stress() {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        let num_tests = if cfg!(feature = "slow_tests") { 250 } else { 1 };
+        let num_tests = if cfg!(feature = "slow_tests") { 50 } else { 1 };
 
         for _ in 0..num_tests {
             let mut fuses = fuses_with_random_uds();


### PR DESCRIPTION
This takes a long time on the subsystem FPGA.