### PR TITLE
Ensure that SoC manifest and runtime are a multiple of 256 bytes

### DIFF
--- a/auth-manifest/app/src/main.rs
+++ b/auth-manifest/app/src/main.rs
@@ -19,7 +19,7 @@ use caliptra_auth_man_types::AuthManifestFlags;
 use caliptra_image_crypto::OsslCrypto as Crypto;
 #[cfg(feature = "rustcrypto")]
 use caliptra_image_crypto::RustCrypto as Crypto;
-use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_image_types::{FwVerificationPqcKeyType, IMAGE_ALIGNMENT};
 use clap::ArgMatches;
 use clap::{arg, value_parser, Command};
 use std::io::Write;
@@ -169,6 +169,12 @@ pub(crate) fn run_auth_man_cmd(args: &ArgMatches) -> anyhow::Result<()> {
         .with_context(|| format!("Failed to create file {}", out_path.display()))?;
 
     out_file.write_all(manifest.as_bytes())?;
+    // Pad to IMAGE_ALIGNMENT boundary
+    let len = manifest.as_bytes().len();
+    let padded = len.next_multiple_of(IMAGE_ALIGNMENT);
+    if padded > len {
+        out_file.write_all(&vec![0u8; padded - len])?;
+    }
 
     Ok(())
 }

--- a/image/serde/src/lib.rs
+++ b/image/serde/src/lib.rs
@@ -32,6 +32,44 @@ impl<W: Write> ImageBundleWriter<W> {
 
         self.writer.write_all(&image.fmc)?;
         self.writer.write_all(&image.runtime)?;
+        // Pad to IMAGE_ALIGNMENT boundary
+        let total = image.manifest.as_bytes().len() + image.fmc.len() + image.runtime.len();
+        let padded = total.next_multiple_of(IMAGE_ALIGNMENT);
+        if padded > total {
+            self.writer.write_all(&vec![0u8; padded - total])?;
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn test_writer_alignment() {
+        let manifest_size = size_of::<ImageManifest>();
+        let fmc = vec![0u8; 100];
+        let runtime = vec![0u8; 37];
+        let mut manifest = ImageManifest::default();
+        manifest.fmc.offset = manifest_size as u32;
+        manifest.fmc.size = fmc.len() as u32;
+        manifest.runtime.offset = (manifest_size + fmc.len()) as u32;
+        manifest.runtime.size = runtime.len() as u32;
+        let bundle = ImageBundle {
+            manifest,
+            fmc,
+            runtime,
+        };
+        let mut buf = Vec::new();
+        let mut writer = ImageBundleWriter::new(&mut buf);
+        writer.write(&bundle).unwrap();
+        assert_eq!(
+            buf.len() % IMAGE_ALIGNMENT,
+            0,
+            "ImageBundleWriter output must be a multiple of IMAGE_ALIGNMENT ({})",
+            IMAGE_ALIGNMENT
+        );
     }
 }


### PR DESCRIPTION
This is required by the recovery interface, so we might as well enforce it when building the image.

This also adds a fix in the DMA driver to ensure that we don't overflow the buffer, as noted
https://github.com/chipsalliance/caliptra-mcu-sw/issues/723.

Fixes https://github.com/chipsalliance/caliptra-mcu-sw/issues/723.