### PR TITLE
drivers: Refactor MLKEM / MLDSA drivers to use common AbrReg

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-703a3084c33e8fb675a8de4e91e7ec6af04638ed27c3bf82fd810529588a7a0e18668378094b23eba2f03b6cad146b38  caliptra-rom-no-log.bin
-ddf85e2c85d3e6c495862003051e34be63f599e58de5807a189e19cae72dc527c99a473e76b3181c969d4fed419ac046  caliptra-rom-with-log.bin
+f19e5bb62c69092de823d30e02465d2a8f5847157268145145d1eb21f02f53cd0a65cc81f3b850f5cb347c915c21c231  caliptra-rom-no-log.bin
+e88e0c32e6efffc7e3be73383d67863ec3277c29a03e964ef8beb5cd2bca443b5aae0b9931833c6507b37678e87db5c0  caliptra-rom-with-log.bin

--- a/common/src/verifier.rs
+++ b/common/src/verifier.rs
@@ -35,20 +35,20 @@ pub enum ImageSource<'a, 'b> {
 }
 
 /// ROM Verification Environemnt
-pub struct FirmwareImageVerificationEnv<'a, 'b> {
+pub struct FirmwareImageVerificationEnv<'a, 'b, 'c> {
     pub sha256: &'a mut Sha256,
     pub sha2_512_384: &'a mut Sha2_512_384,
     pub sha2_512_384_acc: &'a mut Sha2_512_384Acc,
     pub soc_ifc: &'a mut SocIfc,
     pub ecc384: &'a mut Ecc384,
-    pub mldsa87: &'a mut Mldsa87,
+    pub mldsa87: &'a mut Mldsa87<'c>,
     pub data_vault: &'a DataVault,
     pub pcr_bank: &'a mut PcrBank,
     pub image_source: ImageSource<'a, 'b>,
     pub persistent_data: &'a PersistentData,
 }
 
