### PR TITLE
Add runtime command for encrypted boot decryption

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: d74a1d7cf8b0144bd5394fe8d9baf65c833c8144
+  CALIPTRA_MCU_COMMIT: 02ea798304ccccff8e6b5a065781b3d5ed38b118 
 
 jobs:
   check_cache:

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -251,6 +251,8 @@ impl CommandId {
     pub const CM_MLKEM_KEY_GEN: Self = Self(0x434D_4C4B); // "CMLK"
     pub const CM_MLKEM_ENCAPSULATE: Self = Self(0x434D_4C45); // "CMLE"
     pub const CM_MLKEM_DECAPSULATE: Self = Self(0x434D_4C44); // "CMLD"
+    pub const CM_AES_GCM_DECRYPT_DMA: Self = Self(0x434D_4444); // "CMDD"
+    pub const GET_MCU_FW_SIZE: Self = Self(0x474D_4653); // "GMFS"
 
     // OCP LOCK Commands
     pub const OCP_LOCK_REPORT_HEK_METADATA: Self = Self(0x5248_4D54); // "RHMT"
@@ -414,6 +416,8 @@ pub enum MailboxResp {
     CmMlkemEncapsulate(CmMlkemEncapsulateResp),
     CmMlkemDecapsulate(CmMlkemDecapsulateResp),
     CmDeriveStableKey(CmDeriveStableKeyResp),
+    CmAesGcmDecryptDma(CmAesGcmDecryptDmaResp),
+    GetMcuFwSize(GetMcuFwSizeResp),
     ProductionAuthDebugUnlockChallenge(ProductionAuthDebugUnlockChallenge),
     GetPcrLog(GetPcrLogResp),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsResp),
@@ -500,6 +504,8 @@ impl MailboxResp {
             MailboxResp::CmMlkemEncapsulate(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmMlkemDecapsulate(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmAesGcmDecryptDma(resp) => Ok(resp.as_bytes()),
+            MailboxResp::GetMcuFwSize(resp) => Ok(resp.as_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_bytes()),
@@ -584,6 +590,8 @@ impl MailboxResp {
             MailboxResp::CmMlkemEncapsulate(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmMlkemDecapsulate(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmAesGcmDecryptDma(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::GetMcuFwSize(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_mut_bytes()),
@@ -735,6 +743,8 @@ pub enum MailboxReq {
     CmMlkemEncapsulate(CmMlkemEncapsulateReq),
     CmMlkemDecapsulate(CmMlkemDecapsulateReq),
     CmDeriveStableKey(CmDeriveStableKeyReq),
+    CmAesGcmDecryptDma(CmAesGcmDecryptDmaReq),
+    GetMcuFwSize(MailboxReqHeader),
     OcpLockReportHekMetadata(OcpLockReportHekMetadataReq),
     OcpLockGetAlgorithms(OcpLockGetAlgorithmsReq),
     OcpLockEnumerateHpkeHandles(OcpLockEnumerateHpkeHandlesReq),
@@ -839,6 +849,8 @@ impl MailboxReq {
             MailboxReq::CmMlkemEncapsulate(req) => Ok(req.as_bytes()),
             MailboxReq::CmMlkemDecapsulate(req) => Ok(req.as_bytes()),
             MailboxReq::CmDeriveStableKey(req) => Ok(req.as_bytes()),
+            MailboxReq::CmAesGcmDecryptDma(req) => req.as_bytes_partial(),
+            MailboxReq::GetMcuFwSize(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockReportHekMetadata(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockGetAlgorithms(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockEnumerateHpkeHandles(req) => Ok(req.as_bytes()),
@@ -941,6 +953,8 @@ impl MailboxReq {
             MailboxReq::CmMlkemEncapsulate(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmMlkemDecapsulate(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmDeriveStableKey(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CmAesGcmDecryptDma(req) => req.as_bytes_partial_mut(),
+            MailboxReq::GetMcuFwSize(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockReportHekMetadata(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockGetAlgorithms(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockInitializeMekSecret(req) => Ok(req.as_mut_bytes()),
@@ -1043,6 +1057,8 @@ impl MailboxReq {
             MailboxReq::CmMlkemEncapsulate(_) => CommandId::CM_MLKEM_ENCAPSULATE,
             MailboxReq::CmMlkemDecapsulate(_) => CommandId::CM_MLKEM_DECAPSULATE,
             MailboxReq::CmDeriveStableKey(_) => CommandId::CM_DERIVE_STABLE_KEY,
+            MailboxReq::CmAesGcmDecryptDma(_) => CommandId::CM_AES_GCM_DECRYPT_DMA,
+            MailboxReq::GetMcuFwSize(_) => CommandId::GET_MCU_FW_SIZE,
             MailboxReq::GetPcrLog(_) => CommandId::GET_PCR_LOG,
             MailboxReq::FeProg(_) => CommandId::FE_PROG,
             MailboxReq::ProductionAuthDebugUnlockReq(_) => {
@@ -4893,6 +4909,113 @@ pub struct CmDeriveStableKeyResp {
     pub cmk: Cmk,
 }
 impl Response for CmDeriveStableKeyResp {}
+
+/// Maximum AAD size for CM_AES_GCM_DECRYPT_DMA command
+pub const CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE: usize = MAX_CMB_DATA_SIZE;
+
+// CM_AES_GCM_DECRYPT_DMA
+// This command performs in-place AES-GCM decryption of data at an AXI address using DMA.
+// It first verifies the SHA384 of the encrypted data, then performs decryption.
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptDmaReq {
+    pub hdr: MailboxReqHeader,
+    /// CMK (Cryptographic Mailbox Key) - 128 bytes
+    pub cmk: Cmk,
+    /// AES-GCM IV (12 bytes)
+    pub iv: [u32; 3],
+    /// AES-GCM tag (16 bytes)
+    pub tag: [u32; 4],
+    /// SHA384 hash of the encrypted data (48 bytes)
+    pub encrypted_data_sha384: [u8; 48],
+    /// AXI address (64 bits - low 32 bits)
+    pub axi_addr_lo: u32,
+    /// AXI address (64 bits - high 32 bits)
+    pub axi_addr_hi: u32,
+    /// Length of data to decrypt in bytes
+    pub length: u32,
+    /// Length of AAD in bytes
+    pub aad_length: u32,
+    /// AAD data (0..=4095 bytes)
+    pub aad: [u8; CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE],
+}
+
+impl Default for CmAesGcmDecryptDmaReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            cmk: Cmk::default(),
+            iv: [0u32; 3],
+            tag: [0u32; 4],
+            encrypted_data_sha384: [0u8; 48],
+            axi_addr_lo: 0,
+            axi_addr_hi: 0,
+            length: 0,
+            aad_length: 0,
+            aad: [0u8; CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE],
+        }
+    }
+}
+
+impl CmAesGcmDecryptDmaReq {
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.aad_length as usize > CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE - self.aad_length as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+
+    pub fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if self.aad_length as usize > CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE - self.aad_length as usize;
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+
+impl Request for CmAesGcmDecryptDmaReq {
+    const ID: CommandId = CommandId::CM_AES_GCM_DECRYPT_DMA;
+    type Resp = CmAesGcmDecryptDmaResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmAesGcmDecryptDmaResp {
+    pub hdr: MailboxRespHeader,
+    /// Indicates whether the GCM tag was verified successfully (1 = success, 0 = failure)
+    pub tag_verified: u32,
+}
+
+impl Response for CmAesGcmDecryptDmaResp {}
+
+// GET_MCU_FW_SIZE
+/// Response for the GET_MCU_FW_SIZE command, which returns the size and
+/// SHA-384 digest of the MCU firmware image that was downloaded during the
+/// recovery flow. Returning the digest avoids a redundant recomputation by
+/// the MCU ROM before issuing CM_AES_GCM_DECRYPT_DMA.
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetMcuFwSizeResp {
+    pub hdr: MailboxRespHeader,
+    /// Size of the MCU firmware image in bytes
+    pub size: u32,
+    /// SHA-384 digest of the MCU firmware image (ciphertext)
+    pub sha384: [u8; 48],
+}
+
+impl Default for GetMcuFwSizeResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            size: 0,
+            sha384: [0u8; 48],
+        }
+    }
+}
+
+impl Response for GetMcuFwSizeResp {}
 
 // OCP_LOCK_REPORT_HEK_METADATA
 #[repr(C)]

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -893,6 +893,22 @@ impl<'a> DmaRecovery<'a> {
     // TODO: remove this when the FPGA can do fixed burst transfers
     #[cfg(any(feature = "fpga_realtime", feature = "fpga_subsystem"))]
     fn exec_dma_read(&self, read_transaction: DmaReadTransaction) -> CaliptraResult<()> {
+        // When AES mode is requested, use a single DMA transfer so data flows
+        // through the AES engine as one continuous stream.  AES-GCM requires
+        // this because the cipher maintains counter and GHASH state across
+        // blocks — breaking it into per-dword transfers with flush() in
+        // between would reset the pipeline.
+        //
+        // The per-dword workaround below is only needed because the FPGA
+        // cannot do fixed-address burst transfers (e.g. I3C recovery FIFO).
+        // Normal AXI-to-AXI (non-fixed) burst transfers work fine on FPGA.
+        if read_transaction.aes_mode || read_transaction.aes_gcm {
+            self.dma.flush();
+            self.dma.setup_dma_read(read_transaction);
+            self.dma.wait_for_dma_complete();
+            return Ok(());
+        }
+
         // Flush DMA before doing anything
         self.dma.flush();
 

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -79,7 +79,7 @@ pub enum BootMode {
     Normal = 0,
     /// Encrypted firmware boot mode (firmware loaded via RI_DOWNLOAD_ENCRYPTED_FIRMWARE)
     /// In this mode, runtime should not activate MCU firmware after downloading,
-    /// allowing MCU ROM to decrypt firmware first.
+    /// allowing MCU ROM to decrypt the firmware first.
     EncryptedFirmware = 1,
 }
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1809,6 +1809,11 @@ impl CaliptraError {
             0x000E008E,
             "Runtime Error: SHAKE256 context mismatch - SHA3 hardware was used between calls"
         ),
+        (
+            RUNTIME_CMB_DMA_SHA384_MISMATCH,
+            0x000E008F,
+            "Runtime Error: DMA SHA384 hash mismatch during encrypted firmware decryption"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -399,6 +399,9 @@ pub struct BootParams<'a> {
     pub soc_manifest: Option<&'a [u8]>,
     // MCU firmware image passed via the recovery interface
     pub mcu_fw_image: Option<&'a [u8]>,
+    /// Use encrypted firmware boot (RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE).
+    /// This sets BootMode::EncryptedFirmware and skips MCU activation in the recovery flow.
+    pub encrypted_boot: bool,
 }
 
 impl Default for BootParams<'_> {
@@ -412,6 +415,7 @@ impl Default for BootParams<'_> {
             wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
             soc_manifest: Default::default(),
             mcu_fw_image: Default::default(),
+            encrypted_boot: false,
         }
     }
 }
@@ -745,6 +749,18 @@ const RI_DOWNLOAD_FIRMWARE_OPCODE: u32 = 0x5249_4644;
 /// The download encrypted firmware from recovery interface Opcode
 const RI_DOWNLOAD_ENCRYPTED_FIRMWARE_OPCODE: u32 = 0x5249_4645;
 
+/// Boot status value indicating Runtime is ready for mailbox commands.
+const RT_READY_FOR_COMMANDS: u32 = 0x600;
+
+/// Test AES-256 key used for encrypted MCU firmware in sw-emulated models.
+/// On real hardware the MCU ROM obtains the key from its own storage.
+pub const MCU_TEST_AES_KEY: [u8; 32] = [0xaa; 32];
+
+/// Test AES-GCM IV used for encrypted MCU firmware in sw-emulated models.
+pub const MCU_TEST_IV: [u8; 12] = [
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+];
+
 /// Stash Measurement Command Opcode.
 const STASH_MEASUREMENT_CMD_OPCODE: u32 = 0x4D45_4153;
 
@@ -857,11 +873,26 @@ pub trait HwModel: SocManager {
                 }
             )?;
             if subsystem_mode {
-                self.upload_firmware_rri(
-                    fw_image,
-                    boot_params.soc_manifest,
-                    boot_params.mcu_fw_image,
-                )?;
+                if boot_params.encrypted_boot {
+                    self.upload_firmware_rri_encrypted(
+                        fw_image,
+                        boot_params.soc_manifest,
+                        boot_params.mcu_fw_image,
+                    )?;
+                    // Simulate what the MCU ROM does on real hardware: wait for
+                    // Caliptra RT to be ready, then decrypt the MCU firmware
+                    // in-place via CM_IMPORT + CM_AES_GCM_DECRYPT_DMA.
+                    if let Some(mcu_fw) = boot_params.mcu_fw_image {
+                        self.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+                        self.decrypt_encrypted_mcu_firmware(mcu_fw)?;
+                    }
+                } else {
+                    self.upload_firmware_rri(
+                        fw_image,
+                        boot_params.soc_manifest,
+                        boot_params.mcu_fw_image,
+                    )?;
+                }
             } else {
                 self.upload_firmware(fw_image)?;
             }
@@ -1339,7 +1370,8 @@ pub trait HwModel: SocManager {
         Ok(())
     }
 
-    /// Upload encrypted fw image to RRI.
+    /// Upload encrypted fw image to RRI using RI_DOWNLOAD_ENCRYPTED_FIRMWARE command.
+    /// This sets BootMode::EncryptedFirmware and skips MCU activation in the recovery flow.
     fn upload_firmware_rri_encrypted(
         &mut self,
         firmware: &[u8],
@@ -1351,6 +1383,130 @@ pub trait HwModel: SocManager {
         if response.is_some() {
             return Err(ModelError::UploadFirmwareUnexpectedResponse);
         }
+        Ok(())
+    }
+
+    /// Simulate the MCU ROM decrypting the encrypted MCU firmware after the
+    /// RRI download. On real hardware (FPGA), the MCU ROM performs this
+    /// autonomously, so the FPGA model overrides this with a no-op.
+    ///
+    /// The default (sw-emulator) implementation uses [`MCU_TEST_AES_KEY`] and
+    /// [`MCU_TEST_IV`] and performs the mailbox sequence that the MCU ROM would
+    /// execute:
+    ///   1. Query the firmware size and SHA-384 digest via GET_MCU_FW_SIZE
+    ///   2. Import the AES key via CM_IMPORT
+    ///   3. Write the ciphertext to the subsystem staging area
+    ///   4. Issue CM_AES_GCM_DECRYPT_DMA to decrypt in place
+    ///   5. Verify the GCM authentication tag
+    ///
+    /// `encrypted_mcu_fw` must be formatted as `ciphertext || 16-byte GCM tag`.
+    fn decrypt_encrypted_mcu_firmware(
+        &mut self,
+        encrypted_mcu_fw: &[u8],
+    ) -> Result<(), ModelError> {
+        use api::mailbox::{
+            CmAesGcmDecryptDmaReq, CmAesGcmDecryptDmaResp, CmImportReq, CmImportResp, CmKeyUsage,
+            CommandId, GetMcuFwSizeResp, MailboxReqHeader, MailboxRespHeader,
+            CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE,
+        };
+        use zerocopy::transmute;
+
+        assert!(
+            encrypted_mcu_fw.len() > 16,
+            "encrypted MCU firmware must be at least 17 bytes (ciphertext + 16-byte tag)"
+        );
+
+        // Step 1: Query the MCU firmware size via GET_MCU_FW_SIZE (as the
+        // real MCU ROM would do to learn the ciphertext length).
+        let mut get_size_cmd = MailboxReq::GetMcuFwSize(MailboxReqHeader { chksum: 0 });
+        get_size_cmd.populate_chksum().unwrap();
+
+        let resp = self
+            .mailbox_execute(
+                u32::from(CommandId::GET_MCU_FW_SIZE),
+                get_size_cmd.as_bytes().unwrap(),
+            )?
+            .ok_or(ModelError::MailboxNoResponseData)?;
+
+        let size_resp = GetMcuFwSizeResp::ref_from_bytes(resp.as_slice())
+            .map_err(|_| ModelError::MailboxNoResponseData)?;
+
+        let (ciphertext, tag_bytes) = encrypted_mcu_fw.split_at(encrypted_mcu_fw.len() - 16);
+
+        // GET_MCU_FW_SIZE now returns the ciphertext length (excluding the
+        // 16-byte GCM tag) and a SHA-384 computed over that ciphertext only,
+        // matching what CM_AES_GCM_DECRYPT_DMA will verify.
+        assert_eq!(
+            size_resp.size as usize,
+            ciphertext.len(),
+            "GET_MCU_FW_SIZE returned unexpected size"
+        );
+        // Use the SHA-384 digest returned by Caliptra RT instead of
+        // recomputing it (mirrors what the real MCU ROM does).
+        let encrypted_sha384 = size_resp.sha384;
+        let tag: [u8; 16] = tag_bytes.try_into().unwrap();
+
+        // Step 2: Import the test AES key to get a CMK
+        let mut input = [0u8; 64];
+        input[..32].copy_from_slice(&MCU_TEST_AES_KEY);
+
+        let mut cm_import_cmd = MailboxReq::CmImport(CmImportReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            key_usage: CmKeyUsage::Aes.into(),
+            input_size: 32,
+            input,
+        });
+        cm_import_cmd.populate_chksum().unwrap();
+
+        let resp = self
+            .mailbox_execute(
+                u32::from(CommandId::CM_IMPORT),
+                cm_import_cmd.as_bytes().unwrap(),
+            )?
+            .ok_or(ModelError::MailboxNoResponseData)?;
+
+        let cm_import_resp = CmImportResp::ref_from_bytes(resp.as_slice())
+            .map_err(|_| ModelError::MailboxNoResponseData)?;
+        if cm_import_resp.hdr.fips_status != MailboxRespHeader::FIPS_STATUS_APPROVED {
+            return Err(ModelError::MailboxRespInvalidFipsStatus(
+                cm_import_resp.hdr.fips_status,
+            ));
+        }
+        let cmk = cm_import_resp.cmk.clone();
+
+        // Step 3: Write ciphertext to staging area and get the AXI address
+        let mcu_sram_addr = self.write_payload_to_ss_staging_area(ciphertext)?;
+
+        // Step 4: Build and send CM_AES_GCM_DECRYPT_DMA request
+        let decrypt_req = CmAesGcmDecryptDmaReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            cmk,
+            iv: transmute!(MCU_TEST_IV),
+            tag: transmute!(tag),
+            encrypted_data_sha384: encrypted_sha384,
+            axi_addr_lo: mcu_sram_addr as u32,
+            axi_addr_hi: (mcu_sram_addr >> 32) as u32,
+            length: ciphertext.len() as u32,
+            aad_length: 0,
+            aad: [0u8; CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE],
+        };
+
+        let mut decrypt_cmd = MailboxReq::CmAesGcmDecryptDma(decrypt_req);
+        decrypt_cmd.populate_chksum().unwrap();
+
+        let resp = self
+            .mailbox_execute(
+                u32::from(CommandId::CM_AES_GCM_DECRYPT_DMA),
+                decrypt_cmd.as_bytes().unwrap(),
+            )?
+            .ok_or(ModelError::MailboxNoResponseData)?;
+
+        let decrypt_resp = CmAesGcmDecryptDmaResp::ref_from_bytes(resp.as_slice())
+            .map_err(|_| ModelError::MailboxNoResponseData)?;
+        if decrypt_resp.tag_verified != 1 {
+            return Err(ModelError::MailboxCmdFailed(0));
+        }
+
         Ok(())
     }
 

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1069,6 +1069,11 @@ impl ModelFpgaSubsystem {
                 // do the indirect fifo thing
                 println!("Recovery image available; writing blocks");
 
+                // Store the original image length before padding.
+                // The firmware uses this length for DMA transfer and SHA-384 digest,
+                // so it must reflect the actual image size, not the padded size.
+                self.recovery_ctrl_len = image.len();
+
                 // Recovery images must be padded to a multiple of 256 bytes
                 // or the last chunk will not finish.
                 let image = if image.len() % 256 == 0 {
@@ -1078,8 +1083,6 @@ impl ModelFpgaSubsystem {
                     image.resize(image.len().next_multiple_of(256), 0);
                     image
                 };
-
-                self.recovery_ctrl_len = image.len();
                 self.recovery_ctrl_written = false;
 
                 self.recovery_fifo_blocks = image.chunks(256).map(|chunk| chunk.to_vec()).collect();
@@ -2007,6 +2010,14 @@ impl HwModel for ModelFpgaSubsystem {
         } else {
             val & !(1 << 29)
         };
+        // Set encrypted boot wire on mci_generic_input_wires[1] bit 28.
+        // MCU ROM (core_test) checks this bit to decide whether to send
+        // RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE.
+        let val = if boot_params.encrypted_boot {
+            val | 1 << 28
+        } else {
+            val & !(1 << 28)
+        };
         gpio.set(val);
 
         const MAX_WAIT_FOR_CPTRA_BOOT_GO_CYCLES: u64 = 100_000_000;
@@ -2117,12 +2128,39 @@ impl HwModel for ModelFpgaSubsystem {
         // self.setup_mailbox_users(boot_params.valid_axi_user.as_slice())
         //     .map_err(ModelError::from)?;
 
-        self.upload_firmware_rri(
-            boot_params.fw_image.unwrap(),
-            boot_params.soc_manifest,
-            Some(&mcu_fw_image),
-        )
-        .unwrap();
+        if boot_params.encrypted_boot {
+            self.upload_firmware_rri_encrypted(
+                boot_params.fw_image.unwrap(),
+                boot_params.soc_manifest,
+                Some(&mcu_fw_image),
+            )
+            .unwrap();
+
+            // Wait for the MCU ROM to finish its encrypted boot flow
+            // (CM_SHA + CM_IMPORT + CM_AES_GCM_DECRYPT_DMA) before returning.
+            // The MCU ROM sets COLD_BOOT_FLOW_COMPLETE after decrypt_firmware().
+            const MAX_WAIT_DECRYPT_CYCLES: u64 = 1_000_000_000;
+            let start = self.cycle_count();
+            while !self
+                .mci_boot_milestones()
+                .contains(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE)
+            {
+                self.step();
+                if self.cycle_count().wrapping_sub(start) >= MAX_WAIT_DECRYPT_CYCLES {
+                    panic!(
+                        "Timeout waiting for MCU ROM encrypted boot to complete after {} cycles",
+                        self.cycle_count().wrapping_sub(start)
+                    );
+                }
+            }
+        } else {
+            self.upload_firmware_rri(
+                boot_params.fw_image.unwrap(),
+                boot_params.soc_manifest,
+                Some(&mcu_fw_image),
+            )
+            .unwrap();
+        }
 
         Ok(())
     }
@@ -2243,17 +2281,26 @@ impl HwModel for ModelFpgaSubsystem {
             cb(self);
         }
 
-        // TODO: when MCU ROM supports a generic wire to indicate which command to send, we
-        // can re-enable it. But for now, we send the mailbox command ourselves and leave
-        // MCU ROM waiting.
-        let response = self.mailbox_execute(crate::RI_DOWNLOAD_ENCRYPTED_FIRMWARE_OPCODE, &[])?;
-        if response.is_some() {
-            return Err(ModelError::UploadFirmwareUnexpectedResponse);
-        }
+        // MCU ROM checks the encrypted boot wire (mci_generic_input_wires[0] bit 28)
+        // and sends RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE.
+        // We just need to release the gate (bit 31) so MCU ROM proceeds.
+        let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
+        let current = gpio.extract().get();
+        gpio.set(current | 1 << 31);
+
         Ok(())
     }
 
     fn upload_firmware(&mut self, _firmware: &[u8]) -> Result<(), ModelError> {
+        Ok(())
+    }
+
+    /// On FPGA the real MCU ROM handles decryption autonomously after the gate
+    /// is released, so the model has nothing to do.
+    fn decrypt_encrypted_mcu_firmware(
+        &mut self,
+        _encrypted_mcu_fw: &[u8],
+    ) -> Result<(), ModelError> {
         Ok(())
     }
 
@@ -2314,18 +2361,22 @@ impl HwModel for ModelFpgaSubsystem {
         self.staging_physical_address()
     }
 
-    fn read_payload_from_ss_staging_area(&mut self, length: usize) -> Result<Vec<u8>, ModelError> {
+    fn read_payload_from_ss_staging_area(&mut self, len: usize) -> Result<Vec<u8>, ModelError> {
         let staging_offset = 0xc00000_usize / 4; // Convert to u32 offset since mci.ptr is *mut u32
         let staging_ptr = unsafe { self.mmio.mci().unwrap().ptr.add(staging_offset) };
 
-        let length_words = (length + 3) / 4;
-        let mut payload = Vec::with_capacity(length_words * 4);
-        for i in 0..length_words {
+        let mut result = Vec::with_capacity(len);
+        let num_words = len.div_ceil(4);
+
+        for i in 0..num_words {
             let u32_value = unsafe { staging_ptr.add(i).read_volatile() };
-            payload.extend_from_slice(&u32_value.to_le_bytes());
+            let bytes = u32_value.to_le_bytes();
+            let remaining = len - result.len();
+            let take = remaining.min(4);
+            result.extend_from_slice(&bytes[..take]);
         }
-        payload.truncate(length); // Remove any extra bytes from the last chunk
-        Ok(payload)
+
+        Ok(result)
     }
 
     /// Trigger a warm reset and advance the boot

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -461,6 +461,10 @@ impl ModelVerilated {
         todo!()
     }
 
+    fn read_payload_from_ss_staging_area(&mut self, _len: usize) -> Result<Vec<u8>, ModelError> {
+        todo!()
+    }
+
     fn fuses(&self) -> &Fuses {
         &self.fuses
     }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -39,6 +39,19 @@ The Runtime Firmware main function SHALL perform the following on cold boot rese
 * Initialize any SRAM structures used by Runtime Firmware
 * Upload the firwmare to the Manufacturer Control Unit (2.0, susbystem mode only)
 
+#### Encrypted Firmware Support (2.1, subsystem mode only)
+
+When ROM receives the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command instead of `RI_DOWNLOAD_FIRMWARE`, it sets the boot mode to `EncryptedFirmware`. In this mode:
+
+1. Runtime downloads the encrypted MCU firmware to MCU SRAM via the recovery interface
+2. Runtime does **not** activate the MCU firmware immediately
+3. The MCU ROM can then:
+   - Import an AES key using `CM_IMPORT`
+   - Decrypt the firmware in-place using `CM_AES_GCM_DECRYPT_DMA`
+   - Send `CM_ACTIVATE_FIRMWARE` to activate the decrypted MCU firmware
+
+The `CM_AES_GCM_DECRYPT_DMA` command is restricted to the `EncryptedFirmware` boot mode and performs a SHA384 integrity check of the ciphertext before decryption.
+
 For behavior during other types of reset, see [Runtime firmware updates](#runtime-firmware-updates).
 
 If Runtime Firmware detects that Caliptra was reset during the execution of an operation, Runtime Firmware calls `DISABLE_ATTESTATION` because the internal state of Caliptra may be corrupted.
@@ -1336,7 +1349,26 @@ Command Code: `0x494D_4530` ("IME0")
 | Version Number          | u32          | This corresponds to the `Version Number` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
 | Version String          | u8[32]       | This corresponds to the `Version String` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
 
+### GET\_MCU\_FW\_SIZE
 
+Returns the size and SHA-384 digest of the MCU firmware image that was downloaded during the recovery flow. This command is used by MCU ROM during encrypted boot so it can issue `CM_AES_GCM_DECRYPT_DMA` with the correct size and without recomputing the digest.
+
+Command Code: `0x474D_4653` ("GMFS")
+
+*Table: `GET_MCU_FW_SIZE` input arguments*
+
+| **Name** | **Type** | **Description**                                                       |
+| -------------- | -------------- | --------------------------------------------------------------------------- |
+| chksum         | u32            | Checksum over other input arguments, computed by the caller. Little endian. |
+
+*Table: `GET_MCU_FW_SIZE` output arguments*
+
+| **Name** | **Type** | **Description**                                                      |
+| -------------- | -------------- | -------------------------------------------------------------------------- |
+| chksum         | u32            | Checksum over other output arguments, computed by Caliptra. Little endian. |
+| fips_status    | u32            | Indicates if the command is FIPS approved or an error.                     |
+| size           | u32            | Size of the MCU firmware image in bytes.                                   |
+| sha384         | u8[48]         | SHA-384 digest of the encrypted MCU firmware image.                        |
 
 ### ACTIVATE_FIRMWARE
 
@@ -2341,6 +2373,41 @@ Command Code: `0x434D_4446` ("CMDF")
 | tag verified   | u32                | 1 if tags matched, 0 if they did not |
 | plaintext size | u32                | MAY be 0                             |
 | plaintext      | u8[plaintext size] |                                      |
+
+### CM_AES_GCM_DECRYPT_DMA
+
+Performs in-place AES-256-GCM decryption of data at an AXI address using DMA. This command is specifically designed for decrypting MCU firmware that was downloaded via the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command.
+
+**Important restrictions:**
+- This command is only available when the boot mode is `EncryptedFirmware`, which is set by ROM when it receives the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command.
+- The command performs a two-pass operation:
+  1. First pass: Verifies the SHA384 hash of the encrypted data at the AXI address
+  2. Second pass: Performs in-place AES-GCM decryption via DMA
+
+The CMK must be an AES key (key usage = 3) that was previously imported using `CM_IMPORT`.
+
+Command Code: `0x434D_4444` ("CMDD")
+
+*Table: `CM_AES_GCM_DECRYPT_DMA` input arguments*
+| **Name**              | **Type**  | **Description**                                      |
+| --------------------- | --------- | ---------------------------------------------------- |
+| chksum                | u32       | Checksum over other input arguments                  |
+| cmk                   | CMK       | Encrypted CMK containing the AES-256 key             |
+| iv                    | u32[3]    | AES-GCM initialization vector (12 bytes)             |
+| tag                   | u32[4]    | AES-GCM authentication tag (16 bytes)                |
+| encrypted_data_sha384 | u8[48]    | SHA384 hash of the encrypted data for verification   |
+| axi_addr_lo           | u32       | Lower 32 bits of the AXI address                     |
+| axi_addr_hi           | u32       | Upper 32 bits of the AXI address                     |
+| length                | u32       | Length of data to decrypt in bytes                   |
+| aad_length            | u32       | Length of AAD in bytes (0-4095)                      |
+| aad                   | u8[...]   | Additional authenticated data                        |
+
+*Table: `CM_AES_GCM_DECRYPT_DMA` output arguments*
+| **Name**     | **Type** | **Description**                                       |
+| ------------ | -------- | ----------------------------------------------------- |
+| chksum       | u32      | Checksum over other output arguments                  |
+| fips_status  | u32      | FIPS approved or an error                             |
+| tag_verified | u32      | 1 if GCM tag verification succeeded, 0 if it failed   |
 
 ### CM_ECDH_GENERATE
 

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -22,25 +22,26 @@ use caliptra_common::{
     keyids::{KEY_ID_STABLE_IDEV, KEY_ID_STABLE_LDEV},
     mailbox_api::{
         CmAesDecryptInitReq, CmAesDecryptUpdateReq, CmAesEncryptInitReq, CmAesEncryptInitResp,
-        CmAesEncryptUpdateReq, CmAesGcmDecryptFinalReq, CmAesGcmDecryptFinalResp,
-        CmAesGcmDecryptInitReq, CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq,
-        CmAesGcmDecryptUpdateResp, CmAesGcmEncryptFinalReq, CmAesGcmEncryptFinalResp,
-        CmAesGcmEncryptInitReq, CmAesGcmEncryptInitResp, CmAesGcmEncryptUpdateReq,
-        CmAesGcmEncryptUpdateResp, CmAesGcmSpdmDecryptInitReq, CmAesGcmSpdmDecryptInitResp,
-        CmAesGcmSpdmEncryptInitReq, CmAesGcmSpdmEncryptInitResp, CmAesMode, CmAesResp, CmDeleteReq,
-        CmDeriveStableKeyReq, CmDeriveStableKeyResp, CmEcdhFinishReq, CmEcdhFinishResp,
-        CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp,
-        CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm, CmHkdfExpandReq,
-        CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq,
-        CmHmacKdfCounterResp, CmImportReq, CmImportResp, CmKeyUsage, CmMldsaPublicKeyReq,
-        CmMldsaPublicKeyResp, CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq,
-        CmMlkemDecapsulateReq, CmMlkemDecapsulateResp, CmMlkemEncapsulateReq,
-        CmMlkemEncapsulateResp, CmMlkemKeyGenReq, CmMlkemKeyGenResp, CmRandomGenerateReq,
-        CmRandomGenerateResp, CmRandomStirReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp,
-        CmShaUpdateReq, CmShake256FinalReq, CmShake256FinalResp, CmShake256InitReq,
-        CmShake256InitResp, CmShake256UpdateReq, CmStableKeyType, CmStatusResp, Cmk as MailboxCmk,
-        MailboxRespHeader, MailboxRespHeaderVarSize, ResponseVarSize,
-        CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_CONTEXT_SIZE, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE,
+        CmAesEncryptUpdateReq, CmAesGcmDecryptDmaReq, CmAesGcmDecryptDmaResp,
+        CmAesGcmDecryptFinalReq, CmAesGcmDecryptFinalResp, CmAesGcmDecryptInitReq,
+        CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq, CmAesGcmDecryptUpdateResp,
+        CmAesGcmEncryptFinalReq, CmAesGcmEncryptFinalResp, CmAesGcmEncryptInitReq,
+        CmAesGcmEncryptInitResp, CmAesGcmEncryptUpdateReq, CmAesGcmEncryptUpdateResp,
+        CmAesGcmSpdmDecryptInitReq, CmAesGcmSpdmDecryptInitResp, CmAesGcmSpdmEncryptInitReq,
+        CmAesGcmSpdmEncryptInitResp, CmAesMode, CmAesResp, CmDeleteReq, CmDeriveStableKeyReq,
+        CmDeriveStableKeyResp, CmEcdhFinishReq, CmEcdhFinishResp, CmEcdhGenerateReq,
+        CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp, CmEcdsaSignReq,
+        CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm, CmHkdfExpandReq, CmHkdfExpandResp,
+        CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq, CmHmacKdfCounterResp,
+        CmImportReq, CmImportResp, CmKeyUsage, CmMldsaPublicKeyReq, CmMldsaPublicKeyResp,
+        CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq, CmMlkemDecapsulateReq,
+        CmMlkemDecapsulateResp, CmMlkemEncapsulateReq, CmMlkemEncapsulateResp, CmMlkemKeyGenReq,
+        CmMlkemKeyGenResp, CmRandomGenerateReq, CmRandomGenerateResp, CmRandomStirReq,
+        CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmShake256FinalReq,
+        CmShake256FinalResp, CmShake256InitReq, CmShake256InitResp, CmShake256UpdateReq,
+        CmStableKeyType, CmStatusResp, Cmk as MailboxCmk, MailboxRespHeader,
+        MailboxRespHeaderVarSize, ResponseVarSize, CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE,
+        CMB_ECDH_CONTEXT_SIZE, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE,
         CMB_SHAKE256_CONTEXT_PLAINTEXT_SIZE, CMB_SHAKE256_CONTEXT_SIZE, CMB_SHA_CONTEXT_SIZE,
         CMK_MAX_KEY_SIZE_BITS, CMK_SIZE_BYTES, CM_STABLE_KEY_INFO_SIZE_BYTES, MAX_CMB_DATA_SIZE,
         MLKEM1024_SHARED_KEY_SIZE,
@@ -49,18 +50,19 @@ use caliptra_common::{
 use caliptra_drivers::{
     cmac_kdf, hkdf_expand, hkdf_extract, hmac_kdf,
     sha2_512_384::{Sha2DigestOpTrait, SHA512_BLOCK_BYTE_SIZE, SHA512_HASH_SIZE},
-    Aes, AesContext, AesGcmContext, AesGcmIv, AesKey, AesOperation, Array4x12, Array4x16,
-    CaliptraResult, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Seed,
-    Ecc384Signature, HmacMode, KeyReadArgs, LEArray4x1157, LEArray4x3, LEArray4x392, LEArray4x4,
-    LEArray4x8, MlKem1024, MlKem1024Message, MlKem1024MessageSource, MlKem1024Seed, MlKem1024Seeds,
-    MlKem1024SharedKey, MlKem1024SharedKeyOut, Mldsa87Result, Mldsa87Seed, PersistentDataAccessor,
-    Sha2_512_384, Trng, AES_BLOCK_SIZE_BYTES, AES_CONTEXT_SIZE_BYTES, AES_GCM_CONTEXT_SIZE_BYTES,
-    MAX_SEED_WORDS,
+    Aes, AesContext, AesDmaMode, AesGcmContext, AesGcmIv, AesKey, AesOperation, Array4x12,
+    Array4x16, AxiAddr, BootMode, CaliptraResult, DmaRecovery, Ecc384PrivKeyIn, Ecc384PrivKeyOut,
+    Ecc384PubKey, Ecc384Result, Ecc384Seed, Ecc384Signature, HmacMode, KeyReadArgs, LEArray4x1157,
+    LEArray4x3, LEArray4x392, LEArray4x4, LEArray4x8, MlKem1024, MlKem1024Message,
+    MlKem1024MessageSource, MlKem1024Seed, MlKem1024Seeds, MlKem1024SharedKey,
+    MlKem1024SharedKeyOut, Mldsa87Result, Mldsa87Seed, PersistentDataAccessor, Sha2_512_384, Trng,
+    AES_BLOCK_SIZE_BYTES, AES_CONTEXT_SIZE_BYTES, AES_GCM_CONTEXT_SIZE_BYTES, MAX_SEED_WORDS,
 };
 use caliptra_error::CaliptraError;
 use caliptra_image_types::{
     ECC384_SCALAR_BYTE_SIZE, SHA384_DIGEST_BYTE_SIZE, SHA512_DIGEST_BYTE_SIZE,
 };
+use constant_time_eq::constant_time_eq;
 use zerocopy::{transmute, FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const GCM_MAX_KEY_USES: u64 = (1 << 32) - 1;
@@ -2720,6 +2722,140 @@ impl Commands {
             *x = x.swap_bytes();
         });
         Ok(tag.0)
+    }
+
+    /// Performs in-place AES-GCM decryption of data at an AXI address using DMA.
+    ///
+    /// This command:
+    /// 1. Validates that the boot mode was EncryptedFirmware
+    /// 2. Decrypts the CMK
+    /// 3. Verifies the SHA384 hash of the encrypted data at the AXI address (first DMA pass)
+    /// 4. Performs in-place AES-GCM decryption via DMA (second pass)
+    /// 5. Returns whether the GCM tag was verified successfully
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn aes_256_gcm_decrypt_dma(
+        drivers: &mut Drivers,
+        cmd_bytes: &[u8],
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        if !drivers.cryptographic_mailbox.initialized {
+            Err(CaliptraError::RUNTIME_CMB_NOT_INITIALIZED)?;
+        }
+
+        // Validate boot mode - this command is only allowed when boot mode is EncryptedFirmware
+        let boot_mode = drivers.persistent_data.get().rom.boot_mode;
+        if boot_mode != BootMode::EncryptedFirmware {
+            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        }
+
+        if cmd_bytes.len() > core::mem::size_of::<CmAesGcmDecryptDmaReq>() {
+            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        }
+        let mut cmd = CmAesGcmDecryptDmaReq::default();
+        cmd.as_mut_bytes()[..cmd_bytes.len()].copy_from_slice(cmd_bytes);
+
+        // Validate AAD length
+        if cmd.aad_length as usize > cmd.aad.len() {
+            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        }
+        let aad = &cmd.aad[..cmd.aad_length as usize];
+
+        // Decrypt the CMK
+        let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmd.cmk.0[..])
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
+            &mut drivers.aes,
+            &mut drivers.trng,
+            encrypted_cmk,
+        )?;
+
+        // Validate key usage - must be AES key
+        let key_usage = CmKeyUsage::from(cmk.key_usage as u32);
+        if !matches!(key_usage, CmKeyUsage::Aes) {
+            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+        }
+
+        // Get the AXI address
+        let axi_addr = AxiAddr {
+            lo: cmd.axi_addr_lo,
+            hi: cmd.axi_addr_hi,
+        };
+        let length = cmd.length;
+
+        // First pass: Verify SHA384 of encrypted data
+        // Create DMA recovery handle for SHA384 calculation
+        let dma_recovery = DmaRecovery::new(
+            drivers.soc_ifc.recovery_interface_base_addr().into(),
+            drivers.soc_ifc.caliptra_base_axi_addr().into(),
+            drivers.soc_ifc.mci_base_addr().into(),
+            &drivers.dma,
+        );
+
+        let computed_digest = dma_recovery.sha384_image(
+            &mut drivers.sha2_512_384_acc,
+            axi_addr,
+            length,
+            AesDmaMode::None,
+        )?;
+
+        let computed_digest_bytes: [u8; 48] = computed_digest.into();
+        if !constant_time_eq(&computed_digest_bytes, &cmd.encrypted_data_sha384) {
+            Err(CaliptraError::RUNTIME_CMB_DMA_SHA384_MISMATCH)?;
+        }
+
+        // Extract key and IV from CMK
+        let key: [u8; 32] = cmk.key_material[..32]
+            .try_into()
+            .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?;
+        let key: LEArray4x8 = transmute!(key);
+        let iv: LEArray4x3 = LEArray4x3::new(cmd.iv);
+
+        // Initialize AES-GCM for decryption - use initialize_aes_gcm directly
+        // instead of aes_256_gcm_init to avoid zeroizing the engine before DMA
+        let _iv = drivers.aes.initialize_aes_gcm(
+            &mut drivers.trng,
+            AesGcmIv::Array(&iv),
+            AesKey::Array(&key),
+            aad,
+            AesOperation::Decrypt,
+        )?;
+
+        // Set the text phase with the length of the final partial block (or 16 if full)
+        let partial_len = length as usize % 16;
+        let text_len = if partial_len == 0 { 16 } else { partial_len };
+        drivers.aes.gcm_set_text(text_len as u32);
+
+        // Second pass: Perform in-place AES-GCM decryption via DMA
+        // The DMA hardware will read from axi_addr, decrypt through AES engine,
+        // and write back to axi_addr
+        let dma_recovery = DmaRecovery::new(
+            drivers.soc_ifc.recovery_interface_base_addr().into(),
+            drivers.soc_ifc.caliptra_base_axi_addr().into(),
+            drivers.soc_ifc.mci_base_addr().into(),
+            &drivers.dma,
+        );
+
+        dma_recovery.transfer_payload_to_axi(
+            axi_addr,
+            length,
+            axi_addr, // in-place: write back to same address
+            false,    // read_fixed_addr
+            false,    // write_fixed_addr
+            AesDmaMode::AesGcm,
+        )?;
+
+        // Compute and verify the GCM tag
+        let computed_tag = drivers.aes.compute_tag(aad.len(), length as usize)?;
+        let expected_tag: LEArray4x4 = LEArray4x4::new(cmd.tag);
+        let tag_verified = computed_tag.as_bytes() == expected_tag.as_bytes();
+
+        // Build response
+        let resp = mutrefbytes::<CmAesGcmDecryptDmaResp>(resp)?;
+        resp.hdr = MailboxRespHeader::default();
+        resp.tag_verified = tag_verified as u32;
+
+        Ok(core::mem::size_of::<CmAesGcmDecryptDmaResp>())
     }
 }
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -167,6 +167,10 @@ pub struct Drivers {
 
     pub debug_unlock: ProductionDebugUnlock,
     pub ocp_lock_context: OcpLockContext,
+
+    /// MCU firmware metadata recorded during recovery.
+    /// Queried by MCU ROM via GET_MCU_FW_SIZE during encrypted boot.
+    pub mcu_fw_info: crate::get_mcu_fw_size::McuFwInfo,
 }
 
 impl Drivers {
@@ -219,6 +223,7 @@ impl Drivers {
             debug_unlock: ProductionDebugUnlock::new(),
             ocp_lock_context,
             aes,
+            mcu_fw_info: crate::get_mcu_fw_size::McuFwInfo::default(),
         })
     }
 

--- a/runtime/src/get_mcu_fw_size.rs
+++ b/runtime/src/get_mcu_fw_size.rs
@@ -1,0 +1,53 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    get_mcu_fw_size.rs
+
+Abstract:
+
+    File contains GET_MCU_FW_SIZE mailbox command.
+
+--*/
+
+use crate::{mutrefbytes, Drivers};
+use caliptra_common::mailbox_api::{GetMcuFwSizeResp, MailboxRespHeader};
+use caliptra_drivers::CaliptraResult;
+
+/// Metadata about the MCU firmware image downloaded during the recovery flow.
+/// Populated by the recovery flow and returned to MCU ROM via the
+/// GET_MCU_FW_SIZE mailbox command so it can issue CM_AES_GCM_DECRYPT_DMA
+/// without recomputing the digest.
+#[derive(Clone, Copy)]
+pub struct McuFwInfo {
+    /// Size of the MCU firmware image in bytes.
+    pub size: u32,
+    /// SHA-384 digest of the MCU firmware image (ciphertext).
+    pub sha384: [u8; 48],
+}
+
+impl Default for McuFwInfo {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            sha384: [0u8; 48],
+        }
+    }
+}
+
+pub struct GetMcuFwSizeCmd;
+impl GetMcuFwSizeCmd {
+    /// Returns the size and SHA-384 digest of the MCU firmware image downloaded
+    /// during the recovery flow.  Used by MCU ROM during encrypted boot so it
+    /// can issue CM_AES_GCM_DECRYPT_DMA without recomputing the digest.
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers, resp: &mut [u8]) -> CaliptraResult<usize> {
+        let resp = mutrefbytes::<GetMcuFwSizeResp>(resp)?;
+        resp.hdr = MailboxRespHeader::default();
+        resp.size = drivers.mcu_fw_info.size;
+        resp.sha384 = drivers.mcu_fw_info.sha384;
+        Ok(core::mem::size_of::<GetMcuFwSizeResp>())
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,6 +31,7 @@ mod firmware_verify;
 mod get_fmc_alias_csr;
 mod get_idev_csr;
 mod get_image_info;
+mod get_mcu_fw_size;
 pub mod handoff;
 mod hmac;
 pub mod info;
@@ -420,6 +421,7 @@ fn execute_command(
             RevokeExportedCdiHandleCmd::execute(drivers, cmd_bytes)
         }
         CommandId::GET_IMAGE_INFO => GetImageInfoCmd::execute(drivers, cmd_bytes, resp),
+        CommandId::GET_MCU_FW_SIZE => get_mcu_fw_size::GetMcuFwSizeCmd::execute(drivers, resp),
         // Cryptographic mailbox commands
         CommandId::CM_IMPORT => cryptographic_mailbox::Commands::import(drivers, cmd_bytes, resp),
         CommandId::CM_DELETE => cryptographic_mailbox::Commands::delete(drivers, cmd_bytes, resp),
@@ -530,6 +532,9 @@ fn execute_command(
         }
         CommandId::CM_DERIVE_STABLE_KEY => {
             cryptographic_mailbox::Commands::derive_stable_key(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_AES_GCM_DECRYPT_DMA => {
+            cryptographic_mailbox::Commands::aes_256_gcm_decrypt_dma(drivers, cmd_bytes, resp)
         }
         CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ => drivers.debug_unlock.handle_request(
             &mut drivers.trng,

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -24,7 +24,7 @@ use caliptra_common::{
     cprintln,
     mailbox_api::{AuthorizeAndStashReq, ImageHashSource},
 };
-use caliptra_drivers::{printer::HexBytes, AesDmaMode, DmaMmio, DmaRecovery};
+use caliptra_drivers::{printer::HexBytes, AesDmaMode, BootMode, DmaMmio, DmaRecovery};
 use caliptra_kat::{CaliptraError, CaliptraResult};
 use ureg::MmioMut;
 use zerocopy::IntoBytes;
@@ -62,7 +62,7 @@ impl RecoveryFlow {
 
         SetAuthManifestCmd::set_auth_manifest(drivers, source, false)?;
 
-        let digest = {
+        let (digest, mcu_size_bytes) = {
             let dma = &drivers.dma;
             let dma_recovery = DmaRecovery::new(
                 drivers.soc_ifc.recovery_interface_base_addr().into(),
@@ -94,12 +94,13 @@ impl RecoveryFlow {
             let mcu_size_bytes =
                 dma_recovery.download_image_to_mcu(MCU_FIRMWARE_INDEX, AesDmaMode::None)?;
             cprintln!("[rt] Calculating MCU digest");
-            dma_recovery.sha384_mcu_sram(
+            let digest = dma_recovery.sha384_mcu_sram(
                 &mut drivers.sha2_512_384_acc,
                 0,
                 mcu_size_bytes,
                 AesDmaMode::None,
-            )?
+            )?;
+            (digest, mcu_size_bytes)
         };
 
         let digest: [u8; 48] = digest.into();
@@ -130,6 +131,38 @@ impl RecoveryFlow {
                     0,
                 )?;
                 return Err(CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH);
+            }
+
+            // Check if firmware was loaded encrypted - if so, skip MCU activation
+            // MCU ROM will decrypt the firmware and send CM_ACTIVATE_FIRMWARE command
+            let boot_mode = drivers.persistent_data.get().rom.boot_mode;
+            if boot_mode == BootMode::EncryptedFirmware {
+                cprintln!("[rt] Encrypted firmware boot mode - skipping MCU activation");
+
+                // The image in MCU SRAM is ciphertext || 16-byte GCM tag.
+                // CM_AES_GCM_DECRYPT_DMA expects the tag as a separate field
+                // and verifies the SHA-384 against only the ciphertext portion,
+                // so strip the tag from both the size and the digest.
+                const GCM_TAG_SIZE: u32 = 16;
+                let ciphertext_size = mcu_size_bytes
+                    .checked_sub(GCM_TAG_SIZE)
+                    .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+                let ciphertext_digest = dma_recovery.sha384_mcu_sram(
+                    &mut drivers.sha2_512_384_acc,
+                    0,
+                    ciphertext_size,
+                    AesDmaMode::None,
+                )?;
+                drivers.mcu_fw_info.size = ciphertext_size;
+                drivers.mcu_fw_info.sha384 = ciphertext_digest.into();
+                cprintln!(
+                    "[rt] Stored MCU ciphertext size {} for GET_MCU_FW_SIZE",
+                    ciphertext_size
+                );
+
+                // we're done with recovery, but MCU will handle its own boot after decryption
+                dma_recovery.set_recovery_status(DmaRecovery::RECOVERY_STATUS_SUCCESSFUL, 0)?;
+                return Ok(());
             }
 
             // Caliptra sets RESET_REASON.FW_BOOT_UPD_RESET

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -112,6 +112,8 @@ pub struct RuntimeTestArgs<'a> {
     pub ocp_lock_en: bool,
     pub key_type: Option<FwVerificationPqcKeyType>,
     pub rom_callback: Option<ModelCallback>,
+    /// Use encrypted firmware boot (RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE)
+    pub encrypted_boot: bool,
 }
 
 impl RuntimeTestArgs<'_> {
@@ -157,6 +159,7 @@ impl Default for RuntimeTestArgs<'_> {
             ocp_lock_en: cfg!(feature = "ocp-lock"),
             key_type: None,
             rom_callback: None,
+            encrypted_boot: false,
         }
     }
 }
@@ -311,6 +314,7 @@ pub fn start_rt_test_pqc_model(
             initial_dbg_manuf_service_reg: boot_flags,
             soc_manifest,
             mcu_fw_image,
+            encrypted_boot: args.encrypted_boot,
             ..Default::default()
         },
     )

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -14,6 +14,7 @@ mod test_cryptographic_mailbox;
 mod test_debug_unlock;
 mod test_disable;
 mod test_ecdsa;
+mod test_encrypted_firmware;
 mod test_fe_programming;
 mod test_fips;
 mod test_firmware_verify;

--- a/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
@@ -1,0 +1,197 @@
+// Licensed under the Apache-2.0 license
+
+//! Tests for encrypted firmware flow using RI_DOWNLOAD_ENCRYPTED_FIRMWARE and CM_AES_GCM_DECRYPT_DMA
+
+use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
+use aes_gcm::{aead::AeadMutInPlace, Key, KeyInit};
+use caliptra_api::mailbox::{
+    CmAesGcmDecryptDmaReq, CmImportReq, CmImportResp, CmKeyUsage, Cmk, CommandId, MailboxReq,
+    MailboxReqHeader, MailboxRespHeader,
+};
+use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+use caliptra_hw_model::{HwModel, InitParams, SubsystemInitParams, MCU_TEST_AES_KEY, MCU_TEST_IV};
+use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_gen::from_hw_format;
+use caliptra_image_gen::ImageGeneratorCrypto;
+use zerocopy::{FromBytes, IntoBytes};
+
+const RT_READY_FOR_COMMANDS: u32 = 0x600;
+
+/// Import a raw AES key and return the CMK
+fn import_aes_key(model: &mut caliptra_hw_model::DefaultHwModel, key: &[u8; 32]) -> Cmk {
+    let mut input = [0u8; 64];
+    input[..32].copy_from_slice(key);
+
+    let mut cm_import_cmd = MailboxReq::CmImport(CmImportReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Aes.into(),
+        input_size: 32,
+        input,
+    });
+    cm_import_cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_IMPORT),
+            cm_import_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let cm_import_resp = CmImportResp::ref_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        cm_import_resp.hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+    cm_import_resp.cmk.clone()
+}
+
+/// Encrypt data using AES-256-GCM, returning `ciphertext || 16-byte tag`.
+fn aes_gcm_encrypt(key: &[u8; 32], iv: &[u8; 12], aad: &[u8], plaintext: &[u8]) -> Vec<u8> {
+    let key: &Key<aes_gcm::Aes256Gcm> = key.into();
+    let mut cipher = aes_gcm::Aes256Gcm::new(key);
+    let mut ciphertext = plaintext.to_vec();
+    let tag = cipher
+        .encrypt_in_place_detached(iv.into(), aad, &mut ciphertext)
+        .expect("Encryption failed");
+    ciphertext.extend_from_slice(&tag);
+    ciphertext
+}
+
+/// Test that the encrypted firmware boot flow works end-to-end:
+/// 1. Encrypt MCU firmware with the test AES key / IV
+/// 2. Boot with RI_DOWNLOAD_ENCRYPTED_FIRMWARE — the hw-model automatically
+///    simulates MCU ROM decryption (CM_IMPORT + CM_AES_GCM_DECRYPT_DMA)
+/// 3. Verify the decrypted firmware in SRAM matches the original plaintext
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime",), ignore)]
+#[test]
+fn test_encrypted_firmware_decrypt_dma() {
+    // The plaintext MCU firmware
+    let mcu_fw_plaintext: Vec<u8> = (0..256).map(|i| i as u8).collect();
+
+    // Encrypt with the well-known test key/IV (ciphertext || tag)
+    let aad: [u8; 0] = [];
+    let mcu_fw_image = aes_gcm_encrypt(&MCU_TEST_AES_KEY, &MCU_TEST_IV, &aad, &mcu_fw_plaintext);
+
+    // Auth manifest digest must match what the recovery interface delivers,
+    // which is the full image (ciphertext || tag).
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw_image).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata(metadata);
+    let soc_manifest_bytes = soc_manifest.as_bytes();
+
+    // Boot with encrypted_boot — boot() handles the MCU ROM decrypt simulation.
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    let args = RuntimeTestArgs {
+        init_params: Some(InitParams {
+            rom: &rom,
+            subsystem_mode: true,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        soc_manifest: Some(soc_manifest_bytes),
+        mcu_fw_image: Some(&mcu_fw_image),
+        encrypted_boot: true,
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(args);
+
+    // boot() already waited for RT_READY_FOR_COMMANDS and decrypted;
+    // this is a no-op but kept for clarity.
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    // Read back the decrypted firmware from MCU SRAM and verify.
+    let decrypted_fw = model
+        .read_payload_from_ss_staging_area(mcu_fw_plaintext.len())
+        .unwrap();
+
+    assert_eq!(
+        decrypted_fw, mcu_fw_plaintext,
+        "Decrypted firmware does not match original plaintext"
+    );
+}
+
+/// Test that CM_AES_GCM_DECRYPT_DMA fails when not in encrypted firmware mode
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime",), ignore)]
+#[test]
+fn test_decrypt_dma_fails_in_normal_mode() {
+    // Create a simple MCU firmware
+    let mcu_fw = vec![1, 2, 3, 4];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata(metadata);
+    let soc_manifest_bytes = soc_manifest.as_bytes();
+
+    let mut args = RuntimeTestArgs::default();
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    args.init_params = Some(InitParams {
+        rom: &rom,
+        subsystem_mode: true,
+        ..Default::default()
+    });
+    args.soc_manifest = Some(soc_manifest_bytes);
+    args.mcu_fw_image = Some(&mcu_fw);
+
+    // Use normal boot (RI_DOWNLOAD_FIRMWARE, not encrypted)
+    let mut model = run_rt_test(args);
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    // Import an AES key
+    let aes_key: [u8; 32] = [0xaa; 32];
+    let cmk = import_aes_key(&mut model, &aes_key);
+
+    // Get MCU SRAM address
+    let mcu_sram_addr = model
+        .write_payload_to_ss_staging_area(&mcu_fw)
+        .expect("Failed to get MCU SRAM address");
+
+    // Try to use CM_AES_GCM_DECRYPT_DMA - should fail because we're not in encrypted firmware mode
+    let decrypt_req = CmAesGcmDecryptDmaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cmk,
+        iv: [0u32; 3],
+        tag: [0u32; 4],
+        encrypted_data_sha384: [0u8; 48],
+        axi_addr_lo: mcu_sram_addr as u32,
+        axi_addr_hi: (mcu_sram_addr >> 32) as u32,
+        length: mcu_fw.len() as u32,
+        aad_length: 0,
+        aad: [0u8; caliptra_api::mailbox::CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE],
+    };
+
+    let mut decrypt_cmd = MailboxReq::CmAesGcmDecryptDma(decrypt_req);
+    decrypt_cmd.populate_chksum().unwrap();
+
+    // This should fail with RUNTIME_MAILBOX_INVALID_PARAMS because we're not in encrypted firmware mode
+    let result = model.mailbox_execute(
+        u32::from(CommandId::CM_AES_GCM_DECRYPT_DMA),
+        decrypt_cmd.as_bytes().unwrap(),
+    );
+    assert!(
+        result.is_err(),
+        "CM_AES_GCM_DECRYPT_DMA should fail in normal boot mode"
+    );
+}

--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -12,7 +12,7 @@ File contains DMA peripheral implementation.
 
 --*/
 
-use crate::helpers::words_from_bytes_be;
+use crate::helpers::words_from_bytes_le;
 use crate::{
     mci::Mci, Aes, KeyUsage, KeyVault, MailboxRam, Sha512Accelerator, SocRegistersInternal,
 };
@@ -478,7 +478,7 @@ impl Dma {
                 });
 
             let encrypted_data = self.aes.process_block(&data);
-            let encrypted_data_words = words_from_bytes_be(&encrypted_data);
+            let encrypted_data_words = words_from_bytes_le(&encrypted_data);
 
             acc.extend_from_slice(&encrypted_data_words[..chunk.len()]);
             acc


### PR DESCRIPTION
This PR adds support for encrypted firmware boot in subsystem mode, allowing MCU firmware to be loaded encrypted and decrypted in-place via DMA.

## Key Changes

### Encrypted Firmware Boot Mode
- Added `BootMode::EncryptedFirmware` to distinguish encrypted firmware boot from normal boot
- Added `encrypted_boot` flag to `BootParams` to enable encrypted firmware mode
- MCU ROM checks GPIO bit 28 (`mci_generic_input_wires[1]`) to determine which recovery interface command to send:
  - When set: sends `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` 
  - When cleared: sends `RI_DOWNLOAD_FIRMWARE` (normal flow)
- Runtime skips MCU firmware activation when in `EncryptedFirmware` mode, allowing MCU ROM to decrypt first

### CM_AES_GCM_DECRYPT_DMA Command
- New mailbox command (`0x434D4444` / "CMDD") for in-place AES-256-GCM decryption via DMA
- Performs two-pass DMA operation:
  1. First pass: SHA384 verification of encrypted data at AXI address
  2. Second pass: In-place AES-GCM decryption with tag verification
- Restricted to `EncryptedFirmware` boot mode only
- Used by MCU ROM to decrypt firmware after import via `CM_IMPORT`

### HwModel Trait Updates
- Added `read_payload_from_ss_staging_area()` for reading back decrypted firmware
- Added `decrypt_encrypted_mcu_firmware()` with default implementation that orchestrates:
  - AES key import via `CM_IMPORT`
  - Writing encrypted data to staging area
  - In-place decryption via `CM_AES_GCM_DECRYPT_DMA`
  - GCM tag verification
- Added `upload_firmware_rri_encrypted()` for encrypted firmware upload flow

### Implementation Details
- Updated DMA driver to support AES-GCM mode with single continuous transfer (required for maintaining cipher state)
- Updated MCU subsystem commit to bb7ba2a81a3cfc5cb7bf6195f910723a05f88af3
- Fixed AES-GCM DMA word ordering to use little-endian in emulator
- Added comprehensive integration tests for encrypted firmware flow
- Use the same hardcoded IV and KEY in MCU ROM & test