### PR TITLE
Fix missing comma in RegisterSubBlock::Array codegen (2.1)

### DIFF
--- a/ureg/lib/codegen/src/lib.rs
+++ b/ureg/lib/codegen/src/lib.rs
@@ -1042,7 +1042,7 @@ fn generate_subblock_code(
                 pub fn #subblock_fn_name(&self, index: usize) -> #subblock_name<&TMmio> {
                     assert!(index < #len);
                     #subblock_name{
-                        ptr: unsafe { self.ptr.add((#start_offset + index * #stride) / core::mem::size_of::<#raw_ptr_type>()) }
+                        ptr: unsafe { self.ptr.add((#start_offset + index * #stride) / core::mem::size_of::<#raw_ptr_type>()) },
                         mmio: core::borrow::Borrow::borrow(&self.mmio),
                     }
                 }


### PR DESCRIPTION
Sync fix from caliptra-ureg repo:
https://github.com/chipsalliance/caliptra-ureg/commit/0b650ffe3c323a69008e9fa42da02769316cf5d3

Fixes https://github.com/chipsalliance/caliptra-sw/issues/3084