### PR TITLE
Implement MCU hitless firmware update reset sequence (2.1)

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -189,9 +189,6 @@ fn send_activate_firmware_cmd(
                     .reset_request()
                     .modify(|r| r.mcu_req(true));
             };
-            // First interrupt is Caliptra requesting MCU reset
-            clear_interrupt(model);
-            // Second interrupt is Caliptra indicating FW is available
             clear_interrupt(model);
         }
     }
@@ -201,17 +198,9 @@ fn send_activate_firmware_cmd(
         not(feature = "fpga_subsystem")
     ))]
     {
-        if reset_expected {
-            // For sw-emulator, wait for the MCI interrupt to be set, then clear
-            // In a full subsystem, the MCU would do this
-            model.step_until(|m| m.mci.regs.borrow().intr_block_rf_notif0_internal_intr_r != 0);
-            const NOTIF_CPTRA_MCU_RESET_REQ_STS_MASK: u32 = 0x2;
-            model
-                .mci
-                .regs
-                .borrow_mut()
-                .intr_block_rf_notif0_internal_intr_r &= !NOTIF_CPTRA_MCU_RESET_REQ_STS_MASK;
-        }
+        let _ = reset_expected;
+        // In emulator mode, since FW_EXEC_CTRL bit is already cleared,
+        // the MCU will be already in reset state
     }
     model.finish_mailbox_execute()
 }


### PR DESCRIPTION
This update implements the MCU hitless firmware update reset following the steps outlined in the CaliptraSSIntegrationSpecification: https://github.com/chipsalliance/caliptra-ss/blob/main/docs/CaliptraSSIntegrationSpecification.md#mcu-hitless-fw-update

The MCU Hitless FW Update flow includes:
1. MCU firmware monitors for new FW images via cptra_mcu_reset_req interrupt
2. Caliptra clears FW_EXEC_CTRL[2] to indicate FW is ready
3. MCU sets RESET_REQUEST.mcu_req to request reset
4. MCI performs MCU halt req/ack handshake
5. MCI asserts MCU reset (until MIN_MCU_RST_COUNTER overflows)
6. Caliptra waits for RESET_STATUS.MCU_RESET_STS confirmation
7. Caliptra updates MCU SRAM Updatable Execution Region
8. Caliptra sets FW_EXEC_CTRL[2] with FW_HITLESS_UPD_RESET reason
9. MCU boots from updated firmware image in MCU SRAM

Changes include updates to activate_firmware.rs runtime code and corresponding integration tests to validate the hitless update flow.

Fixes: https://github.com/chipsalliance/caliptra-ss/issues/995