### PR TITLE
[EAT] Support class-id-type-choice per CoRIM spec

### DIFF
--- a/common/eat/src/cbor.rs
+++ b/common/eat/src/cbor.rs
@@ -34,6 +34,7 @@ pub mod tag {
     pub const SELF_DESCRIBED_CBOR: u64 = 55799;
     pub const OID: u64 = 111;
     pub const UUID: u64 = 37;
+    pub const BYTES: u64 = 560;
 }
 
 /// Construct a CBOR initial byte from major type and additional info
@@ -414,6 +415,43 @@ impl CborEncodable for TaggedUuid<'_> {
         // Tag 37 for UUID (RFC 9562 Section 4)
         encoder.encode_tag(tag::UUID)?;
         encoder.encode_bytes(self.uuid)?;
+        Ok(())
+    }
+}
+
+/// CBOR-tagged Bytes
+///
+/// Encodes arbitrary byte strings using CBOR tag 560 as specified in
+/// the CoRIM specification for tagged-bytes.
+///
+/// # CBOR Encoding
+///
+/// The structure is encoded as:
+/// - Tag 560 (CBOR tag for tagged-bytes)
+/// - Byte string containing the raw bytes
+#[derive(Debug, Clone, Copy)]
+pub struct TaggedBytes<'a> {
+    /// Raw byte content
+    pub bytes: &'a [u8],
+}
+
+impl<'a> TaggedBytes<'a> {
+    /// Create a new tagged bytes value
+    ///
+    /// # Arguments
+    /// * `bytes` - The raw byte content
+    pub const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl CborEncodable for TaggedBytes<'_> {
+    /// Encode the tagged bytes to CBOR
+    ///
+    /// Produces: tag(560) followed by byte string
+    fn encode(&self, encoder: &mut CborEncoder) -> Result<(), EatError> {
+        encoder.encode_tag(tag::BYTES)?;
+        encoder.encode_bytes(self.bytes)?;
         Ok(())
     }
 }
@@ -811,6 +849,97 @@ mod tests {
         assert_eq!(buffer[2], 0x59); // Byte string major type with 2-byte length
         assert_eq!(buffer[3], 0x01); // High byte of length (256 + 44 = 300)
         assert_eq!(buffer[4], 0x2C); // Low byte of length
+    }
+
+    #[test]
+    fn test_tagged_bytes_encode() {
+        // Test TaggedBytes encoding with tag 560
+        let data = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let tagged_bytes = TaggedBytes::new(data);
+
+        let mut buffer = [0u8; 32];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        tagged_bytes.encode(&mut encoder).expect("Encoding failed");
+
+        let encoded_len = encoder.len();
+
+        // Expected: tag(560) + bytes(8)
+        // Tag 560 = 0xD9 0x02 0x30 (3 bytes, major type 6 with 2-byte value)
+        // Bytes header for 8 bytes = 0x48 (1 byte)
+        // 8 bytes of data
+        // Total: 3 + 1 + 8 = 12 bytes
+        assert_eq!(encoded_len, 12);
+
+        // Verify tag 560 encoding
+        assert_eq!(buffer[0], 0xD9); // Tag major type (6) with additional info 25 (2-byte value)
+        assert_eq!(buffer[1], 0x02); // High byte of 560
+        assert_eq!(buffer[2], 0x30); // Low byte of 560
+
+        // Verify byte string header
+        assert_eq!(buffer[3], 0x48); // Byte string (major type 2) with length 8
+
+        // Verify data bytes
+        assert_eq!(&buffer[4..12], data);
+    }
+
+    #[test]
+    fn test_tagged_bytes_empty() {
+        // Empty bytes
+        let data: &[u8] = &[];
+        let tagged_bytes = TaggedBytes::new(data);
+
+        let mut buffer = [0u8; 16];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        tagged_bytes
+            .encode(&mut encoder)
+            .expect("Empty bytes should encode");
+
+        // Tag 560 (3 bytes) + empty byte string (1 byte) = 4 bytes
+        assert_eq!(encoder.len(), 4);
+        assert_eq!(buffer[0], 0xD9);
+        assert_eq!(buffer[1], 0x02);
+        assert_eq!(buffer[2], 0x30);
+        assert_eq!(buffer[3], 0x40); // Byte string with length 0
+    }
+
+    #[test]
+    fn test_tagged_bytes_creation() {
+        let data = &[0xDE, 0xAD, 0xBE, 0xEF];
+        let tagged_bytes = TaggedBytes::new(data);
+        assert_eq!(tagged_bytes.bytes, data);
+    }
+
+    #[test]
+    fn test_tagged_bytes_buffer_too_small() {
+        let data = &[0xAB; 16];
+        let tagged_bytes = TaggedBytes::new(data);
+
+        // Buffer too small to hold tag(3) + header(1) + data(16) = 20 bytes
+        let mut buffer = [0u8; 10];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        let result = tagged_bytes.encode(&mut encoder);
+
+        assert!(result.is_err());
+        assert!(matches!(result, Err(EatError::BufferTooSmall)));
+    }
+
+    #[test]
+    fn test_tagged_bytes_large() {
+        // Large payload testing 2-byte length encoding
+        let data = &[0xCC; 100];
+        let tagged_bytes = TaggedBytes::new(data);
+
+        let mut buffer = [0u8; 128];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        tagged_bytes.encode(&mut encoder).expect("Encoding failed");
+
+        // Tag 560 (3 bytes) + byte string header (2 bytes for length 100) + 100 bytes = 105 bytes
+        assert_eq!(encoder.len(), 105);
+        assert_eq!(buffer[0], 0xD9);
+        assert_eq!(buffer[1], 0x02);
+        assert_eq!(buffer[2], 0x30);
+        assert_eq!(buffer[3], 0x58); // Byte string major type with 1-byte length
+        assert_eq!(buffer[4], 100); // Length = 100
     }
 
     #[test]

