### PR TITLE
[OCP-LOCK]: Re-add ROM logs after space savings

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-f19e5bb62c69092de823d30e02465d2a8f5847157268145145d1eb21f02f53cd0a65cc81f3b850f5cb347c915c21c231  caliptra-rom-no-log.bin
-e88e0c32e6efffc7e3be73383d67863ec3277c29a03e964ef8beb5cd2bca443b5aae0b9931833c6507b37678e87db5c0  caliptra-rom-with-log.bin
+ce9218a2f5a29bd369c0b531efe1e30187164f739b32af64828cea7980a5139f32c5b033919a018428791f856bf7688b  caliptra-rom-no-log.bin
+be37c582ac78dfc5b625f5a474e8aeea3dfebef7cc9335d582a527447eb37f0ba10a0523bdc45f1d0dd881dad1cd97e9  caliptra-rom-with-log.bin

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -128,20 +128,18 @@ pub extern "C" fn rom_entry() -> ! {
         handle_fatal_error(CaliptraError::ROM_GLOBAL_FAKE_ROM_IN_PRODUCTION.into());
     }
 
-    // TODO(clundin): Re-add after more code savings https://github.com/chipsalliance/caliptra-sw/pull/3073
-    // cprintln!(
-    //     "[state] DebugLocked = {}",
-    //     if env.soc_ifc.debug_locked() {
-    //         "Yes"
-    //     } else {
-    //         "No"
-    //     }
-    // );
+    cprintln!(
+        "[state] DebugLocked = {}",
+        if env.soc_ifc.debug_locked() {
+            "Yes"
+        } else {
+            "No"
+        }
+    );
 
-    // TODO(clundin): Re-add after more code savings https://github.com/chipsalliance/caliptra-sw/pull/3073
-    // if env.soc_ifc.ocp_lock_enabled() {
-    //     cprintln!("[ROM] OCP-LOCK Supported");
-    // }
+    if env.soc_ifc.ocp_lock_enabled() {
+        cprintln!("[ROM] OCP-LOCK Supported");
+    }
 
     // Set the ROM version
     let rom_info = unsafe { &CALIPTRA_ROM_INFO };


### PR DESCRIPTION
This resolves https://github.com/chipsalliance/caliptra-sw/issues/3092