### PR TITLE
[dma] Fix large FIFO to AXI write operations

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -387,11 +387,26 @@ impl Dma {
     /// * `write_addr` - Address to write to
     /// * `buffer`  - Target location to write from
     pub fn write_buffer(&self, write_addr: AxiAddr, buffer: &[u32]) {
-        // TODO(zhalvorsen): figure out why one shot is only writing ~1KB in the emulator and switch
-        // to using a single DMA transaction instead of writing a dword at a time.
-        for (i, write_val) in buffer.iter().enumerate() {
-            self.write_dword(write_addr + (i as u32 * 4), *write_val);
-        }
+        let write_transaction = DmaWriteTransaction {
+            write_addr,
+            fixed_addr: false,
+            // Length is in bytes.
+            length: buffer.len() as u32 * 4,
+            origin: DmaWriteOrigin::AhbFifo,
+            aes_mode: false,
+            aes_gcm: false,
+        };
+        self.flush();
+        self.setup_dma_write(write_transaction);
+        self.with_dma(|dma| {
+            for write_data in buffer.iter() {
+                let max_fifo_depth = dma.cap().read().fifo_max_depth();
+                while max_fifo_depth == dma.status0().read().fifo_depth() {}
+
+                dma.write_data().write(|_| *write_data);
+            }
+        });
+        self.wait_for_dma_complete();
     }
 
     /// Write a 32-bit word to the specified address

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -177,7 +177,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "fpga_realtime"), ignore)]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
 fn test_invoke_dpe_sign_and_certify_key_cmds_with_subsystem() {
     let mut model = run_rt_test(RuntimeTestArgs {
         subsystem_mode: true,

--- a/sw-emulator/lib/periph/src/dma.rs
+++ b/sw-emulator/lib/periph/src/dma.rs
@@ -179,6 +179,7 @@ pub struct Dma {
     // If true, the recovery interface in the MCU will be used,
     // otherwise, the local recovery interface is used.
     use_mcu_recovery_interface: bool,
+    continued_write_xfer: Option<WriteXfer>,
 }
 
 #[derive(Debug)]
@@ -251,6 +252,7 @@ impl Dma {
             pending_axi_to_fifo: false,
             pending_axi_to_mailbox: false,
             use_mcu_recovery_interface,
+            continued_write_xfer: None,
         }
     }
 
@@ -494,7 +496,10 @@ impl Dma {
 
     // Returns true if this completed immediately.
     fn fifo_to_axi(&mut self) -> bool {
-        let xfer = self.write_xfer();
+        let xfer = self
+            .continued_write_xfer
+            .take()
+            .unwrap_or_else(|| self.write_xfer());
 
         for i in (0..xfer.len).step_by(Self::AXI_DATA_WIDTH) {
             let addr = xfer.dest + if xfer.fixed { 0 } else { i as AxiAddr };
@@ -502,7 +507,20 @@ impl Dma {
                 Some(b) => b,
                 None => {
                     // TODO set interrupt bits
-                    return true;
+                    if i != xfer.len {
+                        self.continued_write_xfer = Some(WriteXfer {
+                            dest: xfer.dest + i as u64,
+                            fixed: xfer.fixed,
+                            len: xfer.len - i,
+                        });
+                        self.op_complete_action = Some(
+                            self.timer.schedule_poll_in(
+                                (Self::DMA_CYCLES_PER_WORD * self.byte_count.reg.get() as u64 / 4)
+                                    .max(Self::DMA_CYCLES_MIN),
+                            ),
+                        );
+                    }
+                    return i == xfer.len;
                 }
             };
             self.axi


### PR DESCRIPTION
Previously the write operations returned complete when the FIFO was empty so if more than a single FIFO depth needed to be transferred the rest would be dropped. Now it continues until the full transaction is finished.