### PR TITLE
[nightly]: Make OCP LOCK a test variant for the "core" tests

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -18,6 +18,9 @@ on:
       fpga-itrng:
         default: true
         type: boolean
+      ocp-lock:
+        default: true
+        type: boolean
       hw-version:
         default: "latest"
         type: string
@@ -35,6 +38,9 @@ on:
   workflow_dispatch:
     inputs:
       fpga-itrng:
+        default: true
+        type: boolean
+      ocp-lock:
         default: true
         type: boolean
 
@@ -146,6 +152,9 @@ jobs:
 
           if [ "${{ inputs.workflow_call }}" ]; then
             FEATURES=fpga_realtime,${{ inputs.extra-features }}
+            if [ "${{ inputs.ocp-lock }}" == "true" ]; then
+              FEATURES="${FEATURES},ocp-lock"
+            fi
           else
             FEATURES=fpga_realtime,itrng
           fi

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -83,7 +83,7 @@ jobs:
       rom-version: ${{ matrix.config.rom }}
 
   fpga:
-    name: FPGA Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
+    name: FPGA Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }}, ${{ matrix.ocp_lock.name }})
     needs: find-latest-release-2-x
     if: needs.find-latest-release-2-x.outputs.create_release
     permissions:
@@ -100,12 +100,16 @@ jobs:
         log:
           - { name: "log", rom_logging: true }
           - { name: "nolog", rom_logging: false }
+        ocp_lock:
+          - { name: "", ocp_lock: false }
+          - { name: "ocp-lock", ocp_lock: true }
     with:
-      artifact-suffix: -fpga-realtime-${{ matrix.hw_config.suffix_prefix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}
+      artifact-suffix: -fpga-realtime-${{ matrix.hw_config.suffix_prefix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}-${{ matrix.ocp_lock.name }}
       extra-features: ${{ matrix.rng.extra }}
       hw-version: ${{ matrix.hw_config.hw }}
       rom-logging: ${{ matrix.log.rom_logging }}
       fpga-itrng: ${{ matrix.rng.fpga_itrng }}
+      ocp-lock: ${{ matrix.ocp_lock.ocp_lock }}
       rom-version: ${{ matrix.hw_config.rom }}
 
   fpga-subsystem:


### PR DESCRIPTION
OCP LOCK is always disabled (it requires subsystem hardware) but it is important to make sure that the OCP LOCK firmware will work on the core system.