### PR TITLE
nightly: Increase timeout for test_pl0_pl1_reallocation_range

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -97,7 +97,7 @@ slow-timeout = { period = "30s", terminate-after = 100 }
 
 [[profile.nightly.overrides]]
 filter = 'test(test_pl0_pl1_reallocation_range)'
-slow-timeout = { period = "30s", terminate-after = 12 }
+slow-timeout = { period = "30s", terminate-after = 24 }
 
 [profile.nightly.junit]
 path = "/tmp/junit.xml"


### PR DESCRIPTION
This test took 260 seconds, which is uncomfortably close to the 360 limit and may have caused timeouts on the most recently nightly run?