### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-test-verilator.yml
+++ b/.github/workflows/build-test-verilator.yml
@@ -11,6 +11,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     name: Verilator Build and Test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-24.04

--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -19,6 +19,10 @@ on:
         default: ${{ github.sha }}
         type: string
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build_kernel:
     runs-on: [e2-standard-32, vck190-tools]

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -45,6 +45,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 env:
   CALIPTRA_MCU_COMMIT: 982ca4f02b7e9fefb58850657246b0c8f28e5b53
 

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -42,6 +42,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   check_cache:
     runs-on: ubuntu-22.04

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -17,6 +17,9 @@ on:
         default: "latest"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-fuzzing.yml
+++ b/.github/workflows/nightly-fuzzing.yml
@@ -4,6 +4,9 @@ on:
     # 3:00 AM PST monday-saturday
     - cron: '00 11 * * 1-6'
 
+permissions:
+  contents: read
+
 jobs:
   image_verify_seed_corpus:
     name: Build Image Verifier seed corpus

--- a/.github/workflows/nightly-release-1.x.yml
+++ b/.github/workflows/nightly-release-1.x.yml
@@ -61,6 +61,8 @@ jobs:
     name: FPGA Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
     needs: find-latest-release
     if: needs.find-latest-release.outputs.create_release == 'true'
+    permissions:
+      contents: read
     uses: chipsalliance/caliptra-sw/.github/workflows/fpga.yml@caliptra-1.x
     strategy:
       fail-fast: false
@@ -89,6 +91,8 @@ jobs:
     name: sw-emulator Suite (${{ matrix.config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
     needs: find-latest-release
     if: needs.find-latest-release.outputs.create_release == 'true'
+    permissions:
+      contents: read
     uses: chipsalliance/caliptra-sw/.github/workflows/fw-test-emu.yml@caliptra-1.x
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -61,6 +61,8 @@ jobs:
     name: sw-emulator Suite (${{ matrix.config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
     needs: find-latest-release-2-x
     if: needs.find-latest-release-2-x.outputs.create_release
+    permissions:
+      contents: read
     uses: ./.github/workflows/fw-test-emu.yml
     strategy:
       fail-fast: false
@@ -82,6 +84,8 @@ jobs:
     name: FPGA Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
     needs: find-latest-release-2-x
     if: needs.find-latest-release-2-x.outputs.create_release
+    permissions:
+      contents: read
     uses: ./.github/workflows/fpga.yml
     strategy:
       fail-fast: false
@@ -104,6 +108,8 @@ jobs:
     name: FPGA Subsystem Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }}, ${{ matrix.ocp_lock.name }})
     needs: find-latest-release-2-x
     if: needs.find-latest-release-2-x.outputs.create_release
+    permissions:
+      contents: read
     uses: ./.github/workflows/fpga-subsystem.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-verilator.yml
+++ b/.github/workflows/nightly-verilator.yml
@@ -7,6 +7,9 @@ on:
     # 5:30 PM Pacific on tuesday and friday
     - cron: '30 0 * * 3,6'
 
+permissions:
+  contents: read
+
 jobs:
   smoke_test:
     name: Smoke Test

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   check_policy:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-aflplusplus.yml
+++ b/.github/workflows/reusable-aflplusplus.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   reusable_aflplus_plus:
     # TODO: Set these as parameters?

--- a/.github/workflows/reusable-libfuzzer.yml
+++ b/.github/workflows/reusable-libfuzzer.yml
@@ -21,6 +21,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   reusable_libfuzzer:
     # TODO: Set these as parameters?

--- a/.github/workflows/size-history.yml
+++ b/.github/workflows/size-history.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-24.04

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -4,6 +4,8 @@ on:
     types: [closed]
     branches: [main]
 
+permissions: {}
+
 jobs:
   slack_publish:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Add permissions blocks to all workflow files to address CodeQL security alerts for missing-workflow-permissions (CWE-275). This follows the principle of least privilege by explicitly restricting GITHUB_TOKEN scope rather than relying on repository defaults.