### PR TITLE
Make LMS key generation and signing tools public

### DIFF
--- a/image/crypto/src/openssl.rs
+++ b/image/crypto/src/openssl.rs
@@ -20,6 +20,7 @@ use caliptra_image_gen::{
     from_hw_format, to_hw_format, u8_to_u32_le, ImageGeneratorCrypto, ImageGeneratorHasher,
 };
 use caliptra_image_types::*;
+use caliptra_lms_types::{LmotsAlgorithmType, LmsAlgorithmType};
 use zerocopy::IntoBytes;
 
 use openssl::{
@@ -35,7 +36,7 @@ use openssl::{
     signature::Signature,
 };
 
-use crate::{sign_with_lms_key, Sha256Hasher, SUPPORTED_LMS_Q_VALUE};
+use crate::{sign_with_lms_key, LmsKeyGen, Sha256Hasher, SUPPORTED_LMS_Q_VALUE};
 
 #[derive(Default)]
 pub struct OsslCrypto {}
@@ -211,6 +212,23 @@ impl ImageGeneratorCrypto for OsslCrypto {
     }
 }
 
+impl LmsKeyGen for OsslCrypto {
+    /// Generate a new random LMS private key with the specified tree type and OTS type
+    fn generate_lms_private_key(
+        tree_type: LmsAlgorithmType,
+        otstype: LmotsAlgorithmType,
+    ) -> anyhow::Result<ImageLmsPrivKey> {
+        let mut priv_key = ImageLmsPrivKey {
+            tree_type,
+            otstype,
+            ..Default::default()
+        };
+        openssl::rand::rand_bytes(&mut priv_key.id)?;
+        openssl::rand::rand_bytes(priv_key.seed.as_mut_bytes())?;
+        Ok(priv_key)
+    }
+}
+
 pub struct OpensslHasher(Sha256);
 
 impl Sha256Hasher for OpensslHasher {
@@ -222,5 +240,95 @@ impl Sha256Hasher for OpensslHasher {
     }
     fn finish(self) -> [u8; 32] {
         self.0.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        generate_lms_pubkey, sign_with_lms_key, IMAGE_LMS_OTS_TYPE, IMAGE_LMS_OTS_TYPE_8,
+        IMAGE_LMS_TREE_TYPE, IMAGE_LMS_TREE_TYPE_HT_5,
+    };
+
+    #[test]
+    fn test_lms_keygen_trait() {
+        // Test the LmsKeyGen trait implementation for OsslCrypto
+        let priv_key =
+            OsslCrypto::generate_lms_private_key(IMAGE_LMS_TREE_TYPE_HT_5, IMAGE_LMS_OTS_TYPE_8)
+                .unwrap();
+
+        // Verify the key has correct algorithm types
+        assert_eq!(priv_key.tree_type, IMAGE_LMS_TREE_TYPE_HT_5);
+        assert_eq!(priv_key.otstype, IMAGE_LMS_OTS_TYPE_8);
+
+        // Verify randomness - ID and seed should be non-zero
+        assert_ne!(priv_key.id, [0u8; 16]);
+        assert_ne!(priv_key.seed.as_bytes(), &[0u8; 24]);
+
+        // Test with standard IMAGE types
+        let std_priv_key =
+            OsslCrypto::generate_lms_private_key(IMAGE_LMS_TREE_TYPE, IMAGE_LMS_OTS_TYPE).unwrap();
+        assert_eq!(std_priv_key.tree_type, IMAGE_LMS_TREE_TYPE);
+        assert_eq!(std_priv_key.otstype, IMAGE_LMS_OTS_TYPE);
+
+        // Different invocations should generate different keys
+        let priv_key2 =
+            OsslCrypto::generate_lms_private_key(IMAGE_LMS_TREE_TYPE_HT_5, IMAGE_LMS_OTS_TYPE_8)
+                .unwrap();
+        assert_ne!(priv_key.id, priv_key2.id);
+        assert_ne!(priv_key.seed.as_bytes(), priv_key2.seed.as_bytes());
+    }
+
+    #[test]
+    fn test_lms_keygen_with_pubkey_generation() {
+        // Test full workflow: generate private key using trait, then generate public key
+        let priv_key =
+            OsslCrypto::generate_lms_private_key(IMAGE_LMS_TREE_TYPE_HT_5, IMAGE_LMS_OTS_TYPE_8)
+                .unwrap();
+        let pub_key = generate_lms_pubkey::<OpensslHasher>(&priv_key).unwrap();
+
+        // Public key should match private key metadata
+        assert_eq!(pub_key.tree_type, priv_key.tree_type);
+        assert_eq!(pub_key.otstype, priv_key.otstype);
+        assert_eq!(pub_key.id, priv_key.id);
+
+        // Digest should be non-zero (derived from seed)
+        assert_ne!(pub_key.digest.as_bytes(), &[0u8; 24]);
+    }
+
+    #[test]
+    fn test_lms_keygen_with_signing() {
+        // Test complete workflow: generate key using trait, generate public key, sign message
+        let priv_key =
+            OsslCrypto::generate_lms_private_key(IMAGE_LMS_TREE_TYPE_HT_5, IMAGE_LMS_OTS_TYPE_8)
+                .unwrap();
+        let _pub_key = generate_lms_pubkey::<OpensslHasher>(&priv_key).unwrap();
+
+        // Test signing with generated key
+        let message = b"test message for LmsKeyGen trait";
+        let nonce = [0x42u8; 24];
+        let sig = sign_with_lms_key::<OpensslHasher>(&priv_key, message, &nonce, 1).unwrap();
+
+        // Signature should have correct metadata
+        assert_eq!(sig.tree_type, priv_key.tree_type);
+        assert_eq!(sig.ots.ots_type, priv_key.otstype);
+        assert_eq!(sig.q.get(), 1);
+    }
+
+    /// Generic test function that works with any crypto backend implementing LmsKeyGen
+    fn test_lms_keygen_generic<T: LmsKeyGen>() {
+        let priv_key =
+            T::generate_lms_private_key(IMAGE_LMS_TREE_TYPE_HT_5, IMAGE_LMS_OTS_TYPE_8).unwrap();
+
+        assert_eq!(priv_key.tree_type, IMAGE_LMS_TREE_TYPE_HT_5);
+        assert_eq!(priv_key.otstype, IMAGE_LMS_OTS_TYPE_8);
+        assert_ne!(priv_key.id, [0u8; 16]);
+        assert_ne!(priv_key.seed.as_bytes(), &[0u8; 24]);
+    }
+
+    #[test]
+    fn test_lms_keygen_generic_openssl() {
+        test_lms_keygen_generic::<OsslCrypto>();
     }
 }


### PR DESCRIPTION
This is meant so that MCU xtask can use these to generate signed firmware without duplicating this code.

The key generation code was missing in any case, so added that and some tests for the methods.