### PR TITLE
tests: Add RI_DOWNLOAD_ENCRYPTED_FIRMWARE test

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -650,6 +650,9 @@ const FW_LOAD_CMD_OPCODE: u32 = 0x4657_4C44;
 /// The download firmware from recovery interface Opcode
 const RI_DOWNLOAD_FIRMWARE_OPCODE: u32 = 0x5249_4644;
 
+/// The download encrypted firmware from recovery interface Opcode
+const RI_DOWNLOAD_ENCRYPTED_FIRMWARE_OPCODE: u32 = 0x5249_4645;
+
 /// Stash Measurement Command Opcode.
 const STASH_MEASUREMENT_CMD_OPCODE: u32 = 0x4D45_4153;
 
@@ -1226,6 +1229,21 @@ pub trait HwModel: SocManager {
     ) -> Result<(), ModelError> {
         self.put_firmware_in_rri(firmware, soc_manifest, mcu_firmware)?;
         let response = self.mailbox_execute(RI_DOWNLOAD_FIRMWARE_OPCODE, &[])?;
+        if response.is_some() {
+            return Err(ModelError::UploadFirmwareUnexpectedResponse);
+        }
+        Ok(())
+    }
+
+    /// Upload encrypted fw image to RRI.
+    fn upload_firmware_rri_encrypted(
+        &mut self,
+        firmware: &[u8],
+        soc_manifest: Option<&[u8]>,
+        mcu_firmware: Option<&[u8]>,
+    ) -> Result<(), ModelError> {
+        self.put_firmware_in_rri(firmware, soc_manifest, mcu_firmware)?;
+        let response = self.mailbox_execute(RI_DOWNLOAD_ENCRYPTED_FIRMWARE_OPCODE, &[])?;
         if response.is_some() {
             return Err(ModelError::UploadFirmwareUnexpectedResponse);
         }

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -327,7 +327,7 @@ impl FirmwareProcessor {
                 if txn.cmd() == CommandId::RI_DOWNLOAD_FIRMWARE.into() || encrypted {
                     if !subsystem_mode {
                         cprintln!(
-                            "[fwproc] RI_DOWNLOAD_FIRMWARE cmd not supported in passive mode"
+                            "[fwproc] RI_DOWNLOAD_FIRMWARE / RI_DOWNLOAD_ENCRYPTED_FIRMWARE cmds not supported in passive mode"
                         );
                         // Start and complete the transaction with error
                         let txn = mbox
@@ -342,10 +342,12 @@ impl FirmwareProcessor {
                     // Set boot mode based on command type
                     if encrypted {
                         persistent_data.rom.boot_mode = BootMode::EncryptedFirmware;
+                        cprintln!("[fwproc] Completing RI_DOWNLOAD_ENCRYPTED_FIRMWARE command");
+                    } else {
+                        // Complete the command indicating success
+                        cprintln!("[fwproc] Completing RI_DOWNLOAD_FIRMWARE command");
                     }
 
-                    // Complete the command indicating success
-                    cprintln!("[fwproc] Completing RI_DOWNLOAD_FIRMWARE command");
                     let txn = mbox
                         .peek_recv()
                         .ok_or(CaliptraError::FW_PROC_MAILBOX_STATE_INCONSISTENT)?;


### PR DESCRIPTION
This adds a test that the code in #3043 operates like a normal RI_DOWNLOAD_FIRMWARE for now.

We also update the ROM messages to reflect which kind of boot is being done.