### PR TITLE
Add unused hw-1.0 feature to mailbox API test fw to fix nightly CI failure

### DIFF
--- a/api/test-fw/Cargo.toml
+++ b/api/test-fw/Cargo.toml
@@ -17,6 +17,7 @@ zerocopy.workspace = true
 [features]
 emu = ["caliptra-test-harness/emu"]
 riscv = ["caliptra-test-harness/riscv"]
+"hw-1.0" = []
 
 [[bin]]
 name = "api_mailbox_panic_test"


### PR DESCRIPTION
https://github.com/chipsalliance/caliptra-sw/pull/3303 adds a test build for the mailbox API to ensure it is panic-free. This is causing some 1.0 testing in CI that uses the "hw-1.0" feature to fail because of the way the builder works. Adding this unused feature resolves this.