### PR TITLE
hw-model: Add flash boot support for AXI recovery bypass loading

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -49,7 +49,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: 982ca4f02b7e9fefb58850657246b0c8f28e5b53
+  CALIPTRA_MCU_COMMIT: d74a1d7cf8b0144bd5394fe8d9baf65c833c8144
 
 jobs:
   check_cache:
@@ -169,8 +169,8 @@ jobs:
       - name: Build test MCU ROM
         if: "!steps.restore_mcu_rom_cache.outputs.cache-hit"
         run: |
-          git clone  --depth=1 "https://github.com/chipsalliance/caliptra-mcu-sw"
-          pushd caliptra-mcu-sw
+          git clone  --depth=1 "https://github.com/chipsalliance/caliptra-mcu-sw" /tmp/caliptra-mcu-sw
+          pushd /tmp/caliptra-mcu-sw
           git fetch --depth 1 origin ${CALIPTRA_MCU_COMMIT}
           git reset --hard ${CALIPTRA_MCU_COMMIT}
           git submodule update --init --recursive
@@ -179,9 +179,10 @@ jobs:
 
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
           cargo xtask-fpga rom-build --platform fpga --features core_test
-          scp target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga-core_test.bin target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin
-          scp target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin ../mcu-rom-fpga.bin
-          tar -cvz -f /tmp/caliptra-mcu-binaries.tar.gz -C target/riscv32imc-unknown-none-elf/release/ mcu-rom-fpga.bin
+          cp target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga-core_test.bin target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin
+          popd
+          cp /tmp/caliptra-mcu-sw/target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin mcu-rom-fpga.bin
+          tar -cvz -f /tmp/caliptra-mcu-binaries.tar.gz -C /tmp/caliptra-mcu-sw/target/riscv32imc-unknown-none-elf/release/ mcu-rom-fpga.bin
 
       - name: Save test MCU ROM to cache
         if: "!steps.restore_mcu_rom_cache.outputs.cache-hit"

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -840,6 +840,11 @@ impl<'a> DmaRecovery<'a> {
         })
     }
 
