### PR TITLE
[OCP-LOCK]: Add certificate template for hybrid certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitfield",
+ "const-oid 0.9.6",
  "convert_case",
  "der 0.7.10",
  "hex",
@@ -1078,6 +1079,7 @@ dependencies = [
  "quote",
  "rand",
  "syn 1.0.109",
+ "x509-cert",
  "x509-parser",
  "zeroize",
 ]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -22,6 +22,8 @@ openssl = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 syn = { workspace = true, optional = true }
+x509-cert = { workspace = true, optional = true }
+const-oid = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true
@@ -32,4 +34,4 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 std = []
-generate_templates = ["dep:asn1", "dep:bitfield", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn", "dep:rand"]
+generate_templates = ["dep:asn1", "dep:bitfield", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn", "dep:rand", "dep:x509-cert", "dep:const-oid"]

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -23,6 +23,8 @@ mod csr;
 mod tbs;
 #[cfg(feature = "generate_templates")]
 mod x509;
+#[cfg(feature = "generate_templates")]
+mod x509_cert;
 
 #[cfg(feature = "generate_templates")]
 use {
@@ -62,6 +64,7 @@ fn main() {
         gen_fmc_alias_cert(out_dir);
         gen_rt_alias_cert(out_dir);
         gen_ocp_lock_endorsement_cert(out_dir);
+        gen_ocp_lock_hybrid_endorsement_cert(out_dir);
     }
 }
 
@@ -351,4 +354,46 @@ fn gen_ocp_lock_endorsement_cert(out_dir: &str) {
         ));
     let template = bldr.tbs_template("OCP LOCK HPKE Endorsement ECDH P-384", RT_ALIAS_MLDSA87);
     CodeGen::gen_code("OcpLockEcdh384CertTbsMlDsa87", template, out_dir);
+}
+
+/// Generate OCP LOCK HPKE Endorsement Certificate Templates with Hybrid Keys
+/// This is build with the "x509-cert" crate because OpenSSL does not yet support the ML-KEM &
+/// P-384 hybrid key type.
+#[cfg(feature = "generate_templates")]
+fn gen_ocp_lock_hybrid_endorsement_cert(out_dir: &str) {
+    use x509::{HPKEIdentifiers, HybridP384MlKem1024Algo};
+    use x509_cert::X509CertTemplateBuilder;
+    // 4.2.2.1.3
+    // In addition, the X.509 extended attributes SHALL:
+    // * Indicate the key usage as keyEncipherment
+    let mut usage = KeyUsage::default();
+    usage.set_key_encipherment(true);
+
+    let bldr = X509CertTemplateBuilder::<EcdsaSha384Algo, HybridP384MlKem1024Algo>::new()
+        .add_basic_constraints_ext(false, 0)
+        .add_key_usage_ext(usage)
+        .add_hpke_identifiers_ext(&HPKEIdentifiers::new(
+            HPKEIdentifiers::ML_KEM_1024_ECDH_P384_IANA_CODE_POINT,
+            HPKEIdentifiers::HKDF_SHA384_IANA_CODE_POINT,
+            HPKEIdentifiers::AES_256_GCM_IANA_CODE_POINT,
+        ));
+    let template = bldr.tbs_template(
+        "OCP LOCK HPKE Endorsement ML-KEM-1024-ECDH-P384",
+        RT_ALIAS_ECC384,
+    );
+    CodeGen::gen_code("OcpLockHybridCertTbsEcc384", template, out_dir);
+
+    let bldr = X509CertTemplateBuilder::<MlDsa87Algo, HybridP384MlKem1024Algo>::new()
+        .add_basic_constraints_ext(false, 0)
+        .add_key_usage_ext(usage)
+        .add_hpke_identifiers_ext(&HPKEIdentifiers::new(
+            HPKEIdentifiers::ML_KEM_1024_ECDH_P384_IANA_CODE_POINT,
+            HPKEIdentifiers::HKDF_SHA384_IANA_CODE_POINT,
+            HPKEIdentifiers::AES_256_GCM_IANA_CODE_POINT,
+        ));
+    let template = bldr.tbs_template(
+        "OCP LOCK HPKE Endorsement ML-KEM-1024-ECDH-P384",
+        RT_ALIAS_MLDSA87,
+    );
+    CodeGen::gen_code("OcpLockHybridCertTbsMlDsa87", template, out_dir);
 }

