### PR TITLE
Issue #6: include metadata info for FPGA image

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -9,6 +9,13 @@ on:
       - "ci-tools/fpga-image/**"
       - "hw/fpga/**"
 
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/fpga-image.yml"
+      - "ci-tools/fpga-image/**"
+      - "hw/fpga/**"
+
   schedule:
     # 5:13 AM PST tuesday, thursday
     - cron: '13 13 * * 2,4'
@@ -45,7 +52,7 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.branch }}
 
       - name: Cache Kernel output
@@ -125,10 +132,11 @@ jobs:
         image_variant: [core, subsystem]
     env:
       IMAGE_VARIANT: ${{ matrix.image_variant }}
+      PR_BASE_COMMIT: ${{github.event.pull_request.base.sha}}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        with: 
+        with:
           ref: ${{ inputs.branch }}
 
       - name: 'Download kernel artifact'
@@ -146,19 +154,19 @@ jobs:
       - name: Install pre-requisites
         run: |
           sudo apt-get update
-          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools gcc-aarch64-linux-gnu 
+          sudo apt-get -y install debootstrap binfmt-support qemu-user-static u-boot-tools gcc-aarch64-linux-gnu
           rustup target add aarch64-unknown-linux-gnu
 
       - name: Build SD images
         run: |
           # Build Dev image
           cd ci-tools/fpga-image
-          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=true KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
+          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=true IMAGE_VARIANT=${IMAGE_VARIANT} KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
           # Save Dev image for upload
           sudo mv out/image.img dev-image.img
           sudo rm -rf out/
           # Now build CI image
-          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=false KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
+          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=false IMAGE_VARIANT=${IMAGE_VARIANT} KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
 
       - name: 'Upload dev-image as artifact'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -273,6 +273,12 @@ jobs:
 
 
     steps:
+      - name: Print image metadata
+        run: |
+          if [ -f "/etc/caliptra-build-info" ]; then
+            sudo cat /etc/caliptra-build-info
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
         with:

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -215,6 +215,12 @@ jobs:
 
 
     steps:
+      - name: 'Print image metadata'
+        run: |
+          if [ -f "/etc/caliptra-build-info" ]; then
+            sudo cat /etc/caliptra-build-info
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5
         with:

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -48,10 +48,10 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c 'echo "[Time]" > /etc/systemd/timesyncd.conf'
   chroot out/rootfs bash -c 'echo "NTP=time.google.com" >> /etc/systemd/timesyncd.conf'
 
-if [[ "$BUILD_DEV_IMAGE" == "true" ]]; then
+  if [[ "$BUILD_DEV_IMAGE" == "true" ]]; then
       echo "Adding developer keys to image"
-      chroot out/rootfs bash -c "echo \"PubkeyAuthentication yes\" >> /etc/ssh/sshd_config" 
-      chroot out/rootfs bash -c "echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config" 
+      chroot out/rootfs bash -c "echo \"PubkeyAuthentication yes\" >> /etc/ssh/sshd_config"
+      chroot out/rootfs bash -c "echo \"PasswordAuthentication no\" >> /etc/ssh/sshd_config"
       chroot out/rootfs bash -c "su runner -c \"mkdir /home/runner/.ssh\""
 
       # Authorized project developer keys. Keep alphabetized.
@@ -129,6 +129,25 @@ cp startup-script.service out/rootfs/etc/systemd/system/
 chroot out/rootfs systemctl enable startup-script.service
 
 cp out/io-module.ko out/rootfs/home/runner/io-module.ko
+
+
+CURRDATE=`date`
+chroot out/rootfs bash -c "echo \"Build date: ${CURRDATE}\" > /etc/caliptra-build-info"
+if [[ "$BUILD_DEV_IMAGE" == "true" ]]; then
+  chroot out/rootfs bash -c "echo \"Image env : dev\" >> /etc/caliptra-build-info"
+else
+  chroot out/rootfs bash -c "echo \"Image env : non-dev\" >> /etc/caliptra-build-info"
+fi
+chroot out/rootfs bash -c "echo \"Image variant : ${IMAGE_VARIANT}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Runner version : ${RUNNER_VERSION}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow name : ${GITHUB_WORKFLOW}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow branch : ${GITHUB_HEAD_REF}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow build commit : ${GITHUB_WORKFLOW_SHA}\" >> /etc/caliptra-build-info"
+HASH=`md5sum out/io-module.ko | awk '{print $1}'`
+chroot out/rootfs bash -c "echo \"Hash io-module.ko : ${HASH}\" >> /etc/caliptra-build-info"
+HASH=`md5sum out/system-boot.tar.gz | awk '{print $1}'`
+chroot out/rootfs bash -c "echo \"Hash system-boot.tar.gz : ${HASH}\" >> /etc/caliptra-build-info"
+
 
 rm -f out/image.img
 bootfs_blocks="$((80000 * 4))"


### PR DESCRIPTION
Adding metadata info into FPGA image.
Creating a new file "/etc/caliptra-build-info" to store the metadata, still need to add some more info in the future.

Note: first diff of "if BUILD_DEV_IMAGE" is just an adjust of identation