### PR TITLE
api: Ensure mailbox api is panic-free (2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,10 +232,24 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-api-types",
+ "caliptra-builder",
  "caliptra-emu-types",
  "caliptra-error",
  "caliptra-image-types",
  "caliptra-registers",
+ "ureg",
+ "zerocopy",
+]
+
+[[package]]
+name = "caliptra-api-test-bin"
+version = "0.1.0"
+dependencies = [
+ "caliptra-api",
+ "caliptra-drivers",
+ "caliptra-registers",
+ "caliptra-test-harness",
+ "cfg-if",
  "ureg",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
 
 members = [
   "api",
+  "api/test-fw",
   "api/types",
   "auth-manifest/app",
   "auth-manifest/gen",
@@ -103,6 +104,7 @@ bitfield = "0.14.0"
 bitflags = "2.4.0"
 bit-vec = "0.6.3"
 caliptra-api = { path = "api" }
+caliptra-api-test-bin = { path = "api/test-fw" }
 caliptra-api-types = { path = "api/types" }
 caliptra-auth-man-gen = { path = "auth-manifest/gen", default-features = false }
 caliptra-auth-man-types = { path = "auth-manifest/types", default-features = false }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,3 +16,6 @@ caliptra-registers.workspace = true
 caliptra-api-types.workspace = true
 ureg.workspace = true
 caliptra-image-types = { workspace = true, default-features = false }
+
+[dev-dependencies]
+caliptra-builder.workspace = true

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -10,7 +10,7 @@ use caliptra_image_types::{
 use caliptra_registers::mbox;
 use core::mem::size_of;
 use ureg::MmioMut;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Maximum input data size for cryptographic mailbox commands.
 pub const MAX_CMB_DATA_SIZE: usize = 4096;
@@ -4244,31 +4244,25 @@ pub fn mbox_read_fifo(
     mbox: mbox::RegisterBlock<impl MmioMut>,
     buf: &mut [u8],
 ) -> core::result::Result<(), CaliptraApiError> {
-    use zerocopy::Unalign;
-
-    fn dequeue_words(mbox: &mbox::RegisterBlock<impl MmioMut>, buf: &mut [Unalign<u32>]) {
-        for word in buf.iter_mut() {
-            *word = Unalign::new(mbox.dataout().read());
-        }
-    }
-
     let dlen_bytes = mbox.dlen().read() as usize;
 
     let buf = buf
         .get_mut(..dlen_bytes)
         .ok_or(CaliptraApiError::UnableToReadMailbox)?;
 
-    let len_words = buf.len() / size_of::<u32>();
-    let (mut buf_words, suffix) = Ref::from_prefix_with_elems(buf, len_words)
-        .map_err(|_| CaliptraApiError::ReadBuffTooSmall)?;
-
-    dequeue_words(&mbox, &mut buf_words);
-    if !suffix.is_empty() {
-        let last_word = mbox.dataout().read();
-        let suffix_len = suffix.len();
-        suffix
-            .as_mut_bytes()
-            .copy_from_slice(&last_word.as_bytes()[..suffix_len]);
+    let mut remaining = &mut buf[..];
+    while remaining.len() >= 4 {
+        let (chunk, rest) = remaining.split_at_mut(4);
+        let word = mbox.dataout().read().to_le_bytes();
+        chunk[0] = word[0];
+        chunk[1] = word[1];
+        chunk[2] = word[2];
+        chunk[3] = word[3];
+        remaining = rest;
+    }
+    if !remaining.is_empty() {
+        let last_word = mbox.dataout().read().to_le_bytes();
+        remaining.copy_from_slice(&last_word[..remaining.len()]);
     }
 
     Ok(())

--- a/api/test-fw/Cargo.toml
+++ b/api/test-fw/Cargo.toml
@@ -1,0 +1,24 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-api-test-bin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+caliptra-api = { workspace = true }
+caliptra-drivers = { workspace = true, features = ["emu"] }
+caliptra-registers = { workspace = true }
+caliptra-test-harness = { workspace = true }
+cfg-if.workspace = true
+ureg.workspace = true
+zerocopy.workspace = true
+
+[features]
+emu = ["caliptra-test-harness/emu"]
+riscv = ["caliptra-test-harness/riscv"]
+
+[[bin]]
+name = "api_mailbox_panic_test"
+path = "src/bin/api_mailbox_panic_test.rs"
+required-features = ["riscv"]

--- a/api/test-fw/build.rs
+++ b/api/test-fw/build.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache-2.0 license
+
+fn main() {
+    if cfg!(feature = "riscv") {
+        println!("cargo:rerun-if-changed=../../test-harness/scripts/rom.ld");
+        println!("cargo:rustc-link-arg=-Ttest-harness/scripts/rom.ld");
+    }
+}

--- a/api/test-fw/src/bin/api_mailbox_panic_test.rs
+++ b/api/test-fw/src/bin/api_mailbox_panic_test.rs
@@ -1,0 +1,91 @@
+// Licensed under the Apache-2.0 license
+
+//! Minimal RISC-V binary that calls caliptra-api mailbox functions.
+//!
+//! This binary is not meant to be executed; it exists solely so that the
+//! test_panic_missing integration test can build it for riscv32imc and
+//! inspect the resulting ELF for panic-related symbols.
+//!
+//! It defines a panic handler containing a `panic_is_possible` sentinel
+//! symbol. If any code linked into this binary can panic, the compiler
+//! will keep the panic handler and the sentinel will appear in the ELF.
+
+#![no_std]
+#![no_main]
+
+use caliptra_api::mailbox::StashMeasurementReq;
+use caliptra_api::SocManager;
+use core::hint::black_box;
+use core::panic::PanicInfo;
+use ureg::RealMmioMut;
+
+// Force the test harness to be linked, which provides start.S.
+extern crate caliptra_test_harness;
+
+#[panic_handler]
+#[inline(never)]
+fn panic_handler(_: &PanicInfo) -> ! {
+    panic_is_possible();
+    loop {}
+}
+
+#[no_mangle]
+#[inline(never)]
+fn panic_is_possible() {
+    black_box(());
+    // The existence of this symbol is used to inform test_panic_missing
+    // that panics are possible. Do not remove or rename this symbol.
+}
+
+#[no_mangle]
+extern "C" fn cfi_panic_handler(_code: u32) -> ! {
+    loop {}
+}
+
+/// A minimal SocManager implementation for compilation purposes.
+struct TestSocManager;
+
+impl SocManager for TestSocManager {
+    const SOC_MBOX_ADDR: u32 = 0x3002_0000;
+    const SOC_IFC_ADDR: u32 = 0x3003_0000;
+    const SOC_IFC_TRNG_ADDR: u32 = 0x3003_0000;
+    const MAX_WAIT_CYCLES: u32 = 400_000;
+
+    type TMmio<'a> = RealMmioMut<'a>;
+
+    fn mmio_mut(&mut self) -> Self::TMmio<'_> {
+        RealMmioMut::default()
+    }
+
+    fn delay(&mut self) {}
+}
+
+/// Calls mailbox_exec_req to ensure it is linked into the binary.
+fn test_mailbox_exec_req_linked() {
+    let mut mgr = TestSocManager;
+    let req = StashMeasurementReq::default();
+    let mut resp_bytes = [0u8; 512];
+    // We don't care about the result; the point is that the compiler
+    // must link in the full mailbox_exec_req code path, including any
+    // .unwrap() calls that may introduce panics.
+    let _ = black_box(mgr.mailbox_exec_req(req, &mut resp_bytes));
+}
+
+/// Calls mailbox_exec (the untyped version) to cover that code path too.
+fn test_mailbox_exec_linked() {
+    let mut mgr = TestSocManager;
+    let mut resp_bytes = [0u8; 512];
+    let _ = black_box(mgr.mailbox_exec(0x4d454153, &[0u8; 8], &mut resp_bytes));
+}
+
+#[no_mangle]
+pub extern "C" fn main() {
+    test_mailbox_exec_req_linked();
+    test_mailbox_exec_linked();
+}
+
+#[no_mangle]
+pub extern "C" fn entry_point() {
+    main();
+    caliptra_drivers::ExitCtrl::exit(0);
+}

--- a/api/tests/api_integration_tests/main.rs
+++ b/api/tests/api_integration_tests/main.rs
@@ -1,0 +1,3 @@
+// Licensed under the Apache-2.0 license
+
+mod test_panic_missing;

--- a/api/tests/api_integration_tests/test_panic_missing.rs
+++ b/api/tests/api_integration_tests/test_panic_missing.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::firmware;
+
+/// Verify that the caliptra-api mailbox functions are panic-free.
+#[test]
+fn test_panic_missing() {
+    let api_elf = caliptra_builder::build_firmware_elf(&firmware::api_tests::MAILBOX).unwrap();
+    let symbols = caliptra_builder::elf_symbols(&api_elf).unwrap();
+    if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
+        panic!(
+            "The caliptra-api mailbox test binary contains the panic_is_possible symbol, \
+             which is not allowed. Please remove any code that might panic."
+        )
+    }
+}

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -525,6 +525,21 @@ pub mod runtime_tests {
     };
 }
 
+pub mod api_tests {
+    use super::*;
+
+    const BASE_FWID: FwId = FwId {
+        crate_name: "caliptra-api-test-bin",
+        bin_name: "",
+        features: &["emu"],
+    };
+
+    pub const MAILBOX: FwId = FwId {
+        bin_name: "api_mailbox_panic_test",
+        ..BASE_FWID
+    };
+}
+
 pub const REGISTERED_FW: &[&FwId] = &[
     &ROM,
     &ROM_FPGA,
@@ -608,4 +623,5 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &runtime_tests::MBOX_WITHOUT_UART_FPGA,
     &runtime_tests::PERSISTENT_RT,
     &runtime_tests::MOCK_RT_INTERACTIVE,
+    &api_tests::MAILBOX,
 ];


### PR DESCRIPTION
Fixes some slicing and unwrapping that resulted in panics being generated, which makes the api/ mailbox methods suitable for use in embedded systems that restrict panics.

Adds a test to keep this invariant moving forward.