### PR TITLE
Cancel in-flight PR jobs for FPGA workflows on new ref

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -41,6 +41,10 @@ on:
         default: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CALIPTRA_MCU_COMMIT: 982ca4f02b7e9fefb58850657246b0c8f28e5b53
 

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -38,6 +38,9 @@ on:
         default: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check_cache:


### PR DESCRIPTION
Adds concurrency groups to fpga.yml and fpga-subsystem.yml to cancel previous runs on the same PR when a new commit is pushed.

Non-PR events (workflow_call, etc.) use github.run_id to allow parallel execution.