### PR TITLE
nightly release: Set the correct ROM env for FIPS tests

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -319,6 +319,7 @@ jobs:
 
           if [[ "${{ inputs.workflow_call }}" && "${{ inputs.rom-version }}" != "latest" ]]; then
             VARS+=" CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}""
+            VARS+=" FIPS_TEST_ROM_EXP_VERSION=$(echo "${{ inputs.rom-version }}" | sed 's/\./_/g')"
           fi
 
           echo VARS=${VARS}

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -268,6 +268,7 @@ jobs:
 
           if [[ "${{ inputs.workflow_call }}" && "${{ inputs.rom-version }}" != "latest" ]]; then
             VARS+=" CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}""
+            VARS+=" FIPS_TEST_ROM_EXP_VERSION=$(echo "${{ inputs.rom-version }}" | sed 's/\./_/g')"
           fi
 
           echo VARS=${VARS}

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -63,6 +63,7 @@ jobs:
           export CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware
           if [ "${{ inputs.rom-version }}" != "latest" ]; then
             export CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}"
+            export FIPS_TEST_ROM_EXP_VERSION="$(echo "${{ inputs.rom-version }}" | sed 's/\./_/g')"
           fi
 
           if [ "${{ inputs.rom-logging }}" == "true" ] || [ -z "${{ inputs.rom-logging }}" ]; then

--- a/.github/workflows/nightly-release-2.0.yml
+++ b/.github/workflows/nightly-release-2.0.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { name: "2.0", rom: "2.0", suffix: "rom-2.0", base_features: "slow_tests" }
+          - { name: "2.0", rom: "2.0.0", suffix: "rom-2.0", base_features: "slow_tests" }
           - { name: "latest", rom: "latest", suffix: "hw-latest", base_features: "slow_tests" }
         rng:
           - { name: "etrng", extra: "" }
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         hw_config:
-          - { name: "rom-2.0", hw: "latest", rom: "2.0", suffix_prefix: "rom-2.0" }
+          - { name: "rom-2.0", hw: "latest", rom: "2.0.0", suffix_prefix: "rom-2.0" }
           - { name: "hw-latest", hw: "latest", rom: "latest", suffix_prefix: "latest" }
         rng:
           - { name: "itrng", fpga_itrng: true, extra: "slow_tests,itrng" }
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         hw_config:
-          - { name: "rom-2.0", hw: "latest", rom: "2.0", suffix_prefix: "rom-2.0" }
+          - { name: "rom-2.0", hw: "latest", rom: "2.0.0", suffix_prefix: "rom-2.0" }
           - { name: "hw-latest", hw: "latest", rom: "latest", suffix_prefix: "latest" }
         rng:
           - { name: "itrng", fpga_itrng: true, extra: "slow_tests,itrng" }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -37,7 +37,7 @@ pub const THIS_WORKSPACE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 
 #[derive(Debug, PartialEq)]
 pub enum CiRomVersion {
-    Rom2_0,
+    Rom2_0_0,
     Latest,
 }
 
@@ -366,7 +366,7 @@ pub fn build_firmware_elf(id: &FwId<'static>) -> io::Result<Arc<Vec<u8>>> {
 // Default is Latest
 pub fn get_ci_rom_version() -> CiRomVersion {
     match std::env::var("CPTRA_CI_ROM_VERSION").as_deref() {
-        Ok("2.0") => CiRomVersion::Rom2_0,
+        Ok("2.0.0") => CiRomVersion::Rom2_0_0,
         Ok(version) => panic!("Unknown CI ROM version \'{}\'", version),
         Err(_) => CiRomVersion::Latest,
     }
@@ -377,7 +377,7 @@ pub fn get_ci_rom_version() -> CiRomVersion {
 pub fn rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
     let rom_from_env = firmware::rom_from_env();
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 => {
+        CiRomVersion::Rom2_0_0 => {
             if rom_from_env == &firmware::ROM {
                 Ok(
                     include_bytes!("../../rom/ci_frozen_rom/2.0/caliptra-rom-2.0.0-62c8009.bin")
@@ -403,7 +403,7 @@ pub fn rom_for_fw_integration_tests() -> io::Result<Cow<'static, [u8]>> {
 pub fn rom_for_fw_integration_tests_fpga(fpga: bool) -> io::Result<Cow<'static, [u8]>> {
     let rom_from_env = firmware::rom_from_env_fpga(fpga);
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 => {
+        CiRomVersion::Rom2_0_0 => {
             if rom_from_env == &firmware::ROM {
                 Ok(
                     include_bytes!("../../rom/ci_frozen_rom/2.0/caliptra-rom-2.0.0-62c8009.bin")

--- a/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_idev_csr.rs
@@ -32,7 +32,7 @@ fn test_get_ecc_csr() {
     let result = model.mailbox_execute(CommandId::GET_IDEV_ECC384_CSR.into(), payload.as_bytes());
 
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 | CiRomVersion::Latest => {
+        CiRomVersion::Rom2_0_0 | CiRomVersion::Latest => {
             let response = result.unwrap().unwrap();
 
             let mut get_idv_csr_resp = GetIdevCsrResp::default();
@@ -71,7 +71,7 @@ fn test_get_mldsa_csr() {
     let result = model.mailbox_execute(CommandId::GET_IDEV_MLDSA87_CSR.into(), payload.as_bytes());
 
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 | CiRomVersion::Latest => {
+        CiRomVersion::Rom2_0_0 | CiRomVersion::Latest => {
             let response = result.unwrap().unwrap();
 
             let mut get_idv_csr_resp = GetIdevCsrResp::default();
@@ -110,7 +110,7 @@ fn test_missing_csr() {
         .unwrap_err();
 
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 | CiRomVersion::Latest => assert_eq!(
+        CiRomVersion::Rom2_0_0 | CiRomVersion::Latest => assert_eq!(
             response,
             ModelError::MailboxCmdFailed(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED.into())
         ),
@@ -128,7 +128,7 @@ fn test_missing_csr() {
         .unwrap_err();
 
     match get_ci_rom_version() {
-        CiRomVersion::Rom2_0 | CiRomVersion::Latest => assert_eq!(
+        CiRomVersion::Rom2_0_0 | CiRomVersion::Latest => assert_eq!(
             response,
             ModelError::MailboxCmdFailed(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED.into())
         ),


### PR DESCRIPTION
And make the nightly tests a little more future-proof for ROM version bumps.

Tested here: https://github.com/chipsalliance/caliptra-sw/actions/runs/21797350465