### PR TITLE
runtime: kek_next_iv needs to be initialized to a random value

### DIFF
--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -101,7 +101,7 @@ impl CmStorage {
     pub fn init(&mut self, pdata: &PersistentDataAccessor, trng: &mut Trng) -> CaliptraResult<()> {
         let kek_random_iv = trng.generate4()?;
         // we mask off the top bit so that we always have at least 2^95 usages left.
-        self.context_next_iv = (((kek_random_iv.0 & 0x7fff_ffff) as u128) << 64)
+        self.kek_next_iv = (((kek_random_iv.0 & 0x7fff_ffff) as u128) << 64)
             | ((kek_random_iv.1 as u128) << 32)
             | (kek_random_iv.2 as u128);
         self.kek = Crypto::get_cmb_aes_key(pdata.get());

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -3540,3 +3540,34 @@ fn test_stable_key_aes_cbc_fips_status() {
         );
     }
 }
+
+/// Test that kek_next_iv is properly initialized to a random value.
+/// This is a regression test for https://github.com/chipsalliance/caliptra-sw/issues/3203
+/// The EncryptedCmk structure contains the IV used for encryption, which should be random
+/// and not start at zero.
+#[test]
+fn test_kek_iv_initialized() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // Import a key and check that the IV in the encrypted CMK is not zero
+    let cmk = import_key(&mut model, &[0xaa; 32], CmKeyUsage::Aes);
+
+    // The EncryptedCmk structure layout is:
+    //   domain: u32 (4 bytes)
+    //   domain_metadata: [u8; 16] (16 bytes)
+    //   iv: LEArray4x3 (12 bytes) - this is at offset 20
+    //   ciphertext: [u8; UNENCRYPTED_CMK_SIZE_BYTES]
+    //   gcm_tag: LEArray4x4
+    let iv_offset = 4 + 16; // domain (4) + domain_metadata (16)
+    let iv_bytes = &cmk.0[iv_offset..iv_offset + 12];
+
+    // The IV should not be all zeros (since it should be randomized from TRNG)
+    assert_ne!(
+        iv_bytes, &[0u8; 12],
+        "kek_next_iv was not initialized - IV should be random, not zero"
+    );
+}


### PR DESCRIPTION
In the cryptographic mailbox, we were accidentally setting the context IV twice instead of initializing the KEK next IV.

This shouldn't be too much of an issue, since the KEK is generated randomly on each boot, so there is not a chance that the IV is reused with the same key.

Fixes #3203