### PR TITLE
[Model]: Print stack usage on Drop

### DIFF
--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -223,17 +223,20 @@ pub fn start_rt_test_pqc_model(
     });
 
     let image_info = vec![
-        ImageInfo::new(
+        ImageInfo::with_name(
             StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
             CodeRange::new(ROM_ORG, ROM_ORG + ROM_SIZE),
+            "caliptra-rom".to_owned(),
         ),
-        ImageInfo::new(
+        ImageInfo::with_name(
             StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
             CodeRange::new(FMC_ORG, FMC_ORG + FMC_SIZE),
+            "caliptra-fmc".to_owned(),
         ),
-        ImageInfo::new(
+        ImageInfo::with_name(
             StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
             CodeRange::new(RUNTIME_ORG, RUNTIME_ORG + RUNTIME_SIZE),
+            "caliptra-runtime".to_owned(),
         ),
     ];
 


### PR DESCRIPTION
For the emulator model, print the Caliptra stack usage (if it exists) on drop.

Looks like so:

```
  7,951,266 >>> mbox cmd response data (24 bytes)
  7,951,267 <<< Executing mbox cmd 0x524d504b (2176 bytes) from SoC
  7,963,324 UART: [rt] Received command=0x524d504b (RMPK), len=2176
  8,112,612 >>> mbox cmd response data (160 bytes)
  8,112,613 <<< Executing mbox cmd 0x43415053 (4 bytes) from SoC
  8,113,644 UART: [rt] Received command=0x43415053 (CAPS), len=4
  8,122,489 >>> mbox cmd response data (24 bytes)
  8,122,489 [EMU] Caliptra Stack Usage Summary:
  8,122,489 Image 'caliptra-rom' used 70992 bytes (31408 bytes remaining)
  8,122,489 Image 'caliptra-fmc' used 55856 bytes (91600 bytes remaining)
  8,122,489 Image 'caliptra-runtime' used 140960 bytes (6496 bytes remaining)
```