### PR TITLE
[dpe] Use both RT PCRs in RT DPE context (#3038)

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1243,6 +1243,11 @@ impl CaliptraError {
             0x000E005E,
             "Runtime Error: Reallocate DPE context requested fewer PL1 contexts than are used currently"
         ),
+        (
+            RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED,
+            0x000E005F,
+            "Runtime Error: RT current PCR validation failed"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1075,10 +1075,10 @@ this case, the new Runtime Firmware must:
 
 1. Validate DPE state in SRAM
     1. Ensure the TCI tree is well-formed
-    1. Ensure all nodes chain to the root (TYPE = RTJM, “Internal TCI” flag is set)
+    1. Ensure all nodes chain to the root (TYPE = RTMR, “Internal TCI” flag is set)
 1. Verify that the “Latest TCI” field of the TCI Node that contains the
-   Runtime Journey PCR (TYPE = RTJM, “Internal TCI” flag is set) matches the
-   “Latest” Runtime PCR value from PCRX
+   Runtime PCRs (TYPE = RTMR, “Internal TCI” flag is set) matches the
+   “Latest” and Journey Runtime PCR values.
     1. Ensure `SHA384_HASH(0x00..00, TCI from SRAM) == RT_FW_JOURNEY_PCR`
 1. Check that retired and inactive contexts do not have tags
 1. If any validations fail, Runtime Firmware executes the
@@ -1180,9 +1180,9 @@ Caliptra Runtime Firmware is responsible for initializing DPE’s default contex
 
 * Runtime Firmware SHALL initialize the default context in “internal-cdi” mode.
 * Perform the following initial measurements:
-  * Call DeriveContext with Caliptra Journey PCR
+  * Call DeriveContext with Caliptra RT PCRs
     * INPUT\_DATA = PCRX (RT journey PCR as defined in the FHT)
-    * TYPE = “RTJM”
+    * TYPE = “RTMR”
     * CONTEXT\_HANDLE = default context
     * TARGET\_LOCALITY = Caliptra locality (0xFFFFFFFF)
   * Call DeriveContext with mailbox valid PAUSERS

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -12,7 +12,7 @@ Updates Caliptra with a new firmware image and tests that runtime boots | **test
 Boots runtime using the Caliptra runtime test binary | **test_boot** | N/A
 Boots Caliptra and validates the firmware version | **test_fw_version** | N/A
 Tests the persistent data layout on a RISC-V CPU with the runtime flag enabled| **test_persistent_data** | N/A
-Checks that DPE contains the correct measurements upon booting runtime | **test_boot_tci_data** | N/A 
+Checks that DPE contains the correct measurements upon booting runtime | **test_boot_tci_data** | N/A
 Checks that measurements in the measurement log are added to DPE upon booting runtime | **test_measurement_in_measurement_log_added_to_dpe** | N/A
 
 <br><br>
@@ -148,7 +148,7 @@ Tags the default context, retires the default context, and checks that the dpe_g
 # **Update Reset Tests**
 Test Scenario| Test Name | Runtime Error Code
 ---|---|---
-Checks that the DPE root measurement is set to the RT_FW_JOURNEY_PCR upon update reset | **test_rt_journey_pcr_updated_in_dpe** | N/A
+Checks that the DPE root measurements are set to the RT_FW_CURERNT_PCR and RT_FW_JOURNEY_PCR upon update reset | **test_rt_pcr_updated_in_dpe** | N/A
 Checks that context tags are persisted across update resets | **test_tags_persistence** | N/A
 Corrupts the context tags and checks that an error is thrown upon update reset | **test_context_tags_validation** | RUNTIME_CONTEXT_TAGS_VALIDATION_FAILED
 Corrupts the shape of the DPE context tree and checks that an error is thrown upon update reset | **test_dpe_validation_deformed_structure** | RUNTIME_DPE_VALIDATION_FAILED
@@ -160,7 +160,8 @@ Checks that the pcr reset counter is persisted across update resets | **test_pcr
 # **Warm Reset Tests**
 Test Scenario| Test Name | Runtime Error Code
 ---|---|---
-Corrupts the DPE root measurement, triggers a warm reset, and checks that RT journey PCR validation fails | **test_rt_journey_pcr_validation** | RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED
+Corrupts the DPE root current measurement, triggers a warm reset, and checks that RT current PCR validation fails | **test_rt_current_pcr_validation** | RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED
+Corrupts the DPE root journey measurement, triggers a warm reset, and checks that RT journey PCR validation fails | **test_rt_journey_pcr_validation** | RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED
 Tests that there is a non-fatal error if runtime is executing a mailbox command during warm reset | **test_mbox_busy_during_warm_reset** | RUNTIME_CMD_BUSY_DURING_WARM_RESET
 
 <br><br>

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -120,15 +120,15 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // We don't expect the image_digest to be part of the stash
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     let expected_measurement_hash = hasher.finalize();
 
@@ -176,15 +176,15 @@ fn test_authorize_and_stash_cmd_success() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order to check that stashed measurement was added to DPE
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     hasher.update(IMAGE_DIGEST1);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -161,15 +161,15 @@ fn test_boot_tci_data() {
     };
     let mut model = run_rt_test(args);
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     let expected_measurement_hash = hasher.finalize();
 
@@ -222,15 +222,15 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
 
     model.step_until_boot_status(u32::from(RomBootStatus::ColdResetComplete), true);
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     hasher.update(measurement);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -61,15 +61,15 @@ fn test_stash_measurement() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order to check that stashed measurement was added to DPE
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     hasher.update(measurement);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -36,7 +36,7 @@ pub fn update_fw(model: &mut DefaultHwModel, rt_fw: &FwId<'static>, image_opts: 
 }
 
 #[test]
-fn test_rt_journey_pcr_updated_in_dpe() {
+fn test_rt_pcr_updated_in_dpe() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     model.step_until(|m| {
@@ -49,10 +49,18 @@ fn test_rt_journey_pcr_updated_in_dpe() {
     let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
     let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
 
-    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0000, &[]).unwrap().unwrap();
+    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0001, &[]).unwrap().unwrap();
     let dpe_root_measurement: [u8; 48] = dpe_root_measurement_resp.as_bytes().try_into().unwrap();
 
     assert_eq!(dpe_root_measurement, rt_journey_pcr);
+
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
+
+    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0000, &[]).unwrap().unwrap();
+    let dpe_root_measurement: [u8; 48] = dpe_root_measurement_resp.as_bytes().try_into().unwrap();
+
+    assert_eq!(dpe_root_measurement, rt_current_pcr);
 }
 
 #[test]


### PR DESCRIPTION
Cherry pick of https://github.com/chipsalliance/caliptra-sw/pull/3038

Fixes https://github.com/chipsalliance/caliptra-sw/issues/2775

The original design for DPE only considered having one measurement per context. Later a design change added another to accomodate current and journey measurements. This was not reflected in the RT DPE context so journey was used for both measurements. This was partially due to the fact that the RT current measurement is already reported in the RT alias certificate.

This changes 2.x to report both current and journey measurements in its DPE context. A similar change will be added to 1.x as tracked in https://github.com/chipsalliance/caliptra-sw/issues/3027.