### PR TITLE
feat(hw-model): Reset i3c controller state on cold reset

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -354,7 +354,6 @@ jobs:
                   - test(test_pauser_privilege_levels::test_user_not_pl0)
                   - test(test_mailbox::test_reserved_pauser)
                   - test(test_pauser_privilege_levels::test_change_locality)
-                  - test(test_certs::test_all_measurement_apis)
                   - test(test_reallocate_dpe_context_limits)
                   - test(test_invoke_dpe::test_export_cdi_destroyed_root_context)
                   - test(test_fe_programming::test_fe_programming_cmd)

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2078,6 +2078,12 @@ impl HwModel for ModelFpgaSubsystem {
     }
 
     fn cold_reset(&mut self) {
+        self.i3c_controller()
+            .unwrap()
+            .controller
+            .lock()
+            .unwrap()
+            .set_i3c_not_ready();
         self.set_subsystem_reset(true);
         std::thread::sleep(std::time::Duration::from_micros(1));
         self.init_otp(None)

--- a/hw-model/src/xi3c/controller.rs
+++ b/hw-model/src/xi3c/controller.rs
@@ -226,6 +226,10 @@ impl Controller {
         Ok(())
     }
 
+    pub fn set_i3c_not_ready(&self) {
+        self.ready.set(false);
+    }
+
     pub fn cfg_initialize(&self) -> Result<(), XI3cError> {
         if self.ready.get() {
             return Err(XI3cError::DeviceStarted);


### PR DESCRIPTION
Add i3c_not_ready() call during cold_reset to properly reset the i3c
controller state before subsystem reset. This ensures the controller is
in a clean state during reset operations.