### PR TITLE
[FPGA-Subsystem]: Filter out crashing test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,7 +34,9 @@ default-filter = """
 (package(caliptra-test) &
     ((test(smoke_test::) - test(smoke_test::test_fmc_wdt_timeout) - test(smoke_test::test_rt_wdt_timeout))
     | test(services::)
-    | (test(self_tests::) - test(self_tests::fw_load_halt_check_no_output))
+    | (test(self_tests::) 
+      - test(self_tests::fw_load_halt_check_no_output)
+      - test(kat_sha2_512_384acc_digest_start_op_failure_rom))
     | test(fw_load::)
     | test(warm_reset::)
     | test(fake_collateral_boot_test::)


### PR DESCRIPTION
This test causes the FPGA to crash.