--- a/x509/build/x509_cert.rs
+++ b/x509/build/x509_cert.rs
@@ -1,0 +1,246 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    x509_cert.rs
+
+Abstract:
+
+    File contains a re-implementation of "cert.rs" to workaround the limitations of the OpenSSL
+    API. This is built on "x509-cert" crate.
+
+    You should prefer to create certs from the "cert.rs".
+
+--*/
+
+use std::str::FromStr;
+
+use const_oid::{
+    db::{
+        rfc5280::{
+            ID_CE_AUTHORITY_KEY_IDENTIFIER, ID_CE_BASIC_CONSTRAINTS, ID_CE_KEY_USAGE,
+            ID_CE_SUBJECT_KEY_IDENTIFIER,
+        },
+        rfc5912::ECDSA_WITH_SHA_384,
+    },
+    ObjectIdentifier,
+};
+use x509_cert::{
+    certificate::{TbsCertificate, Version},
+    der::{
+        asn1::{BitString, GeneralizedTime, OctetString},
+        flagset::Flags,
+        DateTime, {Decode, Encode},
+    },
+    ext::{
+        pkix::{
+            AuthorityKeyIdentifier, BasicConstraints, KeyUsage as PkixKeyUsage, KeyUsages,
+            SubjectKeyIdentifier,
+        },
+        Extension,
+    },
+    name::Name,
+    serial_number::SerialNumber,
+    spki::{AlgorithmIdentifier, SubjectPublicKeyInfo},
+    time::{Time, Validity},
+};
+
+use crate::x509::{AsymKey, KeyType, KeyUsage, SigningAlgorithm, HYBRID_MLKEM_1024_ECDH_P384_OID};
+use crate::{
+    tbs::{init_param, sanitize, TbsParam, TbsTemplate},
+    x509::MLDSA_87_OID,
+};
+
+struct CertTemplateParam {
+    tbs_param: TbsParam,
+    needle: Vec<u8>,
+}
+
+pub struct X509CertTemplateBuilder<AlgoIssuer: SigningAlgorithm, AlgoSubject: SigningAlgorithm> {
+    issuer_algo: AlgoIssuer,
+    subject_algo: AlgoSubject,
+    params: Vec<CertTemplateParam>,
+    extensions: Vec<Extension>,
+}
+
+impl<AlgoIssuer: SigningAlgorithm, AlgoSubject: SigningAlgorithm>
+    X509CertTemplateBuilder<AlgoIssuer, AlgoSubject>
+{
+    pub fn new() -> Self {
+        Self {
+            issuer_algo: AlgoIssuer::default(),
+            subject_algo: AlgoSubject::default(),
+            params: vec![],
+            extensions: vec![],
+        }
+    }
+
+    pub fn add_basic_constraints_ext(mut self, ca: bool, path_len: u32) -> Self {
+        let ext = BasicConstraints {
+            ca,
+            path_len_constraint: Some(path_len.try_into().unwrap()),
+        };
+        self.extensions.push(Extension {
+            extn_id: ID_CE_BASIC_CONSTRAINTS,
+            critical: true,
+            extn_value: OctetString::new(ext.to_der().unwrap()).unwrap(),
+        });
+        self
+    }
+
+    /// NOTE: Only supports `KeyUsage::KeyEncipherment`.
+    pub fn add_key_usage_ext(mut self, usage: KeyUsage) -> Self {
+        let mut bits = KeyUsages::none();
+        if usage.key_encipherment() {
+            bits |= KeyUsages::KeyEncipherment;
+        }
+
+        let ext = PkixKeyUsage(bits);
+        self.extensions.push(Extension {
+            extn_id: ID_CE_KEY_USAGE,
+            critical: true,
+            extn_value: OctetString::new(ext.to_der().unwrap()).unwrap(),
+        });
+        self
+    }
+
+    pub fn add_hpke_identifiers_ext(mut self, identifier: &crate::x509::HPKEIdentifiers) -> Self {
+        let oid = ObjectIdentifier::new_unwrap(crate::x509::HPKEIdentifiers::OID);
+        let ext_val = asn1::write_single(identifier).unwrap();
+        self.extensions.push(Extension {
+            extn_id: oid,
+            critical: false,
+            extn_value: OctetString::new(ext_val).unwrap(),
+        });
+        self
+    }
+
+    pub fn tbs_template(mut self, subject_cn: &str, issuer_cn: &str) -> TbsTemplate {
+        let subject_key = self.subject_algo.gen_key();
+        let issuer_key = self.issuer_algo.gen_key();
+
+        let serial_number_bytes = [0x7Fu8; 20];
+        let serial_number = SerialNumber::new(&serial_number_bytes).unwrap();
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("SERIAL_NUMBER", 0, serial_number_bytes.len()),
+            needle: serial_number_bytes.to_vec(),
+        });
+
+        let not_before = "20230101000000Z";
+        let not_after = "99991231235959Z";
+        let validity = Validity {
+            // The Rust Crypto parser is much stricter, so we can't use the exact same date string.
+            not_before: Time::GeneralTime(GeneralizedTime::from_date_time(
+                DateTime::from_str("2023-01-01T00:00:00Z").unwrap(),
+            )),
+            not_after: Time::GeneralTime(GeneralizedTime::from_date_time(
+                DateTime::from_str("9999-12-31T23:59:59Z").unwrap(),
+            )),
+        };
+
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("NOT_BEFORE", 0, not_before.len()),
+            needle: not_before.as_bytes().to_vec(),
+        });
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("NOT_AFTER", 0, not_after.len()),
+            needle: not_after.as_bytes().to_vec(),
+        });
+
+        let subject_name = format!("CN={},serialNumber={}", subject_cn, subject_key.hex_str())
+            .parse::<Name>()
+            .unwrap();
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("SUBJECT_SN", 0, subject_key.hex_str().len()),
+            needle: subject_key.hex_str().into_bytes(),
+        });
+
+        let issuer_name = format!("CN={},serialNumber={}", issuer_cn, issuer_key.hex_str())
+            .parse::<Name>()
+            .unwrap();
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("ISSUER_SN", 0, issuer_key.hex_str().len()),
+            needle: issuer_key.hex_str().into_bytes(),
+        });
+
+        let subject_spki = match subject_key.key_type() {
+            KeyType::MlKem1024P384 => SubjectPublicKeyInfo {
+                algorithm: AlgorithmIdentifier {
+                    oid: ObjectIdentifier::new_unwrap(HYBRID_MLKEM_1024_ECDH_P384_OID),
+                    parameters: None,
+                },
+                subject_public_key: BitString::new(0, subject_key.pub_key()).unwrap(),
+            },
+            _ => {
+                let subject_spki_der = subject_key.priv_key().public_key_to_der().unwrap();
+                SubjectPublicKeyInfo::from_der(&subject_spki_der).unwrap()
+            }
+        };
+
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("PUBLIC_KEY", 0, subject_key.pub_key().len()),
+            needle: subject_key.pub_key().to_vec(),
+        });
+
+        let ski = SubjectKeyIdentifier(OctetString::new(subject_key.sha1()).unwrap());
+        self.extensions.push(Extension {
+            extn_id: ID_CE_SUBJECT_KEY_IDENTIFIER,
+            critical: false,
+            extn_value: OctetString::new(ski.to_der().unwrap()).unwrap(),
+        });
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("SUBJECT_KEY_ID", 0, subject_key.sha1().len()),
+            needle: subject_key.sha1().to_vec(),
+        });
+
+        let aki = AuthorityKeyIdentifier {
+            key_identifier: Some(OctetString::new(issuer_key.sha1()).unwrap()),
+            authority_cert_issuer: None,
+            authority_cert_serial_number: None,
+        };
+        self.extensions.push(Extension {
+            extn_id: ID_CE_AUTHORITY_KEY_IDENTIFIER,
+            critical: false,
+            extn_value: OctetString::new(aki.to_der().unwrap()).unwrap(),
+        });
+        self.params.push(CertTemplateParam {
+            tbs_param: TbsParam::new("AUTHORITY_KEY_ID", 0, issuer_key.sha1().len()),
+            needle: issuer_key.sha1().to_vec(),
+        });
+
+        let signature_oid = match issuer_key.key_type() {
+            KeyType::P384 => ECDSA_WITH_SHA_384,
+            KeyType::MlDsa87 => ObjectIdentifier::new_unwrap(MLDSA_87_OID),
+            _ => panic!("unsupported key type"),
+        };
+
+        let tbs_cert = TbsCertificate {
+            version: Version::V3,
+            serial_number,
+            signature: AlgorithmIdentifier {
+                oid: signature_oid,
+                parameters: None,
+            },
+            issuer: issuer_name,
+            validity,
+            subject: subject_name,
+            subject_public_key_info: subject_spki,
+            issuer_unique_id: None,
+            subject_unique_id: None,
+            extensions: Some(self.extensions),
+        };
+
+        let mut tbs = tbs_cert.to_der().unwrap();
+
+        self.params
+            .sort_by_key(|p| std::cmp::Reverse(p.tbs_param.len));
+        let params = self
+            .params
+            .iter()
+            .map(|p| sanitize(init_param(&p.needle, &tbs, p.tbs_param), &mut tbs))
+            .collect();
+        TbsTemplate::new(tbs, params)
+    }
+}

