### PR TITLE
[Nightly]: Fix smoke tests when ROM has no UART

### DIFF
--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -302,9 +302,10 @@ fn smoke_test() {
             )
             .unwrap();
 
+            hw.step_until_output_contains("[rt] RT listening for mailbox commands...\n")
+                .unwrap();
+
             if firmware::rom_from_env() == &firmware::ROM_WITH_UART {
-                hw.step_until_output_contains("[rt] RT listening for mailbox commands...\n")
-                    .unwrap();
                 let output = hw.output().take(usize::MAX);
                 assert_output_contains(&output, "Running Caliptra ROM");
                 assert_output_contains(&output, "[cold-reset]");


### PR DESCRIPTION
This log line is actually emitted from the RT firmware, so it doesn't matter if the ROM is built with UART logs.