### PR TITLE
rom: Add CM_SHA command

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1984,6 +1984,11 @@ impl CaliptraError {
             "Firmware Processor Error: OCP LOCK is not supported"
         ),
         (
+            FW_PROC_MAILBOX_INVALID_PARAMS,
+            0x0102000E,
+            "Firmware Processor Error: Mailbox invalid parameters"
+        ),
+        (
             FMC_ALIAS_CERT_VERIFY_FAILURE,
             0x01030001,
             "FMC Alias Layer Error: Certificate verification failure"

--- a/rom/dev/src/flow/cold_reset/fw_processor/cm_sha.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/cm_sha.rs
@@ -1,0 +1,85 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    cm_sha.rs
+
+Abstract:
+
+    File contains CM_SHA mailbox command.
+
+--*/
+
+use caliptra_api::mailbox::{CmHashAlgorithm, CmShaReqHdr, CmShaResp, CM_SHA_REQ_HDR_SIZE};
+use caliptra_common::mailbox_api::ResponseVarSize;
+use caliptra_drivers::{CaliptraError, CaliptraResult, Sha2_512_384};
+use caliptra_image_types::{SHA384_DIGEST_BYTE_SIZE, SHA512_DIGEST_BYTE_SIZE};
+use zerocopy::FromBytes;
+
+pub struct CmShaCmd;
+impl CmShaCmd {
+    /// Execute the CM_SHA command.
+    ///
+    /// This parses only the header from cmd_bytes and accesses the input data
+    /// directly to avoid a large stack allocation (the input can be up to 256KB minus header).
+    ///
+    /// # Arguments
+    /// * `cmd_bytes` - The raw command bytes from the mailbox
+    /// * `sha2_512_384` - The SHA2-512/384 hardware driver
+    /// * `resp` - The response buffer to populate
+    ///
+    /// # Returns
+    /// The size of the response in bytes, or an error.
+    #[inline(always)]
+    pub(crate) fn execute(
+        cmd_bytes: &[u8],
+        sha2_512_384: &mut Sha2_512_384,
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        // Parse only the header to avoid large stack allocation
+        let hdr_bytes = cmd_bytes
+            .get(..CM_SHA_REQ_HDR_SIZE)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let req_hdr = CmShaReqHdr::ref_from_bytes(hdr_bytes)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        // Get input data directly from cmd_bytes
+        let input_size = req_hdr.input_size as usize;
+        let input = cmd_bytes
+            .get(CM_SHA_REQ_HDR_SIZE..CM_SHA_REQ_HDR_SIZE.saturating_add(input_size))
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        // Use the response buffer directly as CmShaResp.
+        let resp_buffer_size = core::mem::size_of::<CmShaResp>();
+        let resp = resp
+            .get_mut(..resp_buffer_size)
+            .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+        let sha_resp = CmShaResp::mut_from_bytes(resp)
+            .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
+
+        let hash_algorithm = CmHashAlgorithm::from(req_hdr.hash_algorithm);
+
+        match hash_algorithm {
+            CmHashAlgorithm::Sha384 => {
+                let digest = sha2_512_384.sha384_digest(input)?;
+                let digest_bytes: [u8; SHA384_DIGEST_BYTE_SIZE] = digest.into();
+                sha_resp.hash[..SHA384_DIGEST_BYTE_SIZE].copy_from_slice(&digest_bytes);
+                sha_resp.hdr.data_len = SHA384_DIGEST_BYTE_SIZE as u32;
+            }
+            CmHashAlgorithm::Sha512 => {
+                let digest = sha2_512_384.sha512_digest(input)?;
+                let digest_bytes: [u8; SHA512_DIGEST_BYTE_SIZE] = digest.into();
+                sha_resp.hash[..SHA512_DIGEST_BYTE_SIZE].copy_from_slice(&digest_bytes);
+                sha_resp.hdr.data_len = SHA512_DIGEST_BYTE_SIZE as u32;
+            }
+            CmHashAlgorithm::Reserved => {
+                return Err(CaliptraError::FW_PROC_MAILBOX_INVALID_PARAMS);
+            }
+        }
+
+        let resp_bytes = sha_resp.as_bytes_partial()?;
+        Ok(resp_bytes.len())
+    }
+}

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -52,6 +52,7 @@ mod capabilities;
 mod cm_derive_stable_key;
 mod cm_hmac;
 mod cm_random_generate;
+mod cm_sha;
 mod ecdsa_verify;
 mod get_idev_csr;
 mod get_ldev_cert;
@@ -69,6 +70,7 @@ use capabilities::CapabilitiesCmd;
 use cm_derive_stable_key::CmDeriveStableKeyCmd;
 use cm_hmac::CmHmacCmd;
 use cm_random_generate::CmRandomGenerateCmd;
+use cm_sha::CmShaCmd;
 use ecdsa_verify::EcdsaVerifyCmd;
 use get_idev_csr::{GetIdevEcc384CsrCmd, GetIdevMldsa87CsrCmd};
 use get_ldev_cert::GetLdevCertCmd;
@@ -439,6 +441,7 @@ impl FirmwareProcessor {
                         persistent_data,
                         resp,
                     )?,
+                    CommandId::CM_SHA => CmShaCmd::execute(cmd_bytes, env.sha2_512_384, resp)?,
                     CommandId::OCP_LOCK_REPORT_HEK_METADATA => {
                         OcpLockReportHekMetadataCmd::execute(
                             cmd_bytes,

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -5,6 +5,7 @@ mod helpers;
 mod rv32_unit_tests;
 mod test_capabilities;
 mod test_cfi;
+mod test_cm_sha;
 mod test_cpu_fault;
 mod test_debug_unlock;
 mod test_derive_stable_key;

--- a/rom/dev/tests/rom_integration_tests/test_cm_sha.rs
+++ b/rom/dev/tests/rom_integration_tests/test_cm_sha.rs
@@ -1,0 +1,265 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::mailbox::{
+    CmHashAlgorithm, CmShaReq, MailboxRespHeaderVarSize, MAX_CM_SHA_INPUT_SIZE,
+};
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
+use caliptra_drivers::MBOX_SIZE_SUBSYSTEM;
+use caliptra_hw_model::{Fuses, HwModel};
+use openssl::sha::{sha384, sha512};
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::helpers;
+
+const MAX_CM_SHA_INPUT_SIZE_SUBSYSTEM: usize = 16384 - 12;
+
+#[test]
+fn test_cm_sha_sha384() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Message to hash
+    let msg: &[u8] = b"Hello, Caliptra! This is a test message for SHA-384 hashing.";
+
+    // Calculate expected hash using OpenSSL
+    let expected_hash = sha384(msg);
+
+    // Build the request
+    let mut cmd = CmShaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        input_size: msg.len() as u32,
+        input: [0u8; MAX_CM_SHA_INPUT_SIZE],
+    };
+    cmd.input[..msg.len()].copy_from_slice(msg);
+
+    // Calculate checksum
+    cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CM_SHA),
+        &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
+    );
+
+    let response = hw
+        .mailbox_execute(
+            CommandId::CM_SHA.into(),
+            &cmd.as_bytes()[..MAX_CM_SHA_INPUT_SIZE_SUBSYSTEM],
+        )
+        .unwrap()
+        .unwrap();
+
+    // Parse header and hash separately since response is variable size
+    let resp_bytes = response.as_bytes();
+    let (hdr, hash_bytes) = MailboxRespHeaderVarSize::ref_from_prefix(resp_bytes).unwrap();
+
+    // Verify response checksum
+    assert!(caliptra_common::checksum::verify_checksum(
+        hdr.hdr.chksum,
+        0x0,
+        &resp_bytes[core::mem::size_of_val(&hdr.hdr.chksum)..],
+    ));
+
+    // Verify FIPS status
+    assert_eq!(hdr.hdr.fips_status, MailboxRespHeader::FIPS_STATUS_APPROVED);
+
+    // Verify the hash length
+    assert_eq!(hdr.data_len, 48); // SHA-384 produces 48 bytes
+
+    // Verify the hash matches
+    assert_eq!(&hash_bytes[..48], &expected_hash[..]);
+}
+
+#[test]
+fn test_cm_sha_sha512() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Message to hash
+    let msg: &[u8] = b"Hello, Caliptra! This is a test message for SHA-512 hashing.";
+
+    // Calculate expected hash using OpenSSL
+    let expected_hash = sha512(msg);
+
+    // Build the request
+    let mut cmd = CmShaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        hash_algorithm: CmHashAlgorithm::Sha512.into(),
+        input_size: msg.len() as u32,
+        input: [0u8; MAX_CM_SHA_INPUT_SIZE],
+    };
+    cmd.input[..msg.len()].copy_from_slice(msg);
+
+    // Calculate checksum
+    cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CM_SHA),
+        &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
+    );
+
+    let response = hw
+        .mailbox_execute(
+            CommandId::CM_SHA.into(),
+            &cmd.as_bytes()[..MAX_CM_SHA_INPUT_SIZE_SUBSYSTEM],
+        )
+        .unwrap()
+        .unwrap();
+
+    // Parse header and hash separately since response is variable size
+    let resp_bytes = response.as_bytes();
+    let (hdr, hash_bytes) = MailboxRespHeaderVarSize::ref_from_prefix(resp_bytes).unwrap();
+
+    // Verify response checksum
+    assert!(caliptra_common::checksum::verify_checksum(
+        hdr.hdr.chksum,
+        0x0,
+        &resp_bytes[core::mem::size_of_val(&hdr.hdr.chksum)..],
+    ));
+
+    // Verify FIPS status
+    assert_eq!(hdr.hdr.fips_status, MailboxRespHeader::FIPS_STATUS_APPROVED);
+
+    // Verify the hash length
+    assert_eq!(hdr.data_len, 64); // SHA-512 produces 64 bytes
+
+    // Verify the hash matches
+    assert_eq!(&hash_bytes[..64], &expected_hash[..]);
+}
+
+#[test]
+fn test_cm_sha_empty_input() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Empty message
+    let msg: &[u8] = b"";
+
+    // Calculate expected hash using OpenSSL
+    let expected_hash = sha384(msg);
+
+    // Build the request
+    let mut cmd = CmShaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        input_size: 0,
+        input: [0u8; MAX_CM_SHA_INPUT_SIZE],
+    };
+
+    // Calculate checksum
+    cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CM_SHA),
+        &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
+    );
+
+    let response = hw
+        .mailbox_execute(
+            CommandId::CM_SHA.into(),
+            &cmd.as_bytes()[..MAX_CM_SHA_INPUT_SIZE_SUBSYSTEM],
+        )
+        .unwrap()
+        .unwrap();
+
+    // Parse header and hash separately since response is variable size
+    let resp_bytes = response.as_bytes();
+    let (hdr, hash_bytes) = MailboxRespHeaderVarSize::ref_from_prefix(resp_bytes).unwrap();
+
+    // Verify the hash length
+    assert_eq!(hdr.data_len, 48);
+
+    // Verify the hash matches
+    assert_eq!(&hash_bytes[..48], &expected_hash[..]);
+}
+
+#[test]
+fn test_cm_sha_invalid_algorithm() {
+    use caliptra_hw_model::ModelError;
+    use caliptra_kat::CaliptraError;
+
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Message to hash
+    let msg: &[u8] = b"Test message";
+
+    // Build the request with invalid algorithm (0 = Reserved)
+    let mut cmd = CmShaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        hash_algorithm: 0, // Invalid: Reserved
+        input_size: msg.len() as u32,
+        input: [0u8; MAX_CM_SHA_INPUT_SIZE],
+    };
+    cmd.input[..msg.len()].copy_from_slice(msg);
+
+    // Calculate checksum
+    cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CM_SHA),
+        &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..],
+    );
+
+    // This should fail because the algorithm is invalid
+    let bad_response = hw
+        .mailbox_execute(
+            CommandId::CM_SHA.into(),
+            &cmd.as_bytes()[..MAX_CM_SHA_INPUT_SIZE_SUBSYSTEM],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        bad_response,
+        ModelError::MailboxCmdFailed(CaliptraError::FW_PROC_MAILBOX_INVALID_PARAMS.into())
+    );
+}
+
+#[test]
+fn test_cm_sha_full_mailbox_all_0xff() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    // Create a full mailbox payload filled with 0xff (12 bytes overhead)
+
+    let size = if cfg!(feature = "fpga_subsystem") {
+        (MBOX_SIZE_SUBSYSTEM - 12) as usize
+    } else {
+        MAX_CM_SHA_INPUT_SIZE
+    };
+    let msg = vec![0xffu8; size];
+
+    // Calculate expected hash using OpenSSL
+    let expected_hash = sha384(&msg);
+
+    // Build the request with full payload
+    let mut cmd = CmShaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        hash_algorithm: CmHashAlgorithm::Sha384.into(),
+        input_size: size as u32,
+        input: [0xffu8; MAX_CM_SHA_INPUT_SIZE],
+    };
+
+    // Calculate checksum
+    cmd.hdr.chksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::CM_SHA),
+        &cmd.as_bytes()[core::mem::size_of_val(&cmd.hdr.chksum)..size + 12],
+    );
+
+    let response = hw
+        .mailbox_execute(CommandId::CM_SHA.into(), &cmd.as_bytes()[..size + 12])
+        .unwrap()
+        .unwrap();
+
+    // Parse header and hash separately since response is variable size
+    let resp_bytes = response.as_bytes();
+    let (hdr, hash_bytes) = MailboxRespHeaderVarSize::ref_from_prefix(resp_bytes).unwrap();
+
+    // Verify response checksum
+    assert!(caliptra_common::checksum::verify_checksum(
+        hdr.hdr.chksum,
+        0x0,
+        &resp_bytes[core::mem::size_of_val(&hdr.hdr.chksum)..],
+    ));
+
+    // Verify FIPS status
+    assert_eq!(hdr.hdr.fips_status, MailboxRespHeader::FIPS_STATUS_APPROVED);
+
+    // Verify the hash length
+    assert_eq!(hdr.data_len, 48); // SHA-384 produces 48 bytes
+
+    // Verify the hash matches
+    assert_eq!(&hash_bytes[..48], &expected_hash[..]);
+}

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1338,6 +1338,8 @@ These commands are used by the [Cryptograhic Mailbox](#cryptographic-mailbox-com
 
 This starts the computation of a SHA hash of data, which may be larger than a single mailbox command allows. It also supports additional algorithms.
 
+**Note:** ROM provides a simpler one-shot `CM_SHA` command for hashing data in a single operation. However, that command is ROM-only and is not available in runtime. For runtime, use these streaming commands (CM_SHA_INIT, CM_SHA_UPDATE, CM_SHA_FINAL) which support contexts and incremental hashing of large data.
+
 The sequence to use these are:
 * 1 `CM_SHA_INIT` command
 * 0 or more `CM_SHA_UPDATE` commands


### PR DESCRIPTION
This is a one-shot, ROM-only command meant to make some Device Ownership Transfer-like flows easier from MCU ROM or the SoC manager.

For example, if MCU has something like a Vendor PK hash burned into fuses and needs to match an ECDSA or MLDSA public key against it as part of DOT recovery, then it would need a way in the MCU ROM to compute SHA384/512 hashes, either using Caliptra or with a hardware or software SHA capability in MCU. Since Caliptra is meant to be the only cryptography capabilities for MCU, this means we need at least a simple SHA command offered by Caliptra ROM.

(This could potentially be worked around by using the existing CM_HMAC, and having something similar to a Vendor PK hash using HMACs, but this is cumbersome and would need to be computed per-device, since the only HMAC keys available to Caliptra ROM are stable keys, which are device-specific.)

This is targeted for 2.1 and 2.0.1 ROMs.