### PR TITLE
Move okref to a separate common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "caliptra-hw-model-types",
  "caliptra-image-types",
  "caliptra-lms-types",
+ "caliptra-okref",
  "caliptra-registers",
  "caliptra-test",
  "cfg-if",
@@ -798,6 +799,10 @@ dependencies = [
  "zerocopy",
  "zeroize",
 ]
+
+[[package]]
+name = "caliptra-okref"
+version = "0.1.0"
 
 [[package]]
 name = "caliptra-registers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "ci-tools/file-header-fix",
   "ci-tools/size-history",
   "common",
+  "common/okref",
   "coverage",
   "cpu",
   "drivers",
@@ -132,6 +133,7 @@ caliptra-image-types = { path = "image/types", default-features = false }
 caliptra-image-verify = { path = "image/verify", default-features = false }
 caliptra-kat = { path = "kat" }
 caliptra-lms-types = { path = "lms-types" }
+caliptra-okref = { path = "common/okref" }
 caliptra-registers = { path = "registers" }
 caliptra-registers-latest = { path = "hw/latest/registers" }
 caliptra-runtime = { path = "runtime", default-features = false }

--- a/common/okref/Cargo.toml
+++ b/common/okref/Cargo.toml
@@ -1,0 +1,6 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-okref"
+version = "0.1.0"
+edition = "2021"

--- a/common/okref/src/lib.rs
+++ b/common/okref/src/lib.rs
@@ -1,4 +1,5 @@
 // Licensed under the Apache-2.0 license
+#![cfg_attr(not(test), no_std)]
 
 /// This function makes it easier to efficiently deal with Result types with
 /// large `Ok` variants.
@@ -6,8 +7,6 @@
 /// Consider this code:
 ///
 /// ```
-/// use caliptra_drivers::okref;
-///
 /// fn some_function() -> Result<[u32; 64], u32> {
 ///     Ok([0u32; 64])
 /// }
@@ -26,7 +25,7 @@
 /// original stack location, eliminating the memcpy:
 ///
 /// ```
-/// use caliptra_drivers::okref;
+/// use caliptra_okref::okref;
 ///
 /// fn some_function() -> Result<[u32; 64], u32> {
 ///     Ok([0u32; 64])

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -16,6 +16,7 @@ caliptra-api.workspace = true
 caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types.workspace = true
 caliptra-lms-types.workspace = true
+caliptra-okref.workspace = true
 caliptra-auth-man-types.workspace = true
 caliptra-registers.workspace = true
 cfg-if.workspace = true

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -45,7 +45,6 @@ pub mod memory_layout;
 mod ml_kem;
 mod mldsa87;
 pub mod ocp_lock;
-mod okref;
 mod pcr_bank;
 pub mod pcr_log;
 pub mod pcr_reset;
@@ -74,6 +73,8 @@ pub use array::{
 pub use array_concat::array_concat3;
 pub use bounded_address::{BoundedAddr, MemBounds, RomAddr};
 pub use caliptra_error::{CaliptraError, CaliptraResult};
+pub use caliptra_okref::okmutref;
+pub use caliptra_okref::okref;
 pub use cmac_kdf::cmac_kdf;
 pub use csrng::{
     Csrng, HealthFailCounts as CsrngHealthFailCounts, Seed as CsrngSeed, MAX_SEED_WORDS,
@@ -119,8 +120,6 @@ pub use mldsa87::{
     Mldsa87Signature,
 };
 pub use ocp_lock::HekSeedState;
-pub use okref::okmutref;
-pub use okref::okref;
 pub use pcr_bank::{PcrBank, PcrId};
 pub use pcr_reset::PcrResetCounter;
 pub use persistent::fmc_alias_csr::FmcAliasCsrs;


### PR DESCRIPTION
Starts the discussed concept of common firmware libraries. This will be used to optimize stack usage in `caliptra-dpe`.