### PR TITLE
sw-emulator: Don't fire saved internal timers during reset

### DIFF
--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -754,6 +754,9 @@ impl<TBus: Bus> Cpu<TBus> {
         self.halted = false;
         self.priv_mode = RvPrivMode::M;
         self.csrs.reset();
+        // Disarm internal timers to prevent interrupts scheduled before reset from firing
+        self.csrs.internal_timers.disarm(0);
+        self.csrs.internal_timers.disarm(1);
         self.reset_pc();
     }
 


### PR DESCRIPTION
These internal timers might be saved up during hitless update, where the MCU processor is halted. When it comes out of reset, the timers would immediately try to fire, which could trigger the wrong code to be executed.