### PR TITLE
[dpe] Add comment that initialization is profile agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ This is a combined runtime and FMC release.
 - Encrypted Firmware Support (Subsystem Mode):
   - CM_AES_GCM_DECRYPT_DMA command for in-place AES-256-GCM decryption of data at an AXI address, with SHA384 integrity check of ciphertext before decryption.
   - Works with the ROM RI_DOWNLOAD_ENCRYPTED_FIRMWARE command to support encrypted MCU firmware booting.
+- DPE:
   - Full MLDSA87 certificate chain: GET_IDEV_MLDSA87_CERT, POPULATE_IDEV_MLDSA87_CERT, GET_IDEV_MLDSA87_INFO, GET_LDEV_MLDSA87_CERT, GET_FMC_ALIAS_MLDSA87_CERT, GET_RT_ALIAS_MLDSA87_CERT, and ML-DSA DPE leaf certificates and CSRs through INVOKE_DPE_MLDSA87.
   - INVOKE_DPE_MLDSA87 command for all DPE operations with ML-DSA-87 support.
   - CERTIFY_KEY_EXTENDED_MLDSA87 command for producing ML-DSA-87 DPE leaf certificates or CSRs with custom extensions.
+  - Increased the maximum number of DPE contexts from 32 to 64.
 - MLKEM & SHAKE Mailbox Commands:
   - ML-KEM-1024 (FIPS 203): CM_MLKEM_KEY_GEN, CM_MLKEM_ENCAPSULATE, CM_MLKEM_DECAPSULATE for post-quantum key encapsulation.
   - SHAKE256 streaming hash: CM_SHAKE256_INIT, CM_SHAKE256_UPDATE, CM_SHAKE256_FINAL for extendable-output hashing with encrypted session context.

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -595,6 +595,10 @@ impl Drivers {
     /// Initialize DPE with measurements and store in Drivers
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn initialize_dpe(drivers: &mut Drivers) -> CaliptraResult<()> {
+        // NOTE: All initialization in this function is done using the ECC P384 profile because
+        // these operations are profile agnostic. Using the ML-DSA-87 profile would have an equal
+        // outcome.
+
         let manifest = drivers.persistent_data.get().rom.manifest1;
         let pl0_pauser_locality = manifest.header.pl0_pauser;
         let hashed_rt_pub_key = drivers.compute_ecc_rt_alias_sn()?;


### PR DESCRIPTION
It was confusing why DPE was only intitialized for the ECC P384 profile. This adds a comment to clarify it doesn't need to be done for the ML-DSA profile.

Also adds minor changes to the changelog.