### PR TITLE
[drivers]: Add method to get Array4xN byte size

### DIFF
--- a/drivers/src/array.rs
+++ b/drivers/src/array.rs
@@ -37,6 +37,9 @@ impl<const W: usize, const B: usize> Array4xN<W, B> {
     pub const fn new(val: [u32; W]) -> Self {
         Self(val)
     }
+    pub const fn bytes_size() -> usize {
+        B
+    }
 }
 
 impl<const W: usize, const B: usize> Default for Array4xN<W, B> {


### PR DESCRIPTION
This is useful for getting the underlying byte size of an Array4xN type alias.