### PR TITLE
feat(aes): Add KAT execution to AES driver initialization

### DIFF
--- a/drivers/test-fw/src/bin/aes_tests.rs
+++ b/drivers/test-fw/src/bin/aes_tests.rs
@@ -75,7 +75,7 @@ const EXPECTED_MAC_4256: [u8; 16] = [
 ];
 
 fn test_cmac() {
-    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
     let mut trng = unsafe {
         Trng::new(
             CsrngReg::new(),
@@ -128,7 +128,7 @@ fn test_cmac_kv() {
     );
     assert!(result.is_ok());
 
-    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
     // this is the expected derived key from the above seed.
     let key: [u8; 48] = [
         0xfe, 0xee, 0xf5, 0x54, 0x4a, 0x76, 0x56, 0x49, 0x90, 0x12, 0x8a, 0xd1, 0x89, 0xe8, 0x73,

--- a/drivers/test-fw/src/bin/dma_aes_tests.rs
+++ b/drivers/test-fw/src/bin/dma_aes_tests.rs
@@ -245,7 +245,7 @@ fn test_dma_aes_mcu_sram_inplace() {
     if !soc.subsystem_mode() {
         return;
     }
-    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
 
     let mut trng = unsafe {
         Trng::new(
@@ -288,7 +288,7 @@ fn test_dma_aes_mcu_sram() {
     if !soc.subsystem_mode() {
         return;
     }
-    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
 
     let mut trng = unsafe {
         Trng::new(
@@ -343,7 +343,7 @@ fn test_dma_aes_mcu_sram_256kb() {
     );
 
     // Encrypt MCU SRAM
-    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+    let mut aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
 
     let mut trng = unsafe {
         Trng::new(

--- a/drivers/test-fw/src/lib.rs
+++ b/drivers/test-fw/src/lib.rs
@@ -97,7 +97,7 @@ impl Default for TestRegisters {
         let soc_ifc = unsafe { SocIfcReg::new() };
         let soc = SocIfc::new(soc_ifc);
         let hmac = unsafe { Hmac::new(HmacReg::new()) };
-        let aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()) };
+        let aes = unsafe { Aes::new(AesReg::new(), AesClpReg::new()).unwrap() };
         let trng = unsafe {
             Trng::new(
                 CsrngReg::new(),

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -181,7 +181,7 @@ impl Drivers {
             PersistentDataAccessor::new(),
         )?;
 
-        let aes = Aes::new(AesReg::new(), AesClpReg::new());
+        let aes = Aes::new(AesReg::new(), AesClpReg::new())?;
         let soc_ifc = SocIfc::new(SocIfcReg::new());
         let persistent_data = PersistentDataAccessor::new();
 


### PR DESCRIPTION
Since fe88c48cc1db87b8b40781fd2b11d28c4a796fcb AES KATs are lazily run
to reduce rom size. This means they have yet to run in runtime so add
them in the initialization path.

Execute non-GCM KATs (ECB, CBC, CTR, CMAC) during AES driver
construction. Change Aes::new() to return CaliptraResult to propagate
KAT failures. GCM and CMAC-KDF KATs remain executed by AesGcm::new().

Signed-off-by: Arthur Heymans <arthur.heymans@9elements.com>