--- a/x509/src/fmc_alias_csr_ecc_384.rs
+++ b/x509/src/fmc_alias_csr_ecc_384.rs
@@ -211,10 +211,10 @@ mod tests {
     #[cfg(feature = "generate_templates")]
     fn test_fmc_alias_csr_template() {
         let manual_template =
-            std::fs::read(std::path::Path::new("./build/fmc_alias_csr_tbs.rs")).unwrap();
+            std::fs::read(std::path::Path::new("./build/fmc_alias_csr_tbs_ecc_384.rs")).unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/fmc_alias_csr_tbs.rs"
+            "/fmc_alias_csr_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -48,6 +48,8 @@ pub use rt_alias_cert_mldsa_87::{RtAliasCertTbsMlDsa87, RtAliasCertTbsMlDsa87Par
 pub use ocp_lock_hpke_certs::{
     ecdh_384_ecc_348::{OcpLockEcdh384CertTbsEcc384, OcpLockEcdh384CertTbsEcc384Params},
     ecdh_384_mldsa_87::{OcpLockEcdh384CertTbsMlDsa87, OcpLockEcdh384CertTbsMlDsa87Params},
+    hybrid_ecc_384::{OcpLockHybridCertTbsEcc384, OcpLockHybridCertTbsEcc384Params},
+    hybrid_mldsa_87::{OcpLockHybridCertTbsMlDsa87, OcpLockHybridCertTbsMlDsa87Params},
     ml_kem_ecc_348::{OcpLockMlKemCertTbsEcc384, OcpLockMlKemCertTbsEcc384Params},
     ml_kem_mldsa_87::{OcpLockMlKemCertTbsMlDsa87, OcpLockMlKemCertTbsMlDsa87Params},
 };

--- a/x509/src/ocp_lock_hpke_certs.rs
+++ b/x509/src/ocp_lock_hpke_certs.rs
@@ -640,3 +640,271 @@ pub mod ecdh_384_mldsa_87 {
         }
     }
 }
