### PR TITLE
Fix failed FW verification during FW update (2.1)

### DIFF
--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -21,6 +21,15 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use caliptra_drivers::memory_layout::ICCM_RANGE;
 
+/// Source describing where the firmware image is located for verification.
+#[derive(Copy, Clone)]
+pub enum ImageSource<'b> {
+    /// Image resides in mailbox FIFO.
+    Mailbox { data: &'b [u8] },
+    /// Image resides in staging memory reachable over AXI.
+    Staging { axi_start: AxiAddr },
+}
+
 /// ROM Verification Environemnt
 pub struct FirmwareImageVerificationEnv<'a, 'b> {
     pub sha256: &'a mut Sha256,
@@ -31,10 +40,9 @@ pub struct FirmwareImageVerificationEnv<'a, 'b> {
     pub mldsa87: &'a mut Mldsa87,
     pub data_vault: &'a DataVault,
     pub pcr_bank: &'a mut PcrBank,
-    pub image: &'b [u8],
+    pub image_source: ImageSource<'b>,
     pub dma: &'a Dma,
     pub persistent_data: &'a PersistentData,
-    pub image_in_mcu: bool,
 }
 
 impl FirmwareImageVerificationEnv<'_, '_> {
@@ -52,40 +60,55 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
     /// Calculate 384 digest using SHA2 Engine
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest384> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha384_mcu_sram(self.sha2_512_384_acc, offset, len, dma::AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            let result = self.sha2_512_384.sha384_digest(data)?.0;
-            Ok(result)
-        }
+        let digest = match self.image_source {
+            ImageSource::Staging { axi_start } => {
+                let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
+                let result = dma.sha384_image(
+                    self.sha2_512_384_acc,
+                    axi_start + offset,
+                    len,
+                    dma::AesDmaMode::None,
+                )?;
+                result.into()
+            }
+            ImageSource::Mailbox { data } => {
+                let data = data
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                self.sha2_512_384.sha384_digest(data)?.0
+            }
+        };
+
+        Ok(digest)
     }
 
     /// Calculate 512 digest using SHA2 Engine
     fn sha512_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest512> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha512_mcu_sram(self.sha2_512_384_acc, offset, len, AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            Ok(self.sha2_512_384.sha512_digest(data)?.0)
-        }
+        let digest = match self.image_source {
+            ImageSource::Staging { axi_start } => {
+                let dma = FirmwareImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
+                let result = dma.sha512_image(
+                    self.sha2_512_384_acc,
+                    axi_start + offset,
+                    len,
+                    AesDmaMode::None,
+                )?;
+                result.into()
+            }
+            ImageSource::Mailbox { data } => {
+                let data = data
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                self.sha2_512_384.sha512_digest(data)?.0
+            }
+        };
+
+        Ok(digest)
     }
 
     fn sha384_acc_digest(
@@ -94,7 +117,7 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest384> {
-        if self.image_in_mcu {
+        if matches!(self.image_source, ImageSource::Staging { .. }) {
             // For MCU case, use the existing sha384_digest function
             self.sha384_digest(offset, len).map_err(|_| digest_failure)
         } else {
@@ -120,7 +143,7 @@ impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest512> {
-        if self.image_in_mcu {
+        if matches!(self.image_source, ImageSource::Staging { .. }) {
             // For MCU case, use the existing sha512_digest function
             self.sha512_digest(offset, len).map_err(|_| digest_failure)
         } else {

--- a/rom/dev/src/flow/cold_reset/fw_processor.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor.rs
@@ -42,7 +42,7 @@ use caliptra_common::{
         StashMeasurementReq, StashMeasurementResp,
     },
     pcr::PCR_ID_STASH_MEASUREMENT,
-    verifier::FirmwareImageVerificationEnv,
+    verifier::{FirmwareImageVerificationEnv, ImageSource},
     FuseLogEntryId, PcrLogEntry, PcrLogEntryId,
     RomBootStatus::*,
 };
@@ -152,7 +152,17 @@ impl FirmwareProcessor {
         );
         let manifest = okref(&manifest)?;
 
-        let image_in_mcu = env.soc_ifc.subsystem_mode();
+        let image_source = if env.soc_ifc.subsystem_mode() {
+            let mci_base: AxiAddr = env.soc_ifc.mci_base_addr().into();
+            ImageSource::Staging {
+                axi_start: mci_base + caliptra_drivers::dma::MCU_SRAM_OFFSET,
+            }
+        } else {
+            ImageSource::Mailbox {
+                data: txn.raw_mailbox_contents(),
+            }
+        };
+
         let mut venv = FirmwareImageVerificationEnv {
             sha256: &mut env.sha256,
             sha2_512_384: &mut env.sha2_512_384,
@@ -162,10 +172,9 @@ impl FirmwareProcessor {
             mldsa87: &mut env.mldsa87,
             data_vault: &env.persistent_data.get().data_vault,
             pcr_bank: &mut env.pcr_bank,
-            image: txn.raw_mailbox_contents(),
-            dma: &mut env.dma,
+            image_source,
+            dma: &env.dma,
             persistent_data: env.persistent_data.get(),
-            image_in_mcu,
         };
 
         // Verify the image
@@ -838,9 +847,8 @@ impl FirmwareProcessor {
             data_vault: venv.data_vault,
             ecc384: venv.ecc384,
             mldsa87: venv.mldsa87,
-            image: venv.image,
+            image_source: venv.image_source,
             dma: venv.dma,
-            image_in_mcu: venv.image_in_mcu,
         };
 
         // Random delay for CFI glitch protection.

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -22,6 +22,7 @@ use crate::flow::warm_reset;
 use crate::print::HexBytes;
 use crate::rom_env::RomEnv;
 use caliptra_common::keyids::KEY_ID_ROM_FMC_CDI;
+use caliptra_common::verifier::ImageSource;
 use caliptra_common::FirmwareHandoffTable;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::cprintln;
@@ -197,9 +198,8 @@ pub(crate) struct FakeRomImageVerificationEnv<'a, 'b> {
     pub(crate) data_vault: &'a DataVault,
     pub(crate) ecc384: &'a mut Ecc384,
     pub(crate) mldsa87: &'a mut Mldsa87,
-    pub image: &'b [u8],
+    pub image_source: ImageSource<'b>,
     pub(crate) dma: &'a Dma,
-    pub(crate) image_in_mcu: bool,
 }
 
 impl FakeRomImageVerificationEnv<'_, '_> {
@@ -217,39 +217,55 @@ impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
     /// Calculate 384 digest using SHA2 Engine
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest384> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FakeRomImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha384_mcu_sram(self.sha2_512_384_acc, offset, len, dma::AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            Ok(self.sha2_512_384.sha384_digest(data)?.0)
-        }
+        let digest = match self.image_source {
+            ImageSource::Staging { axi_start } => {
+                let dma = FakeRomImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
+                let result = dma.sha384_image(
+                    self.sha2_512_384_acc,
+                    axi_start + offset,
+                    len,
+                    dma::AesDmaMode::None,
+                )?;
+                result.into()
+            }
+            ImageSource::Mailbox { data } => {
+                let data = data
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                self.sha2_512_384.sha384_digest(data)?.0
+            }
+        };
+
+        Ok(digest)
     }
 
     /// Calculate 512 digest using SHA2 Engine
     fn sha512_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest512> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
-        if self.image_in_mcu {
-            let dma = FakeRomImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
-            let result =
-                dma.sha512_mcu_sram(self.sha2_512_384_acc, offset, len, AesDmaMode::None)?;
-            Ok(result.into())
-        } else {
-            let data = self
-                .image
-                .get(offset as usize..)
-                .ok_or(err)?
-                .get(..len as usize)
-                .ok_or(err)?;
-            Ok(self.sha2_512_384.sha512_digest(data)?.0)
-        }
+        let digest = match self.image_source {
+            ImageSource::Staging { axi_start } => {
+                let dma = FakeRomImageVerificationEnv::create_dma_recovery(self.soc_ifc, self.dma);
+                let result = dma.sha512_image(
+                    self.sha2_512_384_acc,
+                    axi_start + offset,
+                    len,
+                    AesDmaMode::None,
+                )?;
+                result.into()
+            }
+            ImageSource::Mailbox { data } => {
+                let data = data
+                    .get(offset as usize..)
+                    .ok_or(err)?
+                    .get(..len as usize)
+                    .ok_or(err)?;
+                self.sha2_512_384.sha512_digest(data)?.0
+            }
+        };
+
+        Ok(digest)
     }
 
     fn sha384_acc_digest(
@@ -258,7 +274,7 @@ impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest384> {
-        if self.image_in_mcu {
+        if matches!(self.image_source, ImageSource::Staging { .. }) {
             // For MCU case, use the existing sha384_digest function
             self.sha384_digest(offset, len).map_err(|_| digest_failure)
         } else {
@@ -285,7 +301,7 @@ impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
         len: u32,
         digest_failure: CaliptraError,
     ) -> CaliptraResult<ImageDigest512> {
-        if self.image_in_mcu {
+        if matches!(self.image_source, ImageSource::Staging { .. }) {
             // For MCU case, use the existing sha512_digest function
             self.sha512_digest(offset, len).map_err(|_| digest_failure)
         } else {

--- a/runtime/src/firmware_verify.rs
+++ b/runtime/src/firmware_verify.rs
@@ -47,7 +47,7 @@ impl FirmwareVerifyCmd {
     pub(crate) fn execute(drivers: &mut Drivers, src: VerifySrc) -> CaliptraResult<MboxStatusE> {
         let raw_data = drivers.mbox.raw_mailbox_contents();
 
-        let (mut image_size, image_source) = match src {
+        let (image_size, image_source) = match src {
             VerifySrc::Mbox => {
                 Self::load_manifest_from_mbox(drivers.persistent_data.get_mut(), raw_data)?;
                 (drivers.mbox.dlen(), ImageSource::Mailbox { data: raw_data })

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -95,7 +95,7 @@ impl AxiRootBus {
 
     // External Test SRAM is used for testing purposes and is not part of the actual design.
     // This SRAM is accessible from the Caliptra Core and the MCU emulators.
-    pub const EXTERNAL_TEST_SRAM_OFFSET: AxiAddr = 0x00000000_80000000;
+    pub const EXTERNAL_TEST_SRAM_OFFSET: AxiAddr = 0x00000000_B00C0000;
     pub const EXTERNAL_TEST_SRAM_END: AxiAddr =
         Self::EXTERNAL_TEST_SRAM_OFFSET + EXTERNAL_TEST_SRAM_SIZE as u64;
 


### PR DESCRIPTION
During FW update, the downloaded Caliptra FW image is verified through the FIRMWARE_VERIFY mailbox command. For 2.1, the downloaded firmware image is in the external staging memory, not in Mailbox or MCU SRAM.However currently, the image verifier only verifies the image in MCU SRAM or mailbox, not from external staging memory.

To fix this, a new parameter is passed to the verifier to specify where the image to be verified resides. The value of the enum can either be Mailbox, or Staging. If the image is coming from staging then the axi address need to be supplied.

Note that for cold boot recovery flow, the image is temporarily downloaded to MCU SRAM, so the ROM will verify the image in the MCU SRAM, so the image source is Staging with the axi address of the MCU SRAM.

Other changes:
- The EXTERNAL_TEST_SRAM (which corresponds to the FPGA staging peripheral) address has been updated to make it the same as the FPGA staging address. This is to simplify the code so that both emulator and FPGA code can use the same address for staging.
- Some optimization on the code is made to make the ROM size smaller. In the update-reset file, the staging_addr has been retrieved as AxiAddr but passed as u64, and then later on re-parsed as AxiAddr. To make it simpler, we just pass it as AxiAddr and bypass the unnecessary conversions.