### PR TITLE
[OCP-LOCK]: Add HPKE Pub Key Endorsement by MLDSA

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -4314,7 +4314,7 @@ impl Request for OcpLockGetAlgorithmsReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct EndorsementAlgorithms(u32);
 
 bitflags! {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -49,7 +49,7 @@ pub use pmp::lock_datavault_region;
 pub const FMC_ORG: u32 = 0x40000000;
 pub const FMC_SIZE: u32 = 36 * 1024; // Must be 4k aligned
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 163 * 1024;
+pub const RUNTIME_SIZE: u32 = 167 * 1024;
 
 pub use memory_layout::{EXTRA_MEMORY_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -25,10 +25,14 @@ use dpe::U8Bool;
 use zerocopy::{FromBytes, IntoBytes};
 
 use openssl::x509::X509;
+use x509_parser::der_parser::ber::parse_ber_sequence;
 use x509_parser::nom::Parser;
+use x509_parser::oid_registry::asn1_rs::oid;
 use x509_parser::prelude::*;
 
-use crate::common::{get_rt_alias_ecc384_cert, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    get_rt_alias_ecc384_cert, get_rt_alias_mldsa87_cert, run_rt_test, RuntimeTestArgs,
+};
 
 mod test_access_key;
 mod test_derive_mek;
@@ -264,10 +268,26 @@ fn verify_hpke_pub_key(
     model: &mut DefaultHwModel,
     hpke_handle: HpkeHandle,
 ) -> Option<ValidatedHpkeHandle> {
-    // TODO(clundin): Update for ML-DSA endorsement after https://github.com/chipsalliance/caliptra-sw/issues/3106.
+    let ecdsa_res = verify_hpke_pub_key_with_algo(
+        model,
+        hpke_handle.clone(),
+        EndorsementAlgorithms::ECDSA_P384_SHA384,
+    );
+    let mldsa_res =
+        verify_hpke_pub_key_with_algo(model, hpke_handle, EndorsementAlgorithms::ML_DSA_87);
+
+    assert_eq!(ecdsa_res, mldsa_res);
+    ecdsa_res
+}
+
+fn verify_hpke_pub_key_with_algo(
+    model: &mut DefaultHwModel,
+    hpke_handle: HpkeHandle,
+    endorsement_algorithm: EndorsementAlgorithms,
+) -> Option<ValidatedHpkeHandle> {
     let mut cmd = MailboxReq::OcpLockEndorseHpkePubKey(OcpLockEndorseHpkePubKeyReq {
         hpke_handle: hpke_handle.handle,
-        endorsement_algorithm: EndorsementAlgorithms::ECDSA_P384_SHA384,
+        endorsement_algorithm: endorsement_algorithm.clone(),
         ..Default::default()
     });
     cmd.populate_chksum().unwrap();
@@ -295,7 +315,12 @@ fn verify_hpke_pub_key(
         );
         endorse_resp
     })?;
-    verify_endorsement_certificate(model, &endorse_resp);
+    verify_endorsement_certificate(
+        model,
+        &endorse_resp,
+        endorsement_algorithm,
+        &hpke_handle.hpke_algorithm,
+    );
     Some(ValidatedHpkeHandle {
         hpke_handle,
         pub_key: endorse_resp.pub_key[..endorse_resp.pub_key_len as usize].to_vec(),
@@ -305,11 +330,23 @@ fn verify_hpke_pub_key(
 fn verify_endorsement_certificate(
     model: &mut DefaultHwModel,
     endorse_resp: &OcpLockEndorseHpkePubKeyResp,
+    endorsement_algorithm: EndorsementAlgorithms,
+    expected_hpke_alg: &HpkeAlgorithms,
 ) {
     // Get RT Alias Cert
-    let rt_alias_cert_resp = get_rt_alias_ecc384_cert(model);
-    let rt_alias_cert =
-        X509::from_der(&rt_alias_cert_resp.data[..rt_alias_cert_resp.data_size as usize]).unwrap();
+    let rt_alias_cert = match endorsement_algorithm {
+        EndorsementAlgorithms::ECDSA_P384_SHA384 => {
+            let rt_alias_cert_resp = get_rt_alias_ecc384_cert(model);
+            X509::from_der(&rt_alias_cert_resp.data[..rt_alias_cert_resp.data_size as usize])
+                .unwrap()
+        }
+        EndorsementAlgorithms::ML_DSA_87 => {
+            let rt_alias_cert_resp = get_rt_alias_mldsa87_cert(model);
+            X509::from_der(&rt_alias_cert_resp.data[..rt_alias_cert_resp.data_size as usize])
+                .unwrap()
+        }
+        _ => panic!("Unsupported endorsement algorithm"),
+    };
 
     // Verify Endorsement Certificate Signature
     let endorsement_cert_der = &endorse_resp.endorsement[..endorse_resp.endorsement_len as usize];
@@ -325,10 +362,54 @@ fn verify_endorsement_certificate(
     let (_, cert_parsed) = X509CertificateParser::new()
         .parse(endorsement_cert_der)
         .unwrap();
-    let spki = cert_parsed.tbs_certificate.subject_pki;
 
     // Ensure the public key in response is contained in the certificate's SPKI
-    assert_eq!(spki.subject_public_key.data, pub_key_resp);
+    assert_eq!(
+        cert_parsed
+            .tbs_certificate
+            .subject_pki
+            .subject_public_key
+            .data,
+        pub_key_resp
+    );
+
+    // Verify HPKE Identifiers Extension
+    let hpke_oid = oid!(2.23.133 .21 .1 .1);
+    let hpke_ext = cert_parsed
+        .tbs_certificate
+        .extensions()
+        .iter()
+        .find(|e| e.oid == hpke_oid)
+        .expect("HPKE Identifiers extension not found");
+
+    let (_, seq) =
+        parse_ber_sequence(hpke_ext.value).expect("Failed to parse HPKE identifiers sequence");
+
+    let items = seq
+        .content
+        .as_sequence()
+        .expect("HPKE Identifiers extension is not a sequence");
+
+    assert_eq!(items.len(), 3);
+
+    let kem_id = items[0].as_u32().unwrap();
+    let kdf_id = items[1].as_u32().unwrap();
+    let aead_id = items[2].as_u32().unwrap();
+
+    assert_eq!(kdf_id, 0x0002);
+    assert_eq!(aead_id, 0x0002);
+
+    match *expected_hpke_alg {
+        HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM => {
+            assert_eq!(kem_id, 0x0042);
+        }
+        _ => {
+            panic!(
+                "Unverified HPKE alg: {:?} IDs: {} {} {}",
+                expected_hpke_alg, kem_id, kdf_id, aead_id
+            );
+        }
+    }
 }
 
 fn encrypt_message_to_hpke_pub_key(

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_endorse_hpke_pubkey.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_endorse_hpke_pubkey.rs
@@ -11,8 +11,6 @@ use super::{
 // TODO(clundin): Add tests for hybrid and ECDH KEMs once implemented
 // * https://github.com/chipsalliance/caliptra-sw/issues/3033
 // * https://github.com/chipsalliance/caliptra-sw/issues/3034
-//
-// TODO(clundin): Add tests ML-DSA endorsement after https://github.com/chipsalliance/caliptra-sw/issues/3106.
 
 #[test]
 fn test_endorse_hpke_pubkey() {

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
@@ -36,8 +36,8 @@ impl OcpLockEcdh384CertTbsEcc384 {
     const SUBJECT_SN_OFFSET: usize = 255usize;
     const ISSUER_SN_OFFSET: usize = 95usize;
     const SERIAL_NUMBER_OFFSET: usize = 11usize;
-    const SUBJECT_KEY_ID_OFFSET: usize = 517usize;
-    const AUTHORITY_KEY_ID_OFFSET: usize = 550usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 510usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 543usize;
     const NOT_BEFORE_OFFSET: usize = 163usize;
     const NOT_AFTER_OFFSET: usize = 180usize;
     const PUBLIC_KEY_LEN: usize = 97usize;
@@ -48,9 +48,9 @@ impl OcpLockEcdh384CertTbsEcc384 {
     const AUTHORITY_KEY_ID_LEN: usize = 20usize;
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
-    pub const TBS_TEMPLATE_LEN: usize = 570usize;
+    pub const TBS_TEMPLATE_LEN: usize = 563usize;
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
-        48u8, 130u8, 2u8, 54u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 130u8, 2u8, 47u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
         37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8,
@@ -79,15 +79,15 @@ impl OcpLockEcdh384CertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8,
-        1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
-        15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 27u8, 6u8, 6u8, 103u8, 129u8,
-        5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8, 3u8, 2u8, 1u8, 17u8, 48u8, 3u8, 2u8, 1u8,
-        2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8,
-        20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8,
-        48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8,
+        1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8,
+        1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8,
+        21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+        29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8,
     ];
     pub fn new(params: &OcpLockEcdh384CertTbsEcc384Params) -> Self {
         let mut template = Self {
@@ -108,7 +108,7 @@ impl OcpLockEcdh384CertTbsEcc384 {
     fn apply(&mut self, params: &OcpLockEcdh384CertTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
-            buf: &mut [u8; 570usize],
+            buf: &mut [u8; 563usize],
             val: &[u8; LEN],
         ) {
             buf[OFFSET..OFFSET + LEN].copy_from_slice(val);

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
@@ -36,8 +36,8 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
     const SUBJECT_SN_OFFSET: usize = 257usize;
     const ISSUER_SN_OFFSET: usize = 97usize;
     const SERIAL_NUMBER_OFFSET: usize = 11usize;
-    const SUBJECT_KEY_ID_OFFSET: usize = 519usize;
-    const AUTHORITY_KEY_ID_OFFSET: usize = 552usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 512usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 545usize;
     const NOT_BEFORE_OFFSET: usize = 165usize;
     const NOT_AFTER_OFFSET: usize = 182usize;
     const PUBLIC_KEY_LEN: usize = 97usize;
@@ -48,9 +48,9 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
     const AUTHORITY_KEY_ID_LEN: usize = 20usize;
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
-    pub const TBS_TEMPLATE_LEN: usize = 572usize;
+    pub const TBS_TEMPLATE_LEN: usize = 565usize;
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
-        48u8, 130u8, 2u8, 56u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 130u8, 2u8, 49u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
         49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8,
@@ -79,15 +79,15 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8, 48u8, 15u8,
-        6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8,
-        14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8,
-        27u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8, 3u8, 2u8,
-        1u8, 17u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8,
-        29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8,
-        85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8,
+        85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8,
+        3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8,
+        6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8,
+        2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8,
+        128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     pub fn new(params: &OcpLockEcdh384CertTbsMlDsa87Params) -> Self {
         let mut template = Self {
@@ -108,7 +108,7 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
     fn apply(&mut self, params: &OcpLockEcdh384CertTbsMlDsa87Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
-            buf: &mut [u8; 572usize],
+            buf: &mut [u8; 565usize],
             val: &[u8; LEN],
         ) {
             buf[OFFSET..OFFSET + LEN].copy_from_slice(val);

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
@@ -36,8 +36,8 @@ impl OcpLockMlKemCertTbsEcc384 {
     const SUBJECT_SN_OFFSET: usize = 256usize;
     const ISSUER_SN_OFFSET: usize = 95usize;
     const SERIAL_NUMBER_OFFSET: usize = 11usize;
-    const SUBJECT_KEY_ID_OFFSET: usize = 1988usize;
-    const AUTHORITY_KEY_ID_OFFSET: usize = 2021usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 1981usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 2014usize;
     const NOT_BEFORE_OFFSET: usize = 163usize;
     const NOT_AFTER_OFFSET: usize = 180usize;
     const PUBLIC_KEY_LEN: usize = 1568usize;
@@ -48,9 +48,9 @@ impl OcpLockMlKemCertTbsEcc384 {
     const AUTHORITY_KEY_ID_LEN: usize = 20usize;
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
-    pub const TBS_TEMPLATE_LEN: usize = 2041usize;
+    pub const TBS_TEMPLATE_LEN: usize = 2034usize;
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
-        48u8, 130u8, 7u8, 245u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 130u8, 7u8, 238u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8,
         49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8,
@@ -177,15 +177,15 @@ impl OcpLockMlKemCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8, 48u8, 15u8,
-        6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8,
-        14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8,
-        27u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8, 3u8, 2u8,
-        1u8, 66u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8,
-        29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8,
-        85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8,
+        85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8,
+        3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8,
+        6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 2u8, 1u8,
+        2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8,
+        128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     pub fn new(params: &OcpLockMlKemCertTbsEcc384Params) -> Self {
         let mut template = Self {
@@ -206,7 +206,7 @@ impl OcpLockMlKemCertTbsEcc384 {
     fn apply(&mut self, params: &OcpLockMlKemCertTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
-            buf: &mut [u8; 2041usize],
+            buf: &mut [u8; 2034usize],
             val: &[u8; LEN],
         ) {
             buf[OFFSET..OFFSET + LEN].copy_from_slice(val);

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
@@ -36,8 +36,8 @@ impl OcpLockMlKemCertTbsMlDsa87 {
     const SUBJECT_SN_OFFSET: usize = 258usize;
     const ISSUER_SN_OFFSET: usize = 97usize;
     const SERIAL_NUMBER_OFFSET: usize = 11usize;
-    const SUBJECT_KEY_ID_OFFSET: usize = 1990usize;
-    const AUTHORITY_KEY_ID_OFFSET: usize = 2023usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 1983usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 2016usize;
     const NOT_BEFORE_OFFSET: usize = 165usize;
     const NOT_AFTER_OFFSET: usize = 182usize;
     const PUBLIC_KEY_LEN: usize = 1568usize;
@@ -48,9 +48,9 @@ impl OcpLockMlKemCertTbsMlDsa87 {
     const AUTHORITY_KEY_ID_LEN: usize = 20usize;
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
-    pub const TBS_TEMPLATE_LEN: usize = 2043usize;
+    pub const TBS_TEMPLATE_LEN: usize = 2036usize;
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
-        48u8, 130u8, 7u8, 247u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 130u8, 7u8, 240u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
         115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8,
@@ -177,16 +177,15 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 129u8, 128u8, 48u8, 126u8,
-        48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8,
-        0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8,
-        32u8, 48u8, 27u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 17u8, 48u8, 15u8, 48u8,
-        3u8, 2u8, 1u8, 66u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 3u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8,
-        3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8,
-        6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8,
+        15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8,
+        48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8,
+        48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8,
+        66u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8,
+        20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8,
+        48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     pub fn new(params: &OcpLockMlKemCertTbsMlDsa87Params) -> Self {
         let mut template = Self {
@@ -207,7 +206,7 @@ impl OcpLockMlKemCertTbsMlDsa87 {
     fn apply(&mut self, params: &OcpLockMlKemCertTbsMlDsa87Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
-            buf: &mut [u8; 2043usize],
+            buf: &mut [u8; 2036usize],
             val: &[u8; LEN],
         ) {
             buf[OFFSET..OFFSET + LEN].copy_from_slice(val);

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -498,17 +498,17 @@ pub struct AeadId(u16);
 /// Section 4.2.2.1.3.1
 #[derive(asn1::Asn1Read, asn1::Asn1Write)]
 pub struct HPKEIdentifiers {
-    kem_id: KemId,
-    kdf_id: KdfId,
-    aead_id: AeadId,
+    kem_id: u16,
+    kdf_id: u16,
+    aead_id: u16,
 }
 
 impl HPKEIdentifiers {
     pub fn new(kem_id: KemId, kdf_id: KdfId, aead_id: AeadId) -> Self {
         Self {
-            kem_id,
-            kdf_id,
-            aead_id,
+            kem_id: kem_id.0,
+            kdf_id: kdf_id.0,
+            aead_id: aead_id.0,
         }
     }
 }


### PR DESCRIPTION
This signs the HPKE pub key with the Caliptra run time ML-DSA key.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/3170.