### PR TITLE
[2.0 Release]: Rename release tags to not conflict with the latest 2.x

### DIFF
--- a/.github/workflows/nightly-release-2.x.yml
+++ b/.github/workflows/nightly-release-2.x.yml
@@ -1,4 +1,4 @@
-name: Nightly Release 2.x
+name: Nightly Release 2.0
 
 on:
   workflow_dispatch:
@@ -7,8 +7,8 @@ on:
   - cron: '11 10 * * 2-6'
 
 jobs:
-  find-latest-release-2_x:
-    name: Find Latest Release 2.x
+  find-latest-release-2_0:
+    name: Find Latest Release 2.0
     runs-on: ubuntu-22.04
     outputs:
       create_release: ${{ steps.find.outputs.create_release }}
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: main-2.x
+          ref: caliptra-2.0
           submodules: 'true'
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
           TAG_PREFIX="release_v"
           TAG_BASE="${TAG_PREFIX}${DATE}_"
           INDEX=0
-          while git tag | grep ${TAG_BASE}${INDEX}-2.x; do
+          while git tag | grep ${TAG_BASE}${INDEX}-2.0; do
               ((INDEX+=1))
           done
           git submodule update --remote hw/latest/rtl
@@ -52,58 +52,58 @@ jobs:
                   echo "create_release=false" >> $GITHUB_OUTPUT
               fi
           fi
-          echo "new_release_tag=${TAG_BASE}${INDEX}-2.x" >> $GITHUB_OUTPUT
+          echo "new_release_tag=${TAG_BASE}${INDEX}-2.0" >> $GITHUB_OUTPUT
           echo "release_ref=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "Current ref $(git rev-parse HEAD) will receive tag ${TAG_BASE}${INDEX}-2.x after tests"
+          echo "Current ref $(git rev-parse HEAD) will receive tag ${TAG_BASE}${INDEX}-2.0 after tests"
 
-  sw-emulator-hw-latest-full-suite-etrng-log-2_x:
-    name: sw-emulator Suite (etrng, log) 2_x
-    needs: find-latest-release-2_x
-    if: needs.find-latest-release-2_x.outputs.create_release
+  sw-emulator-hw-latest-full-suite-etrng-log-2_0:
+    name: sw-emulator Suite (etrng, log) 2_0
+    needs: find-latest-release-2_0
+    if: needs.find-latest-release-2_0.outputs.create_release
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-latest-etrng-log
       extra-features: slow_tests
       rom-logging: true
 
-  sw-emulator-hw-latest-full-suite-etrng-nolog-2_x:
-    name: sw-emulator Suite (etrng, nolog) 2_x
-    needs: find-latest-release-2_x
-    if: needs.find-latest-release-2_x.outputs.create_release
+  sw-emulator-hw-latest-full-suite-etrng-nolog-2_0:
+    name: sw-emulator Suite (etrng, nolog) 2_0
+    needs: find-latest-release-2_0
+    if: needs.find-latest-release-2_0.outputs.create_release
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-latest-etrng-nolog
       extra-features: slow_tests
       rom-logging: false
 
-  sw-emulator-hw-latest-full-suite-itrng-log-2_x:
-    name: sw-emulator Suite (itrng, log) 2_x
-    needs: find-latest-release-2_x
-    if: needs.find-latest-release-2_x.outputs.create_release
+  sw-emulator-hw-latest-full-suite-itrng-log-2_0:
+    name: sw-emulator Suite (itrng, log) 2_0
+    needs: find-latest-release-2_0
+    if: needs.find-latest-release-2_0.outputs.create_release
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-latest-itrng-log
       extra-features: slow_tests,itrng
       rom-logging: true
 
-  sw-emulator-hw-latest-full-suite-itrng-nolog-2_x:
-    name: sw-emulator Suite (itrng, nolog) 2_x
-    needs: find-latest-release-2_x
-    if: needs.find-latest-release-2_x.outputs.create_release
+  sw-emulator-hw-latest-full-suite-itrng-nolog-2_0:
+    name: sw-emulator Suite (itrng, nolog) 2_0
+    needs: find-latest-release-2_0
+    if: needs.find-latest-release-2_0.outputs.create_release
     uses: ./.github/workflows/fw-test-emu.yml
     with:
       artifact-suffix: -sw-emulator-hw-latest-itrng-nolog
       extra-features: slow_tests,itrng
       rom-logging: false
 
