### PR TITLE
Add utility functions to JTAG TAP

### DIFF
--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -219,13 +219,13 @@ impl OpenOcdJtagTap {
 
     /// Send a halt request to the dmcontrol register
     pub fn halt(&mut self) -> Result<()> {
-        const HALT_REQ: u32 = 1 << 31 | 1;
+        const HALT_REQ: u32 = (1 << 31) | 1;
         self.write_reg(&DmReg::DmControl, HALT_REQ)
     }
 
     /// Send a resume request to the dmcontrol register
     pub fn resume(&mut self) -> Result<()> {
-        const RESUME_REQ: u32 = 1 << 30 | 1;
+        const RESUME_REQ: u32 = (1 << 30) | 1;
         self.write_reg(&DmReg::DmControl, RESUME_REQ)
     }
 


### PR DESCRIPTION
Allow us to halt/resume a hart, as well as write to CSR debug registers.

These are needed for https://github.com/chipsalliance/caliptra-mcu-sw/issues/870