### PR TITLE
[dpe] Unify DPE environment creation

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -145,14 +145,8 @@ pub use soc_ifc::{report_boot_status, CptraGeneration, Lifecycle, MfgFlags, Rese
 pub use trng::Trng;
 
 #[allow(unused_imports)]
-#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
-use caliptra_cfi_derive;
-#[allow(unused_imports)]
 #[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_derive_git as caliptra_cfi_derive;
-#[allow(unused_imports)]
-#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
-use caliptra_cfi_lib;
 #[allow(unused_imports)]
 #[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_lib_git as caliptra_cfi_lib;

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -543,10 +543,10 @@ impl Drivers {
             crypto,
             platform: DpePlatform::new(
                 CALIPTRA_LOCALITY,
-                &hashed_rt_pub_key,
+                hashed_rt_pub_key,
                 &drivers.ecc_cert_chain,
-                &nb,
-                &nf,
+                nb,
+                nf,
                 None,
                 None,
             ),


### PR DESCRIPTION
Previously creating the DPE environment was copy and pasted in several locations and doing almost exactly the same thing in all of them. This unifies the creation into a simple function call. This will save a lot of complexity when we need to keep track of two environments depending on if the command is for ECDSA or MLDSA.