-  create-release-2_x:
-    name: Create New Release 2_x
+  create-release-2_0:
+    name: Create New Release 2_0
     needs:
-      - find-latest-release-2_x
-      - sw-emulator-hw-latest-full-suite-etrng-log-2_x
-      - sw-emulator-hw-latest-full-suite-etrng-nolog-2_x
-      - sw-emulator-hw-latest-full-suite-itrng-log-2_x
-      - sw-emulator-hw-latest-full-suite-itrng-nolog-2_x
+      - find-latest-release-2_0
+      - sw-emulator-hw-latest-full-suite-etrng-log-2_0
+      - sw-emulator-hw-latest-full-suite-etrng-nolog-2_0
+      - sw-emulator-hw-latest-full-suite-itrng-log-2_0
+      - sw-emulator-hw-latest-full-suite-itrng-nolog-2_0
 
     runs-on: ubuntu-22.04
 
@@ -115,12 +115,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-          ref: ${{ needs.find-latest-release-2_x.outputs.release_ref }}
+          ref: ${{ needs.find-latest-release-2_0.outputs.release_ref }}
 
       - name: Generate release zip
         run: |
-          ./ci-tools/release/build_release.sh ${{ needs.find-latest-release-2_x.outputs.new_release_tag }}
-          mv ./release/release.zip ./release/caliptra_${{ needs.find-latest-release-2_x.outputs.new_release_tag }}.zip
+          ./ci-tools/release/build_release.sh ${{ needs.find-latest-release-2_0.outputs.new_release_tag }}
+          mv ./release/release.zip ./release/caliptra_${{ needs.find-latest-release-2_0.outputs.new_release_tag }}.zip
 
       - name: 'Download all artifacts'
         uses: actions/download-artifact@v4
@@ -129,32 +129,32 @@ jobs:
 
       - name: Package all test artifacts for release
         run: |
-          (cd /tmp/artifacts && zip -r - .) > ./release/test_artifacts_${{ needs.find-latest-release-2_x.outputs.new_release_tag }}.zip
+          (cd /tmp/artifacts && zip -r - .) > ./release/test_artifacts_${{ needs.find-latest-release-2_0.outputs.new_release_tag }}.zip
 
       - name: Tag repo with new release number
         run: |
           git config --global user.name "GitHub CI"
           git config --global user.email "username@users.noreply.github.com"
-          git tag ${{ needs.find-latest-release-2_x.outputs.new_release_tag }}
-          git push origin ${{ needs.find-latest-release-2_x.outputs.new_release_tag }}
+          git tag ${{ needs.find-latest-release-2_0.outputs.new_release_tag }}
+          git push origin ${{ needs.find-latest-release-2_0.outputs.new_release_tag }}
 
       - name: Upload release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ./release/caliptra_${{ needs.find-latest-release-2_x.outputs.new_release_tag }}.zip
-            ./release/test_artifacts_${{ needs.find-latest-release-2_x.outputs.new_release_tag }}.zip
-          tag_name: ${{ needs.find-latest-release-2_x.outputs.new_release_tag }}
+            ./release/caliptra_${{ needs.find-latest-release-2_0.outputs.new_release_tag }}.zip
+            ./release/test_artifacts_${{ needs.find-latest-release-2_0.outputs.new_release_tag }}.zip
+          tag_name: ${{ needs.find-latest-release-2_0.outputs.new_release_tag }}
           prerelease: true
 
       - name: Write artifact to workflow with release info
         run: |
-          mkdir /tmp/release-info-2_x
-          echo "${{ needs.find-latest-release-2_x.outputs.new_release_tag }}" > /tmp/release-info-2_x/tag-name
-          echo "caliptra_${{ needs.find-latest-release-2_x.outputs.new_release_tag }}.zip" > /tmp/release-info-2_x/zip-file-name
+          mkdir /tmp/release-info-2_0
+          echo "${{ needs.find-latest-release-2_0.outputs.new_release_tag }}" > /tmp/release-info-2_0/tag-name
+          echo "caliptra_${{ needs.find-latest-release-2_0.outputs.new_release_tag }}.zip" > /tmp/release-info-2_0/zip-file-name
 
       - name: Write artifact with release info
         uses: actions/upload-artifact@v4
         with:
-          name: release-info-2_x
-          path: /tmp/release-info-2_x
+          name: release-info-2_0
+          path: /tmp/release-info-2_0


### PR DESCRIPTION
tag

The 2.0 release branch should use 2.0 instead of 2.x