### PR TITLE
sw-emulator: Halted CPUs should still process events 2.0 (#3247)

### DIFF
--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -827,6 +827,10 @@ impl<TBus: Bus> Cpu<TBus> {
             return returned_action;
         }
 
+        // handle incoming events for this CPU that might be necessary even if we are halted,
+        // such as writes to our memory
+        self.handle_incoming_events();
+
         // We are in a halted state. Don't continue executing but poll the bus for interrupts
         if self.halted {
             self.set_next_pc(self.pc);


### PR DESCRIPTION
Otherwise memory writes during, e.g., hitless fw updates, can be queued until after the CPU resets, which can cause the CPU to try to execute invalid instructions.

(cherry picked from commit 8f764b6dfc83369293cb0a3fd748842f02e751c4)