### PR TITLE
[openocd] add functions to read/write 32bit values over the sysbus

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2100,7 +2100,7 @@ impl HwModel for ModelFpgaSubsystem {
     fn ocp_lock_state(&mut self) -> Option<OcpLockState> {
         let mut mek = [0; 64];
         for (idx, word) in mek.chunks_exact_mut(4).enumerate() {
-            let mut word = u32::mut_from_bytes(word).unwrap();
+            let word = u32::mut_from_bytes(word).unwrap();
             *word = self
                 .wrapper
                 .regs()


### PR DESCRIPTION
This adds functions to the openocd server to read/write 32-bit values from arbitrary memory addresses over the system bus.