### PR TITLE
[drivers]: Allow sha3 driver to take an iterator of slices

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-33a144aabcb65362d088c5c8e932c007602b314d16a5f001232da6805c8bbc650be9efdeb8e69e8ecbebb7a304d437e0  caliptra-rom-no-log.bin
-a039ca29d07881e24062233f5e83ccf1300e183b295e26616ab975e1bd484e226f0ec01378442160c1b6af466ad5f682  caliptra-rom-with-log.bin
+e5605c98d471fae0ca9ab36271d4585a74b17cb1517637eadced1a144c4fa3538dfc788ad39c5f9275cfff608e0569a6  caliptra-rom-no-log.bin
+322a960d02f2bc64ab6a9a9848d42ab7c0d160130b0a5db7d8e0be1d3795ecc1c534e1dd3e26155f50a8a0cbdf7c2681  caliptra-rom-with-log.bin


### PR DESCRIPTION
This helps avoid copying large data onto the stack during a digest operation.