--- a/common/eat/src/lib.rs
+++ b/common/eat/src/lib.rs
@@ -18,8 +18,9 @@
 //!
 //! ```rust,no_run
 //! use ocp_eat::{
-//!     ConciseEvidenceMap, EnvironmentMap, ClassMap, MeasurementMap,
-//!     MeasurementValue, MeasurementFormat, EvidenceTripleRecord, EvTriplesMap, ConciseEvidence
+//!     ConciseEvidenceMap, EnvironmentMap, ClassMap, ClassIdTypeChoice, TaggedOid,
+//!     MeasurementMap, MeasurementValue, MeasurementFormat, EvidenceTripleRecord,
+//!     EvTriplesMap, ConciseEvidence
 //! };
 //!
 //! // Create structured evidence
@@ -27,7 +28,7 @@
 //! let evidence_triple = EvidenceTripleRecord {
 //!     environment: EnvironmentMap {
 //!         class: ClassMap {
-//!             class_id: "example-device",
+//!             class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"example-device")),
 //!             vendor: Some("Example Corp"),
 //!             model: Some("Device-v1.0"),
 //!         },
@@ -77,7 +78,7 @@ pub mod cbor_tags {
 pub use error::EatError;
 
 // Re-export CBOR encoder, trait, and common CBOR types for custom encoding
-pub use cbor::{CborEncodable, CborEncoder, TaggedOid, TaggedUuid};
+pub use cbor::{CborEncodable, CborEncoder, TaggedBytes, TaggedOid, TaggedUuid};
 
 // Re-export standard EAT/CWT claim keys (RFC 8392, RFC 9711)
 // These are shared across both OCP Profile EAT and CSR EAT
@@ -98,6 +99,7 @@ pub use cose::{
 // Reference: https://opencomputeproject.github.io/Security/ietf-eat-profile/HEAD/
 pub use ocp_profile::{
     // Evidence structures (RATS CoRIM format)
+    ClassIdTypeChoice,  // Class ID type choice (tagged OID, UUID, or bytes)
     ClassMap,           // Device class identification
     ConciseEvidence,    // Top-level evidence container (tagged or map)
     ConciseEvidenceMap, // Evidence map with triples

--- a/common/eat/src/main.rs
+++ b/common/eat/src/main.rs
@@ -17,9 +17,9 @@ use ocp_eat::{
 
 #[cfg(feature = "crypto")]
 use ocp_eat::ocp_profile::{
-    ClassMap, ConciseEvidence, ConciseEvidenceMap, DebugStatus, DigestEntry, EnvironmentMap,
-    EvTriplesMap, EvidenceTripleRecord, MeasurementFormat, MeasurementMap, MeasurementValue,
-    OcpEatClaims, TaggedConciseEvidence,
+    ClassIdTypeChoice, ClassMap, ConciseEvidence, ConciseEvidenceMap, DebugStatus, DigestEntry,
+    EnvironmentMap, EvTriplesMap, EvidenceTripleRecord, MeasurementFormat, MeasurementMap,
+    MeasurementValue, OcpEatClaims, TaggedConciseEvidence,
 };
 
 // Cryptographic imports for signature generation (only available with crypto feature)
@@ -322,7 +322,7 @@ fn create_mock_concise_evidence_structured() -> ConciseEvidence<'static> {
     // Create RATS CoRIM compliant evidence structure with 2 environments
     static ENVIRONMENT_MAP_1: EnvironmentMap<'static> = EnvironmentMap {
         class: ClassMap {
-            class_id: "0x0001",
+            class_id: ClassIdTypeChoice::TaggedOid(ocp_eat::TaggedOid::new(b"0x0001")),
             vendor: Some("Example Corp"),
             model: Some("ExampleChip-v1.0"),
         },
@@ -330,7 +330,7 @@ fn create_mock_concise_evidence_structured() -> ConciseEvidence<'static> {
 
     static ENVIRONMENT_MAP_2: EnvironmentMap<'static> = EnvironmentMap {
         class: ClassMap {
-            class_id: "0x0002",
+            class_id: ClassIdTypeChoice::TaggedOid(ocp_eat::TaggedOid::new(b"0x0002")),
             vendor: Some("Example Corp"),
             model: Some("ExampleChip-v1.0"),
         },

--- a/common/eat/src/ocp_profile/concise_evidence.rs
+++ b/common/eat/src/ocp_profile/concise_evidence.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 // Concise Evidence structures and encoding for RATS CoRIM compliance
-use crate::cbor::{CborEncodable, CborEncoder, TaggedOid, TaggedUuid};
+use crate::cbor::{CborEncodable, CborEncoder, TaggedBytes, TaggedOid, TaggedUuid};
 use crate::error::EatError;
 
 // CBOR tag for tagged concise evidence
@@ -184,9 +184,30 @@ impl CborEncodable for MeasurementMap<'_> {
     }
 }
 
+/// Class ID type choice per CoRIM specification:
+/// $class-id-type-choice /= tagged-oid-type    ; #6.111(bstr)
+/// $class-id-type-choice /= tagged-uuid-type   ; #6.37(bstr .size 16)
+/// $class-id-type-choice /= tagged-bytes       ; #6.560(bstr)
+#[derive(Debug, Clone, Copy)]
+pub enum ClassIdTypeChoice<'a> {
+    TaggedOid(TaggedOid<'a>),
+    TaggedUuid(TaggedUuid<'a>),
+    TaggedBytes(TaggedBytes<'a>),
+}
+
+impl CborEncodable for ClassIdTypeChoice<'_> {
+    fn encode(&self, encoder: &mut CborEncoder) -> Result<(), EatError> {
+        match self {
+            ClassIdTypeChoice::TaggedOid(oid) => oid.encode(encoder),
+            ClassIdTypeChoice::TaggedUuid(uuid) => uuid.encode(encoder),
+            ClassIdTypeChoice::TaggedBytes(bytes) => bytes.encode(encoder),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ClassMap<'a> {
-    pub class_id: &'a str,
+    pub class_id: ClassIdTypeChoice<'a>,
     pub vendor: Option<&'a str>,
     pub model: Option<&'a str>,
 }
@@ -203,13 +224,9 @@ impl CborEncodable for ClassMap<'_> {
 
         encoder.encode_map_header(entries)?;
 
-        // Key 0: class-id (mandatory)
+        // Key 0: class-id (mandatory) - encoded per class-id-type-choice
         encoder.encode_int(0)?;
-        // For now, treat class_id as a text string that should be encoded as tagged OID
-        // In a real implementation, you'd parse the OID string and encode it properly
-        // Tag 111 is for OID as per CBOR spec
-        encoder.encode_tag(111)?;
-        encoder.encode_bytes(self.class_id.as_bytes())?;
+        self.class_id.encode(encoder)?;
 
         // Key 1: vendor (optional)
         if let Some(vendor) = self.vendor {
@@ -849,7 +866,7 @@ mod tests {
     #[test]
     fn test_class_map_minimal() {
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.9999",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.9999")),
             vendor: None,
             model: None,
         };
@@ -876,9 +893,76 @@ mod tests {
     }
 
     #[test]
+    fn test_class_map_with_tagged_uuid() {
+        let uuid = [
+            0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44,
+            0x00, 0x00,
+        ];
+        let class_map = ClassMap {
+            class_id: ClassIdTypeChoice::TaggedUuid(TaggedUuid::new(&uuid)),
+            vendor: Some("UUID Corp"),
+            model: None,
+        };
+
+        let mut buffer = [0u8; 128];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        class_map.encode(&mut encoder).expect("Encoding failed");
+
+        let encoded_len = encoder.len();
+
+        // Expected: map(2) + key(0) + tag(37) + uuid(16) + key(1) + vendor
+        let expected_size = CborEncoder::estimate_uint_size(2) + // map header
+                           CborEncoder::estimate_uint_size(0) + // key 0
+                           CborEncoder::estimate_uint_size(37) + // tag 37
+                           CborEncoder::estimate_bytes_string_size(16) + // uuid
+                           CborEncoder::estimate_uint_size(1) + // key 1
+                           CborEncoder::estimate_text_string_size(9); // vendor
+        assert_eq!(encoded_len, expected_size);
+
+        // Verify map header (2 entries)
+        assert_eq!(
+            buffer[0],
+            crate::cbor::cbor_initial_byte(crate::cbor::MajorType::Map, 2)
+        );
+    }
+
+    #[test]
+    fn test_class_map_with_tagged_bytes() {
+        let raw_id = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04];
+        let class_map = ClassMap {
+            class_id: ClassIdTypeChoice::TaggedBytes(TaggedBytes::new(&raw_id)),
+            vendor: Some("Bytes Corp"),
+            model: Some("Model B"),
+        };
+
+        let mut buffer = [0u8; 128];
+        let mut encoder = CborEncoder::new(&mut buffer);
+        class_map.encode(&mut encoder).expect("Encoding failed");
+
+        let encoded_len = encoder.len();
+
+        // Expected: map(3) + key(0) + tag(560) + bytes(8) + key(1) + vendor + key(2) + model
+        let expected_size = CborEncoder::estimate_uint_size(3) + // map header
+                           CborEncoder::estimate_uint_size(0) + // key 0
+                           CborEncoder::estimate_uint_size(560) + // tag 560
+                           CborEncoder::estimate_bytes_string_size(8) + // raw bytes
+                           CborEncoder::estimate_uint_size(1) + // key 1
+                           CborEncoder::estimate_text_string_size(10) + // vendor
+                           CborEncoder::estimate_uint_size(2) + // key 2
+                           CborEncoder::estimate_text_string_size(7); // model
+        assert_eq!(encoded_len, expected_size);
+
+        // Verify map header (3 entries)
+        assert_eq!(
+            buffer[0],
+            crate::cbor::cbor_initial_byte(crate::cbor::MajorType::Map, 3)
+        );
+    }
+
+    #[test]
     fn test_class_map_complete() {
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.9999",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.9999")),
             vendor: Some("ACME Corp"),
             model: Some("Model X"),
         };
@@ -907,7 +991,7 @@ mod tests {
     #[test]
     fn test_environment_map_encode() {
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.8888",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.8888")),
             vendor: Some("Vendor Inc"),
             model: None,
         };
@@ -961,7 +1045,7 @@ mod tests {
         let measurements_array = [measurement_map];
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.7777",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.7777")),
             vendor: Some("Test Vendor"),
             model: Some("Test Model"),
         };
