### PR TITLE
[dpe] Fail early for response sizing

### DIFF
--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,14 +12,14 @@ Abstract:
 
 --*/
 
-use crate::{ec_dpe_env, mldsa_dpe_env, mutrefbytes, AxiAddr, Drivers, PauserPrivileges};
+use crate::{ec_dpe_env, mldsa_dpe_env, AxiAddr, Drivers, PauserPrivileges};
 use arrayvec::ArrayVec;
 use caliptra_api::mailbox::{
     populate_checksum, AxiResponseInfo, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req,
-    MailboxReqHeader, MailboxRespHeader,
+    MailboxReqHeader, MailboxRespHeader, SUBSYSTEM_MAILBOX_SIZE_LIMIT,
 };
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, ResponseVarSize};
+use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp};
 use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult};
 use dpe::{
     commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
@@ -98,6 +98,23 @@ impl InvokeDpeCmd {
         if cmd.flags.external_axi_response() && !drivers.soc_ifc.subsystem_mode() {
             return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
+
+        // Trim the response buffer to the correct size. If the response doesn't fit, it will fail
+        // during DPE execution and not at the transport layer. This is especially important for DPE
+        // handle rotation so the caller doesn't lose the handle.
+        let mbox_resp = if drivers.soc_ifc.subsystem_mode() {
+            let len = if cmd.flags.external_axi_response() {
+                usize::min(mbox_resp.len(), cmd.axi_response.max_size as usize)
+            } else {
+                // The mailbox size is smaller when subsystem is enabled
+                usize::min(mbox_resp.len(), SUBSYSTEM_MAILBOX_SIZE_LIMIT)
+            };
+            mbox_resp
+                .get_mut(..len)
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
+        } else {
+            mbox_resp
+        };
 
         // Execute the DPE command and get the length of the response that was written
         let len = Self::execute(drivers, dpe_cmd_buf, mbox_resp, CaliptraDpeProfile::Mldsa87)?;
@@ -209,8 +226,12 @@ impl InvokeDpeCmd {
         };
 
         let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
-        let invoke_resp = mutrefbytes::<InvokeDpeResp>(mbox_resp)?;
-        let result = invoke_dpe_cmd(profile, drivers, command, None, ueid, &mut invoke_resp.data);
+        let (invoke_resp, data) = InvokeDpeRespHeader::mut_from_prefix(mbox_resp)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        if data.len() < core::mem::size_of::<ResponseHdr>() {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+        let result = invoke_dpe_cmd(profile, drivers, command, None, ueid, data);
 
         if let Command::DestroyCtx(_) = command {
             // clear tags for destroyed contexts
@@ -233,14 +254,13 @@ impl InvokeDpeCmd {
                     drivers.soc_ifc.set_fw_extended_error(ext_err);
                 }
                 let r = ResponseHdr::new(profile.into(), *e);
-                invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
-                    .copy_from_slice(r.as_bytes());
-                let data_size = r.as_bytes().len();
-                invoke_resp.data_size = data_size as u32;
+                data[..core::mem::size_of::<ResponseHdr>()].copy_from_slice(r.as_bytes());
+                invoke_resp.data_size = r.as_bytes().len() as u32;
             }
         };
 
-        invoke_resp.partial_len()
+        Ok(size_of::<InvokeDpeResp>() - InvokeDpeResp::DATA_MAX_SIZE
+            + invoke_resp.data_size as usize)
     }
 
     /// Remove context tags for all inactive DPE contexts
@@ -341,4 +361,15 @@ struct InvokeDpeMldsa87Header {
 const _: () = assert!(
     size_of::<InvokeDpeMldsa87Header>()
         == size_of::<InvokeDpeMldsa87Req>() - InvokeDpeMldsa87Req::DATA_MAX_SIZE
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub data_size: u32,
+}
+
+const _: () = assert!(
+    size_of::<InvokeDpeRespHeader>() == size_of::<InvokeDpeResp>() - InvokeDpeResp::DATA_MAX_SIZE
 );

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -358,7 +358,7 @@ pub fn generate_test_x509_cert(private_key: &PKey<Private>) -> X509 {
     cert_builder.build()
 }
 
-fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
+pub fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
     if let Ok(&ResponseHdr { status, .. }) =
         ResponseHdr::try_ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
     {
@@ -407,15 +407,53 @@ pub fn execute_dpe_cmd(
         ) => flags.exports_cdi(),
         _ => false,
     };
-    let (flags, addr_lo, addr_hi) = if external_response {
+    let external_response_info = if external_response {
         let addr = model.staging_physical_address().unwrap();
+        Some(AxiResponseInfo {
+            addr_lo: addr as u32,
+            addr_hi: (addr >> 32) as u32,
+            max_size: size_of::<InvokeDpeResp>() as u32,
+        })
+    } else {
+        None
+    };
+    let resp = execute_dpe_cmd_raw(model, profile, dpe_cmd, external_response_info);
+    if let DpeResult::MboxCmdFailure(expected_err) = expected_result {
+        assert_error(model, expected_err, resp.unwrap_err());
+        return None;
+    }
+    let resp = resp.unwrap();
+
+    let resp_bytes = &resp.data[..resp.data_size as usize];
+    Some(match expected_result {
+        DpeResult::Success => {
+            // Peek response header so we can panic with an error code in case the command failed.
+            check_dpe_status(resp_bytes, DpeErrorCode::NoError);
+            Response::try_read_from_bytes(dpe_cmd, resp_bytes).unwrap()
+        },
+        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap()),
+        DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
+    })
+}
+
+pub fn execute_dpe_cmd_raw(
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+    dpe_cmd: &mut Command,
+    external_response_info: Option<AxiResponseInfo>,
+) -> Result<InvokeDpeResp, ModelError> {
+    let external_response = external_response_info.is_some();
+    let (flags, axi_response) = if let Some(info) = external_response_info {
         (
             InvokeDpeMldsa87Flags::EXTERNAL_AXI_RESPONSE,
-            addr as u32,
-            (addr >> 32) as u32,
+            AxiResponseInfo {
+                addr_lo: info.addr_lo,
+                addr_hi: info.addr_hi,
+                max_size: info.max_size,
+            },
         )
     } else {
-        (InvokeDpeMldsa87Flags::empty(), 0, 0)
+        (InvokeDpeMldsa87Flags::empty(), AxiResponseInfo::default())
     };
 
     // Fill the request buffer with the correct info
@@ -441,11 +479,7 @@ pub fn execute_dpe_cmd(
             MailboxReq::InvokeDpeMldsa87Command(InvokeDpeMldsa87Req {
                 hdr: MailboxReqHeader { chksum: 0 },
                 flags,
-                axi_response: AxiResponseInfo {
-                    addr_lo,
-                    addr_hi,
-                    max_size: size_of::<InvokeDpeResp>() as u32,
-                },
+                axi_response,
                 data: cmd_data,
                 data_size: (cmd_hdr_buf.len() + dpe_cmd_buf.len()) as u32,
             }),
@@ -453,13 +487,9 @@ pub fn execute_dpe_cmd(
     };
     mbox_cmd.populate_chksum().unwrap();
 
-    let resp = model.mailbox_execute(u32::from(cmd_id), mbox_cmd.as_bytes().unwrap());
-    if let DpeResult::MboxCmdFailure(expected_err) = expected_result {
-        assert_error(model, expected_err, resp.unwrap_err());
-        return None;
-    }
+    let resp = model.mailbox_execute(u32::from(cmd_id), mbox_cmd.as_bytes().unwrap())?;
     // The external mailbox command also sends the mailbox header so we always expect something.
-    let resp = resp.unwrap().expect("We should have received a response");
+    let resp = resp.expect("We should have received a response");
     check_header_checksum(&resp).unwrap();
 
     let mut resp_hdr = InvokeDpeResp::default();
@@ -473,17 +503,7 @@ pub fn execute_dpe_cmd(
         resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
         check_header_checksum(resp_hdr.as_bytes_partial().unwrap()).unwrap();
     };
-
-    let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
-    Some(match expected_result {
-        DpeResult::Success => {
-            // Peek response header so we can panic with an error code in case the command failed.
-            check_dpe_status(resp_bytes, DpeErrorCode::NoError);
-            Response::try_read_from_bytes(dpe_cmd, resp_bytes).unwrap()
-        },
-        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap()),
-        DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
-    })
+    Ok(resp_hdr)
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -1,9 +1,10 @@
 // Licensed under the Apache-2.0 license.
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_ecc384_cert, get_rt_alias_mldsa87_cert, run_rt_test,
-    CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, CreateSignCmdArgs, DpeResult, RuntimeTestArgs,
-    SignCommandNoRef, TEST_MU, TEST_SD_MU, TEST_SD_SHA384,
+    check_dpe_status, execute_dpe_cmd, execute_dpe_cmd_raw, get_rt_alias_ecc384_cert,
+    get_rt_alias_mldsa87_cert, run_rt_test, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs,
+    CreateSignCmdArgs, DpeResult, RuntimeTestArgs, SignCommandNoRef, TEST_MU, TEST_SD_MU,
+    TEST_SD_SHA384,
 };
 use caliptra_api::{
     mailbox::{AxiResponseInfo, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req},
@@ -194,6 +195,8 @@ fn sign_and_certify_key_test_helper(model: &mut DefaultHwModel) {
 }
 
 #[test]
+// This test is the same as test_invoke_dpe_sign_and_certify_key_cmds_with_subsystem on a subsystem FPGA
+#[cfg_attr(feature = "fpga_subsystem", ignore)]
 fn test_invoke_dpe_sign_and_certify_key_cmds() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     sign_and_certify_key_test_helper(&mut model);
@@ -563,4 +566,60 @@ fn test_export_cdi_destroyed_root_context() {
             30_000_000,
         );
     }
+}
+
+#[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+fn test_subsystem_response_buffer_limits() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        ..Default::default()
+    });
+
+    // The ECC384 command should succeed because it can't exceed the size of the mailbox
+    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile: CaliptraDpeProfile::Ecc384,
+        ..Default::default()
+    });
+    let _resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Ecc384,
+        &mut Command::from(&certify_key_cmd),
+        DpeResult::Success,
+    )
+    .unwrap();
+
+    // The ML-DSA command should fail because it can easily surpass the size of the mailbox
+    let profile = CaliptraDpeProfile::Mldsa87;
+    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile,
+        ..Default::default()
+    });
+    let resp = execute_dpe_cmd_raw(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&certify_key_cmd),
+        None,
+    )
+    .unwrap();
+
+    let resp_bytes = resp.as_bytes_partial().unwrap();
+    check_dpe_status(resp_bytes, DpeErrorCode::InvalidMutRefBuf);
+
+    // Set the AXI size too small to ensure there is an error there too
+    let addr = model.staging_physical_address().unwrap();
+    let resp = execute_dpe_cmd_raw(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&certify_key_cmd),
+        Some(AxiResponseInfo {
+            addr_lo: addr as u32,
+            addr_hi: (addr >> 32) as u32,
+            max_size: 16 * 1024,
+        }),
+    )
+    .unwrap();
+
+    let resp_bytes = resp.as_bytes_partial().unwrap();
+    check_dpe_status(resp_bytes, DpeErrorCode::InvalidMutRefBuf);
 }


### PR DESCRIPTION
This change will make sure the DPE commands fail during execution instead of after execution during the transport layer. When dealing with a non-default DPE context, the context handle changes after each operation. If a DPE operation succeeds but fails at the transport layer, the caller could lose access to the context.