### PR TITLE
[dpe] Add HW model support for large DPE responses in subsystem mode

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1660,6 +1660,16 @@ impl Default for InvokeDpeResp {
     }
 }
 
+impl InvokeDpeResp {
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.data_size as usize > Self::DATA_MAX_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+
 // GET_FMC_ALIAS_ECC384_CERT
 #[repr(C)]
 #[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -1288,8 +1288,20 @@ pub trait HwModel: SocManager {
         Ok(Some(result))
     }
 
+    /// Get the physical address of the staging area in external MCU SRAM
+    fn staging_physical_address(&mut self) -> Result<u64, ModelError> {
+        Err(ModelError::SubsystemSramError)
+    }
+
     /// Upload payload to external MCU SRAM
-    fn write_payload_to_ss_staging_area(&mut self, payload: &[u8]) -> Result<u64, ModelError>;
+    fn write_payload_to_ss_staging_area(&mut self, _payload: &[u8]) -> Result<u64, ModelError> {
+        Err(ModelError::SubsystemSramError)
+    }
+
+    /// Read payload from external MCU SRAM staging area
+    fn read_payload_from_ss_staging_area(&mut self, _length: usize) -> Result<Vec<u8>, ModelError> {
+        Err(ModelError::SubsystemSramError)
+    }
 
     /// Upload firmware to the mailbox.
     fn upload_firmware(&mut self, firmware: &[u8]) -> Result<(), ModelError> {

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -715,10 +715,6 @@ impl HwModel for ModelFpgaRealtime {
         todo!()
     }
 
-    fn write_payload_to_ss_staging_area(&mut self, _payload: &[u8]) -> Result<u64, ModelError> {
-        Err(ModelError::SubsystemSramError)
-    }
-
     fn fuses(&self) -> &Fuses {
         &self.fuses
     }


### PR DESCRIPTION
This adds HW model support for large DPE responses over DMA. And duplicates the `test_invoke_dpe_sign_and_certify_key_cmds` test to run in subsystem mode, which will trigger the large DPE response code paths in the HW model.