### PR TITLE
[drivers]: Update ML-KEM & HPKE drivers to use references

### DIFF
--- a/drivers/src/hpke/kem/mod.rs
+++ b/drivers/src/hpke/kem/mod.rs
@@ -20,17 +20,19 @@ pub trait Kem<const NSK: usize, const NENC: usize, const NPK: usize, const NSECR
     /// The extended Kem id, fed into the labeled derive function to expand `ikm`.
     const KEM_ID_EXT: KemIdExt;
 
+    type EK;
+
     /// Derives a KEM keypair from the `ikm` seed.
     fn derive_key_pair(
         &mut self,
         ikm: &[u8; NSK],
-    ) -> CaliptraResult<(EncapsulationKey<NPK>, DecapsulationKey<NSK>)>;
+    ) -> CaliptraResult<(Self::EK, DecapsulationKey<NSK>)>;
 
     /// Generates a shared secret key and associated ciphertext
     fn encap(
         &mut self,
         trng: &mut Trng,
-        encaps_key: &EncapsulationKey<NPK>,
+        encaps_key: &Self::EK,
     ) -> CaliptraResult<(EncapsulatedSecret<NENC>, SharedSecret<NSECRET>)>;
 
     /// Uses the decapsulation key to produce a shared secret key from a ciphertext.

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -225,7 +225,7 @@ impl MlKem1024 {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn encapsulate(
         &mut self,
-        encaps_key: MlKem1024EncapsKey,
+        encaps_key: &MlKem1024EncapsKey,
         message: MlKem1024MessageSource,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<MlKem1024Ciphertext> {
@@ -310,7 +310,7 @@ impl MlKem1024 {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn decapsulate(
         &mut self,
-        decaps_key: MlKem1024DecapsKey,
+        decaps_key: &MlKem1024DecapsKey,
         ciphertext: &MlKem1024Ciphertext,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<()> {

--- a/drivers/test-fw/src/bin/mlkem_tests.rs
+++ b/drivers/test-fw/src/bin/mlkem_tests.rs
@@ -379,7 +379,7 @@ fn test_encapsulate_and_decapsulate() {
     let mut shared_key_out = MlKem1024SharedKey::default();
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Array(&message),
             MlKem1024SharedKeyOut::Array(&mut shared_key_out),
         )
@@ -394,7 +394,7 @@ fn test_encapsulate_and_decapsulate() {
     let mut decaps_shared_key = MlKem1024SharedKey::default();
     mlkem
         .decapsulate(
-            decaps_key,
+            &decaps_key,
             &ciphertext,
             MlKem1024SharedKeyOut::Array(&mut decaps_shared_key),
         )
@@ -446,7 +446,7 @@ fn test_encapsulate_with_kv_message() {
     let mut shared_key_out = MlKem1024SharedKey::default();
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Key(KeyReadArgs::new(msg_key_id)),
             MlKem1024SharedKeyOut::Array(&mut shared_key_out),
         )
@@ -519,7 +519,7 @@ fn test_encapsulate_with_kv_message() {
 
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Key(KeyReadArgs::new(msg_key_id)),
             MlKem1024SharedKeyOut::Key(KeyWriteArgs::new(
                 msg_key_id,
@@ -613,7 +613,7 @@ fn test_encapsulate_with_kv_output() {
     let message = MlKem1024Message::from(MESSAGE);
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Array(&message),
             MlKem1024SharedKeyOut::Key(shared_key_out),
         )
@@ -637,7 +637,7 @@ fn test_keygen_decapsulate() {
     let mut original_shared_key = MlKem1024SharedKey::default();
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Array(&message),
             MlKem1024SharedKeyOut::Array(&mut original_shared_key),
         )
@@ -672,7 +672,7 @@ fn test_keygen_decapsulate_with_kv() {
     let mut original_shared_key = MlKem1024SharedKey::default();
     let ciphertext = mlkem
         .encapsulate(
-            encaps_key,
+            &encaps_key,
             MlKem1024MessageSource::Array(&message),
             MlKem1024SharedKeyOut::Array(&mut original_shared_key),
         )


### PR DESCRIPTION
This saves about 6K of stack space.