### PR TITLE
[xtask] Add xtask flow to update DPE reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,7 +3918,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3940,8 +3940,26 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.9.0",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4530,6 +4548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4634,7 @@ dependencies = [
  "serde",
  "simple_logger",
  "tokio",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ spki = { version = "0.7.3", features = ["alloc"] }
 syn = "1.0.107"
 tinytemplate = "1.1"
 thiserror = "2"
+toml_edit = "0.22"
 tock-registers = { git = "https://github.com/tock/tock.git", rev = "release-2.2" }
 toml = "0.7.0"
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,3 +17,4 @@ octocrab = "0.38.0"
 serde = { workspace = true, features = ["derive"] }
 simple_logger.workspace = true
 tokio = { version = "1.49.0", features = ["rt", "macros"] }
+toml_edit.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,7 @@ use std::{
 mod clippy;
 mod precheckin;
 mod release;
+mod update_dpe;
 mod update_frozen_images;
 
 #[derive(Parser)]
@@ -30,6 +31,12 @@ enum Commands {
     Release {
         #[command(subcommand)]
         command: ReleaseCommands,
+    },
+    /// Update the DPE references
+    UpdateDpe {
+        /// The git revision to update DPE to (tag, branch, or git hash)
+        #[arg(short, long, default_value = "main")]
+        rev: String,
     },
     /// Build ROM images and update the FROZEN_IMAGES.sha384sum file
     UpdateFrozenImages,
@@ -75,6 +82,7 @@ fn main() {
             ReleaseCommands::Check { tag } => release::check(tag),
             ReleaseCommands::Deploy { tag } => release::deploy(tag),
         },
+        Commands::UpdateDpe { rev } => update_dpe::update_dpe(rev),
         Commands::UpdateFrozenImages => update_frozen_images::update_frozen_images(),
     };
     result.unwrap_or_else(|e| {

--- a/xtask/src/update_dpe.rs
+++ b/xtask/src/update_dpe.rs
@@ -1,0 +1,161 @@
+// Licensed under the Apache-2.0 license
+
+use anyhow::{bail, Context, Result};
+use log::info;
+use std::fs;
+use std::process::Command;
+
+use toml_edit::{value, DocumentMut};
+
+const DPE_REPO_URL: &str = "https://github.com/chipsalliance/caliptra-dpe";
+
+pub(crate) fn update_dpe(rev: &str) -> Result<()> {
+    let hash = resolve_git_ref(DPE_REPO_URL, rev)?;
+    info!("Updating DPE references to hash {}", hash);
+
+    update_cargo_toml(&hash)?;
+    update_go_mod(&hash)?;
+
+    Ok(())
+}
+
+fn update_cargo_toml(hash: &str) -> Result<()> {
+    let cargo_toml_path = crate::PROJECT_ROOT.join("Cargo.toml");
+    let content = fs::read_to_string(&cargo_toml_path)
+        .context(format!("Failed to read {:?}", cargo_toml_path))?;
+
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .context("Failed to parse Cargo.toml")?;
+
+    let mut updated = false;
+
+    if let Some(dependencies) = doc
+        .get_mut("workspace")
+        .and_then(|w| w.get_mut("dependencies"))
+        .and_then(|d| d.as_table_like_mut())
+    {
+        for dep in ["dpe", "crypto", "platform"] {
+            if let Some(item) = dependencies.get_mut(dep) {
+                if let Some(table) = item.as_inline_table_mut() {
+                    if table.get("git").and_then(|v| v.as_str()) == Some(DPE_REPO_URL)
+                        && table.get("rev").and_then(|v| v.as_str()) != Some(hash)
+                    {
+                        table.insert("rev", value(hash).into_value().unwrap());
+                        updated = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if !updated {
+        info!("Cargo.toml already has the correct DPE hash");
+        return Ok(());
+    }
+
+    fs::write(&cargo_toml_path, doc.to_string())
+        .context(format!("Failed to write {:?}", cargo_toml_path))?;
+    info!("Updated Cargo.toml with new DPE hash");
+
+    // Sync the lockfile
+    info!("Updating Cargo.lock...");
+    let status = Command::new("cargo")
+        .current_dir(&*crate::PROJECT_ROOT)
+        .args(["update", "-p", "dpe", "-p", "crypto", "-p", "platform"])
+        .status()?;
+
+    if !status.success() {
+        bail!("Failed to run cargo update");
+    }
+
+    Ok(())
+}
+
+fn update_go_mod(hash: &str) -> Result<()> {
+    let go_mod_path = crate::PROJECT_ROOT.join("test/dpe_verification/go.mod");
+    if !go_mod_path.exists() {
+        info!("test/dpe_verification/go.mod does not exist, skipping.");
+        return Ok(());
+    }
+
+    info!("Updating test/dpe_verification/go.mod with new DPE hash");
+
+    let go_dir = go_mod_path.parent().unwrap();
+
+    // Update all DPE dependencies in one command
+    let output = Command::new("go")
+        .current_dir(go_dir)
+        .arg("get")
+        .arg(format!(
+            "github.com/chipsalliance/caliptra-dpe/verification/sim@{}",
+            hash
+        ))
+        .arg(format!(
+            "github.com/chipsalliance/caliptra-dpe/verification/testing@{}",
+            hash
+        ))
+        .arg(format!(
+            "github.com/chipsalliance/caliptra-dpe/verification/client@{}",
+            hash
+        ))
+        .output()?;
+
+    if !output.status.success() {
+        info!(
+            "Note: Failed to update DPE dependencies in go.mod: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Tidy up the go.mod file
+    let output = Command::new("go")
+        .current_dir(go_dir)
+        .args(["mod", "tidy"])
+        .output()?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to run go mod tidy: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+fn resolve_git_ref(repo_url: &str, rev: &str) -> Result<String> {
+    // Check if the rev is already a 40-character hex string (likely a hash)
+    if rev.len() == 40 && rev.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Ok(rev.to_string());
+    }
+
+    info!("Resolving git revision '{}' for {}", rev, repo_url);
+
+    let output = Command::new("git")
+        .args(["ls-remote", repo_url, rev])
+        .output()?;
+
+    if !output.status.success() {
+        bail!("Failed to run git ls-remote on {}", repo_url);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 2 {
+            let hash = parts[0];
+            let ref_name = parts[1];
+            // If the reference is an exact match for the branch or tag
+            if ref_name == format!("refs/heads/{}", rev)
+                || ref_name == format!("refs/tags/{}", rev)
+                || ref_name == rev
+            {
+                return Ok(hash.to_string());
+            }
+        }
+    }
+
+    // If it's still not found, it might be a shortened hash, but we really want a full hash for Cargo.toml
+    bail!("Could not resolve git revision '{}' to a full hash", rev);
+}


### PR DESCRIPTION
This command takes a tag, branch, or git hash and updates the Rust dependencies and golang depencies. If no reference is given, it will assume the commit from `main`.