### PR TITLE
[CI]: Change build logic for MCU

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -158,8 +158,8 @@ jobs:
       - name: Build test MCU ROM
         if: "!steps.restore_mcu_rom_cache.outputs.cache-hit"
         run: |
-          git clone  --depth=1 "https://github.com/chipsalliance/caliptra-mcu-sw"
-          pushd caliptra-mcu-sw
+          git clone  --depth=1 "https://github.com/chipsalliance/caliptra-mcu-sw" /tmp/caliptra-mcu-sw
+          pushd /tmp/caliptra-mcu-sw
           git fetch --depth 1 origin ${CALIPTRA_MCU_COMMIT}
           git reset --hard ${CALIPTRA_MCU_COMMIT}
           git submodule update --init --recursive
@@ -169,8 +169,9 @@ jobs:
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
           cargo xtask-fpga rom-build --platform fpga --features core_test
           scp target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga-core_test.bin target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin
-          scp target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin ../mcu-rom-fpga.bin
-          tar -cvz -f /tmp/caliptra-mcu-binaries.tar.gz -C target/riscv32imc-unknown-none-elf/release/ mcu-rom-fpga.bin
+          popd 
+          /tmp/caliptra-mcu-sw/target/riscv32imc-unknown-none-elf/release/mcu-rom-fpga.bin mcu-rom-fpga.bin
+          tar -cvz -f /tmp/caliptra-mcu-binaries.tar.gz -C /tmp/caliptra-mcu-sw/target/riscv32imc-unknown-none-elf/release/ mcu-rom-fpga.bin
 
       - name: Save test MCU ROM to cache
         if: "!steps.restore_mcu_rom_cache.outputs.cache-hit"


### PR DESCRIPTION
The latest xtask rom-build logic will recurse up a tree to find the deepest Cargo.toml ancestor. This get's confused by the current build flow.