+    /// Wait for the payload_available signal to deassert.
+    pub fn wait_for_payload_not_available(&self) {
+        while self.dma.payload_available() {}
+    }
+
     pub fn reset_recovery_ctrl_activate_rec_img(&self) -> CaliptraResult<()> {
         self.with_regs_mut(|regs_mut| {
             let recovery = regs_mut.sec_fw_recovery_if();

--- a/hw-model/src/flash_image.rs
+++ b/hw-model/src/flash_image.rs
@@ -1,0 +1,203 @@
+// Licensed under the Apache-2.0 license
+
+//! Flash image builder for creating flash images in the MCU ROM format.
+//!
+//! The flash image format consists of:
+//! - A [`FlashHeader`] with magic number "FLSH", version, image count, and checksum
+//! - An array of [`ImageHeader`] entries describing each image
+//! - The image data itself, padded to 256-byte alignment
+//!
+//! This matches the format expected by the MCU ROM's flash boot path in caliptra-mcu-sw.
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+pub const CALIPTRA_FMC_RT_IDENTIFIER: u32 = 0x0000_0000;
+pub const SOC_MANIFEST_IDENTIFIER: u32 = 0x0000_0001;
+pub const MCU_RT_IDENTIFIER: u32 = 0x0000_0002;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct FlashHeader {
+    pub magic: [u8; 4],
+    pub version: u16,
+    pub image_count: u16,
+    pub image_headers_offset: u32,
+    pub header_checksum: u32,
+}
+
+impl FlashHeader {
+    pub const HEADER_VERSION: u16 = 0x0001;
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct ImageHeader {
+    pub identifier: u32,
+    pub offset: u32,
+    pub size: u32,
+    pub image_checksum: u32,
+    pub image_header_checksum: u32,
+}
+
+fn calculate_checksum(data: &[u8]) -> u32 {
+    let sum = data
+        .iter()
+        .fold(0u32, |acc, &byte| acc.wrapping_add(byte as u32));
+    0u32.wrapping_sub(sum)
+}
+
+fn pad_to_256(data: &[u8]) -> Vec<u8> {
+    let padded_len = data.len().next_multiple_of(256);
+    let mut padded = data.to_vec();
+    padded.resize(padded_len, 0);
+    padded
+}
+
+/// Build a flash image from raw firmware data and return it as bytes.
+///
+/// The resulting image can be loaded into `primary_flash_initial_contents`
+/// for flash-based boot testing instead of using the I3C recovery interface.
+pub fn build_flash_image_bytes(
+    caliptra_fw: Option<&[u8]>,
+    soc_manifest: Option<&[u8]>,
+    mcu_runtime: Option<&[u8]>,
+) -> Vec<u8> {
+    let mut images: Vec<(u32, Vec<u8>)> = Vec::new();
+
+    if let Some(data) = caliptra_fw {
+        images.push((CALIPTRA_FMC_RT_IDENTIFIER, pad_to_256(data)));
+    }
+    if let Some(data) = soc_manifest {
+        images.push((SOC_MANIFEST_IDENTIFIER, pad_to_256(data)));
+    }
+    if let Some(data) = mcu_runtime {
+        images.push((MCU_RT_IDENTIFIER, pad_to_256(data)));
+    }
+
+    if images.is_empty() {
+        return Vec::new();
+    }
+
+    let header_size = core::mem::size_of::<FlashHeader>();
+    let image_header_size = core::mem::size_of::<ImageHeader>();
+
+    // Calculate offsets for image data
+    let data_start = header_size + image_header_size * images.len();
+    let mut current_offset = data_start as u32;
+
+    // Build image headers
+    let image_headers: Vec<ImageHeader> = images
+        .iter()
+        .map(|(id, data)| {
+            let image_checksum = calculate_checksum(data);
+            let mut hdr = ImageHeader {
+                identifier: *id,
+                offset: current_offset,
+                size: data.len() as u32,
+                image_checksum,
+                image_header_checksum: 0,
+            };
+            // Checksum covers all fields except image_header_checksum
+            let hdr_bytes = hdr.as_bytes();
+            let checksum_offset = core::mem::offset_of!(ImageHeader, image_header_checksum);
+            hdr.image_header_checksum = calculate_checksum(&hdr_bytes[..checksum_offset]);
+            current_offset += data.len() as u32;
+            hdr
+        })
+        .collect();
+
+    // Build flash header
+    let mut flash_header = FlashHeader {
+        magic: *b"FLSH",
+        version: FlashHeader::HEADER_VERSION,
+        image_count: images.len() as u16,
+        image_headers_offset: header_size as u32,
+        header_checksum: 0,
+    };
+    let hdr_bytes = flash_header.as_bytes();
+    let checksum_offset = core::mem::offset_of!(FlashHeader, header_checksum);
+    flash_header.header_checksum = calculate_checksum(&hdr_bytes[..checksum_offset]);
+
+    // Assemble the final image
+    let mut result = Vec::new();
+    result.extend_from_slice(flash_header.as_bytes());
+    for hdr in &image_headers {
+        result.extend_from_slice(hdr.as_bytes());
+    }
+    for (_, data) in &images {
+        result.extend_from_slice(data);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_flash_image_bytes_empty() {
+        let result = build_flash_image_bytes(None, None, None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_build_flash_image_roundtrip() {
+        let fw = vec![0xAAu8; 100];
+        let manifest = vec![0xBBu8; 200];
+        let mcu = vec![0xCCu8; 50];
+
+        let image = build_flash_image_bytes(Some(&fw), Some(&manifest), Some(&mcu));
+        assert!(!image.is_empty());
+
+        // Parse and verify the header
+        let header = FlashHeader::read_from_prefix(&image).unwrap().0;
+        assert_eq!(&header.magic, b"FLSH");
+        assert_eq!(header.version, FlashHeader::HEADER_VERSION);
+        assert_eq!(header.image_count, 3);
+
+        // Verify header checksum
+        let checksum_offset = core::mem::offset_of!(FlashHeader, header_checksum);
+        let expected = calculate_checksum(&image[..checksum_offset]);
+        assert_eq!(header.header_checksum, expected);
+
+        // Parse image headers
+        let hdr_offset = header.image_headers_offset as usize;
+        let hdr_size = core::mem::size_of::<ImageHeader>();
+
+        for i in 0..3 {
+            let off = hdr_offset + i * hdr_size;
+            let img_hdr = ImageHeader::read_from_prefix(&image[off..]).unwrap().0;
+
+            // Verify image header checksum
+            let ih_checksum_offset = core::mem::offset_of!(ImageHeader, image_header_checksum);
+            let ih_bytes = img_hdr.as_bytes();
+            let expected = calculate_checksum(&ih_bytes[..ih_checksum_offset]);
+            assert_eq!(img_hdr.image_header_checksum, expected);
+
+            // Verify image data checksum
+            let data =
+                &image[img_hdr.offset as usize..img_hdr.offset as usize + img_hdr.size as usize];
+            assert_eq!(img_hdr.image_checksum, calculate_checksum(data));
+        }
+
+        // Verify identifiers
+        let hdr0 = ImageHeader::read_from_prefix(&image[hdr_offset..])
+            .unwrap()
+            .0;
+        let hdr1 = ImageHeader::read_from_prefix(&image[hdr_offset + hdr_size..])
+            .unwrap()
+            .0;
+        let hdr2 = ImageHeader::read_from_prefix(&image[hdr_offset + 2 * hdr_size..])
+            .unwrap()
+            .0;
+        assert_eq!(hdr0.identifier, CALIPTRA_FMC_RT_IDENTIFIER);
+        assert_eq!(hdr1.identifier, SOC_MANIFEST_IDENTIFIER);
+        assert_eq!(hdr2.identifier, MCU_RT_IDENTIFIER);
+
+        // Verify sizes are padded to 256
+        assert_eq!(hdr0.size, 256); // 100 -> 256
+        assert_eq!(hdr1.size, 256); // 200 -> 256
+        assert_eq!(hdr2.size, 256); // 50 -> 256
+    }
+}

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -34,6 +34,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use sha2::Digest;
 
 mod bmc;
+pub mod flash_image;
 mod fpga_regs;
 pub mod jtag;
 pub mod keys;

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -79,6 +79,17 @@ impl RecoveryFlow {
             dma_recovery.set_device_status(
                 DmaRecovery::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE,
             )?;
+
+            // Signal that we are awaiting the MCU firmware image. and wait
+            // for payload_available to deassert. This helps avoid a race
+            // condition in the MCU ROM AXI bypass mode where MCU ROM needs
+            // to clear REC_PAYLOAD_DONE.
+            dma_recovery.set_recovery_status(
+                DmaRecovery::RECOVERY_STATUS_AWAITING_RECOVERY_IMAGE,
+                MCU_FIRMWARE_INDEX,
+            )?;
+            dma_recovery.wait_for_payload_not_available();
+
             cprintln!("[rt] Uploading MCU firmware");
             let mcu_size_bytes =
                 dma_recovery.download_image_to_mcu(MCU_FIRMWARE_INDEX, AesDmaMode::None)?;


### PR DESCRIPTION
Add support for flash-based firmware loading in the FPGA subsystem model, where MCU ROM reads images from the flash controller and loads them into the recovery interface via AXI bypass mode.

Changes:
- Add `flash_image.rs` module to create flash image layout for MCU ROM
- Modify `model_fpga_subsystem.rs` `boot()` to skip BMC/I3C recovery when `flash_boot` is enabled, letting MCU ROM handle loading from flash
- Add `smoke_test_flash_boot` integration test

Tested as working on my local 2.1 subsystem FPGA.

We have to make a small change in the recovery flow to wait for payload_done to not be asserted to avoid a race condition in the MCU ROM flash boot flow, but this should not affect the I3C streaming boot flow.

Fixes #3323