### PR TITLE
Remove CFI feature check

### DIFF
--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -49,8 +49,6 @@ Running Caliptra FMC ...
 // Upon cold reset, fills the reserved field with 0xFFs. Any newly-allocated fields will
 // therefore be marked as implicitly invalid.
 
-const _: () = assert!(cfg!(feature = "cfi"), "CFI must be enabled");
-
 fn fix_fht(env: &mut fmc_env::FmcEnvFips) {
     if env.soc_ifc.reset_reason() == caliptra_drivers::ResetReason::ColdReset {
         cfi_assert_eq(env.soc_ifc.reset_reason(), ResetReason::ColdReset);

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -16,8 +16,6 @@ Abstract:
 #![cfg_attr(feature = "fake-rom", allow(unused_imports))]
 #![cfg_attr(feature = "fips-test-hooks", allow(dead_code))]
 
-const _: () = assert!(cfg!(feature = "cfi"), "CFI must be enabled");
-
 use crate::rom_env::RomEnvFips;
 use crate::{lock::lock_registers, print::HexBytes};
 use caliptra_cfi_lib::{cfi_assert_eq, CfiCounter};

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -14,8 +14,6 @@ Abstract:
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), no_main)]
 
-const _: () = assert!(cfg!(feature = "cfi"), "CFI must be enabled");
-
 #[cfg(target_arch = "riscv32")]
 core::arch::global_asm!(include_str!("ext_intr.S"));
 


### PR DESCRIPTION
Now that the CFI feature has been migrated, we can remove this check.