### PR TITLE
[OCP-LOCK]: Fix flaky tests

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -235,6 +235,26 @@ struct ValidatedHpkeHandle {
     pub_key: Vec<u8>,
 }
 
+impl ValidatedHpkeHandle {
+    pub fn overwrite_encap_key(&mut self) {
+        self.pub_key = match self.hpke_handle.hpke_algorithm {
+            HpkeAlgorithms::ML_KEM_1024_HKDF_SHA384_AES_256_GCM => {
+                let hpke = hpke::HpkeMlKem1024::generate_key_pair();
+                hpke.serialize_ek()
+            }
+            HpkeAlgorithms::ML_KEM_1024_ECDH_P384_HKDF_SHA384_AES_256_GCM => {
+                let hpke = hpke::HpkeHybrid::generate_key_pair();
+                hpke.serialize_ek()
+            }
+            HpkeAlgorithms::ECDH_P384_HKDF_SHA384_AES_256_GCM => {
+                let hpke = hpke::HpkeP384::generate_key_pair();
+                hpke.serialize_ek()
+            }
+            _ => panic!("Unknown HPKE algorithm"),
+        }
+    }
+}
+
 fn get_hpke_handle(model: &mut DefaultHwModel, suite: HpkeAlgorithms) -> Option<HpkeHandle> {
     let mut cmd =
         MailboxReq::OcpLockEnumerateHpkeHandles(OcpLockEnumerateHpkeHandlesReq::default());

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
@@ -56,8 +56,7 @@ fn test_generate_mpk() {
     });
 }
 
-// TODO(clundin): Update default HEK / pass in explicitly to make pass on emu.
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_generate_mpk_invalid_hpke_key() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -67,9 +66,8 @@ fn test_generate_mpk_invalid_hpke_key() {
     });
 
     let mut endorsed_handle = get_validated_hpke_handle(&mut model).unwrap();
-
-    // Scramble pub key so shared secret is incorrect.
-    endorsed_handle.pub_key[5..10].clone_from_slice(&[0xAA; 5]);
+    // Overwrite Caliptra's pub key with a random one.
+    endorsed_handle.overwrite_encap_key();
 
     let info = [0xDE; 256];
     let metadata = [0xFE; OCP_LOCK_WRAPPED_KEY_MAX_METADATA_LEN];

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rewrap_mpk.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rewrap_mpk.rs
@@ -90,7 +90,7 @@ fn test_rewrap_mpk() {
     assert_eq!(mpk1, mpk2);
 }
 
-#[cfg_attr(not(feature = "fpga_subsystem"), ignore)]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_rewrap_invalid_hpke_key() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -118,10 +118,11 @@ fn test_rewrap_invalid_hpke_key() {
     })
     .unwrap();
 
-    // Scramble pub key so shared secret is incorrect.
-    endorsed_handle.pub_key[5..10].clone_from_slice(&[0xAA; 5]);
-
     let new_access_key = [0xCD; 32];
+
+    // Overwrite Caliptra's pub key with a random one.
+    endorsed_handle.overwrite_encap_key();
+
     let cmd = create_rewrap_mpk_req(
         &endorsed_handle,
         &info,


### PR DESCRIPTION
These tests were written with the ML-KEM HPKE algorithm but the failure mode is different for a P-384 HPKE algorithm because the hardware validates the `ENC` param.