### PR TITLE
Add new integration test for hw-model sourced as a dependency

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -229,6 +229,16 @@ jobs:
         run: |
           (cd test/dpe_verification && make run)
 
+      - name: Rust HW_Model Build Integration Test
+        run: |
+          mkdir /tmp/dep-test
+          cd /tmp/dep-test
+          cargo init
+          cat >> Cargo.toml <<EOF
+          caliptra-hw-model = { git = "file://${GITHUB_WORKSPACE}", default-features = false }
+          EOF
+          cargo build
+
   all_checks_passed:
     needs: [build, test_unit, test_compliance, test_rom, test_integration]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds "Rust HW_Model Build Integration Test" to the existing integration tests section.  This test creates a new blank cargo project, sources the hw-model as a dependency and attempts to build the project.

This test is intended to catch issues with dependency + feature resolution that dont present when building in isolation but will be breaking for downstream consumers of hw-model if not caught

NOTE: this test currently fails on main and will continue to fail until #3452 is merged.  It is intended as a check of the sorts of behavior 3452 is fixing.