### PR TITLE
fpga: ModelFpgaSubsystem supports flash-based booting (2.1)

### DIFF
--- a/hw-model/src/fpga_regs.rs
+++ b/hw-model/src/fpga_regs.rs
@@ -58,6 +58,17 @@ register_bitfields! {
         NextChar OFFSET(0) NUMBITS(8) [],
         CharValid OFFSET(8) NUMBITS(1) [],
     ],
+    pub FlashControl [
+        START OFFSET(0) NUMBITS(1) [],
+        OP OFFSET(1) NUMBITS(2) [],
+    ],
+    pub FlashOpStatus [
+        DONE OFFSET(0) NUMBITS(1) [],
+        ERR OFFSET(1) NUMBITS(3) [],
+    ],
+    pub FlashCtrlRegwen [
+        EN OFFSET(0) NUMBITS(1) [],
+    ],
 }
 
 register_structs! {
@@ -70,6 +81,20 @@ register_structs! {
         (0x14 => pub dbg_fifo_data_push: WriteOnly<u32, FifoData::Register>),
         (0x18 => pub dbg_fifo_status: ReadOnly<u32, FifoStatus::Register>),
         (0x1c => @END),
+    },
+    pub FlashCtrlRegs {
+        (0x00 => pub fl_interrupt_state: ReadWrite<u32>),
+        (0x04 => pub fl_interrupt_enable: ReadWrite<u32>),
+        (0x08 => pub page_size: ReadWrite<u32>),
+        (0x0c => pub page_num: ReadWrite<u32>),
+        (0x10 => pub page_addr: ReadWrite<u32>),
+        (0x14 => pub fl_control: ReadWrite<u32, FlashControl::Register>),
+        (0x18 => pub op_status: ReadWrite<u32, FlashOpStatus::Register>),
+        (0x1c => pub ctrl_regwen: ReadWrite<u32, FlashCtrlRegwen::Register>),
+        (0x20 => pub flash_size: ReadWrite<u32>),
+        (0x24 => _reserved0),
+        (0x100 => pub buffer: [ReadWrite<u32>; 64]),
+        (0x200 => @END),
     },
     pub WrapperRegs {
         (0x0 => pub fpga_magic: ReadOnly<u32>),

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -193,6 +193,9 @@ pub struct SubsystemInitParams<'a> {
 
     // Offset of public key hashes in PROD_DEBUG_UNLOCK_PK_HASH_REG register bank for production debug unlock.
     pub prod_dbg_unlock_pk_hashes_offset: u32,
+
+    // Initial contents of the primary flash memory (for flash-based boot testing)
+    pub primary_flash_initial_contents: Option<&'a [u8]>,
 }
 
 impl Default for SubsystemInitParams<'_> {
@@ -204,6 +207,7 @@ impl Default for SubsystemInitParams<'_> {
             raw_unlock_token_hash: [0xf0930a4d, 0xde8a30e6, 0xd1c8cbba, 0x896e4a11],
             num_prod_dbg_unlock_pk_hashes: Default::default(),
             prod_dbg_unlock_pk_hashes_offset: Default::default(),
+            primary_flash_initial_contents: None,
         }
     }
 }

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -1321,8 +1321,9 @@ fn fw_load_error_image_len_more_than_bundle_size() {
             ..Default::default()
         };
         let mut fw_image = build_fw_image(image_options);
-        // Change runtime size to exceed bundle
-        fw_image.manifest.runtime.size += 4;
+        // Change runtime size to exceed bundle by more than 256 bytes to trigger the correct
+        // error on FPGA
+        fw_image.manifest.runtime.size += 260;
         update_manifest(&mut fw_image, HdrDigest::Update, TocDigest::Update);
 
         fw_load_error_flow(


### PR DESCRIPTION
We implement the flash logic in the model itself, backed by an array that can be provisioned by tests.
    
This is used only by MCU tests for now.
    
This also fixes a bug in the FPGA-only ROM that was gating on the the INDIRECT_FIFO_STATUS empty when reading from the I3C fifo, and instead gates on `payload_available`, which maps closer to how the standard DMA transfer works.
    
We also ensure that recovery images in FPGA to multiple of 256 bytes before loading them into the recovery interface to work around hardware issues with the `payload_available` bit (which only goes high if writes are always 256 bytes in size).
    
We have temporarily disabled flash until new bitstreams are available.
