### PR TITLE
runtime: Allow AES DMA decrypting always

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1813,6 +1813,11 @@ impl CaliptraError {
             0x000E008F,
             "Runtime Error: DMA SHA384 hash mismatch during encrypted firmware decryption"
         ),
+        (
+            RUNTIME_CMB_DMA_NOT_SUBSYSTEM_MODE,
+            0x000E0092,
+            "Runtime Error: CM AES GCM decrypt DMA requires subsystem mode"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -50,7 +50,7 @@ When ROM receives the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command instead of `RI_DO
    - Decrypt the firmware in-place using `CM_AES_GCM_DECRYPT_DMA`
    - Send `CM_ACTIVATE_FIRMWARE` to activate the decrypted MCU firmware
 
-The `CM_AES_GCM_DECRYPT_DMA` command is restricted to the `EncryptedFirmware` boot mode and performs a SHA384 integrity check of the ciphertext before decryption.
+The `CM_AES_GCM_DECRYPT_DMA` command is intended to be used for the `EncryptedFirmware` boot mode and performs a SHA384 integrity check of the ciphertext before decryption, but can be used to decrypt other images as well in any boot mode.
 
 For behavior during other types of reset, see [Runtime firmware updates](#runtime-firmware-updates).
 
@@ -2379,6 +2379,7 @@ Command Code: `0x434D_4446` ("CMDF")
 Performs in-place AES-256-GCM decryption of data at an AXI address using DMA. This command is specifically designed for decrypting MCU firmware that was downloaded via the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command.
 
 **Important restrictions:**
+- This command is only available in subsystem mode, as DMA is only available in subsystem.
 - This command is only available when the boot mode is `EncryptedFirmware`, which is set by ROM when it receives the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command.
 - The command performs a two-pass operation:
   1. First pass: Verifies the SHA384 hash of the encrypted data at the AXI address

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -51,7 +51,7 @@ use caliptra_drivers::{
     cmac_kdf, hkdf_expand, hkdf_extract, hmac_kdf,
     sha2_512_384::{Sha2DigestOpTrait, SHA512_BLOCK_BYTE_SIZE, SHA512_HASH_SIZE},
     Aes, AesContext, AesDmaMode, AesGcmContext, AesGcmIv, AesKey, AesOperation, Array4x12,
-    Array4x16, AxiAddr, BootMode, CaliptraResult, DmaRecovery, Ecc384PrivKeyIn, Ecc384PrivKeyOut,
+    Array4x16, AxiAddr, CaliptraResult, DmaRecovery, Ecc384PrivKeyIn, Ecc384PrivKeyOut,
     Ecc384PubKey, Ecc384Result, Ecc384Seed, Ecc384Signature, HmacMode, KeyReadArgs, LEArray4x1157,
     LEArray4x3, LEArray4x392, LEArray4x4, LEArray4x8, MlKem1024, MlKem1024Message,
     MlKem1024MessageSource, MlKem1024Seed, MlKem1024Seeds, MlKem1024SharedKey,
@@ -2739,14 +2739,13 @@ impl Commands {
         cmd_bytes: &[u8],
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        if !drivers.cryptographic_mailbox.initialized {
-            Err(CaliptraError::RUNTIME_CMB_NOT_INITIALIZED)?;
+        // DMA is only available in subsystem mode
+        if !drivers.soc_ifc.subsystem_mode() {
+            Err(CaliptraError::RUNTIME_CMB_DMA_NOT_SUBSYSTEM_MODE)?;
         }
 
-        // Validate boot mode - this command is only allowed when boot mode is EncryptedFirmware
-        let boot_mode = drivers.persistent_data.get().rom.boot_mode;
-        if boot_mode != BootMode::EncryptedFirmware {
-            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        if !drivers.cryptographic_mailbox.initialized {
+            Err(CaliptraError::RUNTIME_CMB_NOT_INITIALIZED)?;
         }
 
         if cmd_bytes.len() > core::mem::size_of::<CmAesGcmDecryptDmaReq>() {

--- a/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
@@ -2,50 +2,19 @@
 
 //! Tests for encrypted firmware flow using RI_DOWNLOAD_ENCRYPTED_FIRMWARE and CM_AES_GCM_DECRYPT_DMA
 
-use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 use aes_gcm::{aead::AeadMutInPlace, Key, KeyInit};
-use caliptra_api::mailbox::{
-    CmAesGcmDecryptDmaReq, CmImportReq, CmImportResp, CmKeyUsage, Cmk, CommandId, MailboxReq,
-    MailboxReqHeader, MailboxRespHeader,
-};
+use caliptra_api::mailbox::{CmAesGcmDecryptDmaReq, CommandId, MailboxReq};
 use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{HwModel, InitParams, SubsystemInitParams, MCU_TEST_AES_KEY, MCU_TEST_IV};
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_gen::from_hw_format;
 use caliptra_image_gen::ImageGeneratorCrypto;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
-
-/// Import a raw AES key and return the CMK
-fn import_aes_key(model: &mut caliptra_hw_model::DefaultHwModel, key: &[u8; 32]) -> Cmk {
-    let mut input = [0u8; 64];
-    input[..32].copy_from_slice(key);
-
-    let mut cm_import_cmd = MailboxReq::CmImport(CmImportReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        key_usage: CmKeyUsage::Aes.into(),
-        input_size: 32,
-        input,
-    });
-    cm_import_cmd.populate_chksum().unwrap();
-
-    let resp = model
-        .mailbox_execute(
-            u32::from(CommandId::CM_IMPORT),
-            cm_import_cmd.as_bytes().unwrap(),
-        )
-        .unwrap()
-        .expect("We should have received a response");
-
-    let cm_import_resp = CmImportResp::ref_from_bytes(resp.as_slice()).unwrap();
-    assert_eq!(
-        cm_import_resp.hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_APPROVED
-    );
-    cm_import_resp.cmk.clone()
-}
 
 /// Encrypt data using AES-256-GCM, returning `ciphertext || 16-byte tag`.
 fn aes_gcm_encrypt(key: &[u8; 32], iv: &[u8; 12], aad: &[u8], plaintext: &[u8]) -> Vec<u8> {
@@ -125,73 +94,29 @@ fn test_encrypted_firmware_decrypt_dma() {
     );
 }
 
-/// Test that CM_AES_GCM_DECRYPT_DMA fails when not in encrypted firmware mode
+/// Test that CM_AES_GCM_DECRYPT_DMA fails when not in subsystem mode.
 #[cfg_attr(any(feature = "verilator", feature = "fpga_realtime",), ignore)]
 #[test]
-fn test_decrypt_dma_fails_in_normal_mode() {
-    // Create a simple MCU firmware
-    let mcu_fw = vec![1, 2, 3, 4];
-    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
-    let mut flags = ImageMetadataFlags(0);
-    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
-    let crypto = Crypto::default();
-    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
-    let metadata = vec![AuthManifestImageMetadata {
-        fw_id: 2,
-        flags: flags.0,
-        digest,
-        ..Default::default()
-    }];
-    let soc_manifest = create_auth_manifest_with_metadata(metadata);
-    let soc_manifest_bytes = soc_manifest.as_bytes();
+fn test_decrypt_dma_requires_subsystem_mode() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    let mut args = RuntimeTestArgs::default();
-    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
-    args.init_params = Some(InitParams {
-        rom: &rom,
-        subsystem_mode: true,
-        ..Default::default()
-    });
-    args.soc_manifest = Some(soc_manifest_bytes);
-    args.mcu_fw_image = Some(&mcu_fw);
+    if model.subsystem_mode() {
+        return;
+    }
 
-    // Use normal boot (RI_DOWNLOAD_FIRMWARE, not encrypted)
-    let mut model = run_rt_test(args);
-    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+    let mut cmd = MailboxReq::CmAesGcmDecryptDma(CmAesGcmDecryptDmaReq::default());
+    cmd.populate_chksum().unwrap();
 
-    // Import an AES key
-    let aes_key: [u8; 32] = [0xaa; 32];
-    let cmk = import_aes_key(&mut model, &aes_key);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_AES_GCM_DECRYPT_DMA),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect_err("CM_AES_GCM_DECRYPT_DMA should fail outside subsystem mode");
 
-    // Get MCU SRAM address
-    let mcu_sram_addr = model
-        .write_payload_to_ss_staging_area(&mcu_fw)
-        .expect("Failed to get MCU SRAM address");
-
-    // Try to use CM_AES_GCM_DECRYPT_DMA - should fail because we're not in encrypted firmware mode
-    let decrypt_req = CmAesGcmDecryptDmaReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        cmk,
-        iv: [0u32; 3],
-        tag: [0u32; 4],
-        encrypted_data_sha384: [0u8; 48],
-        axi_addr_lo: mcu_sram_addr as u32,
-        axi_addr_hi: (mcu_sram_addr >> 32) as u32,
-        length: mcu_fw.len() as u32,
-        aad_length: 0,
-        aad: [0u8; caliptra_api::mailbox::CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE],
-    };
-
-    let mut decrypt_cmd = MailboxReq::CmAesGcmDecryptDma(decrypt_req);
-    decrypt_cmd.populate_chksum().unwrap();
-
-    // This should fail with RUNTIME_MAILBOX_INVALID_PARAMS because we're not in encrypted firmware mode
-    let result = model.mailbox_execute(
-        u32::from(CommandId::CM_AES_GCM_DECRYPT_DMA),
-        decrypt_cmd.as_bytes().unwrap(),
-    );
-    assert!(
-        result.is_err(),
-        "CM_AES_GCM_DECRYPT_DMA should fail in normal boot mode"
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_CMB_DMA_NOT_SUBSYSTEM_MODE,
+        err,
     );
 }


### PR DESCRIPTION
I think we want to allow decrypting firmware (or any other decrypting) even if we are not in the encrypted boot mode, for instance, if other SoC images need to be decrypted, or we simply want to leverage the AES DMA capabilities.