@@ -1058,7 +1142,7 @@ mod tests {
         let measurements_array = [measurement_map];
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.6666",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.6666")),
             vendor: None,
             model: None,
         };
@@ -1121,7 +1205,7 @@ mod tests {
         let measurements_array = [measurement_map];
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.5555",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.5555")),
             vendor: Some("Example Vendor"),
             model: Some("Example Model"),
         };
@@ -1190,7 +1274,7 @@ mod tests {
         let measurements_array = [measurement_map];
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.4444",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.4444")),
             vendor: None,
             model: None,
         };
@@ -1263,7 +1347,7 @@ mod tests {
         let measurements_array = [measurement_map];
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.3333",
+            class_id: ClassIdTypeChoice::TaggedOid(TaggedOid::new(b"1.3.6.1.4.1.3333")),
             vendor: Some("Tagged Vendor"),
             model: Some("Tagged Model"),
         };

--- a/common/eat/src/ocp_profile/eat.rs
+++ b/common/eat/src/ocp_profile/eat.rs
@@ -711,7 +711,9 @@ mod tests {
             mval: measurement_value,
         };
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.1234",
+            class_id: ClassIdTypeChoice::TaggedOid(crate::cbor::TaggedOid::new(
+                b"1.3.6.1.4.1.1234",
+            )),
             vendor: Some("TestVendor"),
             model: Some("TestModel"),
         };
