### PR TITLE
[FPGA-CI]: Make flash boot default

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -21,6 +21,9 @@ on:
       ocp-lock:
         default: true
         type: boolean
+      flash-boot:
+        default: true
+        type: boolean
       hw-version:
         default: "latest"
         type: string
@@ -204,8 +207,11 @@ jobs:
             if [ "${{ inputs.ocp-lock }}" == "true" ]; then
               FEATURES="${FEATURES},ocp-lock"
             fi
+            if [ "${{ inputs.flash-boot }}" == "true" ]; then
+              FEATURES="${FEATURES},flash-boot"
+            fi
           else
-            FEATURES=fpga_subsystem,itrng,ocp-lock
+            FEATURES=fpga_subsystem,itrng,ocp-lock,flash-boot
           fi
           if [[ "${{ inputs.workflow_call }}" && "${{ inputs.hw-version }}" != "latest" ]]; then
             FEATURES=$FEATURES,hw-${{ inputs.hw-version }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -129,14 +129,18 @@ jobs:
         ocp_lock:
           - { name: "", ocp_lock: false }
           - { name: "ocp-lock", ocp_lock: true }
+        flash_boot:
+          - { name: "", flash_boot: false }
+          - { name: "flash-boot", flash_boot: true }
     with:
-      artifact-suffix: -fpga-subsystem-realtime-${{ matrix.hw_config.suffix_prefix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}-${{ matrix.ocp_lock.name }}
+      artifact-suffix: -fpga-subsystem-realtime-${{ matrix.hw_config.suffix_prefix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}-${{ matrix.ocp_lock.name }}-${{ matrix.flash_boot.name }}
       extra-features: ${{ matrix.rng.extra }}
       hw-version: ${{ matrix.hw_config.hw }}
       rom-logging: ${{ matrix.log.rom_logging }}
       fpga-itrng: ${{ matrix.rng.fpga_itrng }}
       ocp-lock: ${{ matrix.ocp_lock.ocp_lock }}
       rom-version: ${{ matrix.hw_config.rom }}
+      flash-boot: ${{ matrix.flash_boot.flash_boot }}
       branch: "main"
 
 

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2078,6 +2078,28 @@ impl HwModel for ModelFpgaSubsystem {
             let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
             let current = gpio.extract().get();
             gpio.set(current | 1 << 31);
+
+            // In encrypted boot + flash boot mode, the MCU ROM decrypts
+            // firmware autonomously after loading it from flash. Wait for
+            // COLD_BOOT_FLOW_COMPLETE so the decrypt finishes before we
+            // return control to the test.
+            if boot_params.encrypted_boot {
+                const MAX_WAIT_DECRYPT_CYCLES: u64 = 1_000_000_000;
+                let start = self.cycle_count();
+                while !self
+                    .mci_boot_milestones()
+                    .contains(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE)
+                {
+                    self.step();
+                    if self.cycle_count().wrapping_sub(start) >= MAX_WAIT_DECRYPT_CYCLES {
+                        panic!(
+                            "Timeout waiting for MCU ROM encrypted boot to complete after {} cycles",
+                            self.cycle_count().wrapping_sub(start)
+                        );
+                    }
+                }
+            }
+
             return Ok(());
         }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -87,6 +87,7 @@ itrng = ["caliptra-drivers/itrng", "caliptra-hw-model/itrng"]
 riscv = ["caliptra-cpu/riscv"]
 std = ["ufmt/std", "caliptra_common/std"]
 slow_tests = []
+flash-boot = []
 verilator = ["caliptra-hw-model/verilator"]
 fips_self_test = []
 cfi = [

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -27,8 +27,9 @@ use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_drivers::MfgFlags;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
-    BootParams, CodeRange, DefaultHwModel, DeviceLifecycle, Fuses, HwModel, ImageInfo, InitParams,
-    ModelCallback, ModelError, SecurityState, StackInfo, StackRange, SubsystemInitParams,
+    flash_image::build_flash_image_bytes, BootParams, CodeRange, DefaultHwModel, DeviceLifecycle,
+    Fuses, HwModel, ImageInfo, InitParams, ModelCallback, ModelError, SecurityState, StackInfo,
+    StackRange, SubsystemInitParams,
 };
 
 use caliptra_runtime::CaliptraDpeProfile;
@@ -307,6 +308,19 @@ pub fn start_rt_test_pqc_model(
         (args.soc_manifest, args.mcu_fw_image)
     };
 
+    let flash_image = build_flash_image_bytes(Some(&image), soc_manifest, mcu_fw_image);
+
+    // When stop_at_rom is true the test wants to manually control firmware
+    // loading (e.g. via RRI or the mailbox) after ROM is ready.  Pre-loading
+    // the flash image would cause MCU ROM to load firmware automatically,
+    // conflicting with the test's intent.
+    let flash_image = if cfg!(feature = "flash-boot") && !args.stop_at_rom {
+        Some(flash_image.as_bytes())
+    } else {
+        None
+    };
+
+    init_params.ss_init_params.primary_flash_initial_contents = flash_image;
     let model = caliptra_hw_model::new(
         init_params,
         BootParams {

--- a/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
@@ -36,8 +36,9 @@ fn aes_gcm_encrypt(key: &[u8; 32], iv: &[u8; 12], aad: &[u8], plaintext: &[u8]) 
 #[cfg_attr(any(feature = "verilator", feature = "fpga_realtime",), ignore)]
 #[test]
 fn test_encrypted_firmware_decrypt_dma() {
-    // The plaintext MCU firmware
-    let mcu_fw_plaintext: Vec<u8> = (0..256).map(|i| i as u8).collect();
+    // The plaintext MCU firmware (240 bytes so that ciphertext+tag = 256,
+    // a multiple of the FPGA BMC's 256-byte recovery FIFO block size).
+    let mcu_fw_plaintext: Vec<u8> = (0..240).map(|i| i as u8).collect();
 
     // Encrypt with the well-known test key/IV (ciphertext || tag)
     let aad: [u8; 0] = [];


### PR DESCRIPTION
- And add a nightly variant with and without flash boot.

This resolves https://github.com/chipsalliance/caliptra-sw/issues/3421.

- Fixed test_encrypted_firmware_decrypt_dma test failing on digest mismatch error.The FPGA BMC pads recovery images to 256-byte boundaries. A 272-byte encrypted image (256 ciphertext + 16 tag) was padded to 512, causing a SHA-384 digest mismatch. Adjust the test plaintext to 240 bytes so the encrypted image is exactly 256 bytes (no padding needed)