### PR TITLE
[OCP-LOCK]: HPKE Generation & Enumeration

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2437,6 +2437,11 @@ impl CaliptraError {
             "Driver Error: HPKE trng failed during encap"
         ),
         (
+            RUNTIME_DRIVER_HPKE_CONVERT_INVALID_CIPHER_SUITE,
+            0xa004_1003,
+            "Driver Error: HPKE attempted to convert an invalid ciphersuite"
+        ),
+        (
             RUNTIME_DRIVER_HPKE_ML_KEM_TRNG_KEYGEN_FAIL,
             0xa004_1100,
             "Driver Error: HPKE ml-kem failed to generate a key pair due to trng failure"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1325,6 +1325,7 @@ Command Code: `0x4143_5446` ("ACTF")
 
 These commands are defined in the OCP LOCK v1.0 [specification](https://github.com/chipsalliance/Caliptra/blob/main/doc/ocp_lock/releases/OCP_LOCK_Specification_v1.0_RC2.pdf).
 
+### ENUMERATE_HPKE_HANDLES
 ### REPORT_HEK_METADATA
 ### GET_ALGORITHMS
 ### INITIALIZE_MEK_SECRET

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -170,7 +170,7 @@ impl Drivers {
     /// any concurrent access to these register blocks does not conflict with
     /// these drivers.
     pub unsafe fn new_from_registers() -> CaliptraResult<Self> {
-        let trng = Trng::new(
+        let mut trng = Trng::new(
             CsrngReg::new(),
             EntropySrcReg::new(),
             SocIfcTrngReg::new(),
@@ -182,7 +182,7 @@ impl Drivers {
         let persistent_data = PersistentDataAccessor::new();
 
         let hek_available = persistent_data.get().rom.ocp_lock_metadata.hek_available;
-        let ocp_lock_context = OcpLockContext::new(&soc_ifc, hek_available);
+        let ocp_lock_context = OcpLockContext::new(&soc_ifc, &mut trng, hek_available)?;
 
         Ok(Self {
             mbox: Mailbox::new(MboxCsr::new()),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -505,6 +505,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         }
         ocp_lock_command_id @ CommandId::OCP_LOCK_GET_ALGORITHMS
         | ocp_lock_command_id @ CommandId::OCP_LOCK_INITIALIZE_MEK_SECRET
+        | ocp_lock_command_id @ CommandId::OCP_LOCK_ENUMERATE_HPKE_HANDLES
         | ocp_lock_command_id @ CommandId::OCP_LOCK_DERIVE_MEK => {
             ocp_lock::command_handler(ocp_lock_command_id, drivers, cmd_bytes, resp)
         }

--- a/runtime/src/ocp_lock/enumerate_hpke_handles.rs
+++ b/runtime/src/ocp_lock/enumerate_hpke_handles.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::mailbox::{MailboxRespHeader, OcpLockEnumerateHpkeHandlesResp};
+use caliptra_cfi_derive_git::cfi_impl_fn;
+
+use caliptra_error::CaliptraResult;
+
+use crate::{mutrefbytes, Drivers};
+
+pub struct EnumerateHpkeHandles;
+impl EnumerateHpkeHandles {
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(
+        drivers: &mut Drivers,
+        _cmd_args: &[u8],
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let resp = mutrefbytes::<OcpLockEnumerateHpkeHandlesResp>(resp)?;
+        resp.hdr = MailboxRespHeader::default();
+        resp.hpke_handle_count = 0;
+
+        for (returned_handle, (handle, cipher)) in resp
+            .hpke_handles
+            .iter_mut()
+            .zip(drivers.ocp_lock_context.iterate_hpke_handles())
+        {
+            returned_handle.handle = handle.into();
+            returned_handle.hpke_algorithm = cipher.try_into()?;
+            resp.hpke_handle_count += 1;
+        }
+        Ok(core::mem::size_of::<OcpLockEnumerateHpkeHandlesResp>())
+    }
+}

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -21,6 +21,7 @@ use zerocopy::{FromBytes, IntoBytes};
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
 mod test_derive_mek;
+mod test_enumerate_hpke_handles;
 mod test_get_algorithms;
 mod test_initialize_mek_secret;
 

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_enumerate_hpke_handles.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_enumerate_hpke_handles.rs
@@ -1,0 +1,66 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::mailbox::{
+    CommandId, HpkeAlgorithms, MailboxReq, MailboxRespHeader, OcpLockEnumerateHpkeHandlesReq,
+    OcpLockEnumerateHpkeHandlesResp,
+};
+use caliptra_hw_model::HwModel;
+
+use zerocopy::{FromBytes, IntoBytes};
+
+use super::{boot_ocp_lock_runtime, validate_ocp_lock_response, OcpLockBootParams};
+
+// TODO(clundin): Add tests for hybrid and ECDH KEMs once implemented
+// * https://github.com/chipsalliance/caliptra-sw/issues/3033
+// * https://github.com/chipsalliance/caliptra-sw/issues/3034
+
+#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
+#[test]
+fn test_enumerate_hpke_handles() {
+    // This command should have no dependency on the HEK's availability, so don't include it here.
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams::default());
+
+    let mut cmd =
+        MailboxReq::OcpLockEnumerateHpkeHandles(OcpLockEnumerateHpkeHandlesReq::default());
+    cmd.populate_chksum().unwrap();
+
+    let response = model.mailbox_execute(
+        CommandId::OCP_LOCK_ENUMERATE_HPKE_HANDLES.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    validate_ocp_lock_response(&mut model, response, |response, _| {
+        let response = response.unwrap().unwrap();
+        let enumerate_resp =
+            OcpLockEnumerateHpkeHandlesResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+        // Verify response checksum
+        assert!(caliptra_common::checksum::verify_checksum(
+            enumerate_resp.hdr.chksum,
+            0x0,
+            &enumerate_resp.as_bytes()[core::mem::size_of_val(&enumerate_resp.hdr.chksum)..],
+        ));
+        // Verify FIPS status
+        assert_eq!(
+            enumerate_resp.hdr.fips_status,
+            MailboxRespHeader::FIPS_STATUS_APPROVED
+        );
+
+        // Currently only ML-KEM is implemented.
+        assert_eq!(enumerate_resp.hpke_handle_count, 1);
+
+        let ml_kem = enumerate_resp
+            .hpke_handles
+            .iter()
+            .find(|entry| {
+                entry.hpke_algorithm == HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM
+            })
+            .unwrap();
+        assert_eq!(
+            ml_kem.hpke_algorithm,
+            HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM
+        );
+        // Handle should not have been rotated yet.
+        assert_eq!(ml_kem.handle, 1);
+    });
+}


### PR DESCRIPTION
* Generate HPKE context on reset
* Add OCP_LOCK_ENUMERATE_HPKE_HANDLES command

This resolves https://github.com/chipsalliance/caliptra-sw/issues/2994