### PR TITLE
docs: fix IME flags bit positions to match code

### DIFF
--- a/auth-manifest/README.md
+++ b/auth-manifest/README.md
@@ -51,7 +51,7 @@ Up to 127 image hashes are supported.
 | **Image Hash**          | 48           | SHA2-384 hash of a SOC image. |
 | **Image Identifier**    | 4            | Unique value selected by the vendor to distinguish between images. |
 | **Component Id**        | 4            | Identifies the image component to be loaded. This corresponds to the `ComponentIdentifier` field defined in the DMTF PLDM Firmware Update Specification (DSP0267). |
-| **Flags**               | 4            | Image-specific flags.<br/>**Bit 0:** If set, the image hash will **not** be verified; otherwise, the metadata image hash will be compared against the calculated hash of the image.<br/>**Bit 1:** If set, indicates that the image is an MCU Runtime image; otherwise, it indicates a SOC image.<br/>**Bits 8–14:** Firmware execution control bit mapped to this image.<br/>Other bits: reserved. |
+| **Flags**               | 4            | Image-specific flags.<br/>**Bits 1:0:** Image source.<br/>**Bit 2:** If set, the image hash will **not** be verified; otherwise, the metadata image hash will be compared against the calculated hash of the image.<br/>**Bits 8–14:** Firmware execution control bit mapped to this image.<br/>Other bits: reserved. |
 | **Image Load Address High** | 4       | High 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
 | **Image Load Address Low**  | 4       | Low 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
 | **Staging Address High**   | 4       | High 4 bytes of the 64-bit AXI address where the image will be temporarily written during firmware update download and verification. |


### PR DESCRIPTION
Cherry-pick of #3419 (commit b8abb033880ba8706821a0fd19b9c91d94f4a844) into caliptra-2.0.

The Image Metadata Entry Flags field description in the spec did not match the
implementation in ImageMetadataFlags (auth-manifest/types/src/lib.rs). The code
defines bits 1:0 as image_source and bit 2 as ignore_auth_check, but the spec
listed bit 0 as ignore_auth_check and bit 1 as MCU Runtime indicator.

Update the spec to match the code, which has been the de facto behavior since
December 2024.

Fixes #3420