### PR TITLE
ci: Rather than 1 giant ZIP file, make 1 ZIP file per subdir

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -178,9 +178,17 @@ jobs:
         with:
           path: /tmp/artifacts
 
-      - name: Package all test artifacts for release
+      - name: Package test artifacts per artifact directory
         run: |
-          (cd /tmp/artifacts && zip -r - .) > ./release/test_artifacts_${{ needs.find-latest-release-2-x.outputs.new_release_tag }}.zip
+          TAG="${{ needs.find-latest-release-2-x.outputs.new_release_tag }}"
+          cd /tmp/artifacts
+          ls -lh
+          du -sh .
+          for dir in */; do
+            dirname="${dir%/}"
+            echo "Zipping ${dirname}"
+            zip -qr "$GITHUB_WORKSPACE/release/test_artifacts_${TAG}_${dirname}.zip" "$dirname"
+          done
 
       - name: Tag repo with new release number
         run: |
@@ -194,7 +202,7 @@ jobs:
         with:
           files: |
             ./release/caliptra_${{ needs.find-latest-release-2-x.outputs.new_release_tag }}.zip
-            ./release/test_artifacts_${{ needs.find-latest-release-2-x.outputs.new_release_tag }}.zip
+            ./release/test_artifacts_*.zip
           tag_name: ${{ needs.find-latest-release-2-x.outputs.new_release_tag }}
           prerelease: true
           # Release as draft. Since immutable releases are enabled we must first create a release as draft so we can upload artifacts and then tag it.


### PR DESCRIPTION
For test artifacts, as the 1 test artifacts ZIP was over 2 GB in size due to all of the variants, which are, for 2.1 right now:

```
caliptra-bitstream-fpga-realtime-latest-itrng-log/
caliptra-bitstream-fpga-realtime-latest-itrng-nolog/
caliptra-bitstream-fpga-subsystem-realtime-latest-itrng-log-/
caliptra-bitstream-fpga-subsystem-realtime-latest-itrng-log-ocp-lock/
caliptra-bitstream-fpga-subsystem-realtime-latest-itrng-nolog-/
caliptra-bitstream-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock/
caliptra-test-binaries-fpga-realtime-latest-itrng-log/
caliptra-test-binaries-fpga-realtime-latest-itrng-nolog/
caliptra-test-binaries-fpga-subsystem-realtime-latest-itrng-log-/
caliptra-test-binaries-fpga-subsystem-realtime-latest-itrng-log-ocp-lock/
caliptra-test-binaries-fpga-subsystem-realtime-latest-itrng-nolog-/
caliptra-test-binaries-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock/
caliptra-test-firmware-fpga-realtime-latest-itrng-log/
caliptra-test-firmware-fpga-realtime-latest-itrng-nolog/
caliptra-test-firmware-fpga-subsystem-realtime-latest-itrng-log-/
caliptra-test-firmware-fpga-subsystem-realtime-latest-itrng-log-ocp-lock/
caliptra-test-firmware-fpga-subsystem-realtime-latest-itrng-nolog-/
caliptra-test-firmware-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock/
caliptra-test-results-fpga-realtime-latest-itrng-log-1/
caliptra-test-results-fpga-realtime-latest-itrng-log-2/
caliptra-test-results-fpga-realtime-latest-itrng-nolog-1/
caliptra-test-results-fpga-realtime-latest-itrng-nolog-2/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log--1/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log--2/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log--3/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log--4/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log-ocp-lock-1/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log-ocp-lock-2/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log-ocp-lock-3/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-log-ocp-lock-4/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog--1/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog--2/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog--3/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog--4/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock-1/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock-2/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock-3/
caliptra-test-results-fpga-subsystem-realtime-latest-itrng-nolog-ocp-lock-4/
caliptra-test-results-sw-emulator-hw-latest-etrng-log/
caliptra-test-results-sw-emulator-hw-latest-etrng-nolog/
caliptra-test-results-sw-emulator-hw-latest-itrng-log/
caliptra-test-results-sw-emulator-hw-latest-itrng-nolog/
```