### PR TITLE
[OCP-LOCK]: Push VEK generation into OCP LOCK module

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -127,7 +127,9 @@ pub use persistent::fmc_alias_csr::FmcAliasCsrs;
 pub use persistent::FwPersistentData;
 pub use persistent::IDEVID_CSR_ENVELOP_MARKER;
 #[cfg(feature = "runtime")]
-pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
+pub use persistent::{
+    AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles, OcpLockMetadataFirmware,
+};
 pub use persistent::{
     BootMode, Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, OcpLockFlags,
     PcrLogArray, PersistentData, PersistentDataAccessor, RomPersistentData, StashMeasurementArray,

--- a/runtime/src/ocp_lock/mix_mpk.rs
+++ b/runtime/src/ocp_lock/mix_mpk.rs
@@ -24,12 +24,14 @@ impl MixMpkCmd {
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
         let enabled_mpk = EnabledMpk::try_from(&cmd.enabled_mpk)?;
+        let state = &drivers.persistent_data.get().fw.ocp_lock_metadata;
 
         drivers.ocp_lock_context.mix_mpk(
             &mut drivers.aes,
             &mut drivers.hmac,
             &mut drivers.trng,
             &enabled_mpk,
+            state,
         )?;
 
         let resp = mutrefbytes::<OcpLockMixMpkResp>(resp)?;


### PR DESCRIPTION
This resolves a feedback item from
https://github.com/chipsalliance/caliptra-sw/pull/3168#discussion_r2723502776.