### PR TITLE
tests: Warm reset has a race condition for subsystem FPGA

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -1005,6 +1005,23 @@ pub trait HwModel: SocManager {
     /// should come via a caliptra_top wire rather than an APB register.
     fn ready_for_fw(&self) -> bool;
 
+    // TODO: refactor all uses of ready_for_fw() to use this method,
+    // since otherwise resets can be flaky.
+    /// Returns true if Caliptra core (and MCU if applicable) have completed
+    /// their boot flows.
+    fn boot_complete(&mut self) -> bool {
+        self.soc_ifc()
+            .cptra_flow_status()
+            .read()
+            .ready_for_runtime()
+            && self.boot_complete_mcu()
+    }
+
+    /// Returns true if MCU (if present) has complete its firmware boot flow.
+    fn boot_complete_mcu(&mut self) -> bool {
+        true
+    }
+
     /// Initializes the fuse values and locks them in until the next reset. This
     /// function can only be called during early boot, shortly after the model
     /// is created with `new_unbooted()`.

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2492,6 +2492,11 @@ impl HwModel for ModelFpgaSubsystem {
         }
         Some(OcpLockState { mek })
     }
+
+    fn boot_complete_mcu(&mut self) -> bool {
+        self.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+    }
 }
 
 pub struct FpgaRealtimeBus<'a> {

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -63,8 +63,9 @@ fn test_rt_journey_pcr_validation() {
     )
     .unwrap();
 
-    // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+    while !model.boot_complete() {
+        model.step();
+    }
 
     let _ = model
         .mailbox_execute(0xD000_0000, &[0u8; TCI_SIZE])
@@ -132,8 +133,9 @@ fn test_rt_current_pcr_validation() {
     )
     .unwrap();
 
-    // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+    while !model.boot_complete() {
+        model.step();
+    }
 
     let _ = model
         .mailbox_execute(0xD000_0001, &[0u8; TCI_SIZE])
@@ -302,13 +304,7 @@ fn test_warm_reset_debug_unlocked() {
         ..Default::default()
     });
 
-    // Wait for runtime
-    while !model
-        .soc_ifc()
-        .cptra_flow_status()
-        .read()
-        .ready_for_runtime()
-    {
+    while !model.boot_complete() {
         model.step();
     }
 


### PR DESCRIPTION
For the subsystem FPGA, which has a real MCU, generally when Caliptra finishes the boot flow, MCU still needs to finish two additional resets to get to its runtime firmware.

If the HwModel issues a warm reset before MCU has completed its firmware boot reset sequence, it can cause a conflict and MCU may not issue the warm reset to Caliptra as expected. (Since the HwModel warm reset goes through MCU ROM, which has to then trigger the Calitpra core warm reset.)

This modifies the test to wait until MCU has finished booting to runtime firmware before issuing the warm reset.