### PR TITLE
[OCP-LOCK]: Remove endorsement algorithm

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -5064,17 +5064,6 @@ impl Request for OcpLockGetAlgorithmsReq {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct EndorsementAlgorithms(u32);
-
-bitflags! {
-    impl EndorsementAlgorithms: u32 {
-        const ECDSA_P384_SHA384 = 1 << 0;
-        const ML_DSA_87 = 1 << 1;
-    }
-}
-
-#[repr(C)]
 #[derive(Clone, Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct HpkeAlgorithms(u32);
 
@@ -5101,7 +5090,6 @@ bitflags! {
 pub struct OcpLockGetAlgorithmsResp {
     pub hdr: MailboxRespHeader,
     pub reserved: [u32; 4],
-    pub endorsement_algorithms: EndorsementAlgorithms,
     pub hpke_algorithms: HpkeAlgorithms,
     pub access_key_sizes: AccessKeySizes,
 }
@@ -5285,7 +5273,6 @@ pub struct OcpLockGetHpkePubKeyReq {
     pub hdr: MailboxReqHeader,
     pub reserved: u32,
     pub hpke_handle: u32,
-    pub endorsement_algorithm: EndorsementAlgorithms,
 }
 impl Request for OcpLockGetHpkePubKeyReq {
     const ID: CommandId = CommandId::OCP_LOCK_GET_HPKE_PUB_KEY;

--- a/runtime/src/ocp_lock/get_algorithms.rs
+++ b/runtime/src/ocp_lock/get_algorithms.rs
@@ -1,8 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_api::mailbox::{
-    AccessKeySizes, EndorsementAlgorithms, HpkeAlgorithms, OcpLockGetAlgorithmsResp,
-};
+use caliptra_api::mailbox::{AccessKeySizes, HpkeAlgorithms, OcpLockGetAlgorithmsResp};
 use caliptra_error::CaliptraResult;
 
 use crate::mutrefbytes;
@@ -14,7 +12,6 @@ impl GetAlgorithmsCmd {
     pub fn execute(resp: &mut [u8]) -> CaliptraResult<usize> {
         let resp = mutrefbytes::<OcpLockGetAlgorithmsResp>(resp)?;
         resp.access_key_sizes = AccessKeySizes::LEN_256;
-        resp.endorsement_algorithms = EndorsementAlgorithms::all();
         resp.hpke_algorithms = HpkeAlgorithms::all();
         Ok(core::mem::size_of::<OcpLockGetAlgorithmsResp>())
     }

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -2,8 +2,8 @@
 
 use caliptra_api::{
     mailbox::{
-        CapabilitiesResp, CommandId, EndorsementAlgorithms, HpkeAlgorithms, HpkeHandle, MailboxReq,
-        MailboxReqHeader, MailboxRespHeader, OcpLockEnableMpkReq, OcpLockEnumerateHpkeHandlesReq,
+        CapabilitiesResp, CommandId, HpkeAlgorithms, HpkeHandle, MailboxReq, MailboxReqHeader,
+        MailboxRespHeader, OcpLockEnableMpkReq, OcpLockEnumerateHpkeHandlesReq,
         OcpLockEnumerateHpkeHandlesResp, OcpLockGenerateMpkReq, OcpLockGenerateMpkResp,
         OcpLockGetHpkePubKeyReq, OcpLockGetHpkePubKeyResp, OcpLockInitializeMekSecretReq,
         OcpLockReportHekMetadataReq, OcpLockReportHekMetadataResp,
@@ -281,17 +281,12 @@ fn verify_hpke_pub_key(
     model: &mut DefaultHwModel,
     hpke_handle: HpkeHandle,
 ) -> Option<ValidatedHpkeHandle> {
-    verify_hpke_pub_key_with_algo(
-        model,
-        hpke_handle.clone(),
-        EndorsementAlgorithms::ECDSA_P384_SHA384,
-    )
+    verify_hpke_pub_key_with_algo(model, hpke_handle.clone())
 }
 
 fn verify_hpke_pub_key_with_algo(
     model: &mut DefaultHwModel,
     hpke_handle: HpkeHandle,
-    _endorsement_algorithm: EndorsementAlgorithms,
 ) -> Option<ValidatedHpkeHandle> {
     let mut cmd = MailboxReq::OcpLockGetHpkePubKey(OcpLockGetHpkePubKeyReq {
         hpke_handle: hpke_handle.handle,

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_get_algorithms.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_get_algorithms.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::mailbox::{
-    AccessKeySizes, CommandId, EndorsementAlgorithms, HpkeAlgorithms, MailboxReqHeader,
-    MailboxRespHeader, OcpLockGetAlgorithmsResp,
+    AccessKeySizes, CommandId, HpkeAlgorithms, MailboxReqHeader, MailboxRespHeader,
+    OcpLockGetAlgorithmsResp,
 };
 use caliptra_api::SocManager;
 use caliptra_hw_model::HwModel;
@@ -49,10 +49,6 @@ fn test_get_algorithms() {
             MailboxRespHeader::FIPS_STATUS_APPROVED
         );
 
-        assert_eq!(
-            get_algs_resp.endorsement_algorithms,
-            EndorsementAlgorithms::all()
-        );
         assert_eq!(get_algs_resp.hpke_algorithms, HpkeAlgorithms::all());
         assert_eq!(get_algs_resp.access_key_sizes, AccessKeySizes::LEN_256);
     });


### PR DESCRIPTION
MCU will be performing the endorsement, so we don't need this info.