### PR TITLE
Fix fpga-image build

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -144,7 +144,6 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools gcc-aarch64-linux-gnu 
           rustup target add aarch64-unknown-linux-gnu
-          cargo +1.88 install cross --git https://github.com/cross-rs/cross --root /tmp/cross
 
       - name: Build SD images
         run: |

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -110,15 +110,10 @@ EOF
 fi
 
 pushd out
-git clone https://github.com/nextest-rs/nextest
-pushd nextest
-git fetch --tags
-git checkout cargo-nextest-0.9.118
-cross +1.90 build --target aarch64-unknown-linux-gnu --features=default-no-update --no-default-features --release
-popd
+podman run --rm -v$PWD:/work-dir -w/work-dir ghcr.io/chipsalliance/caliptra-build-image:latest /bin/bash -c "rustup +1.90 target add aarch64-unknown-linux-gnu && CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo +1.90 install cargo-nextest --version 0.9.118 --target aarch64-unknown-linux-gnu --target-dir /work-dir"
 popd
 
-mv out/nextest/target/aarch64-unknown-linux-gnu/release/cargo-nextest out/rootfs/usr/bin/
+mv out/aarch64-unknown-linux-gnu/release/cargo-nextest out/rootfs/usr/bin/
 
 chroot out/rootfs bash -c 'echo ::1 caliptra-fpga >> /etc/hosts'
 cp startup-script.sh out/rootfs/usr/bin/


### PR DESCRIPTION
* Cross build broke. Take the opportunity to use the Caliptra build container for cross-compiling instead.