### PR TITLE
Optimize emulator hot paths: clock increment + recovery payload conversion

### DIFF
--- a/sw-emulator/lib/periph/src/dma/recovery.rs
+++ b/sw-emulator/lib/periph/src/dma/recovery.rs
@@ -509,7 +509,7 @@ impl RecoveryRegisterInterface {
 fn to_payload(data: &[u32], len: usize) -> Option<Vec<u8>> {
     Some(
         data.iter()
-            .flat_map(|x| x.to_le_bytes().to_vec())
+            .flat_map(|x| x.to_le_bytes())
             .take(len)
             .collect(),
     )


### PR DESCRIPTION
**Summary**
This PR reduces overhead in two runtime hot paths in the SW emulator:
1) removes per-tick locking and reduces tree lookups in `ClockImpl::increment()`
2) eliminates per-word heap allocations in recovery read response payload construction

**Changes**
- sw-emulator/lib/bus/src/clock.rs
  - Replaced `next_action_time: Mutex<Option<u64>>` with an atomic cached next-time:
    - `next_action_time_valid: AtomicBool`
    - `next_action_time: AtomicU64`
  - Updated `increment()` to:
    - use the `fetch_add()` return value to compute `now` without an extra atomic load
    - avoid locking on every increment by checking the cached next-action time atomically
  - Added `has_fired_at(now, action_time)` helper to avoid reloading `now` repeatedly.
  - Reworked `remove_fired_actions()` to iterate the `BTreeSet` once in wraparound order
    (`range(start..).chain(range(..start))`) instead of repeatedly calling
    `find_next_action()` in a loop (reduces repeated `O(log n)` lookups).

- sw-emulator/lib/periph/src/dma/recovery.rs
  - Changed `to_payload()` to use `flat_map(|x| x.to_le_bytes())` instead of
    `to_le_bytes().to_vec()`, removing a heap allocation per `u32`.

**Motivation / Performance**
- `ClockImpl::increment()` is on a hot path; this avoids taking a mutex each tick and
  reduces the cost attributable to `find_next_action()` during timer firing.
- `to_payload()` previously allocated a temporary `Vec<u8>` for every word; this now
  streams bytes directly from the `[u8; 4]` array iterator.

**Correctness / Concurrency Notes**
- The cached next-action time is updated under the existing write lock when scheduling/canceling,
  and published via `next_action_time_valid.store(..., Release)`. Readers use `Acquire` on the
  valid flag to ensure the time value is observed consistently.
- Timer wraparound behavior is preserved by keeping the existing `wrapping_sub` / half-range logic.