### PR TITLE
[drivers]: Return data vault objects as references

### DIFF
--- a/common/src/dice.rs
+++ b/common/src/dice.rs
@@ -29,8 +29,8 @@ use crate::hmac_cm::mutrefbytes;
 ///
 /// # Returns
 ///
-/// * `Ecc384Signature` - The formed signature
-pub fn ldevid_dice_sign(persistent_data: &PersistentData) -> Ecc384Signature {
+/// * `&Ecc384Signature` - The formed signature
+pub fn ldevid_dice_sign(persistent_data: &PersistentData) -> &Ecc384Signature {
     persistent_data.rom.data_vault.ldev_dice_ecc_signature()
 }
 
@@ -42,8 +42,8 @@ pub fn ldevid_dice_sign(persistent_data: &PersistentData) -> Ecc384Signature {
 ///
 /// # Returns
 ///
-/// * `Mldsa87Signature` - The formed signature
-pub fn ldevid_dice_mldsa87_sign(persistent_data: &PersistentData) -> Mldsa87Signature {
+/// * `&Mldsa87Signature` - The formed signature
+pub fn ldevid_dice_mldsa87_sign(persistent_data: &PersistentData) -> &Mldsa87Signature {
     persistent_data.rom.data_vault.ldev_dice_mldsa_signature()
 }
 
@@ -158,7 +158,7 @@ pub fn copy_ldevid_ecc384_cert(
         .ecc_ldevid_tbs
         .get(..persistent_data.rom.fht.ecc_ldevid_tbs_size.into());
     let sig = ldevid_dice_sign(persistent_data);
-    ecc384_cert_from_tbs_and_sig(tbs, &sig, cert).map_err(|_| CaliptraError::GET_LDEVID_CERT_FAILED)
+    ecc384_cert_from_tbs_and_sig(tbs, sig, cert).map_err(|_| CaliptraError::GET_LDEVID_CERT_FAILED)
 }
 
 /// Copy MLDSA LDevID certificate produced by ROM to `cert` buffer
@@ -181,7 +181,7 @@ pub fn copy_ldevid_mldsa87_cert(
         .mldsa_ldevid_tbs
         .get(..persistent_data.rom.fht.mldsa_ldevid_tbs_size.into());
     let sig = ldevid_dice_mldsa87_sign(persistent_data);
-    mldsa87_cert_from_tbs_and_sig(tbs, &sig, cert)
+    mldsa87_cert_from_tbs_and_sig(tbs, sig, cert)
         .map_err(|_| CaliptraError::GET_LDEVID_CERT_FAILED)
 }
 

--- a/drivers/src/data_vault.rs
+++ b/drivers/src/data_vault.rs
@@ -72,8 +72,8 @@ impl DataVault {
     /// # Returns
     ///     ldev dice ECC signature
     ///
-    pub fn ldev_dice_ecc_signature(&self) -> Ecc384Signature {
-        self.cold_reset_entries.ldev_dice_ecc_sig
+    pub fn ldev_dice_ecc_signature(&self) -> &Ecc384Signature {
+        &self.cold_reset_entries.ldev_dice_ecc_sig
     }
 
     /// Set the ldev dice ECC public key.
@@ -90,8 +90,8 @@ impl DataVault {
     /// # Returns
     /// * ldev dice ECC public key
     ///
-    pub fn ldev_dice_ecc_pub_key(&self) -> Ecc384PubKey {
-        self.cold_reset_entries.ldev_dice_ecc_pk
+    pub fn ldev_dice_ecc_pub_key(&self) -> &Ecc384PubKey {
+        &self.cold_reset_entries.ldev_dice_ecc_pk
     }
 
     /// Set the fmc dice ECC signature.
@@ -108,8 +108,8 @@ impl DataVault {
     /// # Returns
     /// * fmc dice ECC signature
     ///
-    pub fn fmc_dice_ecc_signature(&self) -> Ecc384Signature {
-        self.cold_reset_entries.fmc_dice_ecc_sig
+    pub fn fmc_dice_ecc_signature(&self) -> &Ecc384Signature {
+        &self.cold_reset_entries.fmc_dice_ecc_sig
     }
 
     /// Set the fmc ECC public key.
@@ -126,8 +126,8 @@ impl DataVault {
     /// # Returns
     /// * fmc ECC public key
     ///
-    pub fn fmc_ecc_pub_key(&self) -> Ecc384PubKey {
-        self.cold_reset_entries.fmc_ecc_pk
+    pub fn fmc_ecc_pub_key(&self) -> &Ecc384PubKey {
+        &self.cold_reset_entries.fmc_ecc_pk
     }
 
     /// Set the ldev dice MLDSA signature.
@@ -144,8 +144,8 @@ impl DataVault {
     /// # Returns
     /// * ldev dice MLDSA signature
     ///
-    pub fn ldev_dice_mldsa_signature(&self) -> Mldsa87Signature {
-        self.cold_reset_entries.ldev_dice_mldsa_sig
+    pub fn ldev_dice_mldsa_signature(&self) -> &Mldsa87Signature {
+        &self.cold_reset_entries.ldev_dice_mldsa_sig
     }
 
     /// Set the ldev dice MLDSA public key.
@@ -162,8 +162,8 @@ impl DataVault {
     /// # Returns
     /// * ldev dice MLDSA public key
     ///
-    pub fn ldev_dice_mldsa_pub_key(&self) -> Mldsa87PubKey {
-        self.cold_reset_entries.ldev_dice_mldsa_pk
+    pub fn ldev_dice_mldsa_pub_key(&self) -> &Mldsa87PubKey {
+        &self.cold_reset_entries.ldev_dice_mldsa_pk
     }
 
     /// Set the fmc dice MLDSA signature.
@@ -180,8 +180,8 @@ impl DataVault {
     /// # Returns
     /// * fmc dice MLDSA signature
     ///
-    pub fn fmc_dice_mldsa_signature(&self) -> Mldsa87Signature {
-        self.cold_reset_entries.fmc_dice_mldsa_sig
+    pub fn fmc_dice_mldsa_signature(&self) -> &Mldsa87Signature {
+        &self.cold_reset_entries.fmc_dice_mldsa_sig
     }
 
     /// Set the fmc MLDSA public key.
@@ -198,8 +198,8 @@ impl DataVault {
     /// # Returns
     /// * fmc MLDSA public key
     ///
-    pub fn fmc_mldsa_pub_key(&self) -> Mldsa87PubKey {
-        self.cold_reset_entries.fmc_mldsa_pk
+    pub fn fmc_mldsa_pub_key(&self) -> &Mldsa87PubKey {
+        &self.cold_reset_entries.fmc_mldsa_pk
     }
 
     /// Set the fmc tcb component identifier.

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -40,11 +40,11 @@ impl Ecdsa384SignatureAdapter for Ecc384Signature {
 ///
 /// * `DiceInput` - DICE Layer Input
 fn dice_output_from_hand_off(env: &mut FmcEnv) -> CaliptraResult<DiceOutput> {
-    let ecc_auth_pub = HandOff::fmc_ecc_pub_key(env);
+    let ecc_auth_pub = *HandOff::fmc_ecc_pub_key(env);
     let ecc_subj_sn = x509::subj_sn(&mut env.sha256, &PubKey::Ecc(&ecc_auth_pub))?;
     let ecc_subj_key_id = x509::subj_key_id(&mut env.sha256, &PubKey::Ecc(&ecc_auth_pub))?;
 
-    let mldsa_auth_pub = HandOff::fmc_mldsa_pub_key(env);
+    let mldsa_auth_pub = *HandOff::fmc_mldsa_pub_key(env);
     let mldsa_subj_sn = x509::subj_sn(&mut env.sha256, &PubKey::Mldsa(&mldsa_auth_pub))?;
     let mldsa_subj_key_id = x509::subj_key_id(&mut env.sha256, &PubKey::Mldsa(&mldsa_auth_pub))?;
 

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -173,11 +173,11 @@ impl RtAliasLayer {
                 (
                     Ecc384KeyPair {
                         priv_key: HandOff::fmc_ecc_priv_key(env),
-                        pub_key: HandOff::fmc_ecc_pub_key(env),
+                        pub_key: *HandOff::fmc_ecc_pub_key(env),
                     },
                     MlDsaKeyPair {
                         key_pair_seed: HandOff::fmc_mldsa_keypair_seed_key(env),
-                        pub_key: HandOff::fmc_mldsa_pub_key(env),
+                        pub_key: *HandOff::fmc_mldsa_pub_key(env),
                     },
                 )
             };

--- a/fmc/src/hand_off.rs
+++ b/fmc/src/hand_off.rs
@@ -64,7 +64,7 @@ impl HandOff {
     /// # Returns
     /// * fmc ECC public key
     ///
-    pub fn fmc_ecc_pub_key(env: &FmcEnv) -> Ecc384PubKey {
+    pub fn fmc_ecc_pub_key(env: &FmcEnv) -> &Ecc384PubKey {
         env.persistent_data.get().rom.data_vault.fmc_ecc_pub_key()
     }
 
@@ -73,7 +73,7 @@ impl HandOff {
     /// # Returns
     /// * fmc MLDSA public key
     ///
-    pub fn fmc_mldsa_pub_key(env: &FmcEnv) -> Mldsa87PubKey {
+    pub fn fmc_mldsa_pub_key(env: &FmcEnv) -> &Mldsa87PubKey {
         env.persistent_data.get().rom.data_vault.fmc_mldsa_pub_key()
     }
 

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -197,8 +197,8 @@ impl GetRtAliasCertCmd {
 ///
 /// # Returns
 ///
-/// * `Ecc384Signature` - The formed signature
-pub fn fmc_dice_sign(persistent_data: &PersistentData) -> Ecc384Signature {
+/// * `&Ecc384Signature` - The formed signature
+pub fn fmc_dice_sign(persistent_data: &PersistentData) -> &Ecc384Signature {
     persistent_data.rom.data_vault.fmc_dice_ecc_signature()
 }
 
@@ -210,8 +210,8 @@ pub fn fmc_dice_sign(persistent_data: &PersistentData) -> Ecc384Signature {
 ///
 /// # Returns
 ///
-/// * `Mldsa87Signature` - The formed signature
-pub fn fmc_dice_sign_mldsa87(persistent_data: &PersistentData) -> Mldsa87Signature {
+/// * `&Mldsa87Signature` - The formed signature
+pub fn fmc_dice_sign_mldsa87(persistent_data: &PersistentData) -> &Mldsa87Signature {
     persistent_data.rom.data_vault.fmc_dice_mldsa_signature()
 }
 
@@ -235,7 +235,7 @@ pub fn copy_fmc_alias_ecc384_cert(
         .ecc_fmcalias_tbs
         .get(..persistent_data.rom.fht.ecc_fmcalias_tbs_size.into());
     let sig = fmc_dice_sign(persistent_data);
-    ecc384_cert_from_tbs_and_sig(tbs, &sig, cert)
+    ecc384_cert_from_tbs_and_sig(tbs, sig, cert)
         .map_err(|_| CaliptraError::RUNTIME_GET_FMC_ALIAS_CERT_FAILED)
 }
 
@@ -259,7 +259,7 @@ pub fn copy_fmc_alias_mldsa87_cert(
         .mldsa_fmcalias_tbs
         .get(..persistent_data.rom.fht.mldsa_fmcalias_tbs_size.into());
     let sig = fmc_dice_sign_mldsa87(persistent_data);
-    mldsa87_cert_from_tbs_and_sig(tbs, &sig, cert)
+    mldsa87_cert_from_tbs_and_sig(tbs, sig, cert)
         .map_err(|_| CaliptraError::RUNTIME_GET_FMC_ALIAS_CERT_FAILED)
 }
 


### PR DESCRIPTION
These are some pretty big objects that have essentially a static lifetime.

Code that depends on it doesn't necessarily have to put them on the stack. This commit just clones the data, but other features that use this data should see stack savings.

This closes https://github.com/chipsalliance/caliptra-sw/issues/3400