### PR TITLE
Warm reset debug unlocked workaround

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,9 +38,9 @@ pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 
 pub const FMC_ORG: u32 = 0x40000000;
-pub const FMC_SIZE: u32 = 23 * 1024;
+pub const FMC_SIZE: u32 = 24 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 97 * 1024;
+pub const RUNTIME_SIZE: u32 = 96 * 1024;
 
 // Max size of runtime code should be 120K to allow 8k for the manifest
 #[allow(clippy::assertions_on_constants)]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1325,6 +1325,7 @@ impl CaliptraError {
             "FMC Alias CSR Verification Failure"
         ),
         (FMC_ALIAS_CSR_OVERFLOW, 0x000F0013, "FMC Alias CSR Overflow"),
+        (FMC_REGENERATE_FMC_KEY_PAIR_FAILED, 0x000F0014, "FMC Error: Regenerating FMC Key Pair Failed"),
         (
             DRIVER_TRNG_EXT_TIMEOUT,
             0x00100001,

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -134,16 +134,29 @@ impl RtAliasLayer {
     ///
     /// * `DiceInput` - DICE Layer Input
     fn dice_input_from_hand_off(env: &mut FmcEnv) -> CaliptraResult<DiceInput> {
-        let auth_pub = HandOff::fmc_pub_key(env);
-        let auth_serial_number = X509::subj_sn(env, &auth_pub)?;
-        let auth_key_id = X509::subj_key_id(env, &auth_pub)?;
-        // Create initial output
+        // In debug mode, the key vault is wiped on warm reset but IDEV, LDEV,
+        // and FMC alias are not re-derived by the ROM. Regenerate a dummy FMC
+        // key pair from the (now-zeroed) FMC CDI slot so that the RT alias
+        // derivation can still proceed.
+        let reset_reason = env.soc_ifc.reset_reason();
+        let debug_not_locked = !env.soc_ifc.debug_locked();
+        let auth_key_pair = if reset_reason == ResetReason::WarmReset && debug_not_locked {
+            cfi_assert_eq(reset_reason, ResetReason::WarmReset);
+            cfi_assert_bool(debug_not_locked);
+            Self::regenerate_fmc_key_pair(env)?
+        } else {
+            Ecc384KeyPair {
+                priv_key: HandOff::fmc_priv_key(env),
+                pub_key: HandOff::fmc_pub_key(env),
+            }
+        };
+
+        let auth_serial_number = X509::subj_sn(env, &auth_key_pair.pub_key)?;
+        let auth_key_id = X509::subj_key_id(env, &auth_key_pair.pub_key)?;
+
         let input = DiceInput {
             cdi: HandOff::fmc_cdi(env),
-            auth_key_pair: Ecc384KeyPair {
-                priv_key: HandOff::fmc_priv_key(env),
-                pub_key: auth_pub,
-            },
+            auth_key_pair,
             auth_sn: auth_serial_number,
             auth_key_id,
         };
@@ -374,5 +387,37 @@ impl RtAliasLayer {
         };
         dest.copy_from_slice(tbs);
         Ok(())
+    }
+
+    /// Regenerate a dummy FMC alias key pair from the FMC CDI key vault slot.
+    ///
+    /// In debug mode, the key vault is wiped on a warm reset, but the ROM
+    /// does not re-derive IDEV, LDEV, or FMC alias keys. This function
+    /// generates a new FMC key pair from the (now-zeroed) CDI slot so that
+    /// the RT alias derivation flow can still execute. The resulting key
+    /// will not match the key certified in the FMC alias certificate.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - FMC Environment
+    ///
+    /// # Returns
+    ///
+    /// * `Ecc384KeyPair` - Regenerated FMC key pair
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn regenerate_fmc_key_pair(env: &mut FmcEnv) -> CaliptraResult<Ecc384KeyPair> {
+        let fmc_cdi = HandOff::fmc_cdi(env);
+        let fmc_priv_key = HandOff::fmc_priv_key(env);
+
+        cprintln!("[art] Regenerating FMC key pair (debug warm reset)");
+        cprintln!("[art] FMC CDI.KEYID = {}", fmc_cdi as u8);
+        cprintln!("[art] FMC PRIV_KEY.KEYID = {}", fmc_priv_key as u8);
+
+        let key_pair = Crypto::ecc384_key_gen(env, fmc_cdi, b"fmc_alias_keygen", fmc_priv_key)
+            .map_err(|_| CaliptraError::FMC_REGENERATE_FMC_KEY_PAIR_FAILED)?;
+
+        cprintln!("[art] Regenerating FMC key pair - Done");
+
+        Ok(key_pair)
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -272,3 +272,66 @@ fn test_mbox_idle_during_warm_reset() {
         u32::from(CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET)
     );
 }
+
+#[test]
+fn test_warm_reset_debug_unlocked() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(false)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART,
+        ImageOptions::default(),
+    )
+    .unwrap();
+    let vendor_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.vendor_pub_keys.as_bytes()));
+    let owner_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.owner_pub_keys.as_bytes()));
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            security_state,
+            ..Default::default()
+        },
+        BootParams {
+            fuses: Fuses {
+                key_manifest_pk_hash: vendor_pk_hash,
+                owner_pk_hash,
+                ..Default::default()
+            },
+            fw_image: Some(&image.to_bytes().unwrap()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Wait for runtime
+    while !model
+        .soc_ifc()
+        .cptra_flow_status()
+        .read()
+        .ready_for_runtime()
+    {
+        model.step();
+    }
+
+    // Perform warm reset
+    model.warm_reset_flow().unwrap();
+
+    // Wait for runtime
+    while !model
+        .soc_ifc()
+        .cptra_flow_status()
+        .read()
+        .ready_for_runtime()
+    {
+        model.step();
+    }
+
+    assert_eq!(model.soc_ifc().cptra_fw_error_fatal().read(), 0x0);
+    assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0x0);
+}


### PR DESCRIPTION
Re-derive dummy FMC key pair on warm reset in debug unlocked mode. This is required because the key vault is reset to debug values on the warm reset but an FMC key pair is still needed to sign RT alias. This key will not match the FMC cert generated by ROM on the cold boot but allows the boot to proceed.