### PR TITLE
runtime: Add MLKEM1024 cryptographic mailbox commands

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -51,6 +51,15 @@ const _: () = assert!(CMB_SHAKE256_CONTEXT_PLAINTEXT_SIZE + 12 + 16 == CMB_SHAKE
 /// Maximum digest size for SHAKE256 (64 bytes).
 pub const SHAKE256_MAX_DIGEST_BYTE_SIZE: usize = 64;
 
+/// ML-KEM-1024 Encapsulation Key size in bytes.
+pub const MLKEM1024_ENCAPS_KEY_SIZE: usize = 1568;
+/// ML-KEM-1024 Ciphertext size in bytes.
+pub const MLKEM1024_CIPHERTEXT_SIZE: usize = 1568;
+/// ML-KEM-1024 Shared Key size in bytes.
+pub const MLKEM1024_SHARED_KEY_SIZE: usize = 32;
+/// ML-KEM-1024 Seed size in bytes (seed_d + seed_z = 32 + 32).
+pub const MLKEM1024_SEED_SIZE: usize = 64;
+
 /// The max number of HPKE handles that OCP LOCK can manage.
 pub const OCP_LOCK_MAX_HPKE_HANDLES: usize = 3;
 // The largest pub key is the hybrid pub key
@@ -227,6 +236,9 @@ impl CommandId {
     pub const CM_SHAKE256_INIT: Self = Self(0x434D_5849); // "CMXI"
     pub const CM_SHAKE256_UPDATE: Self = Self(0x434D_5855); // "CMXU"
     pub const CM_SHAKE256_FINAL: Self = Self(0x434D_5846); // "CMXF"
+    pub const CM_MLKEM_KEY_GEN: Self = Self(0x434D_4C4B); // "CMLK"
+    pub const CM_MLKEM_ENCAPSULATE: Self = Self(0x434D_4C45); // "CMLE"
+    pub const CM_MLKEM_DECAPSULATE: Self = Self(0x434D_4C44); // "CMLD"
 
     // OCP LOCK Commands
     pub const OCP_LOCK_REPORT_HEK_METADATA: Self = Self(0x5248_4D54); // "RHMT"
@@ -384,6 +396,9 @@ pub enum MailboxResp {
     CmMldsaSign(CmMldsaSignResp),
     CmEcdsaPublicKey(CmEcdsaPublicKeyResp),
     CmEcdsaSign(CmEcdsaSignResp),
+    CmMlkemKeyGen(CmMlkemKeyGenResp),
+    CmMlkemEncapsulate(CmMlkemEncapsulateResp),
+    CmMlkemDecapsulate(CmMlkemDecapsulateResp),
     CmDeriveStableKey(CmDeriveStableKeyResp),
     ProductionAuthDebugUnlockChallenge(ProductionAuthDebugUnlockChallenge),
     GetPcrLog(GetPcrLogResp),
@@ -465,6 +480,9 @@ impl MailboxResp {
             MailboxResp::CmMldsaSign(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmEcdsaPublicKey(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmEcdsaSign(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmMlkemKeyGen(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmMlkemEncapsulate(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmMlkemDecapsulate(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
@@ -544,6 +562,9 @@ impl MailboxResp {
             MailboxResp::CmMldsaSign(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmEcdsaPublicKey(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmEcdsaSign(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmMlkemKeyGen(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmMlkemEncapsulate(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmMlkemDecapsulate(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmDeriveStableKey(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
@@ -689,6 +710,9 @@ pub enum MailboxReq {
     CmEcdsaPublicKey(CmEcdsaPublicKeyReq),
     CmEcdsaSign(CmEcdsaSignReq),
     CmEcdsaVerify(CmEcdsaVerifyReq),
+    CmMlkemKeyGen(CmMlkemKeyGenReq),
+    CmMlkemEncapsulate(CmMlkemEncapsulateReq),
+    CmMlkemDecapsulate(CmMlkemDecapsulateReq),
     CmDeriveStableKey(CmDeriveStableKeyReq),
     OcpLockReportHekMetadata(OcpLockReportHekMetadataReq),
     OcpLockGetAlgorithms(OcpLockGetAlgorithmsReq),
@@ -787,6 +811,9 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(req) => Ok(req.as_bytes()),
             MailboxReq::CmEcdsaSign(req) => req.as_bytes_partial(),
             MailboxReq::CmEcdsaVerify(req) => req.as_bytes_partial(),
+            MailboxReq::CmMlkemKeyGen(req) => Ok(req.as_bytes()),
+            MailboxReq::CmMlkemEncapsulate(req) => Ok(req.as_bytes()),
+            MailboxReq::CmMlkemDecapsulate(req) => Ok(req.as_bytes()),
             MailboxReq::CmDeriveStableKey(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockReportHekMetadata(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockGetAlgorithms(req) => Ok(req.as_bytes()),
@@ -883,6 +910,9 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmEcdsaSign(req) => req.as_bytes_partial_mut(),
             MailboxReq::CmEcdsaVerify(req) => req.as_bytes_partial_mut(),
+            MailboxReq::CmMlkemKeyGen(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CmMlkemEncapsulate(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CmMlkemDecapsulate(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmDeriveStableKey(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockReportHekMetadata(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockGetAlgorithms(req) => Ok(req.as_mut_bytes()),
@@ -979,6 +1009,9 @@ impl MailboxReq {
             MailboxReq::CmEcdsaPublicKey(_) => CommandId::CM_ECDSA_PUBLIC_KEY,
             MailboxReq::CmEcdsaSign(_) => CommandId::CM_ECDSA_SIGN,
             MailboxReq::CmEcdsaVerify(_) => CommandId::CM_ECDSA_VERIFY,
+            MailboxReq::CmMlkemKeyGen(_) => CommandId::CM_MLKEM_KEY_GEN,
+            MailboxReq::CmMlkemEncapsulate(_) => CommandId::CM_MLKEM_ENCAPSULATE,
+            MailboxReq::CmMlkemDecapsulate(_) => CommandId::CM_MLKEM_DECAPSULATE,
             MailboxReq::CmDeriveStableKey(_) => CommandId::CM_DERIVE_STABLE_KEY,
             MailboxReq::GetPcrLog(_) => CommandId::GET_PCR_LOG,
             MailboxReq::FeProg(_) => CommandId::FE_PROG,
@@ -2410,6 +2443,7 @@ pub enum CmKeyUsage {
     Aes = 2,
     Ecdsa = 3,
     Mldsa = 4,
+    Mlkem = 5,
 }
 
 impl From<u32> for CmKeyUsage {
@@ -2419,6 +2453,7 @@ impl From<u32> for CmKeyUsage {
             2_u32 => CmKeyUsage::Aes,
             3_u32 => CmKeyUsage::Ecdsa,
             4_u32 => CmKeyUsage::Mldsa,
+            5_u32 => CmKeyUsage::Mlkem,
             _ => CmKeyUsage::Reserved,
         }
     }
@@ -2431,6 +2466,7 @@ impl From<CmKeyUsage> for u32 {
             CmKeyUsage::Aes => 2,
             CmKeyUsage::Ecdsa => 3,
             CmKeyUsage::Mldsa => 4,
+            CmKeyUsage::Mlkem => 5,
             _ => 0,
         }
     }
@@ -4567,6 +4603,116 @@ impl Request for CmEcdsaVerifyReq {
     const ID: CommandId = CommandId::CM_ECDSA_VERIFY;
     type Resp = MailboxRespHeader;
 }
+
+// CM_MLKEM_KEY_GEN
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmMlkemKeyGenReq {
+    pub hdr: MailboxReqHeader,
+    pub cmk: Cmk,
+}
+
+impl Request for CmMlkemKeyGenReq {
+    const ID: CommandId = CommandId::CM_MLKEM_KEY_GEN;
+    type Resp = CmMlkemKeyGenResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMlkemKeyGenResp {
+    pub hdr: MailboxRespHeader,
+    pub encaps_key: [u8; MLKEM1024_ENCAPS_KEY_SIZE],
+}
+
+impl Default for CmMlkemKeyGenResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            encaps_key: [0u8; MLKEM1024_ENCAPS_KEY_SIZE],
+        }
+    }
+}
+
+impl Response for CmMlkemKeyGenResp {}
+
+// CM_MLKEM_ENCAPSULATE
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMlkemEncapsulateReq {
+    pub hdr: MailboxReqHeader,
+    pub key_usage: u32,
+    pub encaps_key: [u8; MLKEM1024_ENCAPS_KEY_SIZE],
+}
+
+impl Default for CmMlkemEncapsulateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            key_usage: 0,
+            encaps_key: [0u8; MLKEM1024_ENCAPS_KEY_SIZE],
+        }
+    }
+}
+
+impl Request for CmMlkemEncapsulateReq {
+    const ID: CommandId = CommandId::CM_MLKEM_ENCAPSULATE;
+    type Resp = CmMlkemEncapsulateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMlkemEncapsulateResp {
+    pub hdr: MailboxRespHeader,
+    pub ciphertext: [u8; MLKEM1024_CIPHERTEXT_SIZE],
+    pub shared_key: Cmk,
+}
+
+impl Default for CmMlkemEncapsulateResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            ciphertext: [0u8; MLKEM1024_CIPHERTEXT_SIZE],
+            shared_key: Cmk::default(),
+        }
+    }
+}
+
+impl Response for CmMlkemEncapsulateResp {}
+
+// CM_MLKEM_DECAPSULATE
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmMlkemDecapsulateReq {
+    pub hdr: MailboxReqHeader,
+    pub key_usage: u32,
+    pub cmk: Cmk,
+    pub ciphertext: [u8; MLKEM1024_CIPHERTEXT_SIZE],
+}
+
+impl Default for CmMlkemDecapsulateReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            key_usage: 0,
+            cmk: Cmk::default(),
+            ciphertext: [0u8; MLKEM1024_CIPHERTEXT_SIZE],
+        }
+    }
+}
+
+impl Request for CmMlkemDecapsulateReq {
+    const ID: CommandId = CommandId::CM_MLKEM_DECAPSULATE;
+    type Resp = CmMlkemDecapsulateResp;
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Default)]
+pub struct CmMlkemDecapsulateResp {
+    pub hdr: MailboxRespHeader,
+    pub shared_key: Cmk,
+}
+
+impl Response for CmMlkemDecapsulateResp {}
 
 // CM_DERIVE_STABLE_KEY
 pub const CM_STABLE_KEY_INFO_SIZE_BYTES: usize = 32;

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -27,8 +27,6 @@ v2.1:
 
 ## Spec Opens
 
-* Cryptographic Mailbox: ML-KEM support
-
 ## Runtime Firmware environment
 
 This section provides an overview of the Runtime Firmware environment.
@@ -94,7 +92,7 @@ These commands are not meant to be high-performance as they are accessed via mai
 
 CM itself does not provide any storage for the keys: when generated, they are returned to the caller in encrypted form, and must be passed back to be used.
 
-These mailbox commands provide SHA, HMAC, HKDF, AES, RNG, MLDSA, and ECDSA services.
+These mailbox commands provide SHA, HMAC, HKDF, AES, RNG, MLDSA, ECDSA, and ML-KEM services.
 
 Note that while MLDSA and ECDSA keys can be imported, generated, and used in the cryptographic mailbox commands (i.e., `CM_*` commands) through CMKs, these keys are *NOT* tied DICE or DPE, so their use may be restricted for certain purposes.
 
@@ -159,8 +157,10 @@ The internal CMK structure and several commands use a key usage tag to specify h
 | --------- | --------- |
 | 0         | Reserved  |
 | 1         | HMAC      |
-| 2         | HKDF      |
-| 3         | AES       |
+| 2         | AES       |
+| 3         | ECDSA     |
+| 4         | MLDSA     |
+| 5         | ML-KEM    |
 
 #### Replay Prevention and Deletion
 
@@ -1804,6 +1804,73 @@ Command Code: `0x434D_4556` ("CMEV")
 | ----------- | -------- | -------------------------- |
 | chksum      | u32      |                            |
 | fips_status | u32      | FIPS approved or an error  |
+
+### CM_MLKEM_KEY_GEN
+
+Generates an ML-KEM-1024 encapsulation key from the seed (seed\_d || seed\_z, 64 bytes) stored in a CMK with key usage `Mlkem`.
+
+The key generation algorithm is described in [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final).
+
+Command Code: `0x434D_4C4B` ("CMLK")
+
+*Table: `CM_MLKEM_KEY_GEN` input arguments*
+| **Name** | **Type** | **Description**                          |
+| -------- | -------- | ---------------------------------------- |
+| chksum   | u32      |                                          |
+| CMK      | CMK      | ML-KEM seed (seed\_d \|\| seed\_z)       |
+
+*Table: `CM_MLKEM_KEY_GEN` output arguments*
+| **Name**    | **Type** | **Description**                          |
+| ----------- | -------- | ---------------------------------------- |
+| chksum      | u32      |                                          |
+| fips_status | u32      | FIPS approved or an error                |
+| encaps_key  | u8[1568] | ML-KEM-1024 encapsulation key            |
+
+### CM_MLKEM_ENCAPSULATE
+
+Performs ML-KEM-1024 encapsulation against the provided encapsulation key, producing a ciphertext and a shared key wrapped as a CMK.
+
+The encapsulation algorithm is described in [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final).
+
+Command Code: `0x434D_4C45` ("CMLE")
+
+*Table: `CM_MLKEM_ENCAPSULATE` input arguments*
+| **Name**    | **Type** | **Description**                          |
+| ----------- | -------- | ---------------------------------------- |
+| chksum      | u32      |                                          |
+| key_usage   | u32      | Key usage for the output CMK             |
+| encaps_key  | u8[1568] | ML-KEM-1024 encapsulation key            |
+
+*Table: `CM_MLKEM_ENCAPSULATE` output arguments*
+| **Name**    | **Type** | **Description**                          |
+| ----------- | -------- | ---------------------------------------- |
+| chksum      | u32      |                                          |
+| fips_status | u32      | FIPS approved or an error                |
+| ciphertext  | u8[1568] | ML-KEM-1024 ciphertext                   |
+| shared_key  | CMK      | CMK of the shared secret key             |
+
+### CM_MLKEM_DECAPSULATE
+
+Performs ML-KEM-1024 decapsulation using the seed in the provided CMK and the given ciphertext, recovering the shared key wrapped as a CMK. This uses the hardware's combined keygen\_decapsulate operation to avoid materializing the full 3168-byte decapsulation key in memory.
+
+The decapsulation algorithm is described in [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final).
+
+Command Code: `0x434D_4C44` ("CMLD")
+
+*Table: `CM_MLKEM_DECAPSULATE` input arguments*
+| **Name**    | **Type** | **Description**                          |
+| ----------- | -------- | ---------------------------------------- |
+| chksum      | u32      |                                          |
+| key_usage   | u32      | Key usage for the output CMK             |
+| CMK         | CMK      | ML-KEM seed (seed\_d \|\| seed\_z)       |
+| ciphertext  | u8[1568] | ML-KEM-1024 ciphertext to decapsulate    |
+
+*Table: `CM_MLKEM_DECAPSULATE` output arguments*
+| **Name**    | **Type** | **Description**                          |
+| ----------- | -------- | ---------------------------------------- |
+| chksum      | u32      |                                          |
+| fips_status | u32      | FIPS approved or an error                |
+| shared_key  | CMK      | CMK of the shared secret key             |
 
 ### CM_AES_ENCRYPT_INIT
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -516,6 +516,15 @@ fn execute_command(
         CommandId::CM_ECDSA_VERIFY => {
             cryptographic_mailbox::Commands::ecdsa_verify(drivers, cmd_bytes, resp)
         }
+        CommandId::CM_MLKEM_KEY_GEN => {
+            cryptographic_mailbox::Commands::mlkem_key_gen(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_MLKEM_ENCAPSULATE => {
+            cryptographic_mailbox::Commands::mlkem_encapsulate(drivers, cmd_bytes, resp)
+        }
+        CommandId::CM_MLKEM_DECAPSULATE => {
+            cryptographic_mailbox::Commands::mlkem_decapsulate(drivers, cmd_bytes, resp)
+        }
         CommandId::CM_DERIVE_STABLE_KEY => {
             cryptographic_mailbox::Commands::derive_stable_key(drivers, cmd_bytes, resp)
         }


### PR DESCRIPTION
Add CM_MLKEM_KEY_PAIR, CM_MLKEM_ENCAPSULATE, and CM_MLKEM_DECAPSULATE
mailbox commands following the same patterns as the existing MLDSA and
ECDSA commands. Seeds (seed_d || seed_z, 64 bytes) are imported as a
CMK with CmKeyUsage::Mlkem. Decapsulate uses the hardware's combined
keygen_decapsulate operation to avoid materializing the 3168-byte
decapsulation key in memory.