### PR TITLE
drivers: handle mailbox FSM error state and unexpected DataReady

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-fd5dfcb4cc309595b5a6f8ac705afa9eed12295dec480d5dc73370e8da93f31980fd0f29e20f5090798cf77c7181ce95  caliptra-rom-no-log.bin
-fe57041b2193e24cfc462a0f4f5f36e8d1d18a6b2d68ac9409e52e637807749c5e47afa123e2f4fe5a592866c272a6c0  caliptra-rom-with-log.bin
+703a3084c33e8fb675a8de4e91e7ec6af04638ed27c3bf82fd810529588a7a0e18668378094b23eba2f03b6cad146b38  caliptra-rom-no-log.bin
+ddf85e2c85d3e6c495862003051e34be63f599e58de5807a189e19cae72dc527c99a473e76b3181c969d4fed419ac046  caliptra-rom-with-log.bin

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -306,6 +306,11 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
+    pub const MAILBOX_DRIVER_DATA_READY: FwId = FwId {
+        bin_name: "mailbox_driver_data_ready",
+        ..BASE_FWID
+    };
+
     pub const MBOX_SEND_TXN_DROP: FwId = FwId {
         bin_name: "mbox_send_txn_drop",
         ..BASE_FWID
@@ -659,6 +664,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::MAILBOX_DRIVER_RESPONDER,
     &driver_tests::MAILBOX_DRIVER_SENDER,
     &driver_tests::MAILBOX_DRIVER_NEGATIVE_TESTS,
+    &driver_tests::MAILBOX_DRIVER_DATA_READY,
     &driver_tests::MBOX_SEND_TXN_DROP,
     &driver_tests::ML_DSA87,
     &driver_tests::ML_DSA87_EXTERNAL_MU,

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -107,6 +107,11 @@ path = "src/bin/mailbox_driver_negative_tests.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "mailbox_driver_data_ready"
+path = "src/bin/mailbox_driver_data_ready.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "keyvault"
 path = "src/bin/keyvault_tests.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/mailbox_driver_data_ready.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_data_ready.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache-2.0 license
+
+//! Test firmware that sends a mailbox request and verifies that a DataReady
+//! response is treated as an error by the driver.
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::{self, println};
+
+use caliptra_drivers::{self, CaliptraError, Mailbox};
+use caliptra_registers::mbox::MboxCsr;
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    let mut mbox = unsafe { Mailbox::new(MboxCsr::new()) };
+
+    // Send a request; the SoC will respond with DataReady
+    let mut txn = mbox.try_start_send_txn().unwrap();
+    txn.send_request(0xd000_0000, b"Hello").unwrap();
+    while !txn.is_response_ready() {}
+
+    // complete() should return an error since DataReady is unexpected
+    let result = txn.complete();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        CaliptraError::DRIVER_MAILBOX_FSM_ERROR
+    ));
+    drop(txn);
+
+    // Mailbox should be back to idle after the unlock; send another request
+    // to prove recovery worked
+    let mut txn = mbox.wait_until_start_send_txn();
+    txn.send_request(0xd000_1000, b"").unwrap();
+    while !txn.is_response_ready() {}
+    txn.complete().unwrap();
+}

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -439,6 +439,11 @@ impl CaliptraError {
             "Mailbox Error: Uncorrectable ECC"
         ),
         (
+            DRIVER_MAILBOX_FSM_ERROR,
+            0x00080006,
+            "Mailbox Error: FSM entered error state"
+        ),
+        (
             DRIVER_SHA2_512_384ACC_INDEX_OUT_OF_BOUNDS,
             0x00090003,
             "SHA2_512_384ACC Error: Index out of bounds"


### PR DESCRIPTION
Fix mailbox driver to detect and recover from the MBOX_ERROR FSM state during uC→SoC transactions. When the SoC misbehaves (e.g., writing to execute register when it doesn't own the lock), the FSM enters the error state. Previously, is_response_ready() would loop forever.

Also, while we're here, we handle the unexpected DataReady case, where additional data is attempted to be sent through the mailbox after the initial response. We don't support this kind of flow in the firmware today, so we have abort the transaction in this case.

Fixes #718