### PR TITLE
Unified CFI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -74,7 +74,6 @@ store-failure-output = true
 default-filter = """
 not (package(/caliptra-emu-.*/) |
        package(caliptra-builder) |
-       package(caliptra-cfi-derive) |
        package(caliptra-file-header-fix) |
        package(compliance-test) |
        test(test_csrng_runtime_health_failure) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,17 +399,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "caliptra-cfi-derive-git"
-version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -420,18 +410,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-dependencies = [
- "caliptra-cfi-derive",
- "caliptra-error",
- "caliptra-registers",
- "serial_test",
- "ufmt",
-]
-
-[[package]]
-name = "caliptra-cfi-lib-git"
-version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 
 [[package]]
 name = "caliptra-coverage"
@@ -470,9 +449,7 @@ dependencies = [
  "caliptra-auth-man-types",
  "caliptra-builder",
  "caliptra-cfi-derive",
- "caliptra-cfi-derive-git",
  "caliptra-cfi-lib",
- "caliptra-cfi-lib-git",
  "caliptra-drivers-test-bin",
  "caliptra-error",
  "caliptra-hw-model",
@@ -971,8 +948,8 @@ dependencies = [
  "caliptra-auth-man-gen",
  "caliptra-auth-man-types",
  "caliptra-builder",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "caliptra-cpu",
  "caliptra-drivers",
  "caliptra-emu-bus",
@@ -1168,9 +1145,8 @@ dependencies = [
  "bitfield",
  "bitflags 2.9.1",
  "caliptra-api",
- "caliptra-cfi-derive-git",
+ "caliptra-cfi-derive",
  "caliptra-cfi-lib",
- "caliptra-cfi-lib-git",
  "caliptra-cpu",
  "caliptra-drivers",
  "caliptra-error",
@@ -1465,11 +1441,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=337f7e4151f60add8e97445f71fc1393afc661a8#337f7e4151f60add8e97445f71fc1393afc661a8"
 dependencies = [
  "arrayvec",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "constant_time_eq",
  "zerocopy",
  "zeroize",
@@ -1539,19 +1515,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -1665,11 +1628,11 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=337f7e4151f60add8e97445f71fc1393afc661a8#337f7e4151f60add8e97445f71fc1393afc661a8"
 dependencies = [
  "bitflags 2.9.1",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "cfg-if",
  "constant_time_eq",
  "crypto",
@@ -1824,83 +1787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "gdbstub"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,12 +1879,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2233,16 +2113,6 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -2529,29 +2399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,12 +2412,6 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2607,7 +2448,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=337f7e4151f60add8e97445f71fc1393afc661a8#337f7e4151f60add8e97445f71fc1393afc661a8"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -2743,15 +2584,6 @@ name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags 2.9.1",
-]
 
 [[package]]
 name = "regex"
@@ -2943,31 +2775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,18 +2853,6 @@ dependencies = [
  "time",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smlang"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ members = [
   "auth-manifest/gen",
   "auth-manifest/types",
   "builder",
-  "cfi/lib",
-  "cfi/derive",
   "ci-tools/file-header-fix",
   "ci-tools/size-history",
   "common",
@@ -108,10 +106,9 @@ caliptra-api-test-bin = { path = "api/test-fw" }
 caliptra-api-types = { path = "api/types" }
 caliptra-auth-man-gen = { path = "auth-manifest/gen", default-features = false }
 caliptra-auth-man-types = { path = "auth-manifest/types", default-features = false }
-caliptra-cfi-lib = { path = "cfi/lib", default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive = { path = "cfi/derive" }
-caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "a98e499d279e81ae85881991b1e9eee354151189", default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "a98e499d279e81ae85881991b1e9eee354151189"}
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "767d4ef59a106aea683b883c07bd65456fb3ba6b", default-features = false, features = ["cfi", "cfi-counter" ] }
+caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "767d4ef59a106aea683b883c07bd65456fb3ba6b"}
+
 caliptra_common = { path = "common", default-features = false }
 caliptra-coverage = { path = "coverage" }
 caliptra-builder = { path = "builder" }
@@ -234,9 +231,9 @@ itertools = { version = "0.12.0", default-features = false }
 riscv = "0.13.0"
 
 # DPE dependencies; keep git revs in sync alongside test/dpe_verification/go.mod
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false, features = ["hybrid"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false, features = ["hybrid", "cfi"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false, features = ["cfi"] }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "337f7e4151f60add8e97445f71fc1393afc661a8", default-features = false }
 
 # local DPE dependency; useful when developing
 # dpe = { path = "../caliptra-dpe/dpe", default-features = false, features = ["hybrid"] }

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-af37df44b7071686d92134a078d68bdb64f2761af1c00065864374795f4d338912a32b42f884d174875f05519f453401  caliptra-rom-no-log.bin
-9912423627dd9f34bfe179534e7765ad624041eb48218e5e22f80d10f556325568de2186fe9880ed534d07ae6d440e3e  caliptra-rom-with-log.bin
+fd5dfcb4cc309595b5a6f8ac705afa9eed12295dec480d5dc73370e8da93f31980fd0f29e20f5090798cf77c7181ce95  caliptra-rom-no-log.bin
+fe57041b2193e24cfc462a0f4f5f36e8d1d18a6b2d68ac9409e52e637807749c5e47afa123e2f4fe5a592866c272a6c0  caliptra-rom-with-log.bin

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,12 +9,8 @@ edition = "2021"
 [dependencies]
 bitfield.workspace = true
 bitflags.workspace = true
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = [
-    "cfi",
-    "cfi-counter",
-] }
-caliptra-cfi-derive-git.workspace = true
 caliptra-cfi-lib.workspace = true
+caliptra-cfi-derive.workspace = true
 caliptra-cpu.workspace = true
 caliptra-drivers.workspace = true
 caliptra-error.workspace = true

--- a/common/src/verify.rs
+++ b/common/src/verify.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_api::mailbox::{EcdsaVerifyReq, MldsaVerifyReq};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Signature, Mldsa87, Mldsa87PubKey, Mldsa87Result, Mldsa87Signature,

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -30,18 +30,13 @@ caliptra-cfi-lib = { workspace = true, default-features = false, features = [
     "cfi-counter",
 ] }
 caliptra-cfi-derive.workspace = true
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = [
-    "cfi",
-    "cfi-counter",
-], optional = true }
-caliptra-cfi-derive-git = { workspace = true, optional = true }
 
 [features]
 std = []
 emu = []
 riscv = []
 rom = []
-runtime = ["dep:dpe", "dep:caliptra-cfi-lib-git", "dep:caliptra-cfi-derive-git"]
+runtime = ["dep:dpe"]
 fmc = []
 fpga_realtime = ["caliptra-hw-model/fpga_realtime"]
 fpga_subsystem = ["caliptra-hw-model/fpga_subsystem"]

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -164,13 +164,6 @@ pub use sha3::{Sha3, Sha3DigestOp};
 pub use soc_ifc::{report_boot_status, CptraGeneration, Lifecycle, MfgFlags, ResetReason, SocIfc};
 pub use trng::Trng;
 
-#[allow(unused_imports)]
-#[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
-use caliptra_cfi_derive_git as caliptra_cfi_derive;
-#[allow(unused_imports)]
-#[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
-use caliptra_cfi_lib_git as caliptra_cfi_lib;
-
 cfg_if::cfg_if! {
     if #[cfg(feature = "emu")] {
         mod uart;

--- a/drivers/test-fw/src/bin/aes_tests.rs
+++ b/drivers/test-fw/src/bin/aes_tests.rs
@@ -87,7 +87,10 @@ fn test_cmac() {
         .unwrap()
     };
     // Init CFI
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
     CfiCounter::reset(&mut entropy_gen);
 
     let key = KEY_EMPTY.into();

--- a/drivers/test-fw/src/bin/doe_tests.rs
+++ b/drivers/test-fw/src/bin/doe_tests.rs
@@ -59,7 +59,10 @@ fn test_decrypt() {
     };
 
     // Init CFI
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
     CfiCounter::reset(&mut entropy_gen);
 
     assert_eq!(

--- a/drivers/test-fw/src/bin/ecc384_sign_validation_failure_test.rs
+++ b/drivers/test-fw/src/bin/ecc384_sign_validation_failure_test.rs
@@ -48,7 +48,10 @@ fn test_sign_validation_failure() {
     };
 
     // Init CFI
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
     CfiCounter::reset(&mut entropy_gen);
 
     let digest = Array4x12::new([0u32; 12]);

--- a/drivers/test-fw/src/bin/ecc384_tests.rs
+++ b/drivers/test-fw/src/bin/ecc384_tests.rs
@@ -502,7 +502,10 @@ fn test_kat() {
     };
 
     // Init CFI
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
     CfiCounter::reset(&mut entropy_gen);
 
     assert_eq!(

--- a/drivers/test-fw/src/bin/hmac_tests.rs
+++ b/drivers/test-fw/src/bin/hmac_tests.rs
@@ -769,7 +769,10 @@ fn test_kat_384() {
     };
 
     // Init CFI
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
     CfiCounter::reset(&mut entropy_gen);
 
     assert!(Hmac384KdfKat::default()

--- a/drivers/test-fw/src/bin/mldsa87_external_mu_tests.rs
+++ b/drivers/test-fw/src/bin/mldsa87_external_mu_tests.rs
@@ -501,7 +501,10 @@ pub fn test_sign_external_mu() {
         )
         .unwrap()
     };
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
 
     // This needs to happen in the first test
     CfiCounter::reset(&mut entropy_gen);

--- a/drivers/test-fw/src/bin/mldsa87_tests.rs
+++ b/drivers/test-fw/src/bin/mldsa87_tests.rs
@@ -678,7 +678,10 @@ fn test_mldsa_name() {
         )
         .unwrap()
     };
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
 
     // This needs to happen in the first test
     CfiCounter::reset(&mut entropy_gen);

--- a/drivers/test-fw/src/bin/mlkem_tests.rs
+++ b/drivers/test-fw/src/bin/mlkem_tests.rs
@@ -56,7 +56,10 @@ fn test_mlkem_name() {
         )
         .unwrap()
     };
-    let mut entropy_gen = || trng.generate4();
+    let mut entropy_gen = || {
+        trng.generate4()
+            .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+    };
 
     // This needs to happen in the first test
     CfiCounter::reset(&mut entropy_gen);

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -65,7 +65,11 @@ pub extern "C" fn entry_point() -> ! {
 
     if !cfg!(feature = "no-cfi") {
         cprintln!("[state] CFI Enabled");
-        let mut entropy_gen = || env.trng.generate4();
+        let mut entropy_gen = || {
+            env.trng
+                .generate4()
+                .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+        };
         CfiCounter::reset(&mut entropy_gen);
         CfiCounter::reset(&mut entropy_gen);
         CfiCounter::reset(&mut entropy_gen);

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -79,7 +79,10 @@ pub extern "C" fn rom_entry() -> ! {
     // Initialize CFI before creating the rest of the environment
     // (AesGcm::new runs KATs which have CFI annotations)
     if !cfg!(feature = "no-cfi") {
-        let mut entropy_gen = || trng.generate4();
+        let mut entropy_gen = || {
+            trng.generate4()
+                .map_err(|e| caliptra_cfi_lib::CfiError(u32::from(e)))
+        };
         CfiCounter::reset(&mut entropy_gen);
         CfiCounter::reset(&mut entropy_gen);
         CfiCounter::reset(&mut entropy_gen);

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,11 +8,8 @@ build = "build.rs"
 
 [dependencies]
 bitfield.workspace = true
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = [
-    "cfi",
-    "cfi-counter",
-] }
-caliptra-cfi-derive-git.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false, features = ["cfi", "cfi-counter"] }
+caliptra-cfi-derive = { workspace = true }
 caliptra_common = { workspace = true, default-features = false, features = [
     "runtime",
 ] }
@@ -62,7 +59,6 @@ caliptra-image-crypto.workspace = true
 caliptra-auth-man-gen.workspace = true
 caliptra-image-serde.workspace = true
 caliptra-test.workspace = true
-caliptra-cfi-lib-git = { workspace = true, features = ["cfi-test"] }
 cbc.workspace = true
 cipher.workspace = true
 ctr.workspace = true
@@ -94,7 +90,6 @@ fips_self_test = []
 no-cfi = [
     "caliptra-image-verify/no-cfi",
     "caliptra-drivers/no-cfi",
-    "dpe/no-cfi",
 ]
 fpga_realtime = [
     "caliptra-drivers/fpga_realtime",

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -15,8 +15,8 @@ Abstract:
 use crate::manifest::find_metadata_entry;
 use crate::{mutrefbytes, Drivers, StashMeasurementCmd};
 use caliptra_auth_man_types::ImageMetadataFlags;
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 use caliptra_common::mailbox_api::{
     AuthAndStashFlags, AuthorizeAndStashReq, AuthorizeAndStashResp, ImageHashSource,
     MailboxRespHeader,
@@ -80,7 +80,7 @@ impl AuthorizeAndStashCmd {
                 IMAGE_AUTHORIZED
             } else if source == ImageHashSource::InRequest {
                 if cfi_launder(metadata_entry.digest) == cmd.measurement {
-                    caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+                    caliptra_cfi_lib::cfi_assert_eq_12_words(
                         &Array4x12::from(metadata_entry.digest).0,
                         &Array4x12::from(cmd.measurement).0,
                     );
@@ -110,7 +110,7 @@ impl AuthorizeAndStashCmd {
                     .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?
                     .into();
                 if cfi_launder(metadata_entry.digest) == measurement {
-                    caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+                    caliptra_cfi_lib::cfi_assert_eq_12_words(
                         &Array4x12::from(metadata_entry.digest).0,
                         &Array4x12::from(measurement).0,
                     );

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::{mutrefbytes, Drivers};
 use arrayvec::ArrayVec;
 use bitfield::bitfield;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::{
     crypto::{Crypto, EncryptedCmk, UnencryptedCmk, UNENCRYPTED_CMK_SIZE_BYTES},
     hmac_cm::hmac,

--- a/runtime/src/debug_unlock.rs
+++ b/runtime/src/debug_unlock.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::mutrefbytes;
-use caliptra_cfi_lib_git::CfiCounter;
+use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::{
     cprintln,
     mailbox_api::{

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::keyids::KEY_ID_EXPORTED_DPE_CDI;
 use caliptra_drivers::{
     hmac_kdf, Array4x12, CaliptraResult, Ecc384Seed, HmacKey, HmacMode, KeyId, KeyReadArgs,

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::keyids::{
     KEY_ID_DPE_CDI, KEY_ID_DPE_PRIV_KEY, KEY_ID_EXPORTED_DPE_CDI, KEY_ID_TMP,
 };

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -29,8 +29,10 @@ use crate::{
 };
 
 use arrayvec::ArrayVec;
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder};
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{
+    cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder,
+};
 use caliptra_common::cfi_check;
 use caliptra_common::crypto::Crypto;
 use caliptra_common::dice::{copy_ldevid_ecc384_cert, copy_ldevid_mldsa87_cert};

--- a/runtime/src/fe_programming.rs
+++ b/runtime/src/fe_programming.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::FeProgReq;
 use caliptra_common::uds_fe_programming::UdsFeProgrammingFlow;
 use caliptra_drivers::{CaliptraError, CaliptraResult, Lifecycle};

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -11,7 +11,7 @@ Abstract:
     File contains FIPS module and FIPS self test.
 
 --*/
-use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_common::cprintln;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
@@ -63,7 +63,7 @@ impl FipsModule {
 pub mod fips_self_test_cmd {
     use super::*;
     use crate::RtBootStatus::{RtFipSelfTestComplete, RtFipSelfTestStarted};
-    use caliptra_cfi_lib_git::cfi_assert_eq_8_words;
+    use caliptra_cfi_lib::cfi_assert_eq_8_words;
     use caliptra_common::{verifier::FirmwareImageVerificationEnv, FMC_SIZE, RUNTIME_SIZE};
     use caliptra_drivers::{ResetReason, ShaAccLockState};
     use caliptra_image_types::{ImageTocEntry, RomInfo};

--- a/runtime/src/firmware_verify.rs
+++ b/runtime/src/firmware_verify.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::mutrefbytes;
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::populate_checksum;
 use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_common::mailbox_api::{FirmwareVerifyResp, FirmwareVerifyResult};

--- a/runtime/src/get_fmc_alias_csr.rs
+++ b/runtime/src/get_fmc_alias_csr.rs
@@ -2,7 +2,7 @@
 
 use crate::{mutrefbytes, Drivers};
 
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_common::mailbox_api::{GetFmcAliasCsrResp, MailboxRespHeader, ResponseVarSize};
 use caliptra_error::{CaliptraError, CaliptraResult};

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -2,7 +2,7 @@
 
 use crate::{mutrefbytes, Drivers};
 
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxRespHeader, ResponseVarSize};
 use caliptra_error::{CaliptraError, CaliptraResult};
 

--- a/runtime/src/get_image_info.rs
+++ b/runtime/src/get_image_info.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{GetImageInfoReq, GetImageInfoResp, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use zerocopy::FromBytes;

--- a/runtime/src/hmac.rs
+++ b/runtime/src/hmac.rs
@@ -12,8 +12,8 @@ Abstract:
 
 --*/
 
-use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_launder};
 use caliptra_common::{cfi_check, crypto::Ecc384KeyPair, keyids::KEY_ID_TMP};
 use caliptra_drivers::{
     hmac_kdf, sha2_512_384::Sha2DigestOpTrait, Array4x12, HmacData, HmacKey, HmacMode, HmacTag,
@@ -71,7 +71,7 @@ fn ecc384_key_gen(
     if KEY_ID_TMP != priv_key {
         drivers.key_vault.erase_key(KEY_ID_TMP)?;
     } else {
-        cfi_assert_eq(KEY_ID_TMP, priv_key);
+        cfi_assert_eq(u32::from(KEY_ID_TMP), u32::from(priv_key));
     }
 
     Ok(Ecc384KeyPair {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::{ec_dpe_env, mldsa_dpe_env, mutrefbytes, Drivers, PauserPrivileges};
 use arrayvec::ArrayVec;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, ResponseVarSize};
 use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult};
 use dpe::{

--- a/runtime/src/key_ladder.rs
+++ b/runtime/src/key_ladder.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::{handoff::RtHandoff, Drivers, Hmac};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::keyids::KEY_ID_TMP;
 use caliptra_drivers::{CaliptraResult, HmacMode, KeyId};
 use caliptra_error::CaliptraError;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -54,7 +54,9 @@ mod verify;
 pub mod mailbox;
 use arrayvec::ArrayVec;
 use authorize_and_stash::AuthorizeAndStashCmd;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter};
+use caliptra_cfi_lib::{
+    cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter,
+};
 use caliptra_common::cfi_check;
 use caliptra_common::mailbox_api::{ExternalMailboxCmdReq, MailboxReqHeader};
 use crypto::ecdsa::curve_384::EcdsaPub384;
@@ -220,14 +222,20 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
 
     // For firmware update, don't read data from the mailbox
     if drivers.mbox.cmd() == CommandId::FIRMWARE_LOAD {
-        cfi_assert_eq(drivers.mbox.cmd(), CommandId::FIRMWARE_LOAD);
+        cfi_assert_eq(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_LOAD),
+        );
         update::handle_impactless_update(drivers)?;
 
         // If the handler succeeds but does not invoke reset that is
         // unexpected. Denote that the update failed.
         return Err(CaliptraError::RUNTIME_UNEXPECTED_UPDATE_RETURN);
     } else {
-        cfi_assert_ne(drivers.mbox.cmd(), CommandId::FIRMWARE_LOAD);
+        cfi_assert_ne(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_LOAD),
+        );
     }
 
     if drivers.mbox.cmd() == CommandId::FIRMWARE_VERIFY {
@@ -236,7 +244,10 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             firmware_verify::VerifySrc::Mbox,
         );
     } else {
-        cfi_assert_ne(drivers.mbox.cmd(), CommandId::FIRMWARE_VERIFY);
+        cfi_assert_ne(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_VERIFY),
+        );
     }
 
     // Get the command bytes

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -17,7 +17,7 @@ Abstract:
 #[cfg(target_arch = "riscv32")]
 core::arch::global_asm!(include_str!("ext_intr.S"));
 
-use caliptra_cfi_lib_git::CfiCounter;
+use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::{cprintln, handle_fatal_error};
 use caliptra_cpu::{log_trap_record, TrapRecord};
 use caliptra_drivers::{okmutref, FwPersistentData, RomPersistentData};
@@ -61,8 +61,13 @@ pub extern "C" fn entry_point() -> ! {
             drivers
                 .trng
                 .generate()
-                .map(|a| a.0)
-                .map_err(|_| caliptra_cfi_lib_git::CfiPanicInfo::TrngError)
+                .map(|a| {
+                    let b = a.0;
+                    (b[0], b[1], b[2], b[3])
+                })
+                .map_err(|_| {
+                    caliptra_cfi_lib::CfiError(u32::from(caliptra_cfi_lib::CfiPanicInfo::TrngError))
+                })
         };
         CfiCounter::reset(&mut entropy_gen);
         CfiCounter::reset(&mut entropy_gen);

--- a/runtime/src/ocp_lock/derive_mek.rs
+++ b/runtime/src/ocp_lock/derive_mek.rs
@@ -3,7 +3,7 @@
 use crate::{mutrefbytes, Drivers};
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockDeriveMekReq, OcpLockDeriveMekResp};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_error::{CaliptraError, CaliptraResult};
 

--- a/runtime/src/ocp_lock/enable_mpk.rs
+++ b/runtime/src/ocp_lock/enable_mpk.rs
@@ -5,7 +5,7 @@ use crate::{mutrefbytes, Drivers};
 use caliptra_api::mailbox::{
     MailboxRespHeader, OcpLockEnableMpkReq, OcpLockEnableMpkResp, WrappedKey,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_drivers::hpke::{aead::Aes256GCM, HpkeHandle};
 use caliptra_error::{CaliptraError, CaliptraResult};

--- a/runtime/src/ocp_lock/endorse_hpke_pubkey.rs
+++ b/runtime/src/ocp_lock/endorse_hpke_pubkey.rs
@@ -6,7 +6,7 @@ use caliptra_api::mailbox::{
     EndorsementAlgorithms, MailboxRespHeader, OcpLockEndorseHpkePubKeyReq,
     OcpLockEndorseHpkePubKeyResp,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_common::{
     crypto::{Crypto, PubKey},

--- a/runtime/src/ocp_lock/enumerate_hpke_handles.rs
+++ b/runtime/src/ocp_lock/enumerate_hpke_handles.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockEnumerateHpkeHandlesResp};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_error::CaliptraResult;
 

--- a/runtime/src/ocp_lock/generate_mek.rs
+++ b/runtime/src/ocp_lock/generate_mek.rs
@@ -3,7 +3,7 @@
 use crate::{mutrefbytes, Drivers};
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockGenerateMekResp, WrappedKey};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_error::CaliptraResult;
 

--- a/runtime/src/ocp_lock/generate_mpk.rs
+++ b/runtime/src/ocp_lock/generate_mpk.rs
@@ -5,7 +5,7 @@ use crate::{mutrefbytes, Drivers};
 use caliptra_api::mailbox::{
     MailboxRespHeader, OcpLockGenerateMpkReq, OcpLockGenerateMpkResp, WrappedKey,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_drivers::hpke::{aead::Aes256GCM, HpkeHandle};
 use caliptra_error::{CaliptraError, CaliptraResult};

--- a/runtime/src/ocp_lock/get_algorithms.rs
+++ b/runtime/src/ocp_lock/get_algorithms.rs
@@ -9,7 +9,7 @@ use crate::mutrefbytes;
 
 pub struct GetAlgorithmsCmd;
 impl GetAlgorithmsCmd {
-    #[cfg_attr(not(feature = "no-cfi"), caliptra_cfi_derive_git::cfi_impl_fn)]
+    #[cfg_attr(not(feature = "no-cfi"), caliptra_cfi_derive::cfi_impl_fn)]
     #[inline(never)]
     pub fn execute(resp: &mut [u8]) -> CaliptraResult<usize> {
         let resp = mutrefbytes::<OcpLockGetAlgorithmsResp>(resp)?;

--- a/runtime/src/ocp_lock/initialize_mek_secret.rs
+++ b/runtime/src/ocp_lock/initialize_mek_secret.rs
@@ -5,7 +5,7 @@ use crate::{mutrefbytes, Drivers};
 use caliptra_api::mailbox::{
     MailboxRespHeader, OcpLockInitializeMekSecretReq, OcpLockInitializeMekSecretResp,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_error::{CaliptraError, CaliptraResult};
 

--- a/runtime/src/ocp_lock/mix_mpk.rs
+++ b/runtime/src/ocp_lock/mix_mpk.rs
@@ -3,7 +3,7 @@
 use crate::{mutrefbytes, Drivers};
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockMixMpkReq, OcpLockMixMpkResp};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_error::{CaliptraError, CaliptraResult};
 

--- a/runtime/src/ocp_lock/mod.rs
+++ b/runtime/src/ocp_lock/mod.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::mailbox::{CommandId, WrappedKey, OCP_LOCK_WRAPPED_KEY_MAX_METADATA_LEN};
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use caliptra_common::keyids::ocp_lock::{
     KEY_ID_EPK, KEY_ID_HEK, KEY_ID_LOCKED_MPK_ENCRYPTION_KEY, KEY_ID_MDK, KEY_ID_MEK_SECRETS,
     KEY_ID_VEK,

--- a/runtime/src/ocp_lock/rewrap_mpk.rs
+++ b/runtime/src/ocp_lock/rewrap_mpk.rs
@@ -5,7 +5,7 @@ use crate::{mutrefbytes, Drivers};
 use caliptra_api::mailbox::{
     MailboxRespHeader, OcpLockRewrapMpkReq, OcpLockRewrapMpkResp, WrappedKey,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_drivers::hpke::HpkeHandle;
 use caliptra_error::{CaliptraError, CaliptraResult};

--- a/runtime/src/ocp_lock/rotate_hpke_key.rs
+++ b/runtime/src/ocp_lock/rotate_hpke_key.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockRotateHpkeKeyReq, OcpLockRotateHpkeKeyResp};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_drivers::hpke::HpkeHandle;
 

--- a/runtime/src/ocp_lock/test_access_key.rs
+++ b/runtime/src/ocp_lock/test_access_key.rs
@@ -3,7 +3,7 @@
 use crate::{mutrefbytes, Drivers};
 
 use caliptra_api::mailbox::{MailboxRespHeader, OcpLockTestAccessKeyReq, OcpLockTestAccessKeyResp};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_drivers::hpke::{aead::Aes256GCM, HpkeHandle};
 use caliptra_error::{CaliptraError, CaliptraResult};

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::{mutrefbytes, Drivers};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
     AlgorithmType, ExtendPcrReq, GetPcrLogResp, IncrementPcrResetCounterReq, MailboxRespHeader,
     QuotePcrsEcc384Req, QuotePcrsEcc384Resp, QuotePcrsMldsa87Req, QuotePcrsMldsa87Resp,

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -19,7 +19,7 @@ use crate::{
     Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
 };
 use caliptra_auth_man_types::AuthorizationManifest;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::{
     cprintln,
     mailbox_api::{AuthorizeAndStashReq, ImageHashSource},

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -3,9 +3,9 @@
 use crate::{Drivers, PauserPrivileges};
 
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 
 use caliptra_common::mailbox_api::RevokeExportedCdiHandleReq;
 use caliptra_drivers::ExportedCdiEntry;

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -20,8 +20,10 @@ use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, AUTH_MANIFEST_MARKER,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ge, cfi_assert_le, cfi_launder};
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{
+    cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ge, cfi_assert_le, cfi_launder,
+};
 use caliptra_common::mailbox_api::SetAuthManifestReq;
 use caliptra_drivers::{
     Array4x12, Array4xN, CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Signature,
@@ -127,7 +129,7 @@ impl SetAuthManifestCmd {
         {
             Err(CaliptraError::RUNTIME_AUTH_MANIFEST_VENDOR_ECC_SIGNATURE_INVALID)?;
         } else {
-            caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
                 &verify_r.0,
                 &auth_manifest_preamble.vendor_pub_keys_signatures.ecc_sig.r,
             );
@@ -162,7 +164,7 @@ impl SetAuthManifestCmd {
             if candidate_key != pub_key_digest {
                 Err(CaliptraError::RUNTIME_AUTH_MANIFEST_VENDOR_LMS_SIGNATURE_INVALID)?;
             } else {
-                caliptra_cfi_lib_git::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
             }
         } else {
             let vendor_data = Self::offset_data(
@@ -230,7 +232,7 @@ impl SetAuthManifestCmd {
         {
             Err(CaliptraError::RUNTIME_AUTH_MANIFEST_OWNER_ECC_SIGNATURE_INVALID)?;
         } else {
-            caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
                 &verify_r.0,
                 &auth_manifest_preamble.owner_pub_keys_signatures.ecc_sig.r,
             );
@@ -262,7 +264,7 @@ impl SetAuthManifestCmd {
             if candidate_key != pub_key_digest {
                 Err(CaliptraError::RUNTIME_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID)?;
             } else {
-                caliptra_cfi_lib_git::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
             }
         } else {
             let owner_data = Self::offset_data(
@@ -332,7 +334,7 @@ impl SetAuthManifestCmd {
         {
             Err(CaliptraError::RUNTIME_AUTH_MANIFEST_VENDOR_ECC_SIGNATURE_INVALID)?;
         } else {
-            caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
                 &verify_r.0,
                 &auth_manifest_preamble
                     .vendor_image_metdata_signatures
@@ -373,7 +375,7 @@ impl SetAuthManifestCmd {
             if candidate_key != pub_key_digest {
                 Err(CaliptraError::RUNTIME_AUTH_MANIFEST_VENDOR_LMS_SIGNATURE_INVALID)?;
             } else {
-                caliptra_cfi_lib_git::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
             }
         } else {
             let metadata_col_data = Self::offset_data(metadata_col, 0, metadata_col.len() as u32)?;
@@ -440,7 +442,7 @@ impl SetAuthManifestCmd {
         {
             Err(CaliptraError::RUNTIME_AUTH_MANIFEST_OWNER_ECC_SIGNATURE_INVALID)?;
         } else {
-            caliptra_cfi_lib_git::cfi_assert_eq_12_words(
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
                 &verify_r.0,
                 &auth_manifest_preamble
                     .owner_image_metdata_signatures
@@ -481,7 +483,7 @@ impl SetAuthManifestCmd {
             if candidate_key != pub_key_digest {
                 Err(CaliptraError::RUNTIME_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID)?;
             } else {
-                caliptra_cfi_lib_git::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
             }
         } else {
             let metadata_col_data = Self::offset_data(metadata_col, 0, metadata_col.len() as u32)?;

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -2,8 +2,8 @@
 
 use crate::{dpe_crypto::DpeEcCrypto, mutrefbytes, Drivers, PauserPrivileges};
 
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 
 use caliptra_common::cfi_check;
 use caliptra_common::mailbox_api::{

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 #[allow(dead_code)]

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::{
     invoke_dpe::invoke_dpe_cmd, mutrefbytes, CaliptraDpeProfile, Drivers, PauserPrivileges,
 };
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{MailboxRespHeader, StashMeasurementReq, StashMeasurementResp};
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
 use dpe::{

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::{mutrefbytes, Drivers};
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
     GetTaggedTciReq, GetTaggedTciResp, MailboxRespHeader, TagTciReq,
 };

--- a/runtime/src/update.rs
+++ b/runtime/src/update.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_mod_fn;
+use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 
 #[cfg_attr(not(feature = "no-cfi"), cfi_mod_fn)]

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::Drivers;
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::LmsVerifyReq;
 use caliptra_drivers::{CaliptraError, CaliptraResult, LmsResult};
 use caliptra_lms_types::{


### PR DESCRIPTION
* Removes the duplicate git CFI
* Uses the same CFI as DPE

This reduces the total number of CFI symbols in the firmware. Saving on code space in each stage.