### PR TITLE
[openocd] add functions to API

### DIFF
--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -114,6 +114,24 @@ impl OpenOcdJtagTap {
         self.jtag_tap
     }
 
+    pub fn reexamine_cpu_target(&mut self) -> Result<()> {
+        ensure!(
+            self.jtag_tap != JtagTap::NoTap,
+            JtagError::Tap(self.jtag_tap)
+        );
+        let _ = self.openocd.execute("riscv.cpu arp_examine")?;
+        Ok(())
+    }
+
+    pub fn set_sysbus_access(&mut self) -> Result<()> {
+        ensure!(
+            self.jtag_tap != JtagTap::NoTap,
+            JtagError::Tap(self.jtag_tap)
+        );
+        let _ = self.openocd.execute("riscv set_mem_access sysbus")?;
+        Ok(())
+    }
+
     pub fn read_reg(&mut self, reg: &dyn JtagAccessibleReg) -> Result<u32> {
         ensure!(
             self.jtag_tap != JtagTap::NoTap,


### PR DESCRIPTION
This adds functions to the OpenOCD JTAG TAP API to:
1. reexamine the CPU target, and
2. force system bus access mode.

These will be used to enhance the debug unlock testcases on FPGA to match their RTL sim counterparts (see
https://github.com/chipsalliance/caliptra-ss/pull/951).