### PR TITLE
runtime: Add CM_SHAKE256_INIT/UPDATE/FINAL cryptographic mailbox comm…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "platform",
  "rand",
  "sha2",
+ "sha3 0.10.8",
  "spki 0.7.3",
  "ufmt",
  "ureg",

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-a4a31ae621d9279a656dd1334d69dd3c5ab9d6d5b846c51a786d877a7ee0ee6bce2f9db6404f2570c7708fc15dc36214  caliptra-rom-no-log.bin
-796f3c03488acf5d70c2ea763cb50ae7cad3d7245d0b4d98bddfd36d3dc6dc6dbd71a1d719177b9af033e3cc0b43c7e0  caliptra-rom-with-log.bin
+af37df44b7071686d92134a078d68bdb64f2761af1c00065864374795f4d338912a32b42f884d174875f05519f453401  caliptra-rom-no-log.bin
+9912423627dd9f34bfe179534e7765ad624041eb48218e5e22f80d10f556325568de2186fe9880ed534d07ae6d440e3e  caliptra-rom-with-log.bin

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1784,6 +1784,11 @@ impl CaliptraError {
             0x000E008D,
             "Runtime Error: DPE response too large"
         ),
+        (
+            RUNTIME_CM_SHAKE256_CONTEXT_MISMATCH,
+            0x000E008E,
+            "Runtime Error: SHAKE256 context mismatch - SHA3 hardware was used between calls"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -73,6 +73,7 @@ ml-dsa.workspace = true
 openssl.workspace = true
 p384.workspace = true
 sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
+sha3.workspace = true
 spki.workspace = true
 cms.workspace = true
 rand.workspace = true

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -420,6 +420,15 @@ fn execute_command(
         CommandId::CM_SHA_FINAL => {
             cryptographic_mailbox::Commands::sha_final(drivers, cmd_bytes, resp)
         }
+        CommandId::CM_SHAKE256_INIT => {
+            cryptographic_mailbox::Commands::shake256_init(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_SHAKE256_UPDATE => {
+            cryptographic_mailbox::Commands::shake256_update(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_SHAKE256_FINAL => {
+            cryptographic_mailbox::Commands::shake256_final(drivers, cmd_bytes, resp)
+        }
         CommandId::CM_RANDOM_GENERATE => {
             cryptographic_mailbox::Commands::random_generate(drivers, cmd_bytes, resp)
         }

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -50,6 +50,7 @@ mod test_initialize_mek_secret;
 mod test_mix_mpk;
 mod test_rewrap_mpk;
 mod test_rotate_hpke_key;
+mod test_shake256_hpke_interleave;
 mod test_unload_mek;
 
 const ALL_HPKE_ALGS: &[HpkeAlgorithms] = &[

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_shake256_hpke_interleave.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_shake256_hpke_interleave.rs
@@ -1,0 +1,99 @@
+// Licensed under the Apache-2.0 license
+
+//! Verifies that an OCP LOCK command using SHA3 (via HPKE) invalidates
+//! an in-progress CM_SHAKE256 streaming session.
+
+use caliptra_api::mailbox::{
+    CmShake256InitReq, CmShake256InitResp, CmShake256UpdateReq, CommandId, HpkeAlgorithms,
+    MailboxReq, OcpLockGenerateMpkResp, OCP_LOCK_WRAPPED_KEY_MAX_METADATA_LEN,
+};
+use caliptra_hw_model::HwModel;
+
+use super::{
+    boot_ocp_lock_runtime, create_generate_mpk_req, get_hpke_handle, validate_ocp_lock_response,
+    verify_hpke_pub_key, OcpLockBootParams,
+};
+
+use crate::common::assert_error;
+
+use zerocopy::{FromBytes, IntoBytes};
+
+/// Start a SHAKE256 streaming session, then execute an OCP LOCK command
+/// that uses SHA3 (GENERATE_MPK via HPKE decapsulation), and verify that
+/// a subsequent CM_SHAKE256_UPDATE with the original context fails.
+#[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+fn test_shake256_invalidated_by_hpke_operation() {
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
+        hek_available: true,
+        force_ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    // Step 1: Obtain a validated HPKE handle for ML-KEM specifically, since
+    // ML-KEM decapsulation uses SHA3 which will invalidate the SHAKE256 session.
+    let hpke_handle = get_hpke_handle(
+        &mut model,
+        HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM,
+    )
+    .unwrap();
+    let endorsed_handle = verify_hpke_pub_key(&mut model, hpke_handle).unwrap();
+
+    // Step 2: Start a SHAKE256 streaming session
+    let mut req = CmShake256InitReq {
+        input_size: 5,
+        ..Default::default()
+    };
+    req.input[..5].copy_from_slice(b"hello");
+    let mut init = MailboxReq::CmShake256Init(req);
+    init.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_SHAKE256_INIT),
+            init.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("Should have gotten a context");
+    let resp = CmShake256InitResp::ref_from_bytes(resp_bytes.as_slice()).unwrap();
+    let shake_context = resp.context;
+
+    // Step 3: Execute GENERATE_MPK — this uses SHA3 via HPKE decapsulation,
+    // which will clear the active_session_token in the SHA3 driver.
+    let info = [0xDE; 256];
+    let metadata = [0xFE; OCP_LOCK_WRAPPED_KEY_MAX_METADATA_LEN];
+    let access_key = [0xAE; 32];
+    let cmd = create_generate_mpk_req(&endorsed_handle, &info, &metadata, &access_key);
+
+    let response = model.mailbox_execute(
+        CommandId::OCP_LOCK_GENERATE_MPK.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    validate_ocp_lock_response(&mut model, response, |response, _| {
+        let response = response.unwrap().unwrap();
+        let _response = OcpLockGenerateMpkResp::ref_from_bytes(response.as_bytes()).unwrap();
+    });
+
+    // Step 4: Try to UPDATE the SHAKE256 session — should fail because
+    // the HPKE decapsulation used SHA3 (shake256_digest_init), which
+    // cleared the active_session_token in the SHA3 driver.
+    let mut req = CmShake256UpdateReq {
+        context: shake_context,
+        input_size: 5,
+        ..Default::default()
+    };
+    req.input[..5].copy_from_slice(b"world");
+    let mut update = MailboxReq::CmShake256Update(req);
+    update.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_SHAKE256_UPDATE),
+            update.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_CM_SHAKE256_CONTEXT_MISMATCH,
+        resp,
+    );
+}


### PR DESCRIPTION
…ands

Implements multi-step SHAKE256 hashing via the cryptographic mailbox, following the init/update/final pattern used by the existing CM_SHA commands.

Since the SHA3 hardware cannot save/restore Keccak state, the context returned to callers is an encrypted random session token (u128). On INIT, a random token is generated from TRNG and stored in the SHA3 driver. On UPDATE/FINAL the driver verifies the token matches the active session, preventing replay attacks and detecting if another SHA3 operation disturbed the hardware state between calls. Any new SHA3 driver operation will erase the current token.

Fixes #3184.