### PR TITLE
[OCP-LOCK]: Write Lock HEK & MDK KVs

### DIFF
--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -17,7 +17,7 @@ mod fmc_alias;
 pub mod fw_processor;
 mod idev_id;
 mod ldev_id;
-mod ocp_lock;
+pub mod ocp_lock;
 mod x509;
 
 use crate::fht;

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -11,10 +11,12 @@ Abstract:
     File contains the implementation of update reset flow.
 
 --*/
+use crate::flow::cold_reset::ocp_lock;
 #[cfg(feature = "fake-rom")]
 use crate::flow::fake::FakeRomImageVerificationEnv;
 use crate::key_ladder;
 use crate::{cprintln, pcr, rom_env::RomEnv};
+
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::CommandId;
@@ -42,6 +44,8 @@ impl UpdateResetFlow {
     pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[update-reset] ++");
         report_boot_status(UpdateResetStarted.into());
+
+        ocp_lock::wr_lock_keyvault(&mut env.key_vault);
 
         // Check persistent data is valid
         let pdata = env.persistent_data.get();

--- a/rom/dev/src/flow/warm_reset.rs
+++ b/rom/dev/src/flow/warm_reset.rs
@@ -11,7 +11,7 @@ Abstract:
     File contains the implementation of warm reset flow.
 
 --*/
-use crate::{cprintln, rom_env::RomEnv};
+use crate::{cprintln, flow::cold_reset::ocp_lock, rom_env::RomEnv};
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert_eq, cfi_assert_ne, cfi_launder};
@@ -32,6 +32,8 @@ impl WarmResetFlow {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[warm-reset] ++");
+
+        ocp_lock::wr_lock_keyvault(&mut env.key_vault);
 
         // Check persistent data is valid
         let pdata = env.persistent_data.get();


### PR DESCRIPTION
https://github.com/chipsalliance/caliptra-rtl/blob/main/docs/CaliptraHardwareSpecification.md#keyvault-access-rules--filtering-when-lock_in_progress-is-set

> KV22 (HEK): locked for writes until warm reset (ROM requirement).
> KV16 (MDK): locked for writes until warm reset (ROM requirement).