### PR TITLE
[dpe] Add optional ML-DSA response over DMA

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -380,6 +380,20 @@ impl Dma {
         self.wait_for_dma_complete();
     }
 
+    /// Writes an arbitrary length buffer to the given AXI address
+    ///
+    /// # Arguments
+    ///
+    /// * `write_addr` - Address to write to
+    /// * `buffer`  - Target location to write from
+    pub fn write_buffer(&self, write_addr: AxiAddr, buffer: &[u32]) {
+        // TODO(zhalvorsen): figure out why one shot is only writing ~1KB in the emulator and switch
+        // to using a single DMA transaction instead of writing a dword at a time.
+        for (i, write_val) in buffer.iter().enumerate() {
+            self.write_dword(write_addr + (i as u32 * 4), *write_val);
+        }
+    }
+
     /// Write a 32-bit word to the specified address
     ///
     /// # Arguments

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -888,13 +888,14 @@ int rt_test_all_commands(const test_info *info)
     // INVOKE_DPE_MLDSA87
     // Using GET_PROFILE as an example command
     // TODO: Coverage of other DPE commands should be added
+    struct caliptra_invoke_dpe_mldsa87_req dpe_mldsa87_req = {};
 
-    dpe_req.data_size = sizeof(struct dpe_get_profile_cmd);
-    dpe_req.get_profile_cmd.cmd_hdr.magic = DPE_MAGIC;
-    dpe_req.get_profile_cmd.cmd_hdr.cmd_id = DPE_GET_PROFILE;
-    dpe_req.get_profile_cmd.cmd_hdr.profile = 0x2;
+    dpe_mldsa87_req.data_size = sizeof(struct dpe_get_profile_cmd);
+    dpe_mldsa87_req.get_profile_cmd.cmd_hdr.magic = DPE_MAGIC;
+    dpe_mldsa87_req.get_profile_cmd.cmd_hdr.cmd_id = DPE_GET_PROFILE;
+    dpe_mldsa87_req.get_profile_cmd.cmd_hdr.profile = 0x2;
 
-    status = caliptra_invoke_dpe_mldsa87_command(&dpe_req, &dpe_resp, false);
+    status = caliptra_invoke_dpe_mldsa87_command(&dpe_mldsa87_req, &dpe_resp, false);
 
     if (status)
     {

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -207,7 +207,7 @@ int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struc
 int caliptra_invoke_dpe_command(struct caliptra_invoke_dpe_req *req, struct caliptra_invoke_dpe_resp *resp, bool async);
 
 // DPE MLDSA87 command
-int caliptra_invoke_dpe_mldsa87_command(struct caliptra_invoke_dpe_req *req, struct caliptra_invoke_dpe_resp *resp, bool async);
+int caliptra_invoke_dpe_mldsa87_command(struct caliptra_invoke_dpe_mldsa87_req *req, struct caliptra_invoke_dpe_resp *resp, bool async);
 
 // Disable attestation
 int caliptra_disable_attestation(bool async);

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -612,6 +612,29 @@ struct caliptra_invoke_dpe_req
     };
 };
 
