### PR TITLE
FIPS test hook optimizations to reduce code size when enabled

### DIFF
--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -367,7 +367,7 @@ impl Ecc384 {
         let digest = Array4x12::new([0u32; 12]);
 
         #[cfg(feature = "fips-test-hooks")]
-        let pub_key = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::ECC384_PAIRWISE_CONSISTENCY_ERROR,
                 &pub_key,
@@ -391,7 +391,7 @@ impl Ecc384 {
         self.zeroize_internal();
 
         #[cfg(feature = "fips-test-hooks")]
-        let pub_key = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::ECC384_CORRUPT_KEY_PAIR,
                 &pub_key,
@@ -522,12 +522,12 @@ impl Ecc384 {
         caliptra_cfi_lib::cfi_assert_eq_12_words(&_r.0, &sig.r.0);
 
         #[cfg(feature = "fips-test-hooks")]
-        let sig_result = Ok(unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::ECC384_CORRUPT_SIGNATURE,
                 sig,
             )
-        });
+        };
 
         sig_result
     }

--- a/drivers/src/hmac384.rs
+++ b/drivers/src/hmac384.rs
@@ -555,7 +555,7 @@ impl<'a> Hmac384Op<'a> {
         let buf = &self.buf[..self.buf_idx];
 
         #[cfg(feature = "fips-test-hooks")]
-        let buf = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::HMAC384_CORRUPT_TAG,
                 &buf,

--- a/drivers/src/lms.rs
+++ b/drivers/src/lms.rs
@@ -438,7 +438,7 @@ impl Lms {
         lms_sig: &LmsSignature<6, 51, 15>,
     ) -> CaliptraResult<LmsResult> {
         #[cfg(feature = "fips-test-hooks")]
-        let input_string = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::LMS_CORRUPT_INPUT,
                 &input_string,

--- a/drivers/src/sha1.rs
+++ b/drivers/src/sha1.rs
@@ -97,14 +97,12 @@ impl Sha1 {
         }
 
         #[cfg(feature = "fips-test-hooks")]
-        {
-            self.compressor.hash = unsafe {
-                crate::FipsTestHook::corrupt_data_if_hook_set(
-                    crate::FipsTestHook::SHA1_CORRUPT_DIGEST,
-                    &self.compressor.hash,
-                )
-            };
-        }
+        unsafe {
+            crate::FipsTestHook::corrupt_data_if_hook_set(
+                crate::FipsTestHook::SHA1_CORRUPT_DIGEST,
+                &self.compressor.hash,
+            )
+        };
 
         Ok(self.compressor.hash().into())
     }

--- a/drivers/src/sha256.rs
+++ b/drivers/src/sha256.rs
@@ -128,7 +128,7 @@ impl Sha256Alg for Sha256 {
         let digest = Array4x8::read_from_reg(self.sha256.regs().digest());
 
         #[cfg(feature = "fips-test-hooks")]
-        let digest = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::SHA256_CORRUPT_DIGEST,
                 &digest,

--- a/drivers/src/sha2_512_384acc.rs
+++ b/drivers/src/sha2_512_384acc.rs
@@ -275,14 +275,12 @@ impl Sha2_512_384AccOp<'_> {
         *digest = Array4x16::read_from_reg(sha_acc.digest());
 
         #[cfg(feature = "fips-test-hooks")]
-        {
-            *digest = unsafe {
-                crate::FipsTestHook::corrupt_data_if_hook_set(
-                    crate::FipsTestHook::SHA2_512_384_ACC_CORRUPT_DIGEST_512,
-                    digest,
-                )
-            };
-        }
+        unsafe {
+            crate::FipsTestHook::corrupt_data_if_hook_set(
+                crate::FipsTestHook::SHA2_512_384_ACC_CORRUPT_DIGEST_512,
+                digest,
+            )
+        };
 
         // Zeroize the hardware registers.
         self.sha512_acc

--- a/drivers/src/sha384.rs
+++ b/drivers/src/sha384.rs
@@ -110,7 +110,7 @@ impl Sha384 {
         let digest = self.read_digest();
 
         #[cfg(feature = "fips-test-hooks")]
-        let digest = unsafe {
+        unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::SHA384_CORRUPT_DIGEST,
                 &digest,


### PR DESCRIPTION
Reduces the code size increase when FIPS test hooks are turned on