### PR TITLE
Fix failed FW verification during FW update (2.1)

### DIFF
--- a/runtime/src/firmware_verify.rs
+++ b/runtime/src/firmware_verify.rs
@@ -63,7 +63,10 @@ impl FirmwareVerifyCmd {
                 )?;
                 (
                     image_size,
-                    caliptra_common::verifier::ImageSource::McuSram(&drivers.dma),
+                    caliptra_common::verifier::ImageSource::Axi {
+                        dma: &drivers.dma,
+                        axi_start: axi_address,
+                    },
                 )
             }
         };

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -93,9 +93,10 @@ impl AxiRootBus {
     pub const TEST_SRAM_OFFSET: AxiAddr = 0x00000000_00500000;
     pub const TEST_SRAM_END: AxiAddr = Self::TEST_SRAM_OFFSET + TEST_SRAM_SIZE as u64;
 
-    // External Test SRAM is used for testing purposes and is not part of the actual design.
+    // External Test SRAM maps to the external staging area used for transferring
+    // large data between Caliptra and MCU.
     // This SRAM is accessible from the Caliptra Core and the MCU emulators.
-    pub const EXTERNAL_TEST_SRAM_OFFSET: AxiAddr = 0x00000000_80000000;
+    pub const EXTERNAL_TEST_SRAM_OFFSET: AxiAddr = 0x00000000_B00C0000;
     pub const EXTERNAL_TEST_SRAM_END: AxiAddr =
         Self::EXTERNAL_TEST_SRAM_OFFSET + EXTERNAL_TEST_SRAM_SIZE as u64;
 


### PR DESCRIPTION
During FW update, the downloaded Caliptra FW image is verified through the FIRMWARE_VERIFY mailbox command. For 2.1, the downloaded firmware image is in the external staging memory, not in Mailbox or MCU SRAM.However currently, the image verifier only verifies the image in MCU SRAM or mailbox, not from external staging memory.

Added a type for image_source for verification which can include the Axi address of the image to be verified.

Note that for cold boot recovery flow, the image is temporarily

Other changes:
- The EXTERNAL_TEST_SRAM (which corresponds to the FPGA staging memory peripheral) address has been updated to make it the same as the FPGA staging address. This is to simplify the code so that both emulator and FPGA code can use the same address for staging.