### PR TITLE
Fix nightly release job

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          submodules: 'true'
 
       - name: Find latest release
         id: find


### PR DESCRIPTION
The nightly needs to checkout the hardware submodules to create a release