+
+pub mod hybrid_ecc_384 {
+
+    #[cfg(feature = "generate_templates")]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/ocp_lock_hybrid_cert_tbs_ecc_384.rs"
+    ));
+    #[cfg(not(feature = "generate_templates"))]
+    include! {"ocp_lock_hybrid_cert_tbs_ecc_384.rs"}
+
+    #[cfg(all(test, target_family = "unix"))]
+    mod tests {
+        use openssl::ecdsa::EcdsaSig;
+        use openssl::sha::Sha384;
+        use openssl::x509::X509;
+        use x509_parser::nom::Parser;
+        use x509_parser::oid_registry::asn1_rs::oid;
+        use x509_parser::oid_registry::Oid;
+        use x509_parser::prelude::X509CertificateParser;
+        use x509_parser::x509::X509Version;
+
+        use super::*;
+        use crate::test_util::tests::*;
+        use crate::{NotAfter, NotBefore};
+
+        #[test]
+        fn test_cert() {
+            let subject_key = HybridP384MlKem1024AsymKey::default();
+            let issuer_key = Ecc384AsymKey::default();
+            let ec_key = issuer_key.priv_key().ec_key().unwrap();
+            let params = OcpLockHybridCertTbsEcc384Params {
+                serial_number: &[0xABu8; OcpLockHybridCertTbsEcc384Params::SERIAL_NUMBER_LEN],
+                public_key:
+                    TryInto::<&[u8; OcpLockHybridCertTbsEcc384Params::PUBLIC_KEY_LEN]>::try_into(
+                        subject_key.pub_key(),
+                    )
+                    .unwrap(),
+                subject_sn:
+                    &TryInto::<[u8; OcpLockHybridCertTbsEcc384Params::SUBJECT_SN_LEN]>::try_into(
+                        subject_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                issuer_sn:
+                    &TryInto::<[u8; OcpLockHybridCertTbsEcc384Params::ISSUER_SN_LEN]>::try_into(
+                        issuer_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                subject_key_id: &TryInto::<
+                    [u8; OcpLockHybridCertTbsEcc384Params::SUBJECT_KEY_ID_LEN],
+                >::try_into(subject_key.sha1())
+                .unwrap(),
+                authority_key_id: &TryInto::<
+                    [u8; OcpLockHybridCertTbsEcc384Params::AUTHORITY_KEY_ID_LEN],
+                >::try_into(issuer_key.sha1())
+                .unwrap(),
+                not_before: &NotBefore::default().value,
+                not_after: &NotAfter::default().value,
+            };
+
+            let cert = OcpLockHybridCertTbsEcc384::new(&params);
+
+            let sig = cert
+                .sign(|b| {
+                    let mut sha = Sha384::new();
+                    sha.update(b);
+                    EcdsaSig::sign(&sha.finish(), &ec_key)
+                })
+                .unwrap();
+
+            assert_ne!(cert.tbs(), OcpLockHybridCertTbsEcc384::TBS_TEMPLATE);
+            assert_eq!(
+                &cert.tbs()[OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                    ..OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                        + OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN],
+                params.public_key,
+            );
+
+            let ecdsa_sig = crate::Ecdsa384Signature {
+                r: TryInto::<[u8; 48]>::try_into(sig.r().to_vec_padded(48).unwrap()).unwrap(),
+                s: TryInto::<[u8; 48]>::try_into(sig.s().to_vec_padded(48).unwrap()).unwrap(),
+            };
+
+            let builder = crate::Ecdsa384CertBuilder::new(cert.tbs(), &ecdsa_sig).unwrap();
+            let mut buf = vec![0u8; builder.len()];
+            builder.build(&mut buf).unwrap();
+
+            let cert: X509 = X509::from_der(&buf).unwrap();
+            assert!(cert.verify(issuer_key.priv_key()).unwrap());
+
+            let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+            let parsed_cert = match parser.parse(&buf) {
+                Ok((_, parsed_cert)) => parsed_cert,
+                Err(e) => panic!("x509 parsing failed: {:?}", e),
+            };
+
+            assert_eq!(parsed_cert.version(), X509Version::V3);
+            let basic_constraints = parsed_cert.basic_constraints().unwrap().unwrap();
+            assert!(basic_constraints.critical);
+            assert!(!basic_constraints.value.ca);
+
+            // Check key usage. OCP LOCK HPKE certs should only allow key encipherment
+            let key_usage = parsed_cert.key_usage().unwrap().unwrap();
+            assert!(key_usage.critical);
+            assert!(key_usage.value.key_encipherment());
+
+            // Check that HPKE Identifiers extension is present
+            let ext_map = parsed_cert.extensions_map().unwrap();
+            const HPKE_IDENTIFIERS_OID: Oid = oid!(2.23.133 .21 .1 .1);
+            assert!(!ext_map[&HPKE_IDENTIFIERS_OID].critical);
+        }
+
+        #[test]
+        #[cfg(feature = "generate_templates")]
+        fn test_ocp_lock_hybrid_ecc384_template() {
+            let manual_template = std::fs::read(std::path::Path::new(
+                "./src/ocp_lock_hybrid_cert_tbs_ecc_384.rs",
+            ))
+            .unwrap();
+            let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+                env!("OUT_DIR"),
+                "/ocp_lock_hybrid_cert_tbs_ecc_384.rs"
+            )))
+            .unwrap();
+            if auto_generated_template != manual_template {
+                panic!(
+                "Auto-generated OCP LOCK Hybrid EC Certificate template is not equal to the manual template."
+            )
+            }
+        }
+    }
+}
+
+pub mod hybrid_mldsa_87 {
+
+    #[cfg(feature = "generate_templates")]
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs"
+    ));
+    #[cfg(not(feature = "generate_templates"))]
+    include! {"ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs"}
+
+    #[cfg(all(test, target_family = "unix"))]
+    mod tests {
+        use openssl::pkey_ctx::PkeyCtx;
+        use openssl::pkey_ml_dsa::Variant;
+        use openssl::signature::Signature;
+        use openssl::x509::X509;
+        use x509_parser::nom::Parser;
+        use x509_parser::oid_registry::asn1_rs::oid;
+        use x509_parser::oid_registry::Oid;
+        use x509_parser::prelude::X509CertificateParser;
+        use x509_parser::x509::X509Version;
+
+        use super::*;
+        use crate::test_util::tests::*;
+        use crate::{NotAfter, NotBefore};
+
+        #[test]
+        fn test_cert() {
+            let subject_key = HybridP384MlKem1024AsymKey::default();
+            let issuer_key = MlDsa87AsymKey::default();
+            let mldsa_key = issuer_key.priv_key();
+
+            let params = OcpLockHybridCertTbsMlDsa87Params {
+                serial_number: &[0xABu8; OcpLockHybridCertTbsMlDsa87Params::SERIAL_NUMBER_LEN],
+                public_key:
+                    TryInto::<&[u8; OcpLockHybridCertTbsMlDsa87Params::PUBLIC_KEY_LEN]>::try_into(
+                        subject_key.pub_key(),
+                    )
+                    .unwrap(),
+                subject_sn:
+                    &TryInto::<[u8; OcpLockHybridCertTbsMlDsa87Params::SUBJECT_SN_LEN]>::try_into(
+                        subject_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                issuer_sn:
+                    &TryInto::<[u8; OcpLockHybridCertTbsMlDsa87Params::ISSUER_SN_LEN]>::try_into(
+                        issuer_key.hex_str().into_bytes(),
+                    )
+                    .unwrap(),
+                subject_key_id: &TryInto::<
+                    [u8; OcpLockHybridCertTbsMlDsa87Params::SUBJECT_KEY_ID_LEN],
+                >::try_into(subject_key.sha1())
+                .unwrap(),
+                authority_key_id: &TryInto::<
+                    [u8; OcpLockHybridCertTbsMlDsa87Params::AUTHORITY_KEY_ID_LEN],
+                >::try_into(issuer_key.sha1())
+                .unwrap(),
+                not_before: &NotBefore::default().value,
+                not_after: &NotAfter::default().value,
+            };
+
+            let cert = OcpLockHybridCertTbsMlDsa87::new(&params);
+
+            let sig = cert
+                .sign(|b| {
+                    let mut signature = vec![];
+                    let mut ctx = PkeyCtx::new(mldsa_key)?;
+                    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87)?;
+                    ctx.sign_message_init(&mut algo)?;
+                    ctx.sign_to_vec(b, &mut signature)?;
+                    Ok::<Vec<u8>, openssl::error::ErrorStack>(signature)
+                })
+                .unwrap();
+
+            assert_ne!(cert.tbs(), OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE);
+            assert_eq!(
+                &cert.tbs()[OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                    ..OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                        + OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN],
+                params.public_key,
+            );
+
+            let mldsa_sig = crate::MlDsa87Signature {
+                sig: sig.try_into().unwrap(),
+            };
+
+            let builder = crate::MlDsa87CertBuilder::new(cert.tbs(), &mldsa_sig).unwrap();
+            let mut buf = vec![0u8; builder.len()];
+            builder.build(&mut buf).unwrap();
+
+            let cert: X509 = X509::from_der(&buf).unwrap();
+            assert!(cert.verify(issuer_key.priv_key()).unwrap());
+
+            let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
+            let parsed_cert = match parser.parse(&buf) {
+                Ok((_, parsed_cert)) => parsed_cert,
+                Err(e) => panic!("x509 parsing failed: {:?}", e),
+            };
+
+            assert_eq!(parsed_cert.version(), X509Version::V3);
+            let basic_constraints = parsed_cert.basic_constraints().unwrap().unwrap();
+            assert!(basic_constraints.critical);
+            assert!(!basic_constraints.value.ca);
+
+            // Check key usage. OCP LOCK HPKE certs should only allow key encipherment
+            let key_usage = parsed_cert.key_usage().unwrap().unwrap();
+            assert!(key_usage.critical);
+            assert!(key_usage.value.key_encipherment());
+
+            // Check that HPKE Identifiers extension is present
+            let ext_map = parsed_cert.extensions_map().unwrap();
+            const HPKE_IDENTIFIERS_OID: Oid = oid!(2.23.133 .21 .1 .1);
+            assert!(!ext_map[&HPKE_IDENTIFIERS_OID].critical);
+        }
+
+        #[test]
+        #[cfg(feature = "generate_templates")]
+        fn test_ocp_lock_hybrid_mldsa87_template() {
+            let manual_template = std::fs::read(std::path::Path::new(
+                "./src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs",
+            ))
+            .unwrap();
+            let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+                env!("OUT_DIR"),
+                "/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs"
+            )))
+            .unwrap();
+            if auto_generated_template != manual_template {
+                panic!(
+                "Auto-generated OCP LOCK Hybrid ML-DSA Certificate template is not equal to the manual template."
+            )
+            }
+        }
+    }
+}

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
@@ -1,0 +1,254 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+#[allow(clippy::needless_lifetimes)]
+pub struct OcpLockHybridCertTbsEcc384Params<'a> {
+    pub public_key: &'a [u8; 1665usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+}
+impl OcpLockHybridCertTbsEcc384Params<'_> {
+    pub const PUBLIC_KEY_LEN: usize = 1665usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+}
+pub struct OcpLockHybridCertTbsEcc384 {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl OcpLockHybridCertTbsEcc384 {
+    const PUBLIC_KEY_OFFSET: usize = 352usize;
+    const SUBJECT_SN_OFFSET: usize = 209usize;
+    const ISSUER_SN_OFFSET: usize = 56usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 2088usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 2121usize;
+    const NOT_BEFORE_OFFSET: usize = 163usize;
+    const NOT_AFTER_OFFSET: usize = 180usize;
+    const PUBLIC_KEY_LEN: usize = 1665usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    pub const TBS_TEMPLATE_LEN: usize = 2141usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
+        73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 37u8,
+        48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8,
+        116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+        129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8, 79u8, 67u8, 80u8,
+        32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
+        111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8, 69u8,
+        77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8, 80u8, 51u8, 56u8,
+        52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8,
+        63u8, 3u8, 130u8, 6u8, 130u8, 0u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8,
+        29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8,
+        85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8,
+        2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8,
+        20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &OcpLockHybridCertTbsEcc384Params) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &OcpLockHybridCertTbsEcc384Params) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 2141usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+    }
+}

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
@@ -1,0 +1,254 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+#[allow(clippy::needless_lifetimes)]
+pub struct OcpLockHybridCertTbsMlDsa87Params<'a> {
+    pub public_key: &'a [u8; 1665usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub issuer_sn: &'a [u8; 64usize],
+    pub serial_number: &'a [u8; 20usize],
+    pub subject_key_id: &'a [u8; 20usize],
+    pub authority_key_id: &'a [u8; 20usize],
+    pub not_before: &'a [u8; 15usize],
+    pub not_after: &'a [u8; 15usize],
+}
+impl OcpLockHybridCertTbsMlDsa87Params<'_> {
+    pub const PUBLIC_KEY_LEN: usize = 1665usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const ISSUER_SN_LEN: usize = 64usize;
+    pub const SERIAL_NUMBER_LEN: usize = 20usize;
+    pub const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    pub const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    pub const NOT_BEFORE_LEN: usize = 15usize;
+    pub const NOT_AFTER_LEN: usize = 15usize;
+}
+pub struct OcpLockHybridCertTbsMlDsa87 {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl OcpLockHybridCertTbsMlDsa87 {
+    const PUBLIC_KEY_OFFSET: usize = 354usize;
+    const SUBJECT_SN_OFFSET: usize = 211usize;
+    const ISSUER_SN_OFFSET: usize = 57usize;
+    const SERIAL_NUMBER_OFFSET: usize = 11usize;
+    const SUBJECT_KEY_ID_OFFSET: usize = 2090usize;
+    const AUTHORITY_KEY_ID_OFFSET: usize = 2123usize;
+    const NOT_BEFORE_OFFSET: usize = 165usize;
+    const NOT_AFTER_OFFSET: usize = 182usize;
+    const PUBLIC_KEY_LEN: usize = 1665usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const ISSUER_SN_LEN: usize = 64usize;
+    const SERIAL_NUMBER_LEN: usize = 20usize;
+    const SUBJECT_KEY_ID_LEN: usize = 20usize;
+    const AUTHORITY_KEY_ID_LEN: usize = 20usize;
+    const NOT_BEFORE_LEN: usize = 15usize;
+    const NOT_AFTER_LEN: usize = 15usize;
+    pub const TBS_TEMPLATE_LEN: usize = 2143usize;
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [
+        48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
+        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8,
+        38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+        55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 48u8, 129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
+        64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8,
+        79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+        110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+        45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8,
+        80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8,
+        5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8,
+        3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8,
+        6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8,
+        6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8,
+        1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8,
+        22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    pub fn new(params: &OcpLockHybridCertTbsMlDsa87Params) -> Self {
+        let mut template = Self {
+            tbs: Self::TBS_TEMPLATE,
+        };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &OcpLockHybridCertTbsMlDsa87Params) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 2143usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::ISSUER_SN_OFFSET }, { Self::ISSUER_SN_LEN }>(
+            &mut self.tbs,
+            params.issuer_sn,
+        );
+        apply_slice::<{ Self::SERIAL_NUMBER_OFFSET }, { Self::SERIAL_NUMBER_LEN }>(
+            &mut self.tbs,
+            params.serial_number,
+        );
+        apply_slice::<{ Self::SUBJECT_KEY_ID_OFFSET }, { Self::SUBJECT_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.subject_key_id,
+        );
+        apply_slice::<{ Self::AUTHORITY_KEY_ID_OFFSET }, { Self::AUTHORITY_KEY_ID_LEN }>(
+            &mut self.tbs,
+            params.authority_key_id,
+        );
+        apply_slice::<{ Self::NOT_BEFORE_OFFSET }, { Self::NOT_BEFORE_LEN }>(
+            &mut self.tbs,
+            params.not_before,
+        );
+        apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
+            &mut self.tbs,
+            params.not_after,
+        );
+    }
+}