-impl FirmwareImageVerificationEnv<'_, '_> {
+impl FirmwareImageVerificationEnv<'_, '_, '_> {
     fn create_dma_recovery<'a>(soc_ifc: &'a SocIfc, dma: &'a Dma) -> DmaRecovery<'a> {
         DmaRecovery::new(
             soc_ifc.recovery_interface_base_addr().into(),
@@ -98,7 +98,7 @@ impl FirmwareImageVerificationEnv<'_, '_> {
     }
 }
 
-impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_> {
+impl ImageVerificationEnv for &mut FirmwareImageVerificationEnv<'_, '_, '_> {
     /// Calculate 384 digest using SHA2 Engine
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest384> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;

--- a/drivers/src/abr.rs
+++ b/drivers/src/abr.rs
@@ -1,0 +1,106 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    abr.rs
+
+Abstract:
+
+    File contains ABR (Adams Bridge) hardware driver that provides
+    closure-based access to ML-KEM and ML-DSA functionality.
+
+--*/
+
+use caliptra_registers::abr::AbrReg;
+
+use crate::{MlKem1024, Mldsa87};
+
+/// ABR (Adams Bridge) hardware driver.
+///
+/// This driver owns the ABR register block and provides methods to
+/// use the ML-KEM and ML-DSA functionality through closures.
+/// This ensures that only one driver is using the hardware at a time.
+pub struct Abr {
+    // We store the AbrReg to signify ownership. The actual access
+    // is through temporary drivers created in the closure methods.
+    abr: AbrReg,
+}
+
+impl Abr {
+    /// Create a new ABR driver.
+    ///
+    /// # Arguments
+    ///
+    /// * `abr` - The ABR register block
+    pub fn new(abr: AbrReg) -> Self {
+        Self { abr }
+    }
+
+    /// Get a mutable reference to the ABR register block.
+    ///
+    /// This allows creating `Mldsa87` or `MlKem1024` drivers directly
+    /// when the closure-based API is not suitable due to lifetime constraints.
+    pub fn abr_reg(&mut self) -> &mut AbrReg {
+        &mut self.abr
+    }
+
+    /// Execute a closure with access to the ML-DSA-87 driver.
+    ///
+    /// The closure receives an `Mldsa87` driver by value that can be used
+    /// for ML-DSA cryptographic operations. The driver is automatically
+    /// dropped when the closure returns.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - Closure that receives `Mldsa87`
+    ///
+    /// # Returns
+    ///
+    /// The return value of the closure
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let pub_key = abr.with_mldsa87(|mut mldsa| {
+    ///     mldsa.key_pair(seed, trng, None)
+    /// })?;
+    /// ```
+    pub fn with_mldsa87<'s, F, R>(&'s mut self, f: F) -> R
+    where
+        F: FnOnce(Mldsa87<'s>) -> R,
+    {
+        let mldsa87 = Mldsa87::new(&mut self.abr);
+        f(mldsa87)
+    }
+
+    /// Execute a closure with access to the ML-KEM-1024 driver.
+    ///
+    /// The closure receives an `MlKem1024` driver by value that can be used
+    /// for ML-KEM cryptographic operations. The driver is automatically
+    /// dropped when the closure returns.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - Closure that receives `MlKem1024`
+    ///
+    /// # Returns
+    ///
+    /// The return value of the closure
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let (encaps_key, decaps_key) = abr.with_ml_kem(|mut ml_kem| {
+    ///     ml_kem.key_pair(seeds)
+    /// })?;
+    /// ```
+    pub fn with_ml_kem<'s, F, R>(&'s mut self, f: F) -> R
+    where
+        F: FnOnce(MlKem1024<'s>) -> R,
+    {
+        let ml_kem = MlKem1024::new(&mut self.abr);
+        f(ml_kem)
+    }
+}

--- a/drivers/src/hpke/kem/hybrid.rs
+++ b/drivers/src/hpke/kem/hybrid.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     Array4x28, Array4x8, Ecc384, Hmac, LEArray4x8, MlKem1024, MlKem1024EncapsKey, Sha3, Trng,
 };
+use caliptra_registers::abr::AbrReg;
 
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -146,28 +147,30 @@ impl MlKem1024P384 {
     }
 }
 
-pub struct MlKem1024P384KemContext<'a> {
+pub struct MlKem1024P384KemContext<'a, 'b: 'a> {
     trng: &'a mut Trng,
     sha: &'a mut Sha3,
-    ml_kem: &'a mut MlKem1024,
+    abr_reg: &'a mut AbrReg,
     ecc: &'a mut Ecc384,
     hmac: &'a mut Hmac,
+    _phantom: core::marker::PhantomData<&'b ()>,
 }
 
-impl<'a> MlKem1024P384KemContext<'a> {
+impl<'a, 'b: 'a> MlKem1024P384KemContext<'a, 'b> {
     pub fn new(
         trng: &'a mut Trng,
         sha: &'a mut Sha3,
-        ml_kem: &'a mut MlKem1024,
+        abr_reg: &'a mut AbrReg,
         ecc: &'a mut Ecc384,
         hmac: &'a mut Hmac,
     ) -> Self {
         Self {
             trng,
             sha,
-            ml_kem,
+            abr_reg,
             ecc,
             hmac,
+            _phantom: core::marker::PhantomData,
         }
     }
 }
@@ -181,10 +184,13 @@ impl
     > for MlKem1024P384
 {
     const KEM_ID: KemId = KemId::ML_KEM_1024_P384;
-    type CONTEXT<'a> = MlKem1024P384KemContext<'a>;
+    type CONTEXT<'a, 'b>
+        = MlKem1024P384KemContext<'a, 'b>
+    where
+        'b: 'a;
     type EK = HybridEncapsulationKey;
 
-    fn derive_key_pair(ctx: &mut Self::CONTEXT<'_>, ikm: &[u8; 32]) -> CaliptraResult<Self> {
+    fn derive_key_pair(ctx: &mut Self::CONTEXT<'_, '_>, ikm: &[u8; 32]) -> CaliptraResult<Self> {
         let (_, trad_seed) = Self::expand_seed(ctx.sha, ikm)?;
         let mut ctx = P384KemContext::new(ctx.trng, ctx.ecc, ctx.hmac);
         let trad = P384::derive_key_pair_raw(&mut ctx, &trad_seed)?;
@@ -193,7 +199,7 @@ impl
 
     fn encap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         encaps_key: &Self::EK,
     ) -> CaliptraResult<(HybridEncapsulatedSecret, HybridSharedSecret)> {
         let encaps_key: &[u8; Self::NPK] = encaps_key.as_ref();
@@ -209,7 +215,8 @@ impl
 
         let (pq_enc, pq_shared_secret) = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.encap(&mut ctx, pq_ek)?
         };
@@ -233,7 +240,7 @@ impl
 
     fn decap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         enc: &HybridEncapsulatedSecret,
     ) -> CaliptraResult<HybridSharedSecret> {
         let enc = enc.as_ref();
@@ -244,7 +251,8 @@ impl
 
         let pq_shared_secret = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.decap(&mut ctx, pq_enc)?
         };
@@ -267,11 +275,12 @@ impl
 
     fn serialize_public_key(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
     ) -> CaliptraResult<HybridEncapsulationKey> {
         let pq_ek = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.serialize_public_key(&mut ctx)?
         };

--- a/drivers/src/hpke/kem/mlkem.rs
+++ b/drivers/src/hpke/kem/mlkem.rs
@@ -84,15 +84,15 @@ impl From<[u8; 64]> for MlKemDecapsulationKey {
     }
 }
 
-pub struct MlKemContext<'a> {
+pub struct MlKemContext<'a, 'b> {
     sha: &'a mut Sha3,
-    ml_kem: &'a mut MlKem1024,
+    ml_kem: &'a mut MlKem1024<'b>,
     trng: &'a mut Trng,
 }
 
-impl<'a> MlKemContext<'a> {
+impl<'a, 'b> MlKemContext<'a, 'b> {
     /// Create a new instance of `MlKemContext`
-    pub fn new(trng: &'a mut Trng, sha: &'a mut Sha3, ml_kem: &'a mut MlKem1024) -> Self {
+    pub fn new(trng: &'a mut Trng, sha: &'a mut Sha3, ml_kem: &'a mut MlKem1024<'b>) -> Self {
         Self { trng, sha, ml_kem }
     }
 }
@@ -123,7 +123,7 @@ impl MlKem {
     /// compute the corresponding encapsulation key
     fn expand_decaps_key(
         &mut self,
-        ctx: &mut MlKemContext<'_>,
+        ctx: &mut MlKemContext<'_, '_>,
     ) -> CaliptraResult<(MlKem1024EncapsKey, MlKem1024DecapsKey)> {
         let (a, b) = {
             let mut a = [0; 32];
@@ -145,11 +145,14 @@ impl MlKem {
 
 impl Kem<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }> for MlKem {
     const KEM_ID: KemId = KemId::ML_KEM_1024;
-    type CONTEXT<'a> = MlKemContext<'a>;
+    type CONTEXT<'a, 'b>
+        = MlKemContext<'a, 'b>
+    where
+        'b: 'a;
     type EK = MlKem1024EncapsKey;
 
     fn derive_key_pair(
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         ikm: &[u8; MlKem::NSK],
     ) -> CaliptraResult<Self> {
         let ikm: Array4x16 = kdf::Shake256::<{ MlKem::NSK as u16 }>::labeled_derive(
@@ -164,7 +167,7 @@ impl Kem<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }> fo
 
     fn encap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         encaps_key: &Self::EK,
     ) -> CaliptraResult<(MlKemEncapsulatedSecret, MlKemSharedSecret)> {
         let message = {
@@ -190,7 +193,7 @@ impl Kem<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }> fo
     /// See https://datatracker.ietf.org/doc/draft-ietf-hpke-pq/03/ section 3.
     fn decap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         enc: &MlKemEncapsulatedSecret,
     ) -> CaliptraResult<MlKemSharedSecret> {
         let (_ek, dk) = self.expand_decaps_key(ctx)?;
@@ -204,7 +207,7 @@ impl Kem<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }> fo
 
     fn serialize_public_key(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
     ) -> CaliptraResult<EncapsulationKey<{ MlKem::NPK }>> {
         let (ek, _dk) = self.expand_decaps_key(ctx)?;
         Ok(MlKemEncapsulationKey::from(ek))

--- a/drivers/src/hpke/kem/mod.rs
+++ b/drivers/src/hpke/kem/mod.rs
@@ -29,34 +29,34 @@ pub trait Kem<const NSK: usize, const NENC: usize, const NPK: usize, const NSECR
 
     /// Holds a KEM specific GAT for objects whose lifetime must be shorter than the KEM
     /// implementer.
-    type CONTEXT<'a>;
+    type CONTEXT<'a, 'b: 'a>;
 
     /// The encapsulation key.
     type EK;
 
     /// Derives a KEM keypair from the `ikm` seed.
-    fn derive_key_pair(ctx: &mut Self::CONTEXT<'_>, ikm: &[u8; NSK]) -> CaliptraResult<Self>
+    fn derive_key_pair(ctx: &mut Self::CONTEXT<'_, '_>, ikm: &[u8; NSK]) -> CaliptraResult<Self>
     where
         Self: Sized;
 
     /// Generates a shared secret key and associated ciphertext
     fn encap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         encaps_key: &Self::EK,
     ) -> CaliptraResult<(EncapsulatedSecret<NENC>, SharedSecret<NSECRET>)>;
 
     /// Uses the decapsulation key to produce a shared secret key from a ciphertext.
     fn decap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         enc: &EncapsulatedSecret<NENC>,
     ) -> CaliptraResult<SharedSecret<NSECRET>>;
 
     /// Serializes the public key
     fn serialize_public_key(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
     ) -> CaliptraResult<EncapsulationKey<NPK>>;
 }
 

--- a/drivers/src/hpke/kem/p384.rs
+++ b/drivers/src/hpke/kem/p384.rs
@@ -106,7 +106,7 @@ impl P384 {
     // Derive a key pair without first running through a KDF.
     // For use in Hybrid KEMs
     pub(super) fn derive_key_pair_raw(
-        ctx: &mut P384KemContext<'_>,
+        ctx: &mut P384KemContext<'_, '_>,
         seed: &[u8; Self::NSK],
     ) -> CaliptraResult<Self> {
         let seed = Ecc384Scalar::from(seed);
@@ -134,7 +134,7 @@ impl P384 {
     /// Hybrid KEMs need the raw shared secret of the KEM algorithm.
     pub(super) fn raw_encap(
         &mut self,
-        ctx: &mut P384KemContext<'_>,
+        ctx: &mut P384KemContext<'_, '_>,
         encaps_key: &P384EncapsulationKey,
     ) -> CaliptraResult<(P384EncapsulatedSecret, P384SharedSecret)> {
         // NOTE: The HPKE specification states that:
@@ -165,7 +165,7 @@ impl P384 {
     /// Hybrid KEMs need the raw shared secret of the KEM algorithm.
     pub(super) fn raw_decap(
         &mut self,
-        ctx: &mut P384KemContext<'_>,
+        ctx: &mut P384KemContext<'_, '_>,
         enc: &P384EncapsulatedSecret,
     ) -> CaliptraResult<P384SharedSecret> {
         // NOTE: The HPKE specification states that:
@@ -189,23 +189,37 @@ impl P384 {
     }
 }
 
-pub struct P384KemContext<'a> {
+use core::marker::PhantomData;
+
+pub struct P384KemContext<'a, 'b: 'a> {
     trng: &'a mut Trng,
     ecc: &'a mut Ecc384,
     hmac: &'a mut Hmac,
+    _phantom: PhantomData<&'b ()>,
 }
 
-impl<'a> P384KemContext<'a> {
+impl<'a, 'b: 'a> P384KemContext<'a, 'b> {
     pub fn new(trng: &'a mut Trng, ecc: &'a mut Ecc384, hmac: &'a mut Hmac) -> Self {
-        Self { trng, ecc, hmac }
+        Self {
+            trng,
+            ecc,
+            hmac,
+            _phantom: PhantomData,
+        }
     }
 }
 
 impl Kem<{ P384::NSK }, { P384::NENC }, { P384::NPK }, { P384::NSECRET }> for P384 {
     const KEM_ID: KemId = KemId::P_384;
     type EK = P384EncapsulationKey;
-    type CONTEXT<'a> = P384KemContext<'a>;
-    fn derive_key_pair(ctx: &mut Self::CONTEXT<'_>, ikm: &[u8; P384::NSK]) -> CaliptraResult<Self> {
+    type CONTEXT<'a, 'b>
+        = P384KemContext<'a, 'b>
+    where
+        'b: 'a;
+    fn derive_key_pair(
+        ctx: &mut Self::CONTEXT<'_, '_>,
+        ikm: &[u8; P384::NSK],
+    ) -> CaliptraResult<Self> {
         let suite_id = &CipherSuite::Kem(Self::KEM_ID);
 
         let mut kdf = Hmac384::new(ctx.hmac);
@@ -242,7 +256,7 @@ impl Kem<{ P384::NSK }, { P384::NENC }, { P384::NPK }, { P384::NSECRET }> for P3
 
     fn encap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         encaps_key: &Self::EK,
     ) -> CaliptraResult<(P384EncapsulatedSecret, P384SharedSecret)> {
         let (enc, shared_secret) = self.raw_encap(ctx, encaps_key)?;
@@ -260,7 +274,7 @@ impl Kem<{ P384::NSK }, { P384::NENC }, { P384::NPK }, { P384::NSECRET }> for P3
 
     fn decap(
         &mut self,
-        ctx: &mut Self::CONTEXT<'_>,
+        ctx: &mut Self::CONTEXT<'_, '_>,
         enc: &P384EncapsulatedSecret,
     ) -> CaliptraResult<P384SharedSecret> {
         let shared_secret = self.raw_decap(ctx, enc)?;
@@ -278,7 +292,7 @@ impl Kem<{ P384::NSK }, { P384::NENC }, { P384::NPK }, { P384::NSECRET }> for P3
 
     fn serialize_public_key(
         &mut self,
-        _ctx: &mut Self::CONTEXT<'_>,
+        _ctx: &mut Self::CONTEXT<'_, '_>,
     ) -> CaliptraResult<P384EncapsulationKey> {
         Ok(self.pub_key.to_der().into())
     }

--- a/drivers/src/hpke/mod.rs
+++ b/drivers/src/hpke/mod.rs
@@ -13,7 +13,8 @@ use suites::HpkeCipherSuite;
 use zerocopy::{transmute, FromBytes};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::{Ecc384, Hmac, LEArray4x392, MlKem1024, Sha3, Trng};
+use crate::{Abr, Ecc384, Hmac, LEArray4x392, MlKem1024, Sha3, Trng};
+use caliptra_registers::abr::AbrReg;
 
 pub mod aead;
 mod encryption_context;
@@ -209,7 +210,7 @@ impl HpkeContext {
     pub fn get_pub_key(
         &mut self,
         sha: &mut Sha3,
-        ml_kem: &mut MlKem1024,
+        abr: &mut Abr,
         ecc: &mut crate::Ecc384,
         trng: &mut Trng,
         hmac: &mut Hmac,
@@ -219,13 +220,16 @@ impl HpkeContext {
         for key in self.priv_keys.iter() {
             match key {
                 HpkePrivateKey::MlKem { handle, context } if handle == hpke_handle => {
-                    let mut ctx = MlKemContext::new(trng, sha, ml_kem);
-                    let mut kem = MlKem::derive_key_pair(&mut ctx, context.as_ref())?;
+                    let mut kem = {
+                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg());
+                        let mut ctx = MlKemContext::new(trng, sha, &mut ml_kem_driver);
+                        MlKem::derive_key_pair(&mut ctx, context.as_ref())?
+                    };
                     let pub_out = pub_out
                         .get_mut(..MlKem::NPK)
                         .and_then(|pub_out| <[u8; MlKem::NPK]>::mut_from_bytes(pub_out).ok())
                         .ok_or(CaliptraError::RUNTIME_DRIVER_HPKE_INVALID_PUB_KEY_BUFFER_SIZE)?;
-                    let mut ctx = HpkeMlKemDrivers::new(trng, sha, hmac, ml_kem);
+                    let mut ctx = HpkeMlKemDrivers::new(trng, sha, hmac, abr.abr_reg());
                     return context.serialize_public_key(&mut kem, &mut ctx, pub_out);
                 }
                 HpkePrivateKey::P384 { handle, context } if handle == hpke_handle => {
@@ -239,7 +243,7 @@ impl HpkeContext {
                     return context.serialize_public_key(&mut kem, &mut ctx, pub_out);
                 }
                 HpkePrivateKey::Hybrid { handle, context } if handle == hpke_handle => {
-                    let mut ctx = MlKem1024P384KemContext::new(trng, sha, ml_kem, ecc, hmac);
+                    let mut ctx = MlKem1024P384KemContext::new(trng, sha, abr.abr_reg(), ecc, hmac);
                     let mut kem = MlKem1024P384::derive_key_pair(&mut ctx, context.as_ref())?;
                     let pub_out = pub_out
                         .get_mut(..MlKem1024P384::NPK)
@@ -247,7 +251,7 @@ impl HpkeContext {
                             <[u8; MlKem1024P384::NPK]>::mut_from_bytes(pub_out).ok()
                         })
                         .ok_or(CaliptraError::RUNTIME_DRIVER_HPKE_INVALID_PUB_KEY_BUFFER_SIZE)?;
-                    let mut ctx = HpkeHybridDrivers::new(trng, sha, hmac, ml_kem, ecc);
+                    let mut ctx = HpkeHybridDrivers::new(trng, sha, hmac, abr.abr_reg(), ecc);
                     return context.serialize_public_key(&mut kem, &mut ctx, pub_out);
                 }
                 _ => (),
@@ -285,7 +289,7 @@ impl HpkeContext {
     pub fn decap(
         &mut self,
         sha: &mut Sha3,
-        ml_kem: &mut MlKem1024,
+        abr: &mut Abr,
         ecc: &mut Ecc384,
         hmac: &mut Hmac,
         trng: &mut Trng,
@@ -301,10 +305,13 @@ impl HpkeContext {
                         .and_then(|enc| MlKemEncapsulatedSecret::ref_from_bytes(enc).ok())
                         .ok_or(CaliptraError::RUNTIME_OCP_LOCK_DESERIALIZE_ENC_FAILURE)?;
 
-                    let mut ctx = MlKemContext::new(trng, sha, ml_kem);
-                    let mut kem = MlKem::derive_key_pair(&mut ctx, context.as_ref())?;
+                    let mut kem = {
+                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg());
+                        let mut ctx = MlKemContext::new(trng, sha, &mut ml_kem_driver);
+                        MlKem::derive_key_pair(&mut ctx, context.as_ref())?
+                    };
 
-                    let mut ctx = HpkeMlKemDrivers::new(trng, sha, hmac, ml_kem);
+                    let mut ctx = HpkeMlKemDrivers::new(trng, sha, hmac, abr.abr_reg());
                     return context.setup_base_r(&mut kem, &mut ctx, enc, info);
                 }
                 HpkePrivateKey::P384 { handle, context } if handle == hpke_handle => {
@@ -324,10 +331,10 @@ impl HpkeContext {
                         .and_then(|enc| HybridEncapsulatedSecret::ref_from_bytes(enc).ok())
                         .ok_or(CaliptraError::RUNTIME_OCP_LOCK_DESERIALIZE_ENC_FAILURE)?;
 
-                    let mut ctx = MlKem1024P384KemContext::new(trng, sha, ml_kem, ecc, hmac);
+                    let mut ctx = MlKem1024P384KemContext::new(trng, sha, abr.abr_reg(), ecc, hmac);
                     let mut kem = MlKem1024P384::derive_key_pair(&mut ctx, context.as_ref())?;
 
-                    let mut ctx = HpkeHybridDrivers::new(trng, sha, hmac, ml_kem, ecc);
+                    let mut ctx = HpkeHybridDrivers::new(trng, sha, hmac, abr.abr_reg(), ecc);
                     return context.setup_base_r(&mut kem, &mut ctx, enc, info);
                 }
                 _ => (),
@@ -366,7 +373,7 @@ impl Iterator for HpkeContextIter<'_> {
 
 pub struct HpkeMlKemDrivers<'a> {
     sha: &'a mut Sha3,
-    ml_kem: &'a mut MlKem1024,
+    abr_reg: &'a mut AbrReg,
     trng: &'a mut Trng,
     hmac: &'a mut Hmac,
 }
@@ -376,11 +383,11 @@ impl<'a> HpkeMlKemDrivers<'a> {
         trng: &'a mut Trng,
         sha: &'a mut Sha3,
         hmac: &'a mut Hmac,
-        ml_kem: &'a mut MlKem1024,
+        abr_reg: &'a mut AbrReg,
     ) -> Self {
         Self {
             sha,
-            ml_kem,
+            abr_reg,
             trng,
             hmac,
         }
@@ -434,8 +441,11 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
         let pkr = LEArray4x392::ref_from_bytes(pkr.as_ref())
             .map_err(|_| CaliptraError::RUNTIME_DRIVER_HPKE_ML_KEM_PKR_DESERIALIZATION_FAIL)?;
 
-        let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
-        let (enc, shared_secret) = kem.encap(&mut kem_ctx, pkr)?;
+        let (enc, shared_secret) = {
+            let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+            let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
+            kem.encap(&mut kem_ctx, pkr)?
+        };
 
         let mut kdf = Hmac384::new(ctx.hmac);
         let (key, base_nonce, _exporter_secret) = kdf.combine_secrets::<{ MlKem::NSECRET }>(
@@ -455,8 +465,11 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
         enc: &MlKemEncapsulatedSecret,
         info: &[u8],
     ) -> CaliptraResult<EncryptionContext<Receiver>> {
-        let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
-        let shared_secret = kem.decap(&mut kem_ctx, enc)?;
+        let shared_secret = {
+            let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+            let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
+            kem.decap(&mut kem_ctx, enc)?
+        };
 
         let mut kdf = Hmac384::new(ctx.hmac);
         let (key, base_nonce, _exporter_secret) = kdf.combine_secrets::<{ MlKem::NSECRET }>(
@@ -475,8 +488,9 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
         ctx: &mut Self::DriverContext<'_>,
         out_key: &mut [u8; MlKem::NPK],
     ) -> CaliptraResult<usize> {
-        let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, ctx.ml_kem);
-        let ek = kem.serialize_public_key(&mut ctx)?;
+        let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+        let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
+        let ek = kem.serialize_public_key(&mut kem_ctx)?;
         out_key.clone_from_slice(ek.as_ref());
         Ok(MlKem::NPK)
     }
@@ -584,7 +598,7 @@ pub struct HpkeHybridDrivers<'a> {
     trng: &'a mut Trng,
     sha: &'a mut Sha3,
     hmac: &'a mut Hmac,
-    ml_kem: &'a mut MlKem1024,
+    abr_reg: &'a mut AbrReg,
     ecc: &'a mut Ecc384,
 }
 
@@ -594,14 +608,14 @@ impl<'a> HpkeHybridDrivers<'a> {
         trng: &'a mut Trng,
         sha: &'a mut Sha3,
         hmac: &'a mut Hmac,
-        ml_kem: &'a mut MlKem1024,
+        abr_reg: &'a mut AbrReg,
         ecc: &'a mut Ecc384,
     ) -> Self {
         Self {
             trng,
             sha,
             hmac,
-            ml_kem,
+            abr_reg,
             ecc,
         }
     }
@@ -648,7 +662,7 @@ impl
         info: &[u8],
     ) -> CaliptraResult<(HybridEncapsulatedSecret, EncryptionContext<Sender>)> {
         let mut kem_ctx =
-            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.ml_kem, ctx.ecc, ctx.hmac);
+            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.abr_reg, ctx.ecc, ctx.hmac);
         let (enc, shared_secret) = kem.encap(&mut kem_ctx, pkr)?;
 
         let mut kdf = Hmac384::new(ctx.hmac);
@@ -671,7 +685,7 @@ impl
         info: &[u8],
     ) -> CaliptraResult<EncryptionContext<Receiver>> {
         let mut kem_ctx =
-            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.ml_kem, ctx.ecc, ctx.hmac);
+            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.abr_reg, ctx.ecc, ctx.hmac);
         let shared_secret = kem.decap(&mut kem_ctx, enc)?;
 
         let mut kdf = Hmac384::new(ctx.hmac);
@@ -693,7 +707,7 @@ impl
         out_key: &mut [u8; MlKem1024P384::NPK],
     ) -> CaliptraResult<usize> {
         let mut kem_ctx =
-            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.ml_kem, ctx.ecc, ctx.hmac);
+            MlKem1024P384KemContext::new(ctx.trng, ctx.sha, ctx.abr_reg, ctx.ecc, ctx.hmac);
         let ek = kem.serialize_public_key(&mut kem_ctx)?;
         out_key.copy_from_slice(ek.as_ref());
         Ok(MlKem1024P384::NPK)

--- a/drivers/src/kats/mlkem1024_kat.rs
+++ b/drivers/src/kats/mlkem1024_kat.rs
@@ -64,7 +64,7 @@ const KAT_SK_DIGEST: Array4x16 = Array4x16::new([
     0x51FD3214, 0xD686BB49, 0x76432EC1, 0x2B40DE7E, 0x4E68A595, 0x260B7E9E, 0x5B7A522B, 0x4D0F05AA,
 ]);
 
-pub fn execute_mlkem1024_kat(mlkem: &mut MlKem1024) -> CaliptraResult<()> {
+pub fn execute_mlkem1024_kat(mlkem: &mut MlKem1024<'_>) -> CaliptraResult<()> {
     cprintln!("[kat] MLKEM1024");
     let mut sha2 = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
 
@@ -72,7 +72,10 @@ pub fn execute_mlkem1024_kat(mlkem: &mut MlKem1024) -> CaliptraResult<()> {
     Ok(())
 }
 
-fn kat_keygen_encaps_decaps(mlkem: &mut MlKem1024, sha2: &mut Sha2_512_384) -> CaliptraResult<()> {
+fn kat_keygen_encaps_decaps(
+    mlkem: &mut MlKem1024<'_>,
+    sha2: &mut Sha2_512_384,
+) -> CaliptraResult<()> {
     // Generate keypair from seeds
     let seeds = MlKem1024Seeds::Arrays(&KEYGEN_SEED_D, &KEYGEN_SEED_Z);
     let (ek, dk) = mlkem

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -35,6 +35,7 @@ mod array;
 mod array_concat;
 mod wait;
 
+mod abr;
 mod aes;
 mod bounded_address;
 pub mod cmac_kdf;
@@ -79,6 +80,7 @@ mod soc_ifc;
 mod trng;
 mod trng_ext;
 
+pub use abr::Abr;
 pub use aes::{
     Aes, AesCmacOp, AesContext, AesGcm, AesGcmContext, AesGcmIv, AesGcmIvBlock, AesGcmOp,
     AesGcmTag, AesKey, AesOperation, AES_BLOCK_SIZE_BYTES, AES_BLOCK_SIZE_WORDS,

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -128,15 +128,13 @@ impl From<KeyWriteArgs> for MlKem1024SharedKeyOut<'_> {
 }
 
 /// ML-KEM-1024 API
-pub struct MlKem1024 {
-    mlkem: AbrReg,
+pub struct MlKem1024<'a> {
+    mlkem: &'a mut AbrReg,
 }
 
-impl MlKem1024 {
-    pub fn new(mlkem: AbrReg) -> CaliptraResult<Self> {
-        let mut s = Self { mlkem };
-        s.run_kats()?;
-        Ok(s)
+impl<'a> MlKem1024<'a> {
+    pub fn new(mlkem: &'a mut AbrReg) -> Self {
+        Self { mlkem }
     }
 
     /// Re-run KATs (for FIPS self-test).

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -106,12 +106,12 @@ impl<'a> From<&'a Mldsa87PrivKey> for Mldsa87Seed<'a> {
 }
 
 /// MLDSA-87  API
-pub struct Mldsa87 {
-    mldsa87: AbrReg,
+pub struct Mldsa87<'a> {
+    mldsa87: &'a mut AbrReg,
 }
 
-impl Mldsa87 {
-    pub fn new(mldsa87: AbrReg) -> Self {
+impl<'a> Mldsa87<'a> {
+    pub fn new(mldsa87: &'a mut AbrReg) -> Self {
         Self { mldsa87 }
     }
 

--- a/drivers/test-fw/src/bin/hpke_tests.rs
+++ b/drivers/test-fw/src/bin/hpke_tests.rs
@@ -15,6 +15,7 @@ Abstract:
 #![no_main]
 
 use caliptra_cfi_lib::CfiCounter;
+use caliptra_drivers::MlKem1024;
 use caliptra_drivers::{
     hpke::{
         kem::{
@@ -68,13 +69,16 @@ fn test_ml_kem_1024_test_vector() {
     // HPKE implementation against a known test vector.
     let hpke = unsafe { HpkeMlKemContext::from_seed(MLKEM_TEST_VECTOR.ikm_r.try_into().unwrap()) };
 
-    let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut regs.ml_kem);
-    let mut kem = MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap();
+    let mut kem = {
+        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg());
+        let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut ml_kem_driver);
+        MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap()
+    };
     let mut kem_ctx = HpkeMlKemDrivers::new(
         &mut regs.trng,
         &mut regs.sha3,
         &mut regs.hmac,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
     );
 
     let mut pk_rm = [0; MlKem::NPK];
@@ -106,13 +110,16 @@ fn test_ml_kem_1024_self_talk() {
     let mut regs = TestRegisters::default();
 
     let hpke = HpkeMlKemContext::generate(&mut regs.trng).unwrap();
-    let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut regs.ml_kem);
-    let mut kem = MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap();
+    let mut kem = {
+        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg());
+        let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut ml_kem_driver);
+        MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap()
+    };
     let mut kem_ctx = HpkeMlKemDrivers::new(
         &mut regs.trng,
         &mut regs.sha3,
         &mut regs.hmac,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
     );
 
     let mut pk_rm = [0; MlKem::NPK];
@@ -291,7 +298,7 @@ fn test_hybrid_test_vector() {
     let mut kem_ctx = MlKem1024P384KemContext::new(
         &mut regs.trng,
         &mut regs.sha3,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
         &mut regs.ecc,
         &mut regs.hmac,
     );
@@ -314,7 +321,7 @@ fn test_hybrid_test_vector() {
         &mut regs.trng,
         &mut regs.sha3,
         &mut regs.hmac,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
         &mut regs.ecc,
     );
     let mut reader = hpke
@@ -351,7 +358,7 @@ fn test_hybrid_self_talk() {
     let mut kem_ctx = MlKem1024P384KemContext::new(
         &mut regs.trng,
         &mut regs.sha3,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
         &mut regs.ecc,
         &mut regs.hmac,
     );
@@ -360,7 +367,7 @@ fn test_hybrid_self_talk() {
         &mut regs.trng,
         &mut regs.sha3,
         &mut regs.hmac,
-        &mut regs.ml_kem,
+        regs.abr.abr_reg(),
         &mut regs.ecc,
     );
 

--- a/drivers/test-fw/src/bin/mldsa87_external_mu_tests.rs
+++ b/drivers/test-fw/src/bin/mldsa87_external_mu_tests.rs
@@ -509,7 +509,8 @@ pub fn test_sign_external_mu() {
     // This needs to happen in the first test
     CfiCounter::reset(&mut entropy_gen);
 
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let sign_rnd = Mldsa87SignRnd::default(); // Deterministic signing
     let test = acvp_vector::EXTERNAL_MU_TEST;
@@ -527,7 +528,8 @@ pub fn test_sign_external_mu() {
 }
 
 pub fn test_verify_external_mu() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let test = acvp_vector::EXTERNAL_MU_TEST;
     assert_eq!(

--- a/drivers/test-fw/src/bin/mldsa87_tests.rs
+++ b/drivers/test-fw/src/bin/mldsa87_tests.rs
@@ -706,7 +706,8 @@ fn test_gen_key_pair() {
         )
         .unwrap()
     };
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut hmac = unsafe { Hmac::new(HmacReg::new()) };
     let key_out_1 = KeyWriteArgs {
@@ -730,7 +731,8 @@ fn test_gen_key_pair() {
 }
 
 fn test_sign() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -758,7 +760,8 @@ fn test_sign() {
 }
 
 fn test_sign_caller_provided_private_key() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -795,7 +798,8 @@ fn generate_msg<const N: usize>() -> [u8; N] {
 }
 
 fn test_sign_and_verify_var() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -843,7 +847,8 @@ fn test_sign_and_verify_var() {
 
 #[allow(dead_code)]
 fn test_sign_caller_provided_private_key_var_msg() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -874,7 +879,8 @@ fn test_sign_caller_provided_private_key_var_msg() {
 }
 
 fn test_keygen_caller_provided_seed() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -904,7 +910,8 @@ fn test_keygen_caller_provided_seed() {
 
 #[allow(dead_code)]
 fn test_keygen_caller_provided_seed_var_msg() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let mut trng = unsafe {
         Trng::new(
@@ -935,7 +942,8 @@ fn test_keygen_caller_provided_seed_var_msg() {
 }
 
 fn test_verify() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     assert_eq!(
         ml_dsa87
@@ -950,7 +958,8 @@ fn test_verify() {
 }
 
 fn test_verify_failure() {
-    let mut ml_dsa87 = unsafe { Mldsa87::new(AbrReg::new()) };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut ml_dsa87 = Mldsa87::new(&mut abr_reg);
 
     let msg = Mldsa87Msg::from([0xff; 64]);
 

--- a/drivers/test-fw/src/bin/mlkem_tests.rs
+++ b/drivers/test-fw/src/bin/mlkem_tests.rs
@@ -74,7 +74,8 @@ fn test_mlkem_name() {
 }
 
 fn test_key_pair_generation() {
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
 
     // Test key pair generation with arrays
     let seed_d = LEArray4x8::from(SEED_D);
@@ -280,7 +281,8 @@ fn test_key_pair_generation_from_kv() {
         .unwrap()
     };
 
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
     let mut hmac = unsafe { Hmac::new(HmacReg::new()) };
 
     // Store seeds in key vault
@@ -371,7 +373,8 @@ fn test_key_pair_generation_from_kv() {
 }
 
 fn test_encapsulate_and_decapsulate() {
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
 
     // Generate key pair
     let seed_d = LEArray4x8::from(SEED_D);
@@ -421,7 +424,8 @@ fn test_encapsulate_with_kv_message() {
         .unwrap()
     };
 
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
     let mut hmac = unsafe { Hmac::new(HmacReg::new()) };
 
     // Generate key pair
@@ -599,7 +603,8 @@ fn test_encapsulate_with_kv_message() {
 }
 
 fn test_encapsulate_with_kv_output() {
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
 
     // Generate key pair
     let seed_d = LEArray4x8::from(SEED_D);
@@ -630,7 +635,8 @@ fn test_encapsulate_with_kv_output() {
 }
 
 fn test_keygen_decapsulate() {
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
 
     // Generate key pair for encapsulation
     let seed_d = LEArray4x8::from(SEED_D);
@@ -667,7 +673,8 @@ fn test_keygen_decapsulate() {
 }
 
 fn test_keygen_decapsulate_with_kv() {
-    let mut mlkem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let mut mlkem = MlKem1024::new(&mut abr_reg);
 
     // Generate key pair for encapsulation using KV
     let seeds_kv = MlKem1024Seeds::Key(KeyReadArgs::new(KEY_ID));

--- a/drivers/test-fw/src/lib.rs
+++ b/drivers/test-fw/src/lib.rs
@@ -3,8 +3,8 @@
 #![no_std]
 
 use caliptra_drivers::{
-    Aes, Array4x16, DeobfuscationEngine, Dma, DmaEncryptionEngine, Ecc384, Ecc384PubKey, Hmac,
-    HmacData, HmacKey, HmacMode, KeyId, KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs, MlKem1024,
+    Abr, Aes, Array4x16, DeobfuscationEngine, Dma, DmaEncryptionEngine, Ecc384, Ecc384PubKey, Hmac,
+    HmacData, HmacKey, HmacMode, KeyId, KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs,
     PersistentDataAccessor, Sha3, SocIfc, Trng,
 };
 use caliptra_kat::CaliptraResult;
@@ -88,7 +88,7 @@ pub struct TestRegisters {
     pub dma: Dma,
     pub doe: DeobfuscationEngine,
     pub kv: KeyVault,
-    pub ml_kem: MlKem1024,
+    pub abr: Abr,
     pub sha3: Sha3,
     pub ecc: Ecc384,
 }
@@ -112,7 +112,7 @@ impl Default for TestRegisters {
         let dma = Dma::default();
         let doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
         let kv = unsafe { KeyVault::new(KvReg::new()) };
-        let ml_kem = unsafe { MlKem1024::new(AbrReg::new()).unwrap() };
+        let abr = unsafe { Abr::new(AbrReg::new()) };
         let sha3 = unsafe { Sha3::new(KmacReg::new()) };
         let ecc = unsafe { Ecc384::new(EccReg::new()) };
 
@@ -124,7 +124,7 @@ impl Default for TestRegisters {
             dma,
             doe,
             kv,
-            ml_kem,
+            abr,
             sha3,
             ecc,
         }

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -171,13 +171,15 @@ fn make_mldsa_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     let tbs = FmcAliasTbsMlDsa87::new(&params);
 
     // Sign the `To Be Signed` portion
-    let mut sig = Crypto::mldsa87_sign_and_verify(
-        &mut env.mldsa,
-        &mut env.trng,
-        key_pair.key_pair_seed,
-        &key_pair.pub_key,
-        tbs.tbs(),
-    )?;
+    let mut sig = env.abr.with_mldsa87(|mut mldsa87| {
+        Crypto::mldsa87_sign_and_verify(
+            &mut mldsa87,
+            &mut env.trng,
+            key_pair.key_pair_seed,
+            &key_pair.pub_key,
+            tbs.tbs(),
+        )
+    })?;
 
     // Build the CSR with `To Be Signed` & `Signature`
     let mldsa87_signature = caliptra_x509::MlDsa87Signature {

--- a/fmc/src/fmc_env.rs
+++ b/fmc/src/fmc_env.rs
@@ -16,8 +16,8 @@ Abstract:
 --*/
 
 use caliptra_drivers::{
-    CaliptraResult, Ecc384, Hmac, KeyVault, Mailbox, Mldsa87, PcrBank, PersistentDataAccessor,
-    Sha1, Sha256, Sha2_512_384, Sha2_512_384Acc, SocIfc, Trng,
+    Abr, CaliptraResult, Ecc384, Hmac, KeyVault, Mailbox, PcrBank, PersistentDataAccessor, Sha1,
+    Sha256, Sha2_512_384, Sha2_512_384Acc, SocIfc, Trng,
 };
 use caliptra_registers::{
     abr::AbrReg, csrng::CsrngReg, ecc::EccReg, entropy_src::EntropySrcReg, hmac::HmacReg,
@@ -61,8 +61,8 @@ pub struct FmcEnv {
     /// Persistent Data
     pub persistent_data: PersistentDataAccessor,
 
-    /// Mldsa87 Engine
-    pub mldsa: Mldsa87,
+    /// ABR Engine (ML-DSA)
+    pub abr: Abr,
 }
 
 impl FmcEnv {
@@ -94,7 +94,7 @@ impl FmcEnv {
             pcr_bank: PcrBank::new(PvReg::new()),
             trng,
             persistent_data: PersistentDataAccessor::new(),
-            mldsa: Mldsa87::new(AbrReg::new()),
+            abr: Abr::new(AbrReg::new()),
         })
     }
 }

--- a/kat/src/kats_env.rs
+++ b/kat/src/kats_env.rs
@@ -8,7 +8,7 @@ use caliptra_drivers::{
     Ecc384, Hmac, Lms, Mldsa87, Sha256, Sha2_512_384, Sha2_512_384Acc, Sha3, ShaAccLockState, Trng,
 };
 
-pub struct KatsEnv<'a> {
+pub struct KatsEnv<'a, 'b> {
     // SHA2-256 Engine
     pub sha256: &'a mut Sha256,
 
@@ -37,7 +37,7 @@ pub struct KatsEnv<'a> {
     pub sha_acc_lock_state: ShaAccLockState,
 
     /// MLDSA Engine
-    pub mldsa87: &'a mut Mldsa87,
+    pub mldsa87: &'a mut Mldsa87<'b>,
 
     /// AES-GCM Engine (for ROM builds - provides access to GCM and CMAC-KDF KATs)
     #[cfg(feature = "rom")]
@@ -48,5 +48,5 @@ pub struct KatsEnv<'a> {
     pub aes: &'a mut Aes,
 
     #[cfg(not(feature = "rom"))]
-    pub mlkem1024: &'a mut MlKem1024,
+    pub mlkem1024: Option<&'a mut MlKem1024<'b>>,
 }

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -53,7 +53,7 @@ pub struct InitializedDrivers {
 /// # Arguments
 ///
 /// * `env` - ROM Environment
-pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<InitializedDrivers> {
+pub fn execute_kat(env: &mut KatsEnv<'_, '_>) -> CaliptraResult<InitializedDrivers> {
     cprintln!("[kat] ++");
 
     cprintln!("[kat] sha1");
@@ -107,7 +107,9 @@ pub fn execute_kat(env: &mut KatsEnv) -> CaliptraResult<InitializedDrivers> {
         caliptra_drivers::kats::execute_ctr_kat(env.aes)?;
         caliptra_drivers::kats::execute_cmac_kat(env.aes)?;
         caliptra_drivers::kats::execute_gcm_kat(env.aes, env.trng)?;
-        caliptra_drivers::kats::execute_mlkem1024_kat(env.mlkem1024)?;
+        if let Some(mlkem1024) = env.mlkem1024.as_mut() {
+            caliptra_drivers::kats::execute_mlkem1024_kat(mlkem1024)?;
+        }
     }
 
     cprintln!("[kat] LMS");

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -169,14 +169,16 @@ impl FmcAliasLayer {
         let ecc_keypair = result?;
 
         // Derive the MLDSA Key Pair.
-        let result = Crypto::mldsa87_key_gen(
-            &mut env.mldsa87,
-            &mut env.hmac,
-            &mut env.trng,
-            cdi,
-            b"alias_fmc_mldsa_key",
-            mldsa_keypair_seed,
-        );
+        let result = env.abr.with_mldsa87(|mut mldsa87| {
+            Crypto::mldsa87_key_gen(
+                &mut mldsa87,
+                &mut env.hmac,
+                &mut env.trng,
+                cdi,
+                b"alias_fmc_mldsa_key",
+                mldsa_keypair_seed,
+            )
+        });
         cfi_check!(result);
         let mldsa_keypair = result?;
 
@@ -315,13 +317,15 @@ impl FmcAliasLayer {
             "[afmc] MLDSA Signing Cert w/ AUTHORITY.KEYID = {}",
             auth_priv_key as u8
         );
-        let mut sig = Crypto::mldsa87_sign_and_verify(
-            &mut env.mldsa87,
-            &mut env.trng,
-            auth_priv_key,
-            auth_pub_key,
-            tbs.tbs(),
-        );
+        let mut sig = env.abr.with_mldsa87(|mut mldsa87| {
+            Crypto::mldsa87_sign_and_verify(
+                &mut mldsa87,
+                &mut env.trng,
+                auth_priv_key,
+                auth_pub_key,
+                tbs.tbs(),
+            )
+        });
         let sig = okmutref(&mut sig)?;
 
         // Clear the authority private key

--- a/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/self_test.rs
@@ -24,7 +24,7 @@ impl SelfTestStartCmd {
     #[inline(always)]
     pub(crate) fn execute(
         cmd_bytes: &[u8],
-        env: &mut KatsEnv,
+        env: &mut KatsEnv<'_, '_>,
         self_test_in_progress: bool,
         _resp: &mut [u8],
     ) -> CaliptraResult<(bool, usize)> {

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -254,14 +254,16 @@ impl LocalDevIdLayer {
         let ecc_keypair = result?;
 
         // Derive the MLDSA Key Pair.
-        let result = Crypto::mldsa87_key_gen(
-            &mut env.mldsa87,
-            &mut env.hmac,
-            &mut env.trng,
-            cdi,
-            b"ldevid_mldsa_key",
-            mldsa_keypair_seed,
-        );
+        let result = env.abr.with_mldsa87(|mut mldsa87| {
+            Crypto::mldsa87_key_gen(
+                &mut mldsa87,
+                &mut env.hmac,
+                &mut env.trng,
+                cdi,
+                b"ldevid_mldsa_key",
+                mldsa_keypair_seed,
+            )
+        });
         if cfi_launder(result.is_ok()) {
             cfi_assert!(result.is_ok());
         } else {
@@ -384,13 +386,15 @@ impl LocalDevIdLayer {
             "[ldev] Signing Cert with MLDSA AUTHORITY.KEYID = {}",
             mldsa_auth_priv_key as u8
         );
-        let mut sig = Crypto::mldsa87_sign_and_verify(
-            &mut env.mldsa87,
-            &mut env.trng,
-            mldsa_auth_priv_key,
-            mldsa_auth_pub_key,
-            mldsa_tbs.tbs(),
-        );
+        let mut sig = env.abr.with_mldsa87(|mut mldsa87| {
+            Crypto::mldsa87_sign_and_verify(
+                &mut mldsa87,
+                &mut env.trng,
+                mldsa_auth_priv_key,
+                mldsa_auth_pub_key,
+                mldsa_tbs.tbs(),
+            )
+        });
         let sig = okmutref(&mut sig)?;
 
         // Clear the authority private key

--- a/rom/dev/src/flow/debug_unlock.rs
+++ b/rom/dev/src/flow/debug_unlock.rs
@@ -206,17 +206,19 @@ fn handle_auth_debug_unlock_token(
     token_bytes.copy_from_slice(cmd_bytes);
 
     // Use common validation function
-    let result = debug_unlock::validate_debug_unlock_token(
-        &env.soc_ifc,
-        &mut env.sha2_512_384,
-        &mut env.sha2_512_384_acc,
-        &mut env.ecc384,
-        &mut env.mldsa87,
-        &mut env.dma,
-        request,
-        challenge,
-        &token,
-    );
+    let result = env.abr.with_mldsa87(|mut mldsa87| {
+        debug_unlock::validate_debug_unlock_token(
+            &env.soc_ifc,
+            &mut env.sha2_512_384,
+            &mut env.sha2_512_384_acc,
+            &mut env.ecc384,
+            &mut mldsa87,
+            &mut env.dma,
+            request,
+            challenge,
+            &token,
+        )
+    });
 
     // Send response
     let _ = txn.send_response(MailboxRespHeader::default().as_bytes());

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -209,18 +209,18 @@ pub enum ImageSource<'a, 'b> {
 }
 
 // ROM Verification Environment
-pub(crate) struct FakeRomImageVerificationEnv<'a, 'b> {
+pub(crate) struct FakeRomImageVerificationEnv<'a, 'b, 'c> {
     pub(crate) sha256: &'a mut Sha256,
     pub(crate) sha2_512_384: &'a mut Sha2_512_384,
     pub(crate) sha2_512_384_acc: &'a mut Sha2_512_384Acc,
     pub(crate) soc_ifc: &'a mut SocIfc,
     pub(crate) data_vault: &'a DataVault,
     pub(crate) ecc384: &'a mut Ecc384,
-    pub(crate) mldsa87: &'a mut Mldsa87,
+    pub(crate) mldsa87: &'a mut Mldsa87<'c>,
     pub image_source: ImageSource<'a, 'b>,
 }
 
-impl FakeRomImageVerificationEnv<'_, '_> {
+impl FakeRomImageVerificationEnv<'_, '_, '_> {
     fn create_dma_recovery<'a>(soc_ifc: &'a SocIfc, dma: &'a Dma) -> DmaRecovery<'a> {
         DmaRecovery::new(
             soc_ifc.recovery_interface_base_addr().into(),
@@ -231,7 +231,7 @@ impl FakeRomImageVerificationEnv<'_, '_> {
     }
 }
 
-impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_> {
+impl ImageVerificationEnv for &mut FakeRomImageVerificationEnv<'_, '_, '_> {
     /// Calculate 384 digest using SHA2 Engine
     fn sha384_digest(&mut self, offset: u32, len: u32) -> CaliptraResult<ImageDigest384> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -161,48 +161,51 @@ pub extern "C" fn rom_entry() -> ! {
             sha1: Sha1::new().unwrap(),
         }
     } else {
-        let mut kats_env = caliptra_kat::KatsEnv {
-            // sha256
-            sha256: &mut env.sha256,
+        let result = env.abr.with_mldsa87(|mut mldsa87| {
+            let mut kats_env = caliptra_kat::KatsEnv {
+                // sha256
+                sha256: &mut env.sha256,
 
-            // SHA2-512/384 Engine
-            sha2_512_384: &mut env.sha2_512_384,
+                // SHA2-512/384 Engine
+                sha2_512_384: &mut env.sha2_512_384,
 
-            // SHA2-512/384 Accelerator
-            sha2_512_384_acc: &mut env.sha2_512_384_acc,
+                // SHA2-512/384 Accelerator
+                sha2_512_384_acc: &mut env.sha2_512_384_acc,
 
-            // SHA3/SHAKE
-            sha3: &mut env.sha3,
+                // SHA3/SHAKE
+                sha3: &mut env.sha3,
 
-            // Hmac-512/384 Engine
-            hmac: &mut env.hmac,
+                // Hmac-512/384 Engine
+                hmac: &mut env.hmac,
 
-            // Cryptographically Secure Random Number Generator
-            trng: &mut env.trng,
+                // Cryptographically Secure Random Number Generator
+                trng: &mut env.trng,
 
-            // LMS Engine
-            lms: &mut env.lms,
+                // LMS Engine
+                lms: &mut env.lms,
 
-            // MLDSA87 Engine
-            mldsa87: &mut env.mldsa87,
+                // MLDSA87 Engine
+                mldsa87: &mut mldsa87,
 
-            // Ecc384 Engine
-            ecc384: &mut env.ecc384,
+                // Ecc384 Engine
+                ecc384: &mut env.ecc384,
 
-            // SHA Acc lock state.
-            // SHA Acc is guaranteed to be locked on Cold and Warm Resets;
-            // On an Update Reset, it is expected to be unlocked.
-            // Not having it unlocked will result in a fatal error.
-            sha_acc_lock_state: if reset_reason == ResetReason::UpdateReset {
-                ShaAccLockState::NotAcquired
-            } else {
-                ShaAccLockState::AssumedLocked
-            },
+                // AES-GCM Engine (for GCM and CMAC-KDF KATs)
+                aes_gcm: &mut env.aes_gcm,
 
-            // AES-GCM Engine (for GCM and CMAC-KDF KATs)
-            aes_gcm: &mut env.aes_gcm,
-        };
-        match run_fips_tests(&mut kats_env) {
+                // SHA Acc lock state.
+                // SHA Acc is guaranteed to be locked on Cold and Warm Resets;
+                // On an Update Reset, it is expected to be unlocked.
+                // Not having it unlocked will result in a fatal error.
+                sha_acc_lock_state: if reset_reason == ResetReason::UpdateReset {
+                    ShaAccLockState::NotAcquired
+                } else {
+                    ShaAccLockState::AssumedLocked
+                },
+            };
+            run_fips_tests(&mut kats_env)
+        });
+        match result {
             Err(err) => handle_fatal_error(err.into()),
             Ok(initialized) => initialized,
         }
@@ -247,7 +250,7 @@ pub extern "C" fn rom_entry() -> ! {
     caliptra_drivers::ExitCtrl::exit(0);
 }
 
-fn run_fips_tests(env: &mut KatsEnv) -> CaliptraResult<InitializedDrivers> {
+fn run_fips_tests(env: &mut KatsEnv<'_, '_>) -> CaliptraResult<InitializedDrivers> {
     report_boot_status(KatStarted.into());
 
     cprintln!("[kat] SHA2-256");
@@ -271,7 +274,7 @@ fn run_fips_tests(env: &mut KatsEnv) -> CaliptraResult<InitializedDrivers> {
     Ok(initialized_drivers)
 }
 
-fn rom_integrity_test(env: &mut KatsEnv, expected_digest: &[u32; 8]) -> CaliptraResult<()> {
+fn rom_integrity_test(env: &mut KatsEnv<'_, '_>, expected_digest: &[u32; 8]) -> CaliptraResult<()> {
     // WARNING: It is undefined behavior to dereference a zero (null) pointer in
     // rust code. This is only safe because the dereference is being done by an
     // an assembly routine ([`ureg::opt_riscv::copy_16_words`]) rather

--- a/rom/dev/src/rom_env.rs
+++ b/rom/dev/src/rom_env.rs
@@ -16,7 +16,7 @@ Abstract:
 --*/
 
 use caliptra_drivers::{
-    AesGcm, DeobfuscationEngine, Dma, Ecc384, Hmac, KeyVault, Lms, Mailbox, Mldsa87, PcrBank,
+    Abr, AesGcm, DeobfuscationEngine, Dma, Ecc384, Hmac, KeyVault, Lms, Mailbox, PcrBank,
     PersistentDataAccessor, Sha1, Sha256, Sha2_512_384, Sha2_512_384Acc, Sha3, SocIfc, Trng,
 };
 use caliptra_error::CaliptraResult;
@@ -72,8 +72,8 @@ pub struct RomEnv {
     /// Mechanism to access the persistent data safely
     pub persistent_data: PersistentDataAccessor,
 
-    /// Mldsa87 Engine
-    pub mldsa87: Mldsa87,
+    /// ABR Engine (ML-DSA)
+    pub abr: Abr,
 
     /// Dma engine
     pub dma: Dma,
@@ -121,7 +121,7 @@ impl RomEnv {
             pcr_bank: PcrBank::new(PvReg::new()),
             trng,
             persistent_data: PersistentDataAccessor::new(),
-            mldsa87: Mldsa87::new(AbrReg::new()),
+            abr: Abr::new(AbrReg::new()),
             dma: Dma::default(),
             aes_gcm,
         })

--- a/runtime/src/attested_csr/mod.rs
+++ b/runtime/src/attested_csr/mod.rs
@@ -233,7 +233,8 @@ impl DevIdKeyType {
         let rt_seed = Drivers::get_key_id_rt_mldsa_keypair_seed(drivers)?;
         let key_args = KeyReadArgs::new(rt_seed);
 
-        let signature = drivers.mldsa87.sign_var(
+        let mut mldsa87 = caliptra_drivers::Mldsa87::new(drivers.abr.abr_reg());
+        let signature = mldsa87.sign_var(
             Mldsa87Seed::Key(key_args),
             &rt_pub_key,
             digest.as_bytes(),

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -52,7 +52,7 @@ use caliptra_drivers::{
     Aes, AesContext, AesGcmContext, AesGcmIv, AesKey, AesOperation, Array4x12, Array4x16,
     CaliptraResult, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Seed,
     Ecc384Signature, HmacMode, KeyReadArgs, LEArray4x1157, LEArray4x3, LEArray4x392, LEArray4x4,
-    LEArray4x8, MlKem1024Message, MlKem1024MessageSource, MlKem1024Seed, MlKem1024Seeds,
+    LEArray4x8, MlKem1024, MlKem1024Message, MlKem1024MessageSource, MlKem1024Seed, MlKem1024Seeds,
     MlKem1024SharedKey, MlKem1024SharedKeyOut, Mldsa87Result, Mldsa87Seed, PersistentDataAccessor,
     Sha2_512_384, Trng, AES_BLOCK_SIZE_BYTES, AES_CONTEXT_SIZE_BYTES, AES_GCM_CONTEXT_SIZE_BYTES,
     MAX_SEED_WORDS,
@@ -2178,7 +2178,9 @@ impl Commands {
 
         let seed = Self::decrypt_mldsa_seed(drivers, &cmd.cmk)?;
         let seed = Mldsa87Seed::Array4x8(&seed);
-        let public_key = drivers.mldsa87.key_pair(seed, &mut drivers.trng, None)?;
+        let public_key = drivers
+            .abr
+            .with_mldsa87(|mut mldsa| mldsa.key_pair(seed, &mut drivers.trng, None))?;
 
         let resp = mutrefbytes::<CmMldsaPublicKeyResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
@@ -2206,14 +2208,12 @@ impl Commands {
 
         let seed = Self::decrypt_mldsa_seed(drivers, &cmd.cmk)?;
         let seed = Mldsa87Seed::Array4x8(&seed);
-        let pub_key = &drivers.mldsa87.key_pair(seed, &mut drivers.trng, None)?;
 
-        let sign_rnd = LEArray4x8::default();
-
-        let signature =
-            drivers
-                .mldsa87
-                .sign_var(seed, pub_key, msg, &sign_rnd, &mut drivers.trng)?;
+        let signature = drivers.abr.with_mldsa87(|mut mldsa| {
+            let pub_key = mldsa.key_pair(seed, &mut drivers.trng, None)?;
+            let sign_rnd = LEArray4x8::default();
+            mldsa.sign_var(seed, &pub_key, msg, &sign_rnd, &mut drivers.trng)
+        })?;
 
         let resp = mutrefbytes::<CmMldsaSignResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
@@ -2241,11 +2241,14 @@ impl Commands {
 
         let seed = Self::decrypt_mldsa_seed(drivers, &cmd.cmk)?;
         let seed = Mldsa87Seed::Array4x8(&seed);
-        let pub_key = &drivers.mldsa87.key_pair(seed, &mut drivers.trng, None)?;
-
         let signature: &LEArray4x1157 = &cmd.signature.into();
 
-        match drivers.mldsa87.verify_var(pub_key, msg, signature)? {
+        let result = drivers.abr.with_mldsa87(|mut mldsa| {
+            let pub_key = mldsa.key_pair(seed, &mut drivers.trng, None)?;
+            mldsa.verify_var(&pub_key, msg, signature)
+        })?;
+
+        match result {
             Mldsa87Result::Success => {
                 let resp = mutrefbytes::<MailboxRespHeader>(resp)?;
                 *resp = MailboxRespHeader::default();
@@ -2467,7 +2470,8 @@ impl Commands {
 
         let (seed_d, seed_z) = Self::decrypt_mlkem_seeds(drivers, &cmd.cmk)?;
         let seeds = MlKem1024Seeds::Arrays(&seed_d, &seed_z);
-        let (encaps_key, _decaps_key) = drivers.ml_kem.key_pair(seeds)?;
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        let (encaps_key, _decaps_key) = ml_kem.key_pair(seeds)?;
 
         let resp = mutrefbytes::<CmMlkemKeyGenResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
@@ -2505,7 +2509,8 @@ impl Commands {
         };
 
         let mut shared_key = MlKem1024SharedKey::default();
-        let ciphertext = drivers.ml_kem.encapsulate(
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        let ciphertext = ml_kem.encapsulate(
             &encaps_key,
             MlKem1024MessageSource::Array(&message),
             MlKem1024SharedKeyOut::Array(&mut shared_key),
@@ -2545,7 +2550,8 @@ impl Commands {
         let ciphertext: LEArray4x392 = (&cmd.ciphertext).into();
 
         let mut shared_key = MlKem1024SharedKey::default();
-        drivers.ml_kem.keygen_decapsulate(
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        ml_kem.keygen_decapsulate(
             seeds,
             &ciphertext,
             MlKem1024SharedKeyOut::Array(&mut shared_key),

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -25,6 +25,7 @@ use caliptra_drivers::{
     Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87SignRnd, Sha2DigestOp, Sha2_512_384,
     Trng,
 };
+use caliptra_registers::abr::AbrReg;
 use constant_time_eq::constant_time_eq;
 use core::marker::PhantomData;
 use crypto::{
@@ -109,7 +110,7 @@ impl<'a> DpeMldsaCrypto<'a> {
     pub fn new(
         sha2_512_384: &'a mut Sha2_512_384,
         trng: &'a mut Trng,
-        mldsa: &'a mut Mldsa87,
+        abr_reg: &'a mut AbrReg,
         hmac: &'a mut Hmac,
         key_vault: &'a mut KeyVault,
         rt_pub_key: PubKey,
@@ -122,7 +123,7 @@ impl<'a> DpeMldsaCrypto<'a> {
             trng,
             hmac,
             key_vault,
-            signer: Signer::Mldsa(mldsa),
+            signer: Signer::Mldsa(abr_reg),
             rt_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
@@ -205,7 +206,8 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> DpeCrypto<'_, S, D, SD> 
                 )));
                 Ok((key_id, pub_key))
             }
-            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(mldsa)) => {
+            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(abr_reg)) => {
+                let mut mldsa = Mldsa87::new(abr_reg);
                 let pub_key = mldsa
                     .key_pair(
                         Mldsa87Seed::Key(KeyReadArgs::new(KEY_ID_TMP)),
@@ -276,7 +278,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> DpeCrypto<'_, S, D, SD> 
 
     #[inline(never)]
     fn sign_mldsa(
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         trng: &mut Trng,
         data: &SignData,
         priv_key: &KeyId,
@@ -320,8 +322,9 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> DpeCrypto<'_, S, D, SD> 
             (SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384), Signer::Ec(ecc384)) => {
                 Self::sign_ec(ecc384, sha2_512_384, trng, data, priv_key, pub_key)
             }
-            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(mldsa)) => {
-                Self::sign_mldsa(mldsa, trng, data, priv_key, pub_key)
+            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(abr_reg)) => {
+                let mut mldsa = Mldsa87::new(abr_reg);
+                Self::sign_mldsa(&mut mldsa, trng, data, priv_key, pub_key)
             }
             _ => Err(CryptoError::MismatchedAlgorithm),
         }
@@ -510,5 +513,5 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for DpeCrypto<'_,
 
 enum Signer<'a> {
     Ec(&'a mut Ecc384),
-    Mldsa(&'a mut Mldsa87),
+    Mldsa(&'a mut AbrReg),
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -42,11 +42,11 @@ use caliptra_drivers::{
     hand_off::DataStore,
     pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
-    Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms, Mldsa87,
+    Abr, Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms,
     PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha256, Sha256Alg, Sha2_512_384,
     Sha2_512_384Acc, Sha3, SocIfc, Trng,
 };
-use caliptra_drivers::{okref, Dma, DmaMmio, MlKem1024, Mldsa87PubKey};
+use caliptra_drivers::{okref, Dma, DmaMmio, Mldsa87PubKey};
 use caliptra_image_types::ImageManifest;
 use caliptra_registers::aes::AesReg;
 use caliptra_registers::aes_clp::AesClpReg;
@@ -137,11 +137,8 @@ pub struct Drivers {
     /// Ecc384 Engine
     pub ecc384: Ecc384,
 
-    /// Mldsa87 Engine
-    pub mldsa87: Mldsa87,
-
-    /// ML-KEM Engine
-    pub ml_kem: MlKem1024,
+    /// ABR Engine (ML-DSA and ML-KEM)
+    pub abr: Abr,
 
     pub persistent_data: PersistentDataAccessor,
 
@@ -205,10 +202,7 @@ impl Drivers {
             sha3: Sha3::new(KmacReg::new()),
             hmac: Hmac::new(HmacReg::new()),
             ecc384: Ecc384::new(EccReg::new()),
-            // TODO(clundin): Don't pass multiple `AbrReg`'s to higher level drivers.
-            // https://github.com/chipsalliance/caliptra-sw/issues/3107
-            mldsa87: Mldsa87::new(AbrReg::new()),
-            ml_kem: MlKem1024::new(AbrReg::new())?,
+            abr: Abr::new(AbrReg::new()),
             lms: Lms::default(),
             trng,
             persistent_data,
@@ -961,14 +955,16 @@ impl Drivers {
     pub fn get_key_id_rt_mldsa_pub_key(drivers: &mut Drivers) -> CaliptraResult<Mldsa87PubKey> {
         let rt_cdi = Self::get_key_id_rt_cdi(drivers)?;
         let rt_mldsa_key = Self::get_key_id_rt_mldsa_keypair_seed(drivers)?;
-        let mldsa_key_pair = Crypto::mldsa87_key_gen(
-            &mut drivers.mldsa87,
-            &mut drivers.hmac,
-            &mut drivers.trng,
-            rt_cdi,
-            b"alias_rt_mldsa_key",
-            rt_mldsa_key,
-        )?;
+        let mldsa_key_pair = drivers.abr.with_mldsa87(|mut mldsa87| {
+            Crypto::mldsa87_key_gen(
+                &mut mldsa87,
+                &mut drivers.hmac,
+                &mut drivers.trng,
+                rt_cdi,
+                b"alias_rt_mldsa_key",
+                rt_mldsa_key,
+            )
+        })?;
         Ok(mldsa_key_pair.pub_key)
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -337,9 +337,9 @@ fn execute_command(
             caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)
         }
         CommandId::LMS_SIGNATURE_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
-        CommandId::MLDSA87_SIGNATURE_VERIFY => {
-            caliptra_common::verify::MldsaVerifyCmd::execute(&mut drivers.mldsa87, cmd_bytes)
-        }
+        CommandId::MLDSA87_SIGNATURE_VERIFY => drivers.abr.with_mldsa87(|mut mldsa| {
+            caliptra_common::verify::MldsaVerifyCmd::execute(&mut mldsa, cmd_bytes)
+        }),
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers, cmd_bytes, resp),
         CommandId::DISABLE_ATTESTATION => DisableAttestationCmd::execute(drivers),
@@ -537,15 +537,17 @@ fn execute_command(
             cmd_bytes,
             resp,
         ),
-        CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN => drivers.debug_unlock.handle_token(
-            &mut drivers.soc_ifc,
-            &mut drivers.sha2_512_384,
-            &mut drivers.sha2_512_384_acc,
-            &mut drivers.ecc384,
-            &mut drivers.mldsa87,
-            &mut drivers.dma,
-            cmd_bytes,
-        ),
+        CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN => drivers.abr.with_mldsa87(|mut mldsa| {
+            drivers.debug_unlock.handle_token(
+                &mut drivers.soc_ifc,
+                &mut drivers.sha2_512_384,
+                &mut drivers.sha2_512_384_acc,
+                &mut drivers.ecc384,
+                &mut mldsa,
+                &mut drivers.dma,
+                cmd_bytes,
+            )
+        }),
         CommandId::FE_PROG => FeProgrammingCmd::execute(drivers, cmd_bytes),
         CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => {
             ReallocateDpeContextLimitsCmd::execute(drivers, cmd_bytes, resp)
@@ -858,7 +860,7 @@ fn mldsa_dpe_env(
     let crypto = DpeMldsaCrypto::new(
         &mut drivers.sha2_512_384,
         &mut drivers.trng,
-        &mut drivers.mldsa87,
+        drivers.abr.abr_reg(),
         &mut drivers.hmac,
         &mut drivers.key_vault,
         rt_pub_key,

--- a/runtime/src/ocp_lock/enable_mpk.rs
+++ b/runtime/src/ocp_lock/enable_mpk.rs
@@ -60,7 +60,7 @@ impl EnableMpkCmd {
 
         let access_key = drivers.ocp_lock_context.decapsulate_access_key(
             &mut drivers.sha3,
-            &mut drivers.ml_kem,
+            &mut drivers.abr,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.trng,

--- a/runtime/src/ocp_lock/generate_mpk.rs
+++ b/runtime/src/ocp_lock/generate_mpk.rs
@@ -54,7 +54,7 @@ impl GenerateMpkCmd {
 
         let access_key = drivers.ocp_lock_context.decapsulate_access_key(
             &mut drivers.sha3,
-            &mut drivers.ml_kem,
+            &mut drivers.abr,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.trng,

--- a/runtime/src/ocp_lock/get_hpke_pubkey.rs
+++ b/runtime/src/ocp_lock/get_hpke_pubkey.rs
@@ -28,7 +28,7 @@ impl GetHpkePubKeyCmd {
         resp.hdr = MailboxRespHeader::default();
         resp.pub_key_len = drivers.ocp_lock_context.get_hpke_public_key(
             &mut drivers.sha3,
-            &mut drivers.ml_kem,
+            &mut drivers.abr,
             &mut drivers.ecc384,
             &mut drivers.trng,
             &mut drivers.hmac,

--- a/runtime/src/ocp_lock/mod.rs
+++ b/runtime/src/ocp_lock/mod.rs
@@ -14,8 +14,8 @@ use caliptra_drivers::{
     },
     preconditioned_aes::{preconditioned_aes_decrypt, preconditioned_aes_encrypt},
     sha2_512_384::Sha2DigestOpTrait,
-    Aes, AesKey, AesOperation, Array4x12, Ecc384, Hmac, HmacKey, HmacMode, HmacTag, KeyReadArgs,
-    KeyUsage, KeyVault, KeyWriteArgs, LEArray4x16, LEArray4x3, LEArray4x4, LEArray4x8, MlKem1024,
+    Abr, Aes, AesKey, AesOperation, Array4x12, Ecc384, Hmac, HmacKey, HmacMode, HmacTag,
+    KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs, LEArray4x16, LEArray4x3, LEArray4x4, LEArray4x8,
     OcpLockFlags, OcpLockMetadataFirmware, Sha2_512_384, Sha3, SocIfc, Trng,
 };
 
@@ -1119,7 +1119,7 @@ impl OcpLockContext {
     pub fn decapsulate_access_key(
         &mut self,
         sha: &mut Sha3,
-        ml_kem: &mut MlKem1024,
+        abr: &mut Abr,
         ecc: &mut Ecc384,
         hmac: &mut Hmac,
         trng: &mut Trng,
@@ -1131,9 +1131,9 @@ impl OcpLockContext {
         tag: &[u8; 16],
         ct: &[u8; AccessKey::<Current>::KEY_LEN],
     ) -> CaliptraResult<AccessKey<Current>> {
-        let mut ctx =
-            self.hpke_context
-                .decap(sha, ml_kem, ecc, hmac, trng, hpke_handle, enc, info)?;
+        let mut ctx = self
+            .hpke_context
+            .decap(sha, abr, ecc, hmac, trng, hpke_handle, enc, info)?;
         AccessKey::<Current>::from_ciphertext(aes, trng, &mut ctx, metadata, tag, ct)
     }
 
@@ -1142,7 +1142,7 @@ impl OcpLockContext {
     pub fn decapsulate_rotation_access_keys(
         &mut self,
         sha: &mut Sha3,
-        ml_kem: &mut MlKem1024,
+        abr: &mut Abr,
         ecc: &mut Ecc384,
         hmac: &mut Hmac,
         trng: &mut Trng,
@@ -1154,9 +1154,9 @@ impl OcpLockContext {
         current: &EncryptedAccessKey<Current>,
         new: &EncryptedAccessKey<New>,
     ) -> CaliptraResult<(AccessKey<Current>, AccessKey<New>)> {
-        let mut ctx =
-            self.hpke_context
-                .decap(sha, ml_kem, ecc, hmac, trng, hpke_handle, enc, info)?;
+        let mut ctx = self
+            .hpke_context
+            .decap(sha, abr, ecc, hmac, trng, hpke_handle, enc, info)?;
         let current = AccessKey::<Current>::from_ciphertext(
             aes,
             trng,
@@ -1354,7 +1354,7 @@ impl OcpLockContext {
     pub fn get_hpke_public_key(
         &mut self,
         sha: &mut Sha3,
-        ml_kem: &mut MlKem1024,
+        abr: &mut Abr,
         ecc: &mut Ecc384,
         trng: &mut Trng,
         hmac: &mut Hmac,
@@ -1362,7 +1362,7 @@ impl OcpLockContext {
         pub_out: &mut [u8],
     ) -> CaliptraResult<usize> {
         self.hpke_context
-            .get_pub_key(sha, ml_kem, ecc, trng, hmac, hpke_handle, pub_out)
+            .get_pub_key(sha, abr, ecc, trng, hmac, hpke_handle, pub_out)
     }
 
     /// Retrieve the Ciphersuite for an HPKE handle

--- a/runtime/src/ocp_lock/rewrap_mpk.rs
+++ b/runtime/src/ocp_lock/rewrap_mpk.rs
@@ -70,7 +70,7 @@ impl RewrapMpkCmd {
 
         let (current_ak, new_ak) = drivers.ocp_lock_context.decapsulate_rotation_access_keys(
             &mut drivers.sha3,
-            &mut drivers.ml_kem,
+            &mut drivers.abr,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.trng,

--- a/runtime/src/ocp_lock/test_access_key.rs
+++ b/runtime/src/ocp_lock/test_access_key.rs
@@ -54,7 +54,7 @@ impl TestAccessKeyCmd {
 
         let access_key = drivers.ocp_lock_context.decapsulate_access_key(
             &mut drivers.sha3,
-            &mut drivers.ml_kem,
+            &mut drivers.abr,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.trng,

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -93,7 +93,9 @@ impl GetPcrQuoteCmd {
 
                 pcr_hash.0.reverse(); // Reverse the order of the DWORDs for MLDSA.
 
-                let signature = drivers.mldsa87.pcr_sign_flow(&mut drivers.trng)?;
+                let signature = drivers
+                    .abr
+                    .with_mldsa87(|mut mldsa| mldsa.pcr_sign_flow(&mut drivers.trng))?;
 
                 let resp = mutrefbytes::<QuotePcrsMldsa87Resp>(resp)?;
                 resp.hdr = MailboxRespHeader::default();

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -103,7 +103,7 @@ impl SetAuthManifestCmd {
         sha2: &mut Sha2_512_384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         pqc_key_type: FwVerificationPqcKeyType,
     ) -> CaliptraResult<()> {
         let range = AuthManifestPreamble::vendor_signed_data_range();
@@ -205,7 +205,7 @@ impl SetAuthManifestCmd {
         sha2: &mut Sha2_512_384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         pqc_key_type: FwVerificationPqcKeyType,
     ) -> CaliptraResult<()> {
         let range = AuthManifestPreamble::owner_pub_keys_range();
@@ -305,7 +305,7 @@ impl SetAuthManifestCmd {
         image_metadata_col_digest: &ImageDigest384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         _sha2: &mut Sha2_512_384,
         pqc_key_type: FwVerificationPqcKeyType,
         metadata_col: &[u8],
@@ -417,7 +417,7 @@ impl SetAuthManifestCmd {
         image_metadata_col_digest: &ImageDigest384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         _sha2: &mut Sha2_512_384,
         pqc_key_type: FwVerificationPqcKeyType,
         metadata_col: &[u8],
@@ -559,7 +559,7 @@ impl SetAuthManifestCmd {
         sha2: &mut Sha2_512_384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
-        mldsa: &mut Mldsa87,
+        mldsa: &mut Mldsa87<'_>,
         pqc_key_type: FwVerificationPqcKeyType,
         verify_only: bool,
     ) -> CaliptraResult<()> {
@@ -754,41 +754,43 @@ impl SetAuthManifestCmd {
             fuse_pqc_key_type
         };
         let persistent_data = drivers.persistent_data.get_mut();
-        // Verify the vendor signed data (vendor public keys + flags).
-        Self::verify_vendor_signed_data(
-            auth_manifest_preamble,
-            &persistent_data.rom.manifest1.preamble,
-            &mut drivers.sha2_512_384,
-            &mut drivers.ecc384,
-            &mut drivers.sha256,
-            &mut drivers.mldsa87,
-            pqc_key_type,
-        )?;
+        drivers.abr.with_mldsa87(|mut mldsa87| {
+            // Verify the vendor signed data (vendor public keys + flags).
+            Self::verify_vendor_signed_data(
+                auth_manifest_preamble,
+                &persistent_data.rom.manifest1.preamble,
+                &mut drivers.sha2_512_384,
+                &mut drivers.ecc384,
+                &mut drivers.sha256,
+                &mut mldsa87,
+                pqc_key_type,
+            )?;
 
-        // Verify the owner public keys.
-        Self::verify_owner_pub_keys(
-            auth_manifest_preamble,
-            &persistent_data.rom.manifest1.preamble,
-            &mut drivers.sha2_512_384,
-            &mut drivers.ecc384,
-            &mut drivers.sha256,
-            &mut drivers.mldsa87,
-            pqc_key_type,
-        )?;
+            // Verify the owner public keys.
+            Self::verify_owner_pub_keys(
+                auth_manifest_preamble,
+                &persistent_data.rom.manifest1.preamble,
+                &mut drivers.sha2_512_384,
+                &mut drivers.ecc384,
+                &mut drivers.sha256,
+                &mut mldsa87,
+                pqc_key_type,
+            )?;
 
-        Self::process_image_metadata_col(
-            manifest_buf
-                .get(preamble_size..)
-                .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
-            auth_manifest_preamble,
-            &mut persistent_data.fw.auth_manifest_image_metadata_col,
-            &mut drivers.sha2_512_384,
-            &mut drivers.ecc384,
-            &mut drivers.sha256,
-            &mut drivers.mldsa87,
-            pqc_key_type,
-            verify_only,
-        )?;
+            Self::process_image_metadata_col(
+                manifest_buf
+                    .get(preamble_size..)
+                    .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
+                auth_manifest_preamble,
+                &mut persistent_data.fw.auth_manifest_image_metadata_col,
+                &mut drivers.sha2_512_384,
+                &mut drivers.ecc384,
+                &mut drivers.sha256,
+                &mut mldsa87,
+                pqc_key_type,
+                verify_only,
+            )
+        })?;
 
         if !verify_only {
             persistent_data.fw.auth_manifest_digest =


### PR DESCRIPTION
That is borrowed in a closure to avoid both drivers having a copy of AbrReg.

Most uses can be replaced with the closures, but there are some tricky borrowing situations where it is easier to borrow the underlying AbrReg itself.

Fixes #3107.