### PR TITLE
[HPKE]: Refactor for additional implementations

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -49,7 +49,7 @@ pub use pmp::lock_datavault_region;
 pub const FMC_ORG: u32 = 0x40000000;
 pub const FMC_SIZE: u32 = 36 * 1024; // Must be 4k aligned
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 184 * 1024;
+pub const RUNTIME_SIZE: u32 = 190 * 1024;
 
 pub use memory_layout::{EXTRA_MEMORY_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/drivers/src/hpke/suites.rs
+++ b/drivers/src/hpke/suites.rs
@@ -1,43 +1,86 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::mailbox::HpkeAlgorithms;
-use caliptra_error::CaliptraError;
 
-/// Describes a HPKE CipherSuite.
-pub struct CipherSuite {
-    pub kem: KemId,
-    pub kdf: KdfId,
-    pub aead: AeadId,
+/// The type of cipher suite
+/// HPKE differentiates KEM & HPKE cipher suites.
+pub enum CipherSuite {
+    Kem(KemId),
+    Hpke(HpkeCipherSuite),
 }
 
 impl CipherSuite {
-    /// ML_KEM based ciphersuite
-    pub const ML_KEM_1024: Self = Self {
-        kem: KemId::ML_KEM_1024,
-        kdf: KdfId::HKDF_SHA384,
-        aead: AeadId::AES_256_GCM,
-    };
-}
-
-impl TryFrom<CipherSuite> for HpkeAlgorithms {
-    type Error = CaliptraError;
-    fn try_from(value: CipherSuite) -> Result<Self, Self::Error> {
-        match value {
-            CipherSuite { kem, .. } if kem == KemId::ML_KEM_1024 => {
-                Ok(HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM)
-            }
-            _ => Err(CaliptraError::RUNTIME_DRIVER_HPKE_CONVERT_INVALID_CIPHER_SUITE),
+    /// In HPKE, an ikm in a KEM algorithm (e.g. derive key pair) SHALL use the following for the
+    /// suite-id: suite_id = concat("KEM", I2OSP(kem_id, 2))
+    ///
+    /// If it not used by a KEM algorithm, the IKM SHALL use the following for the suite-id:
+    /// suite_id = concat(
+    ///  "HPKE",
+    ///  I2OSP(kem_id, 2),
+    ///  I2OSP(kdf_id, 2),
+    ///  I2OSP(aead_id, 2)
+    /// )
+    pub fn ikm_prefix(&self) -> &'static [u8] {
+        match self {
+            Self::Kem(_) => &b"KEM"[..],
+            Self::Hpke(_) => &b"HPKE"[..],
         }
     }
 }
 
-impl From<&CipherSuite> for [u8; 6] {
-    fn from(value: &CipherSuite) -> Self {
-        // Truncate u16 to u8. This is safe because the IDs only use the lower 8 bits.
-        let kem = value.kem.0 as u8;
-        let kdf = value.kdf.0 as u8;
-        let aead = value.aead.0 as u8;
-        [0x0, kem, 0x0, kdf.to_be(), 0x0, aead.to_be()]
+impl AsRef<[u8]> for CipherSuite {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Kem(kem) => kem.as_ref(),
+            Self::Hpke(hpke) => hpke.as_ref(),
+        }
+    }
+}
+
+/// Describes a HPKE CipherSuite.
+pub struct HpkeCipherSuite {
+    pub val: [u8; 6],
+    pub alg: HpkeAlgorithms,
+    pub kem: KemId,
+}
+
+impl HpkeCipherSuite {
+    /// ML_KEM based ciphersuite
+    pub const ML_KEM_1024: Self = Self::new(
+        HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM,
+        KemId::ML_KEM_1024,
+        KdfId::HKDF_SHA384,
+        AeadId::AES_256_GCM,
+    );
+
+    /// P-384 based ciphersuite
+    pub const P_384: Self = Self::new(
+        HpkeAlgorithms::ECDH_P384_HKDF_SHA384_AES_256_GCM,
+        KemId::P_384,
+        KdfId::HKDF_SHA384,
+        AeadId::AES_256_GCM,
+    );
+    const fn new(alg: HpkeAlgorithms, kem: KemId, kdf: KdfId, aead: AeadId) -> Self {
+        let serialized_kem = kem.value as u8;
+        let kdf = kdf.0 as u8;
+        let aead = aead.0 as u8;
+        Self {
+            val: [0x0, serialized_kem, 0x0, kdf.to_be(), 0x0, aead.to_be()],
+            alg,
+            kem,
+        }
+    }
+}
+
+impl From<HpkeCipherSuite> for HpkeAlgorithms {
+    fn from(value: HpkeCipherSuite) -> Self {
+        value.alg
+    }
+}
+
+impl AsRef<[u8]> for HpkeCipherSuite {
+    fn as_ref(&self) -> &[u8] {
+        &self.val
     }
 }
 
@@ -54,21 +97,25 @@ impl AeadId {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct KemId(u16);
+pub struct KemId {
+    value: u16,
+    /// Split out a serialized big-endian representation so we can use it in our derivations without
+    /// any allocations.
+    serialized_be: [u8; 2],
+}
 impl KemId {
-    pub const ML_KEM_1024: Self = Self(0x0042);
+    pub const ML_KEM_1024: Self = Self {
+        value: 0x0042,
+        serialized_be: [0x00, 0x42],
+    };
+    pub const P_384: Self = Self {
+        value: 0x0011,
+        serialized_be: [0x00, 0x11],
+    };
 }
 
-#[derive(Copy, Clone)]
-pub struct KemIdExt([u8; 5]);
-impl KemIdExt {
-    /// ML-KEM-1024: KEM + 0x00 + 0x42 (hex: 4b454d0042)
-    /// Source: https://www.ietf.org/archive/id/draft-ietf-hpke-pq-03.html#section-3-4.
-    pub const ML_KEM_1024: Self = Self([0x4b, 0x45, 0x4d, 0x00, 0x42]);
-}
-
-impl AsRef<[u8]> for KemIdExt {
+impl AsRef<[u8]> for KemId {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        &self.serialized_be
     }
 }

--- a/drivers/test-fw/src/bin/hpke_tests.rs
+++ b/drivers/test-fw/src/bin/hpke_tests.rs
@@ -17,7 +17,7 @@ Abstract:
 use caliptra_cfi_lib::CfiCounter;
 use caliptra_drivers::hpke::{
     self,
-    kem::{MlKemEncapsulatedSecret, MlKemEncapsulationKey},
+    kem::{Kem, MlKem, MlKemContext, MlKemEncapsulatedSecret, MlKemEncapsulationKey},
     Hpke, HpkeMlKemContext,
 };
 use caliptra_drivers_test_bin::TestRegisters;
@@ -39,22 +39,24 @@ fn test_ml_kem_1024_test_vector() {
     // SAFETY: This API is unsafe to discourage usage in firmware. It's used here to verify the
     // HPKE implementation against a known test vector.
     let hpke = unsafe { HpkeMlKemContext::from_seed(MLKEM_TEST_VECTOR.ikm_r.try_into().unwrap()) };
-    let mut ml_kem = hpke::kem::MlKem::new(&mut regs.sha3, &mut regs.ml_kem);
-    let mut hkdf = hpke::kdf::Hmac384::new(&mut regs.hmac);
+
+    let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut regs.ml_kem);
+    let mut kem = MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap();
+    let mut kem_ctx = hpke::HpkeMlKemDrivers::new(
+        &mut regs.trng,
+        &mut regs.sha3,
+        &mut regs.hmac,
+        &mut regs.ml_kem,
+    );
 
     let mut pk_rm = [0; hpke::kem::MlKem::NPK];
-    hpke.serialize_public_key(&mut ml_kem, &mut pk_rm).unwrap();
+    hpke.serialize_public_key(&mut kem, &mut kem_ctx, &mut pk_rm)
+        .unwrap();
     assert_eq!(pk_rm.as_ref(), MLKEM_TEST_VECTOR.pk_rm);
 
-    let enc = MlKemEncapsulatedSecret::ref_from_bytes(MLKEM_TEST_VECTOR.enc).unwrap();
+    let enc = MlKemEncapsulatedSecret::read_from_bytes(MLKEM_TEST_VECTOR.enc).unwrap();
     let mut reader = hpke
-        .setup_base_r(
-            &mut ml_kem,
-            &mut hkdf,
-            &mut regs.trng,
-            enc,
-            &MLKEM_TEST_VECTOR.info,
-        )
+        .setup_base_r(&mut kem, &mut kem_ctx, &enc, &MLKEM_TEST_VECTOR.info)
         .unwrap();
 
     for vector in MLKEM_TEST_VECTOR.encryptions {
@@ -76,28 +78,29 @@ fn test_ml_kem_1024_self_talk() {
     let mut regs = TestRegisters::default();
 
     let hpke = HpkeMlKemContext::generate(&mut regs.trng).unwrap();
-    let mut kem = hpke::kem::MlKem::new(&mut regs.sha3, &mut regs.ml_kem);
-    let mut hkdf = hpke::kdf::Hmac384::new(&mut regs.hmac);
+    let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut regs.ml_kem);
+    let mut kem = MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap();
+    let mut kem_ctx = hpke::HpkeMlKemDrivers::new(
+        &mut regs.trng,
+        &mut regs.sha3,
+        &mut regs.hmac,
+        &mut regs.ml_kem,
+    );
 
     let mut pk_rm = [0; hpke::kem::MlKem::NPK];
-    hpke.serialize_public_key(&mut kem, &mut pk_rm).unwrap();
+    hpke.serialize_public_key(&mut kem, &mut kem_ctx, &mut pk_rm)
+        .unwrap();
+
     let (enc, mut sender) = hpke
         .setup_base_s(
             &mut kem,
-            &mut hkdf,
-            &mut regs.trng,
+            &mut kem_ctx,
             &MlKemEncapsulationKey::from(pk_rm),
             &MLKEM_TEST_VECTOR.info,
         )
         .unwrap();
     let mut reader = hpke
-        .setup_base_r(
-            &mut kem,
-            &mut hkdf,
-            &mut regs.trng,
-            &enc,
-            &MLKEM_TEST_VECTOR.info,
-        )
+        .setup_base_r(&mut kem, &mut kem_ctx, &enc, &MLKEM_TEST_VECTOR.info)
         .unwrap();
 
     for vector in MLKEM_TEST_VECTOR.encryptions {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2587,22 +2587,22 @@ impl CaliptraError {
         ),
         (
             RUNTIME_DRIVER_HPKE_ML_KEM_TRNG_KEYGEN_FAIL,
-            0xa004_1100,
+            0xa004_1010,
             "Driver Error: HPKE ml-kem failed to generate a key pair due to trng failure"
         ),
         (
             RUNTIME_DRIVER_HPKE_ML_KEM_PKR_DESERIALIZATION_FAIL,
-            0xa004_1101,
+            0xa004_1011,
             "Driver Error: HPKE ml-kem failed to deseriliaze the PKR in setup base s"
         ),
         (
             RUNTIME_DRIVER_HPKE_ML_KEM_ENCAP_SECRET_DESERIALIZATION_FAIL,
-            0xa004_1102,
+            0xa004_1012,
             "Driver Error: HPKE ml-kem failed to deseriliaze the encapsulated secret"
         ),
         (
             RUNTIME_DRIVER_HPKE_ML_KEM_ENCAP_KEY_SERIALIZATION_FAIL,
-            0xa004_1103,
+            0xa004_1013,
             "Driver Error: HPKE ml-kem failed to seriliaze the encap key"
         ),
         (

--- a/runtime/src/ocp_lock/endorse_hpke_pubkey.rs
+++ b/runtime/src/ocp_lock/endorse_hpke_pubkey.rs
@@ -15,7 +15,7 @@ use caliptra_common::{
 };
 use caliptra_drivers::hpke::{
     kem::MlKemEncapsulationKey,
-    suites::{CipherSuite, KemId},
+    suites::{HpkeCipherSuite, KemId},
     HpkeHandle,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
@@ -44,11 +44,13 @@ impl EndorseHpkePubkeyCmd {
         resp.pub_key_len = drivers.ocp_lock_context.get_hpke_public_key(
             &mut drivers.sha3,
             &mut drivers.ml_kem,
+            &mut drivers.trng,
+            &mut drivers.hmac,
             &hpke_handle,
             &mut resp.pub_key,
         )? as u32;
 
-        let CipherSuite { kem, .. } = drivers
+        let HpkeCipherSuite { kem, .. } = drivers
             .ocp_lock_context
             .get_hpke_cipher_suite(&hpke_handle)?;
 

--- a/runtime/src/ocp_lock/enumerate_hpke_handles.rs
+++ b/runtime/src/ocp_lock/enumerate_hpke_handles.rs
@@ -26,7 +26,7 @@ impl EnumerateHpkeHandles {
             .zip(drivers.ocp_lock_context.iterate_hpke_handles())
         {
             returned_handle.handle = handle.into();
-            returned_handle.hpke_algorithm = cipher.try_into()?;
+            returned_handle.hpke_algorithm = cipher.into();
             resp.hpke_handle_count += 1;
         }
         Ok(core::mem::size_of::<OcpLockEnumerateHpkeHandlesResp>())

--- a/runtime/src/ocp_lock/mod.rs
+++ b/runtime/src/ocp_lock/mod.rs
@@ -9,7 +9,7 @@ use caliptra_common::keyids::ocp_lock::{
 use caliptra_drivers::{
     cmac_kdf, hmac_kdf,
     hpke::{
-        aead::Aes256GCM, suites::CipherSuite, EncryptionContext, HpkeContext, HpkeContextIter,
+        aead::Aes256GCM, suites::HpkeCipherSuite, EncryptionContext, HpkeContext, HpkeContextIter,
         HpkeHandle, Receiver,
     },
     preconditioned_aes::{preconditioned_aes_decrypt, preconditioned_aes_encrypt},
@@ -1285,18 +1285,20 @@ impl OcpLockContext {
         &mut self,
         sha: &mut Sha3,
         ml_kem: &mut MlKem1024,
+        trng: &mut Trng,
+        hmac: &mut Hmac,
         hpke_handle: &HpkeHandle,
         pub_out: &mut [u8],
     ) -> CaliptraResult<usize> {
         self.hpke_context
-            .get_pub_key(sha, ml_kem, hpke_handle, pub_out)
+            .get_pub_key(sha, ml_kem, trng, hmac, hpke_handle, pub_out)
     }
 
     /// Retrieve the Ciphersuite for an HPKE handle
     pub fn get_hpke_cipher_suite(
         &mut self,
         hpke_handle: &HpkeHandle,
-    ) -> CaliptraResult<CipherSuite> {
+    ) -> CaliptraResult<HpkeCipherSuite> {
         self.hpke_context.get_cipher_suite(hpke_handle)
     }
 }


### PR DESCRIPTION
* Use GAT to make KEM interface driver agnostic 
* Move registers into GAT context to avoid borrowing a driver for too long
* Make KDF interface flexible so it can also be used during KEM operations (Needed for P-384).
* Put KEM in HPKE interface to allow supplying an external KEM.