### PR TITLE
[EMU]: OCP LOCK feature changes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,6 +157,7 @@ jobs:
         run: |
           CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked
           CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" run --manifest-path ./coverage/Cargo.toml
+          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test -p caliptra-runtime --features ocp-lock test_ocp_lock --locked
 
           CARGO_TARGET_DIR=target cargo --config "$EXTRA_CARGO_CONFIG" test --locked --manifest-path ci-tools/fpga-boss/Cargo.toml
 

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
@@ -64,6 +64,7 @@ fn test_derive_mek() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_eq!(response.mek_checksum, EXPECTED_MEK.checksum);
         assert_eq!(actual_mek.mek, EXPECTED_MEK.mek);
     });
@@ -99,6 +100,7 @@ fn test_derive_mek_warm_reset() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_eq!(response.mek_checksum, EXPECTED_MEK.checksum);
         assert_eq!(actual_mek.mek, EXPECTED_MEK.mek);
     });
@@ -130,6 +132,7 @@ fn test_derive_mek_warm_reset() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_eq!(response.mek_checksum, EXPECTED_MEK.checksum);
         assert_eq!(actual_mek.mek, EXPECTED_MEK.mek);
     });
@@ -213,6 +216,7 @@ fn test_derive_mek_debug_unlocked() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_eq!(response.mek_checksum, expected_debug_unlocked_mek.checksum);
         assert_eq!(actual_mek.mek, expected_debug_unlocked_mek.mek);
 
@@ -283,6 +287,7 @@ fn test_derive_corrupted_sek_no_checksum() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_ne!(response.mek_checksum, EXPECTED_MEK.checksum);
         assert_ne!(actual_mek.mek, EXPECTED_MEK.mek);
     });
@@ -350,6 +355,7 @@ fn test_derive_consumed_secret_seed() {
     validate_ocp_lock_response(&mut model, response, |response, actual_mek| {
         let response = response.unwrap().unwrap();
         let response = OcpLockDeriveMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+        let actual_mek = actual_mek.unwrap();
         assert_eq!(response.mek_checksum, EXPECTED_MEK.checksum);
         assert_eq!(actual_mek.mek, EXPECTED_MEK.mek);
     });

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_endorse_hpke_pubkey.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_endorse_hpke_pubkey.rs
@@ -14,7 +14,6 @@ use super::{
 //
 // TODO(clundin): Add tests ML-DSA endorsement after https://github.com/chipsalliance/caliptra-sw/issues/3106.
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_endorse_hpke_pubkey() {
     // This command should have no dependency on the HEK's availability, so don't include it here.
@@ -26,7 +25,6 @@ fn test_endorse_hpke_pubkey() {
     );
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_endorse_unknown_hpke_handle() {
     // This command should have no dependency on the HEK's availability, so don't include it here.

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_enumerate_hpke_handles.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_enumerate_hpke_handles.rs
@@ -14,7 +14,6 @@ use super::{boot_ocp_lock_runtime, validate_ocp_lock_response, OcpLockBootParams
 // * https://github.com/chipsalliance/caliptra-sw/issues/3033
 // * https://github.com/chipsalliance/caliptra-sw/issues/3034
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_enumerate_hpke_handles() {
     // This command should have no dependency on the HEK's availability, so don't include it here.

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mek.rs
@@ -16,7 +16,6 @@ use zerocopy::{FromBytes, IntoBytes};
 const WRAPPED_MEK_TYPE: u16 = 0x3;
 const WRAPPED_KEY_LEN: u32 = 64;
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_mek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -44,7 +43,6 @@ fn test_generate_mek() {
     });
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_missing_secret_seed() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -71,7 +69,6 @@ fn test_generate_missing_secret_seed() {
     });
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_consumed_secret_seed() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -113,7 +110,6 @@ fn test_generate_consumed_secret_seed() {
     });
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_mek_missing_hek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
@@ -17,8 +17,8 @@ use zerocopy::{FromBytes, IntoBytes};
 const WRAPPED_MEK_TYPE: u16 = 0x1;
 const WRAPPED_KEY_LEN: u32 = 32;
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
 fn test_generate_mpk() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
         hek_available: true,
@@ -49,6 +49,7 @@ fn test_generate_mpk() {
     });
 }
 
+// TODO(clundin): Update default HEK / pass in explicitly to make pass on emu.
 #[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_mpk_invalid_hpke_key() {
@@ -85,6 +86,7 @@ fn test_generate_mpk_invalid_hpke_key() {
     });
 }
 