--- a/x509/src/test_util.rs
+++ b/x509/src/test_util.rs
@@ -174,4 +174,44 @@ pub mod tests {
             }
         }
     }
+
+    pub struct HybridP384MlKem1024AsymKey {
+        pub_key: Vec<u8>,
+    }
+
+    impl HybridP384MlKem1024AsymKey {
+        pub fn pub_key(&self) -> &[u8] {
+            &self.pub_key
+        }
+
+        pub fn sha256(&self) -> [u8; 32] {
+            let mut sha = Sha256::new();
+            sha.update(self.pub_key());
+            sha.finish()
+        }
+
+        pub fn sha1(&self) -> [u8; 20] {
+            let mut sha = Sha1::new();
+            sha.update(self.pub_key());
+            sha.finish()
+        }
+
+        pub fn hex_str(&self) -> String {
+            hex::encode(self.sha256()).to_uppercase()
+        }
+    }
+
+    impl Default for HybridP384MlKem1024AsymKey {
+        fn default() -> Self {
+            let ecc384 = Ecc384AsymKey::default();
+            let mlkem1024 = MlKem1024AsymKey::default();
+
+            let pq = mlkem1024.pub_key();
+            let trad = ecc384.pub_key();
+            let mut pub_key = Vec::with_capacity(pq.len() + trad.len());
+            pub_key.extend_from_slice(pq);
+            pub_key.extend_from_slice(trad);
+            Self { pub_key }
+        }
+    }
 }


### PR DESCRIPTION
Additionally, re-implements `cert.rs` with `x509-cert` to workaround OpenSSL limitations.