### PR TITLE
cherry-pick to 2.0: sw-emulator: Remove DMA block size panic (#3083)

### DIFF
--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -344,19 +344,8 @@ impl Dma {
         }
     }
 
-    fn check_block_size(&self) {
-        match (self.read_xfer().fixed, self.block_size.reg.get()) {
-            (true, 64) => (),
-            (false, 0) => (),
-            _ => {
-                panic!("Unsupported DMA block size: must be 64 for I3C to mailbox and 0 otherwise")
-            }
-        }
-    }
-
     // Returns true if this completed immediately.
     fn axi_to_mailbox(&mut self) -> bool {
-        self.check_block_size();
         let xfer = self.read_xfer();
 
         // check if we have to do the read async
@@ -384,7 +373,6 @@ impl Dma {
 
     // Returns true if this completed immediately.
     fn axi_to_fifo(&mut self) -> bool {
-        self.check_block_size();
         let xfer = self.read_xfer();
 
         // check if we have to do the read async
@@ -414,7 +402,6 @@ impl Dma {
 
     // Returns true if this completed immediately.
     fn axi_to_axi(&mut self) -> bool {
-        self.check_block_size();
         let read_xfer = self.read_xfer();
         let write_xfer = self.write_xfer();
 
@@ -457,10 +444,6 @@ impl Dma {
         let xfer = self.write_xfer();
         let mbox_ram = self.mailbox.borrow_mut();
 
-        if self.block_size.reg.get() != 0 {
-            panic!("Unsupported DMA block size: must be 0 for mailbox to AXI");
-        }
-
         for i in (0..xfer.len).step_by(Self::AXI_DATA_WIDTH) {
             let addr = xfer.dest + if xfer.fixed { 0 } else { i as AxiAddr };
             let data = mbox_ram
@@ -476,10 +459,6 @@ impl Dma {
     // Returns true if this completed immediately.
     fn fifo_to_axi(&mut self) -> bool {
         let xfer = self.write_xfer();
-
-        if self.block_size.reg.get() != 0 {
-            panic!("Unsupported DMA block size: must be 0 for FIFO to AXI");
-        }
 
         for i in (0..xfer.len).step_by(Self::AXI_DATA_WIDTH) {
             let addr = xfer.dest + if xfer.fixed { 0 } else { i as AxiAddr };


### PR DESCRIPTION
This check will cause problems when testing the 2.0.0 ROM with the latest emulator and firmware, since the 2.0.0 ROM uses a block size of 256.

This does work on the real hardware in the cases the ROM uses.

This change was originally part of #2938

(cherry picked from commit 6fb5d4ab638b875235f077aedccce2e6b29b47f6)