+// TODO(clundin): Update default HEK / pass in explicitly to make pass on emu.
 #[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_generate_mpk_missing_hek() {

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_initialize_mek_secret.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_initialize_mek_secret.rs
@@ -8,7 +8,6 @@ use caliptra_kat::CaliptraError;
 
 use super::{boot_ocp_lock_runtime, validate_ocp_lock_response, OcpLockBootParams};
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_valid_mek_secret_seed() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -35,7 +34,6 @@ fn test_valid_mek_secret_seed() {
     });
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_initialize_mek_secret_no_hek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams::default());

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rotate_hpke_key.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rotate_hpke_key.rs
@@ -18,7 +18,6 @@ use super::{
 // TODO(clundin): Verify that the public key from endorsement changes.
 // TODO(clundin): When multiple algs are supported verify different orders of rotations will work.
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_rotate_ml_kem_hpke_handle() {
     // This command should have no dependency on the HEK's availability, so don't include it here.
@@ -108,7 +107,6 @@ fn test_rotate_ml_kem_hpke_handle() {
     }
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_rotate_unknown_hpke_handle() {
     // This command should have no dependency on the HEK's availability, so don't include it here.

--- a/sw-emulator/lib/periph/src/doe.rs
+++ b/sw-emulator/lib/periph/src/doe.rs
@@ -492,11 +492,10 @@ mod tests {
         let expected_uds = [0u8; 64];
         let expected_doe_key = [0u8; 32];
         let expected_fe = [0u8; 32];
-        let expected_hek_seed = [0u8; 32];
         let clock = Rc::new(Clock::new());
         let key_vault = KeyVault::new();
         let mci = Mci::new(vec![]);
-        let mut soc_reg = SocRegistersInternal::new(
+        let soc_reg = SocRegistersInternal::new(
             MailboxInternal::new(&clock, MailboxRam::default()),
             Iccm::new(&clock),
             mci.clone(),
@@ -506,12 +505,10 @@ mod tests {
                 ..CaliptraRootBusArgs::default()
             },
         );
-        soc_reg.set_hek_seed(&[0xABAB_ABAB; 8]);
         let mut doe = Doe::new(&clock, key_vault, soc_reg.clone());
         assert_ne!(soc_reg.uds(), expected_uds);
         assert_ne!(soc_reg.doe_key(), expected_doe_key);
         assert_ne!(soc_reg.field_entropy(), expected_fe);
-        assert_ne!(soc_reg.doe_hek_seed(), expected_hek_seed);
 
         assert_eq!(
             doe.write(
@@ -538,6 +535,5 @@ mod tests {
         assert_eq!(soc_reg.uds(), expected_uds);
         assert_eq!(soc_reg.doe_key(), expected_doe_key);
         assert_eq!(soc_reg.field_entropy(), expected_fe);
-        assert_eq!(soc_reg.doe_hek_seed(), expected_hek_seed);
     }
 }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1123,7 +1123,6 @@ impl SocRegistersImpl {
         self.fuse_uds_seed = [0u32; 16];
         self.fuse_field_entropy = [0u32; 8];
         self.internal_obf_key = [0u32; 8];
-        self.fuse_hek_seed = [0u32; 8];
     }
 
     fn write_disabled(&mut self, _size: RvSize, _val: RvData) -> Result<(), BusError> {


### PR DESCRIPTION
This makes the emulator work for a larger set of OCP LOCK tests. (test_derive_mek does not yet pass).

* Add OCP LOCK runtime tests to emulator PR check.
* Store last seen MEK for convenience (Not used yet).
* Clean up fuse management (Hek seed fuses were not being set / erased)