@@ -792,7 +794,9 @@ mod tests {
             mval: measurement_value,
         };
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.1234",
+            class_id: ClassIdTypeChoice::TaggedOid(crate::cbor::TaggedOid::new(
+                b"1.3.6.1.4.1.1234",
+            )),
             vendor: Some("TestVendor"),
             model: Some("TestModel"),
         };
@@ -895,7 +899,9 @@ mod tests {
         };
 
         let class_map = ClassMap {
-            class_id: "1.3.6.1.4.1.1234",
+            class_id: ClassIdTypeChoice::TaggedOid(crate::cbor::TaggedOid::new(
+                b"1.3.6.1.4.1.1234",
+            )),
             vendor: Some("TestVendor"),
             model: Some("TestModel"),
         };

--- a/common/eat/src/ocp_profile/mod.rs
+++ b/common/eat/src/ocp_profile/mod.rs
@@ -11,7 +11,7 @@ pub use eat::{
 
 // Re-export only used items from the concise_evidence module
 pub use concise_evidence::{
-    ClassMap, ConciseEvidence, ConciseEvidenceMap, DigestEntry, EnvironmentMap, EvTriplesMap,
-    EvidenceTripleRecord, IntegrityRegisterEntry, IntegrityRegisterIdChoice, MeasurementMap,
-    MeasurementValue, TaggedConciseEvidence,
+    ClassIdTypeChoice, ClassMap, ConciseEvidence, ConciseEvidenceMap, DigestEntry, EnvironmentMap,
+    EvTriplesMap, EvidenceTripleRecord, IntegrityRegisterEntry, IntegrityRegisterIdChoice,
+    MeasurementMap, MeasurementValue, TaggedConciseEvidence,
 };


### PR DESCRIPTION
Replace hardcoded tagged-OID encoding of `ClassMap.class_id` with a `ClassIdTypeChoice` enum supporting all three `class-id-type-choice` alternatives defined in the CoRIM specification:
  - `tagged-oid-type:  #6.111(bstr)`
  - `tagged-uuid-type: #6.37(bstr .size 16)`
  - `tagged-bytes:     #6.560(bstr)`