### PR TITLE
Fix to issue #3408:  [Runtime]: Packet::get_from_mbox does not validate dlen against mailbox SRAM size

### DIFF
--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -36,6 +36,11 @@ impl Packet {
         // Get reference to raw mailbox contents
         let raw_data = mbox.raw_mailbox_contents();
 
+        // Bounds check: dlen must not exceed the mailbox SRAM size
+        if dlen > raw_data.len() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        }
+
         // Create the packet with raw pointers to the mailbox data
         let packet = Packet {
             cmd: cmd.into(),
@@ -75,7 +80,8 @@ impl Packet {
     pub fn payload(&self) -> &[u8] {
         unsafe {
             // Safety: This is safe because:
-            // 1. None of the mailbox request handlers use the mailbox in a way that
+            // 1. payload_len is bounds-checked against the mailbox SRAM size in get_from_mbox().
+            // 2. None of the mailbox request handlers use the mailbox in a way that
             //    modifies the mailbox sram content before sending back a reply.
             core::slice::from_raw_parts(self.payload_ptr, self.payload_len)
         }


### PR DESCRIPTION
Packet::get_from_mbox reads dlen from the mailbox register and uses it to construct a raw pointer slice into mailbox SRAM, but did not verify that dlen falls within the SRAM bounds. A malformed or malicious dlen value could cause an out-of-bounds read when the payload is later accessed via Packet::payload().

Added a bounds check that returns RUNTIME_MAILBOX_INVALID_PARAMS if dlen exceeds the mailbox SRAM size, and update the safety comment on payload() to document this invariant.

