### PR TITLE
fix an  issue marker and size field of the Envelope data structure not initialized

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -124,6 +124,7 @@ pub use pcr_reset::PcrResetCounter;
 pub use persistent::fmc_alias_csr::FmcAliasCsrs;
 #[cfg(any(feature = "fmc", feature = "runtime"))]
 pub use persistent::FwPersistentData;
+pub use persistent::IDEVID_CSR_ENVELOP_MARKER;
 #[cfg(feature = "runtime")]
 pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
 pub use persistent::{

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -40,8 +40,6 @@ use zeroize::Zeroize;
 /// Initialization Vector used by Deobfuscation Engine during UDS / field entropy decryption.
 const DOE_IV: Array4x4 = Array4xN::<4, 16>([0xfb10365b, 0xa1179741, 0xfba193a1, 0x0f406d7e]);
 
-use caliptra_drivers::IDEVID_CSR_ENVELOP_MARKER;
-
 /// Dice Initial Device Identity (IDEVID) Layer
 pub enum InitDevIdLayer {}
 
@@ -308,9 +306,12 @@ impl InitDevIdLayer {
         // Create a HMAC tag for the CSR Envelop.
         let csr_envelop = &mut env.persistent_data.get_mut().rom.idevid_csr_envelop;
 
-        // Explicitly initialize envelope metadata for marker and size.
-        csr_envelop.marker = IDEVID_CSR_ENVELOP_MARKER;
-        csr_envelop.size = core::mem::size_of::<InitDevIdCsrEnvelope>() as u32;
+        // Explicitly initialize envelope metadata for marker and size. use InitDevIdCsrEnvelope::default();
+        // as it's already in ROM
+       let default = InitDevIdCsrEnvelope::default();
+csr_envelop.marker = default.marker;
+csr_envelop.size = default.size;
+
 
         // Data to be HMACed is everything before the CSR MAC.
         let offset = offset_of!(InitDevIdCsrEnvelope, csr_mac);
@@ -375,13 +376,11 @@ impl InitDevIdLayer {
 
         let _pub_x: [u8; 48] = key_pair.pub_key.x.into();
         let _pub_y: [u8; 48] = key_pair.pub_key.y.into();
-        cprintln!("[idev] ECC PUB.X = {}", HexBytes(&_pub_x));
-        cprintln!("[idev] ECC PUB.Y = {}", HexBytes(&_pub_y));
+
 
         let _sig_r: [u8; 48] = (&sig.r).into();
         let _sig_s: [u8; 48] = (&sig.s).into();
-        cprintln!("[idev] ECC SIG.R = {}", HexBytes(&_sig_r));
-        cprintln!("[idev] ECC SIG.S = {}", HexBytes(&_sig_s));
+
 
         // Build the CSR with `To Be Signed` & `Signature`
         let csr_envelop = &mut env.persistent_data.get_mut().rom.idevid_csr_envelop;

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -40,6 +40,8 @@ use zeroize::Zeroize;
 /// Initialization Vector used by Deobfuscation Engine during UDS / field entropy decryption.
 const DOE_IV: Array4x4 = Array4xN::<4, 16>([0xfb10365b, 0xa1179741, 0xfba193a1, 0x0f406d7e]);
 
+use caliptra_drivers::IDEVID_CSR_ENVELOP_MARKER;
+
 /// Dice Initial Device Identity (IDEVID) Layer
 pub enum InitDevIdLayer {}
 
@@ -305,6 +307,10 @@ impl InitDevIdLayer {
 
         // Create a HMAC tag for the CSR Envelop.
         let csr_envelop = &mut env.persistent_data.get_mut().rom.idevid_csr_envelop;
+
+        // Explicitly initialize envelope metadata for marker and size.
+        csr_envelop.marker = IDEVID_CSR_ENVELOP_MARKER;
+        csr_envelop.size = core::mem::size_of::<InitDevIdCsrEnvelope>() as u32;
 
         // Data to be HMACed is everything before the CSR MAC.
         let offset = offset_of!(InitDevIdCsrEnvelope, csr_mac);

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -373,12 +373,6 @@ impl InitDevIdLayer {
         );
         let sig = okmutref(&mut sig)?;
 
-        let _pub_x: [u8; 48] = key_pair.pub_key.x.into();
-        let _pub_y: [u8; 48] = key_pair.pub_key.y.into();
-
-        let _sig_r: [u8; 48] = (&sig.r).into();
-        let _sig_s: [u8; 48] = (&sig.s).into();
-
         // Build the CSR with `To Be Signed` & `Signature`
         let csr_envelop = &mut env.persistent_data.get_mut().rom.idevid_csr_envelop;
         let ecdsa384_sig = sig.to_ecdsa();

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -308,10 +308,9 @@ impl InitDevIdLayer {
 
         // Explicitly initialize envelope metadata for marker and size. use InitDevIdCsrEnvelope::default();
         // as it's already in ROM
-       let default = InitDevIdCsrEnvelope::default();
-csr_envelop.marker = default.marker;
-csr_envelop.size = default.size;
-
+        let default = InitDevIdCsrEnvelope::default();
+        csr_envelop.marker = default.marker;
+        csr_envelop.size = default.size;
 
         // Data to be HMACed is everything before the CSR MAC.
         let offset = offset_of!(InitDevIdCsrEnvelope, csr_mac);
@@ -377,10 +376,8 @@ csr_envelop.size = default.size;
         let _pub_x: [u8; 48] = key_pair.pub_key.x.into();
         let _pub_y: [u8; 48] = key_pair.pub_key.y.into();
 
-
         let _sig_r: [u8; 48] = (&sig.r).into();
         let _sig_s: [u8; 48] = (&sig.s).into();
-
 
         // Build the CSR with `To Be Signed` & `Signature`
         let csr_envelop = &mut env.persistent_data.get_mut().rom.idevid_csr_envelop;

--- a/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
+++ b/rom/dev/tests/rom_integration_tests/tests_get_idev_csr.rs
@@ -3,7 +3,8 @@
 use caliptra_api::SocManager;
 use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, GetIdevCsrResp, MailboxReqHeader};
-use caliptra_drivers::{InitDevIdCsrEnvelope, MfgFlags};
+use caliptra_drivers::{InitDevIdCsrEnvelope, MfgFlags, IDEVID_CSR_ENVELOP_MARKER};
+
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DeviceLifecycle, Fuses, HwModel, ModelError};
 use core::mem::offset_of;
@@ -135,6 +136,12 @@ fn test_validate_csr_mac() {
         csr_envelop
     };
 
+    assert_eq!(csr_envelop.marker, IDEVID_CSR_ENVELOP_MARKER);
+    assert_eq!(
+        csr_envelop.size,
+        core::mem::size_of::<InitDevIdCsrEnvelope>() as u32
+    );
+
     let hmac = {
         let offset = offset_of!(InitDevIdCsrEnvelope, csr_mac);
         let envelope_slice = csr_envelop.as_bytes().get(..offset).unwrap().to_vec();
@@ -167,6 +174,11 @@ fn test_get_mldsa_csr() {
 
         let csr_envelop = helpers::get_csr_envelop(&mut hw).unwrap();
 
+        assert_eq!(csr_envelop.marker, IDEVID_CSR_ENVELOP_MARKER);
+        assert_eq!(
+            csr_envelop.size,
+            core::mem::size_of::<InitDevIdCsrEnvelope>() as u32
+        );
         hw.step_until(|m| {
             m.soc_ifc()
                 .cptra_flow_status()


### PR DESCRIPTION
Explicitly initialize envelope metadata for marker and size in make_csr_envelop