### PR TITLE
Ensure that conflicting compile flags are not present

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,23 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(
+    target_arch = "riscv32",
+    not(clippy),
+    feature = "rom",
+    feature = "runtime"
+))]
+compile_error!("features \"rom\" and \"runtime\" are mutually exclusive");
+#[cfg(all(target_arch = "riscv32", not(clippy), feature = "rom", feature = "fmc"))]
+compile_error!("features \"rom\" and \"fmc\" are mutually exclusive");
+#[cfg(all(
+    target_arch = "riscv32",
+    not(clippy),
+    feature = "fmc",
+    feature = "runtime"
+))]
+compile_error!("features \"fmc\" and \"runtime\" are mutually exclusive");
+
 pub mod boot_status;
 pub mod capabilities {
     pub use caliptra_api::Capabilities;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -14,6 +14,23 @@ Abstract:
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(
+    target_arch = "riscv32",
+    not(clippy),
+    feature = "rom",
+    feature = "runtime"
+))]
+compile_error!("features \"rom\" and \"runtime\" are mutually exclusive");
+#[cfg(all(target_arch = "riscv32", not(clippy), feature = "rom", feature = "fmc"))]
+compile_error!("features \"rom\" and \"fmc\" are mutually exclusive");
+#[cfg(all(
+    target_arch = "riscv32",
+    not(clippy),
+    feature = "fmc",
+    feature = "runtime"
+))]
+compile_error!("features \"fmc\" and \"runtime\" are mutually exclusive");
+
 mod array;
 mod array_concat;
 mod wait;


### PR DESCRIPTION
A little tricky since clippy and workspace builds will unify flags, but as long as we check them only when building firmware (riscv32) and not clippy, then this should be sufficient.

Fixes #2286