### PR TITLE
Fix SHA ACC lock release during debug unlock causing KAT failure

### DIFF
--- a/common/src/debug_unlock.rs
+++ b/common/src/debug_unlock.rs
@@ -137,13 +137,9 @@ pub fn validate_debug_unlock_token(
         .len();
 
         let mut request_digest = Array4x12::default();
-        let lock_state = if cfg!(feature = "rom") {
-            ShaAccLockState::AssumedLocked
-        } else {
-            ShaAccLockState::NotAcquired
-        };
+
         let mut acc_op = sha2_512_384_acc
-            .try_start_operation(lock_state)?
+            .try_start_operation(ShaAccLockState::NotAcquired)?
             .ok_or(CaliptraError::SS_DBG_UNLOCK_PROD_INVALID_TOKEN_WRONG_PUBLIC_KEYS)?;
 
         acc_op.digest_384(

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -101,10 +101,6 @@ pub extern "C" fn rom_entry() -> ! {
     };
     cprintln!("[state] LifecycleState = {}", lifecycle);
 
-    if let Err(err) = crate::flow::debug_unlock::debug_unlock(&mut env) {
-        handle_fatal_error(err.into());
-    }
-
     // UDS programming.
     if let Err(err) = crate::flow::UdsProgrammingFlow::program_uds(&mut env) {
         handle_fatal_error(err.into());
@@ -192,6 +188,11 @@ pub extern "C" fn rom_entry() -> ! {
         if let Err(err) = result {
             handle_fatal_error(err.into());
         }
+    }
+
+    // Only run DBG unlock after KAT succeed since we use the sha acc peripherals
+    if let Err(err) = crate::flow::debug_unlock::debug_unlock(&mut env) {
+        handle_fatal_error(err.into());
     }
 
     if let Err(err) = flow::run(&mut env) {

--- a/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_debug_unlock.rs
@@ -473,6 +473,14 @@ fn test_dbg_unlock_prod_success() {
     }
     soc_debug_level += 1;
     assert!(soc_debug_level == unlock_level);
+
+    // Step till we are ready for mailbox processing
+    hw.step_until(|m| {
+        m.soc_ifc()
+            .cptra_flow_status()
+            .read()
+            .ready_for_mb_processing()
+    });
 }
 
 //TODO: https://github.com/chipsalliance/caliptra-sw/issues/2070


### PR DESCRIPTION
After Product-Debug Unlock in PROD lifecycle state, the SHA ACC
KAT test was failing with
DRIVER_SHA2_512_384ACC_UNEXPECTED_ACQUIRED_LOCK_STATE.

The root cause was that validate_debug_unlock_token() released the SHA
ACC lock when the Sha2_512_384AccOp was dropped at the end of its scope.
Subsequent KAT tests expected the lock to remain held (using
ShaAccLockState::AssumedLocked on cold/warm reset).

Fix by moving KAT earlier since we want to have KAT run before using
crypto engine anyway.

Fixes: chipsalliance/caliptra-sw#3050