### PR TITLE
emu: Add peripheral event processing during halt

### DIFF
--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -829,6 +829,11 @@ impl<TBus: Bus> Cpu<TBus> {
 
         // We are in a halted state. Don't continue executing but poll the bus for interrupts
         if self.halted {
+            // The incoming events loop contains interactions with peripherals, including memory,
+            // mci, etc. which are responsive even when the CPU is halted.  As such process events
+            // during the halt step as well.
+            self.handle_incoming_events();
+
             self.set_next_pc(self.pc);
             return StepAction::Continue;
         }


### PR DESCRIPTION
While diagnosing an issue causing update reset test to fail in subsystem, it was determined peripheral events were being halted while the MCU core was halted.  This is incorrect as the SRAM and MCI peripherals can and must still process events even while the core is in the halt state.