+struct caliptra_invoke_dpe_mldsa87_req
+{
+    struct caliptra_req_header hdr;
+    uint32_t flags;
+    uint32_t axi_addr_lo;
+    uint32_t axi_addr_hi;
+    uint32_t axi_max_size;
+    uint32_t data_size;
+    union
+    {
+        struct dpe_cmd_hdr cmd_hdr;
+        struct dpe_get_profile_cmd get_profile_cmd;
+        struct dpe_initialize_context_cmd initialize_context_cmd;
+        struct dpe_derive_context_cmd derive_context_cmd;
+        struct dpe_certify_key_cmd certify_key_cmd;
+        struct dpe_sign_cmd sign_cmd;
+        struct dpe_rotate_context_handle_cmd rotate_context_handle_cmd;
+        struct dpe_destroy_context_cmd destroy_context_cmd;
+        struct dpe_get_certificate_chain_cmd get_certificate_chain_cmd;
+        uint8_t data[0];
+    };
+};
+
 struct caliptra_invoke_dpe_resp
 {
     struct caliptra_resp_header cpl;

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -835,17 +835,34 @@ Command Code: `0x4450_4543` ("DPEC")
 
 ### INVOKE\_DPE\_MLDSA87
 
-Invokes a serialized ML-DSA-87 DPE profile command.
+Invokes a serialized ML-DSA-87 DPE profile command. In subsystem mode a response
+can be DMA'ed to an external address. This is especially useful for large
+commands like `CertifyKey` or `DeriveContext` when exporting a CDI. Both of
+these responses contain a potentially large certificate/CSR. To use this
+feature, set the EXTERNAL_AXI_RESPONSE in `flags` and set the corresponding
+AXI address and size fields. The response over the mailbox will only contain a
+mailbox header (`chksum` and `fips_status`). The full response including the
+mailbox header will be found at the given address.
 
 Command Code: `0x4450_4543` ("DPEC")
 
 *Table: `INVOKE_DPE_MLDSA87` input arguments*
 
-| **Name**     | **Type**      | **Description**
-| --------     | --------      | ---------------
-| chksum       | u32           | Checksum over other input arguments, computed by the caller. Little endian.
-| data\_size   | u32           | Length in bytes of the valid data in the data field.
-| data         | u8[...]       | DPE command structure as defined in the DPE iRoT profile.
+| **Name**       | **Type** | **Description**                                                             |
+| -------------- | -------- | --------------------------------------------------------------------------- |
+| chksum         | u32      | Checksum over other input arguments, computed by the caller. Little endian. |
+| flags          | u32      | Flags to give configurations of the command.                                |
+| axi\_addr\_lo  | u32      | Lower word of the destination physical address.                             |
+| axi\_addr\_hi  | u32      | Upper word of the destination physical address.                             |
+| axi\_max\_size | u32      | Maximum DMA response size.                                                  |
+| data\_size     | u32      | Length in bytes of the valid data in the data field.                        |
+| data           | u8[...]  | DPE command structure as defined in the DPE iRoT profile.                   |
+
+*Table: `INVOKE_DPE_MLDSA87` input flags*
+
+| **Name**                | **Value** |
+| ----------------------- | --------- |
+| EXTERNAL\_AXI\_RESPONSE | 1 << 31   |
 
 *Table: `INVOKE_DPE_MLDSA87` output arguments*
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -330,12 +330,8 @@ fn execute_command(
         CommandId::GET_LDEV_MLDSA87_CERT => {
             GetLdevCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
-        CommandId::INVOKE_DPE_ECC384 => {
-            InvokeDpeCmd::execute(drivers, cmd_bytes, resp, CaliptraDpeProfile::Ecc384)
-        }
-        CommandId::INVOKE_DPE_MLDSA87 => {
-            InvokeDpeCmd::execute(drivers, cmd_bytes, resp, CaliptraDpeProfile::Mldsa87)
-        }
+        CommandId::INVOKE_DPE_ECC384 => InvokeDpeCmd::execute_ecc384(drivers, cmd_bytes, resp),
+        CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeCmd::execute_mldsa87(drivers, cmd_bytes, resp),
         CommandId::ECDSA384_SIGNATURE_VERIFY => {
             caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)
         }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -1,7 +1,10 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::{
-    mailbox::{GetFmcAliasMlDsa87CertResp, Request},
+    mailbox::{
+        AxiResponseInfo, GetFmcAliasMlDsa87CertResp, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req,
+        Request,
+    },
     SocManager,
 };
 use caliptra_builder::{
@@ -394,8 +397,11 @@ pub fn execute_dpe_cmd(
         ),
         CaliptraDpeProfile::Mldsa87 => (
             CommandId::INVOKE_DPE_MLDSA87,
-            MailboxReq::InvokeDpeMldsa87Command(InvokeDpeReq {
+            MailboxReq::InvokeDpeMldsa87Command(InvokeDpeMldsa87Req {
                 hdr: MailboxReqHeader { chksum: 0 },
+                // TODO(zhalvorsen): Add support for external responses
+                flags: InvokeDpeMldsa87Flags::empty(),
+                axi_response: AxiResponseInfo::default(),
                 data: cmd_data,
                 data_size: (cmd_hdr_buf.len() + dpe_cmd_buf.len()) as u32,
             }),


### PR DESCRIPTION
The worst case scenario DPE certificate/CSR is too large to fit in the Caliptra core mailbox in subsystem mode. This change adds an optional external ML-DSA response DMA address to the ML-DSA variant of the request. This allows executing all DPE commands without the need to split the certificate/CSR into multiple parts and reassemble it on the caller side.