### PR TITLE
Add support for encrypted firmware flow via DMA

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -126,6 +126,9 @@ impl CommandId {
     // The download firmware from recovery interface command.
     pub const RI_DOWNLOAD_FIRMWARE: Self = Self(0x5249_4644); // "RIFD"
 
+    // The download encrypted firmware from recovery interface command.
+    pub const RI_DOWNLOAD_ENCRYPTED_FIRMWARE: Self = Self(0x5249_4645); // "RIFE"
+
     // The get IDevID ECC CSR command.
     pub const GET_IDEV_ECC384_CSR: Self = Self(0x4944_4352); // "IDCR"
 

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -130,7 +130,7 @@ pub use persistent::IDEVID_CSR_ENVELOP_MARKER;
 #[cfg(feature = "runtime")]
 pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
 pub use persistent::{
-    Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, OcpLockFlags,
+    BootMode, Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, OcpLockFlags,
     PcrLogArray, PersistentData, PersistentDataAccessor, RomPersistentData, StashMeasurementArray,
     ECC384_MAX_FMC_ALIAS_CSR_SIZE, ECC384_MAX_IDEVID_CSR_SIZE, FUSE_LOG_MAX_COUNT,
     MEASUREMENT_MAX_COUNT, MLDSA87_MAX_CSR_SIZE, PCR_LOG_MAX_COUNT,

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -662,7 +662,7 @@ During this phase, the ROM executes specific mailbox commands. Based on the oper
 
 #### Handling commands from mailbox
 
-ROM supports the following set of commands before handling the FW_DOWNLOAD command in PASSIVE mode (described in section 9.6) or RI_DOWNLOAD_FIRMWARE command in SUBSYSTEM mode. Once the FW_DOWNLOAD or RI_DOWNLOAD_FIRMWARE is issued, ROM stops processing any additional mailbox commands.
+ROM supports the following set of commands before handling the FW_DOWNLOAD command in PASSIVE mode (described in section 9.6) or RI_DOWNLOAD_FIRMWARE/RI_DOWNLOAD_ENCRYPTED_FIRMWARE command in SUBSYSTEM mode. Once the FW_DOWNLOAD, RI_DOWNLOAD_FIRMWARE, or RI_DOWNLOAD_ENCRYPTED_FIRMWARE is issued, ROM stops processing any additional mailbox commands.
 
 1. **STASH_MEASUREMENT**: Up to eight measurements can be sent to the ROM for recording. Sending more than eight measurements will result in an FW_PROC_MAILBOX_STASH_MEASUREMENT_MAX_LIMIT fatal error. Format of a measurement is documented at [Stash Measurement command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#stash_measurement).
 2. **VERSION**: Get version info about the module. [Version command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#version).
@@ -736,7 +736,11 @@ There are two modes in which the ROM executes: PASSIVE mode or SUBSYSTEM mode. F
 
 Following is the sequence of steps that are performed to download the firmware image into the mailbox in SUBSYSTEM mode.
 
-1. On receiving the RI_DOWNLOAD_FIRMWARE mailbox command, set the RI PROT_CAP2 register version to 1.1 and the `Agent Capability` field bits:
+ROM supports two commands for firmware download in SUBSYSTEM mode:
+- **RI_DOWNLOAD_FIRMWARE** (Command Code: `0x5249_4644` / "RIFD"): Standard firmware download. After downloading and validating the firmware, the runtime will activate the MCU firmware immediately.
+- **RI_DOWNLOAD_ENCRYPTED_FIRMWARE** (Command Code: `0x5249_4645` / "RIFE"): Encrypted firmware download. Sets the boot mode to `EncryptedFirmware`, which signals to the runtime that the MCU firmware is encrypted and should not be activated until it has been decrypted using the `CM_AES_GCM_DECRYPT_DMA` command.
+
+1. On receiving the RI_DOWNLOAD_FIRMWARE or RI_DOWNLOAD_ENCRYPTED_FIRMWARE mailbox command, set the RI PROT_CAP2 register version to 1.1 and the `Agent Capability` field bits:
     - `Device ID`
     - `Device Status`
     - `Push C-image support`

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -320,8 +320,11 @@ impl FirmwareProcessor {
                     return Ok((Some(txn), image_size_bytes));
                 }
 
-                // Handle RI_DOWNLOAD_FIRMWARE as a separate case since it needs mutable access to mbox
-                if txn.cmd() == CommandId::RI_DOWNLOAD_FIRMWARE.into() {
+                // Handle RI_DOWNLOAD_FIRMWARE and RI_DOWNLOAD_ENCRYPTED_FIRMWARE
+                // Both commands download firmware from recovery interface, but encrypted variant
+                // sets boot_mode so runtime knows not to activate MCU firmware after downloading
+                let encrypted = txn.cmd() == CommandId::RI_DOWNLOAD_ENCRYPTED_FIRMWARE.into();
+                if txn.cmd() == CommandId::RI_DOWNLOAD_FIRMWARE.into() || encrypted {
                     if !subsystem_mode {
                         cprintln!(
                             "[fwproc] RI_DOWNLOAD_FIRMWARE cmd not supported in passive mode"
@@ -335,6 +338,11 @@ impl FirmwareProcessor {
                         Err(CaliptraError::FW_PROC_MAILBOX_INVALID_COMMAND)?;
                     }
                     cfi_assert_bool(subsystem_mode);
+
+                    // Set boot mode based on command type
+                    if encrypted {
+                        persistent_data.rom.boot_mode = BootMode::EncryptedFirmware;
+                    }
 
                     // Complete the command indicating success
                     cprintln!("[fwproc] Completing RI_DOWNLOAD_FIRMWARE command");

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -59,6 +59,7 @@ impl ColdResetFlow {
         env.persistent_data.get_mut().rom.marker = RomPersistentData::MAGIC;
         env.persistent_data.get_mut().rom.major_version = RomPersistentData::MAJOR_VERSION;
         env.persistent_data.get_mut().rom.minor_version = RomPersistentData::MINOR_VERSION;
+        env.persistent_data.get_mut().rom.boot_mode = BootMode::Normal;
 
         {
             let data_vault = &mut env.persistent_data.get_mut().rom.data_vault;


### PR DESCRIPTION
This PR introduces the necessary changes to support an encrypted firmware loading flow via the recovery interface. It addresses https://github.com/chipsalliance/caliptra-sw/issues/2950 by allowing the system to boot in an encrypted firmware mode where MCU activation is deferred until decryption is performed.

(This PR is ROM only -- we will move the rest of the changes  into a separate PR)

### Key Changes
*   **Mailbox API**: Added `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` and `CM_AES_GCM_DECRYPT_DMA` command identifiers and their associated request/response structures.
*   **Persistent Data**: Introduced `BootMode` to distinguish between `Normal` and `EncryptedFirmware` boots, stored in `RomPersistentData`.
*   **ROM Changes**: Updated the firmware processor to handle the new encrypted download command and persist the boot mode.
*   **Runtime Changes**:
    *   Implemented `aes_256_gcm_decrypt_dma` in the cryptographic mailbox to perform in-place decryption of MCU firmware using DMA.
    *   Updated the recovery flow to skip MCU activation when `EncryptedFirmware` boot mode is detected.
*   **HW Model**: Added support for encrypted boot parameters and a new `read_payload_from_ss_staging_area` method to facilitate testing firmware contents in MCU SRAM.
*   **Testing**: Added integration tests to verify the end-to-end encrypted firmware flow, including key import, DMA decryption, and tag verification. These are currently emulator only

### Implementation Details
*   The `CM_AES_GCM_DECRYPT_DMA` command performs a two-pass operation on AXI memory: a first pass to verify the SHA384 hash of the encrypted data, and a second pass for in-place AES-GCM decryption.
*   This command is restricted to scenarios where the ROM has explicitly set the boot mode to `EncryptedFirmware`.