### PR TITLE
[dpe] Add ML-DSA DPE Crypto trait

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -117,8 +117,8 @@ pub use ml_kem::{
     MlKem1024SharedKeyOut, MlKemResult,
 };
 pub use mldsa87::{
-    Mldsa87, Mldsa87Msg, Mldsa87PrivKey, Mldsa87PubKey, Mldsa87Result, Mldsa87Seed, Mldsa87SignRnd,
-    Mldsa87Signature,
+    Mldsa87, Mldsa87Msg, Mldsa87Mu, Mldsa87PrivKey, Mldsa87PubKey, Mldsa87Result, Mldsa87Seed,
+    Mldsa87SignRnd, Mldsa87Signature,
 };
 pub use ocp_lock::HekSeedState;
 pub use pcr_bank::{PcrBank, PcrId};


### PR DESCRIPTION
This will be used when invoking DPE commands with the ML-DSA profile.

This also simplifies the DPE command handling logic so `execute` is only called once instead of per command.