### PR TITLE
Set FW_EXEC_CTRL value before resetting MCU (2.1)

### DIFF
--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1420,14 +1420,14 @@ impl SocRegistersImpl {
         if index >= self.ss_generic_fw_exec_ctrl.len() {
             return Err(BusError::StoreAccessFault);
         }
-        if index == MCU_FW_EXEC_CTRL_INDEX
+        let is_mcu_exec_ctrl_cleared = index == MCU_FW_EXEC_CTRL_INDEX
             && ((val & MCU_FW_EXEC_CTRL_MASK) == 0)
-            && (self.ss_generic_fw_exec_ctrl[index] & MCU_FW_EXEC_CTRL_MASK) != 0
-        {
+            && (self.ss_generic_fw_exec_ctrl[index] & MCU_FW_EXEC_CTRL_MASK) != 0;
+        self.ss_generic_fw_exec_ctrl[index] = val;
+        if is_mcu_exec_ctrl_cleared {
             // If the MCU FW execute bit is cleared, request a reset.
             self.mci.cptra_request_mcu_reset();
         }
-        self.ss_generic_fw_exec_ctrl[index] = val;
         Ok(())
     }
 


### PR DESCRIPTION
The value of FW_EXEC_CTRL controls the behavior of MCU reset.

Currently, if the FW_EXEC_CTRL[2] is cleared, it will trigger an MCI interrupt to MCU which will cause the MCU to request MCI for a reset. The MCI emulator peripheral will then check the value of FW_EXEC_CTRL[2]. If the value is 1, it will immediately reboot, but if the value is 0, then the MCU will halt until FW_EXEC_CTRL[2] is set back to 1.

This sequence causes the MCI emulator peripheral to read the old value of FW_EXEC_CTRL resulting to the incorrect behavior.

The FW_EXEC_CTRL bit value must be set first before triggering the MCI interrupt so that MCI emulator peripheral will read the latest value.