### PR TITLE
[EAT] Use naming consistently and add mldsa87 support for cose

### DIFF
--- a/common/eat/README.md
+++ b/common/eat/README.md
@@ -36,7 +36,7 @@ runtime/userspace/api/eat/
 │   ├── claim_key.rs       # EAT claim key definitions
 │   └── error.rs           # Error handling modules
 │   └── ocp_profile/       # OCP profile-specific EAT claims encoding modules for attestation
-│   └── csr_eat.rs         # Envelope Signed CSR EAT claims encoding module
+│   └── csr_eat.rs         # Attested CSR EAT claims encoding module
 ├── output/                # Auto-created output directory for tokens
 │   └── *.cbor            # Generated CBOR token files
 ├── Cargo.toml            # Rust package manifest

--- a/common/eat/src/cose.rs
+++ b/common/eat/src/cose.rs
@@ -55,6 +55,16 @@ impl ProtectedHeader<'_> {
         }
     }
 
+    /// Create a new protected header for MLDSA87
+    /// with default content type APPLICATION_EAT_CWT and no key ID.
+    pub fn new_mldsa87() -> Self {
+        Self {
+            alg: cose_alg::MLDSA87,
+            content_type: content_type::APPLICATION_EAT_CWT,
+            kid: None,
+        }
+    }
+
     /// Estimate the size required for encoding this protected header
     pub fn estimate_size(&self) -> usize {
         let mut size = 0;

--- a/common/eat/src/csr_eat.rs
+++ b/common/eat/src/csr_eat.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-//! Envelope Signed CSR EAT (Envelope Signed Certificate Signing Request Entity Attestation Token)
+//! Attested CSR EAT (Attested Certificate Signing Request Entity Attestation Token)
 //!
 //! This module implements CSR EAT claims according to the CDDL specification
-//! for envelope-signed CSR EAT tokens.
+//! for attested CSR EAT tokens.
 //!
 //! # CBOR Structure Example
 //!
@@ -31,9 +31,9 @@ use crate::claim_keys::*;
 use crate::error::EatError;
 use crate::TaggedOid;
 
-// Envelope Signed CSR specific private claim keys (must be < -65536 per RFC 8392)
-const ENV_SIGNED_CSR_CLAIM_KEY_CSR: i64 = -70001;
-const ENV_SIGNED_CSR_CLAIM_KEY_ATTRIB: i64 = -70002;
+// Attested CSR specific private claim keys (must be < -65536 per RFC 8392)
+const CLAIM_KEY_ATTESTED_CSR: i64 = -70001;
+const CLAIM_KEY_ATTESTED_CSR_KEY_ATTRIB: i64 = -70002;
 
 /// OCP Security OID definitions for Device Identity Provisioning
 ///
@@ -45,9 +45,9 @@ pub mod oids {
     /// Base OID for all OCP Security specifications
     pub const OCP_SECURITY: &[u8] = &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0xCD, 0x1F, 0x01];
 
-    /// Envelope-signed EAT profile OID: {1 3 6 1 4 1 42623 1 1}
+    /// Attested EAT profile OID: {1 3 6 1 4 1 42623 1 1}
     ///
-    /// Identifies the OCP DIP Envelope-signed EAT profile
+    /// Identifies the OCP DIP Attested EAT profile
     pub const OCP_SECURITY_OID_EAT_PROFILE: &[u8] =
         &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0xCD, 0x1F, 0x01, 0x01];
 
@@ -94,9 +94,9 @@ pub mod oids {
     ];
 }
 
-/// Envelope Signed CSR EAT Claims
+/// Attested CSR EAT Claims
 ///
-/// Payload structure for Envelope Signed CSR (Certificate Signing Request) EAT tokens.
+/// Payload structure for Attested CSR (Certificate Signing Request) EAT tokens.
 /// Contains a CSR along with key attribute OIDs that describe the requested certificate's
 /// key properties. Used in device identity provisioning workflows.
 ///
@@ -179,11 +179,11 @@ impl<'a> CsrEatClaims<'a> {
         }
 
         // CSR claim (required)
-        encoder.encode_int(ENV_SIGNED_CSR_CLAIM_KEY_CSR)?;
+        encoder.encode_int(CLAIM_KEY_ATTESTED_CSR)?;
         encoder.encode_bytes(self.csr)?;
 
         // Attributes claim (required, array of tagged OIDs)
-        encoder.encode_int(ENV_SIGNED_CSR_CLAIM_KEY_ATTRIB)?;
+        encoder.encode_int(CLAIM_KEY_ATTESTED_CSR_KEY_ATTRIB)?;
         encoder.encode_array_header(self.attributes.len() as u64)?;
         for attr in self.attributes {
             attr.encode(encoder)?;
@@ -437,8 +437,8 @@ mod tests {
     #[test]
     fn test_cbor_claim_keys() {
         // Verify CSR claim keys are negative and < -65536
-        assert_eq!(ENV_SIGNED_CSR_CLAIM_KEY_CSR, -70001);
-        assert_eq!(ENV_SIGNED_CSR_CLAIM_KEY_ATTRIB, -70002);
+        assert_eq!(CLAIM_KEY_ATTESTED_CSR, -70001);
+        assert_eq!(CLAIM_KEY_ATTESTED_CSR_KEY_ATTRIB, -70002);
         // Verify standard nonce claim key
         assert_eq!(CLAIM_KEY_NONCE, 10);
     }

--- a/common/eat/src/lib.rs
+++ b/common/eat/src/lib.rs
@@ -119,6 +119,6 @@ pub use ocp_profile::{
     PrivateClaim, // Custom private claims (keys < -65536)
 };
 
-// Re-export Envelope Signed CSR EAT types for provisioning workflows
+// Re-export Attested CSR EAT types for provisioning workflows
 // Reference: https://opencomputeproject.github.io/Security/device-identity-provisioning/
 pub use csr_eat::CsrEatClaims; // CSR EAT token payload with nonce and attributes


### PR DESCRIPTION
Keep the CSR EAT (ATTESTED_CSR) name consistent with the mailbox command and add mldsa87 support for cose.