### PR TITLE
docs: Fix markdown tables, update links

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -683,22 +683,22 @@ During this phase, the ROM executes specific mailbox commands. Based on the oper
 
 ROM supports the following set of commands before handling the FW_DOWNLOAD command in PASSIVE mode (described in section 9.6) or RI_DOWNLOAD_FIRMWARE/RI_DOWNLOAD_ENCRYPTED_FIRMWARE command in SUBSYSTEM mode. Once the FW_DOWNLOAD, RI_DOWNLOAD_FIRMWARE, or RI_DOWNLOAD_ENCRYPTED_FIRMWARE is issued, ROM stops processing any additional mailbox commands.
 
-1. **STASH_MEASUREMENT**: Up to eight measurements can be sent to the ROM for recording. Sending more than eight measurements will result in an FW_PROC_MAILBOX_STASH_MEASUREMENT_MAX_LIMIT fatal error. Format of a measurement is documented at [Stash Measurement command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#stash_measurement).
-2. **VERSION**: Get version info about the module. [Version command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#version).
-3. **SELF_TEST_START**: This command is used to invoke the FIPS Known-Answer-Tests (aka KAT) on demand. [Self Test Start command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#self_test_start).
-4. **SELF_TEST_GET_RESULTS**: This command is used to check if a SELF_TEST command is in progress. [Self Test Get Results command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#self_test_get_results).
-5. **SHUTDOWN**: This command is used clear the hardware crypto blocks including the keyvault. [Shutdown command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#shutdown).
-6. **CAPABILITIES**: This command is used to query the ROM capabilities. Capabilities is a 128-bit value with individual bits indicating a specific capability. Capabilities are documented in the [Capabilities command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#capabilities).
-7. **GET_IDEVID_CSR**: This command is used to fetch the IDevID CSR from ROM. [Fetch IDevIDCSR command](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#get_idevid_csr).
-8. **CM_DERIVE_STABLE_KEY**: This command is used to derive a stable key for Device Ownership Transfer or other flows. [CM_DERIVE_STABLE_KEY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#cm_derive_stable_key)
-9. **CM_HMAC**: This command uses derived stable keys for Device Ownership Transfer or other flows. [CM_HMAC](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#cm_hmac)
-10. **ECDSA384_SIGNATURE_VERIFY**: This command verifies ECDSA384 signatures for Device Ownership Transfer or other flows. [ECDSA384_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#ecdsa384_signature_verify)
-11. **MLDSA87_SIGNATURE_VERIFY**: This command verifies MLDSA87 signatures for Device Ownership Transfer or other flows. [MLDSA87_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#mldsa87_signature_verify)
-12. **CM_RANDOM_GENERATE**: This command returns random numbers from Caliptra's RNG for Device Ownership Transfer or other flows. [CM_RANDOM_GENERATE](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime/README.md#cm_random_generate)
+1. **STASH_MEASUREMENT**: Up to eight measurements can be sent to the ROM for recording. Sending more than eight measurements will result in an FW_PROC_MAILBOX_STASH_MEASUREMENT_MAX_LIMIT fatal error. Format of a measurement is documented at [Stash Measurement command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#stash_measurement).
+2. **VERSION**: Get version info about the module. [Version command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#version).
+3. **SELF_TEST_START**: This command is used to invoke the FIPS Known-Answer-Tests (aka KAT) on demand. [Self Test Start command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#self_test_start).
+4. **SELF_TEST_GET_RESULTS**: This command is used to check if a SELF_TEST command is in progress. [Self Test Get Results command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#self_test_get_results).
+5. **SHUTDOWN**: This command is used clear the hardware crypto blocks including the keyvault. [Shutdown command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#shutdown).
+6. **CAPABILITIES**: This command is used to query the ROM capabilities. Capabilities is a 128-bit value with individual bits indicating a specific capability. Capabilities are documented in the [Capabilities command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#capabilities).
+7. **GET_IDEVID_CSR**: This command is used to fetch the IDevID CSR from ROM. [Fetch IDevIDCSR command](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#get_idevid_csr).
+8. **CM_DERIVE_STABLE_KEY**: This command is used to derive a stable key for Device Ownership Transfer or other flows. [CM_DERIVE_STABLE_KEY](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#cm_derive_stable_key)
+9. **CM_HMAC**: This command uses derived stable keys for Device Ownership Transfer or other flows. [CM_HMAC](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#cm_hmac)
+10. **ECDSA384_SIGNATURE_VERIFY**: This command verifies ECDSA384 signatures for Device Ownership Transfer or other flows. [ECDSA384_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#ecdsa384_signature_verify)
+11. **MLDSA87_SIGNATURE_VERIFY**: This command verifies MLDSA87 signatures for Device Ownership Transfer or other flows. [MLDSA87_SIGNATURE_VERIFY](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#mldsa87_signature_verify)
+12. **CM_RANDOM_GENERATE**: This command returns random numbers from Caliptra's RNG for Device Ownership Transfer or other flows. [CM_RANDOM_GENERATE](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime/README.md#cm_random_generate)
 13. **CM_SHA**: This ROM-only command (ROM 2.0.1+ only) computes a SHA-384 or SHA-512 hash of input data in a single operation. This is useful for MCU ROM to verify signatures and hashes against Vendor PK hash without needing its own hash implementation. Unlike the runtime CM_SHA_INIT/CM_SHA_UPDATE/CM_SHA_FINAL commands, this is a one-shot operation that does not support streaming or contexts. See [CM_SHA](#cm_sha) below for details.
-14. **GET_LDEV_ECC384_CERT**: This command fetches an LDevID ECC384 certificate signed by the ECC384 IDevID private key. [GET_LDEV_ECC384_CERT](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime#get_ldev_ecc384_cert)
-15. **GET_LDEV_MLDSA87_CERT**: This command fetches an LDevID MLDSA87 certificate signed by the MLDSA87 IDevID private key. [GET_LDEV_MLDSA87_CERT](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime#get_ldev_mldsa87_cert)
-16. **INSTALL_OWNER_PK_HASH**: This command saves the owner public key hash to persistent data. [INSTALL_OWNER_PK_HASH](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/runtime#install_owner_pk_hash)
+14. **GET_LDEV_ECC384_CERT**: This command fetches an LDevID ECC384 certificate signed by the ECC384 IDevID private key. [GET_LDEV_ECC384_CERT](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime#get_ldev_ecc384_cert)
+15. **GET_LDEV_MLDSA87_CERT**: This command fetches an LDevID MLDSA87 certificate signed by the MLDSA87 IDevID private key. [GET_LDEV_MLDSA87_CERT](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime#get_ldev_mldsa87_cert)
+16. **INSTALL_OWNER_PK_HASH**: This command saves the owner public key hash to persistent data. [INSTALL_OWNER_PK_HASH](https://github.com/chipsalliance/caliptra-sw/blob/main/runtime#install_owner_pk_hash)
 17. **OCP_LOCK_REPORT_HEK_METADATA**: This command allows the MCU to report HEK seed state and metadata to the ROM, which determines if the HEK is available. See the [OCP LOCK specification](https://github.com/chipsalliance/Caliptra/blob/main/doc/ocp_lock/releases/OCP_LOCK_Specification_v1.0_RC2.pdf) for details.
 18. **ZEROIZE_UDS_FE**
 
@@ -1038,7 +1038,7 @@ Alias FMC Layer includes the measurement of the FMC and other security states. T
  - **ICCM**
 
 ### Launch FMC
-The ROM initializes and populates the Firmware Handoff Table (FHT) to relay essential parameters to the FMC. The format of the FHT is documented [here](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/fmc/README.md#firmware-handoff-table). Upon successful population, the ROM transfers execution control to the FMC.
+The ROM initializes and populates the Firmware Handoff Table (FHT) to relay essential parameters to the FMC. The format of the FHT is documented [here](https://github.com/chipsalliance/caliptra-sw/blob/main/fmc/README.md#firmware-handoff-table). Upon successful population, the ROM transfers execution control to the FMC.
 
 ## Warm reset flow
 ROM does not perform any DICE derivations or firmware validation during warm reset.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -199,7 +199,7 @@ The Caliptra Measurement manifest feature expands on Caliptra-provided secure ve
 
 Each of these abilities are tied to Caliptra Vendor and Owner FW signing keys and should be independent of any SoC RoT FW signing keys.
 
-Manifest-based image authorization is implemented via two mailbox commands: [`SET_AUTH_MANIFEST`](#set-auth-manifest), and [`AUTHORIZE_AND_STASH`](#authorize-and-stash).
+Manifest-based image authorization is implemented via two mailbox commands: [`SET_AUTH_MANIFEST`](#set_auth_manifest), and [`AUTHORIZE_AND_STASH`](#authorize_and_stash).
 
 ### Caliptra-Endorsed Aggregated Measured Boot
 
@@ -1265,8 +1265,8 @@ Command Code: `0x4154_4D4E` ("ATMN")
 
 *Table: `SET_AUTH_MANIFEST` input arguments*
 
-| **Name**            | **Type**  | **Description**
-| --------            | --------  | ---------------
+| **Name**            | **Type**  | **Description** |
+| --------            | --------  | --------------- |
 | chksum                        | u32          | Checksum over other input arguments, computed by the caller. Little endian. |
 | manifest size                 | u32          | The size of the full Authentication Manifest                                |
 | preamble\_marker              | u32          | Marker needs to be 0x4154_4D4E for the preamble to be valid                 |
@@ -1300,16 +1300,16 @@ Command Code: `0x4154_4D4E` ("ATMN")
 | **Name**               | **Type** | **Description** |
 |------------------------|---------|----------------|
 | Image Hash              | u8[48]      | SHA2-384 hash of a SOC image. |
-| Image_id                | u32            | This corresponds to the `Image Identifier` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Component_id            | u32            | This corresponds to the `Component Id` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| flags                   | u32            | This corresponds to the `flags` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Image Load Address High | u32          | This corresponds to the `Image Load Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Image Load Address Low  | u32          | This corresponds to the `Image Load Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Staging Address High    | u32          | This corresponds to the `Staging Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Staging Address Low     | u32          | This corresponds to the `Staging Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Classification          | u32          | This corresponds to the `Classification` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Version Number          | u32          | This corresponds to the `Version Number` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Version String          | u8[32]       | This corresponds to the `Version String` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
+| Image_id                | u32            | This corresponds to the `Image Identifier` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Component_id            | u32            | This corresponds to the `Component Id` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| flags                   | u32            | This corresponds to the `flags` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Image Load Address High | u32          | This corresponds to the `Image Load Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Image Load Address Low  | u32          | This corresponds to the `Image Load Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Staging Address High    | u32          | This corresponds to the `Staging Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Staging Address Low     | u32          | This corresponds to the `Staging Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Classification          | u32          | This corresponds to the `Classification` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Version Number          | u32          | This corresponds to the `Version Number` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Version String          | u8[32]       | This corresponds to the `Version String` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
 
 ### VERIFY_AUTH_MANIFEST
 
@@ -1331,11 +1331,11 @@ Command Code: `0x4154_5348` ("ATSH")
 
 *Table: `AUTHORIZE_AND_STASH` input arguments*
 
-| **Name**    | **Type** | **Description**
-| ------------| -------- | ---------------
+| **Name**    | **Type** | **Description** |
+| ------------| -------- | --------------- |
 | chksum      | u32      | Checksum over other input arguments, computed by the caller. Little endian.       |
 | fw_id       | u8[4]    | Firmware id of the image, in little-endian format |
-| measurement | u8[48]   | Digest of the image requested for authorization. The `source` field needs to be set to '1` for InRequest, otherwise<br />this field is ignored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| measurement | u8[48]   | Digest of the image requested for authorization. The `source` field needs to be set to '1` for InRequest, otherwise<br />this field is ignored. |
 | context     | u8[48]   | Context field for `svn`; e.g., a hash of the public key that authenticated the SVN. |
 | svn         | u32      | The version of the image |
 | flags       | u32      | See AUTHORIZE_AND_STASH_FLAGS below |
@@ -1352,7 +1352,7 @@ Command Code: `0x4154_5348` ("ATSH")
 | --------------- | -------- | -------------------------------------------------------------------------- |
 | chksum          | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | fips_status     | u32      | Indicates if the command is FIPS approved or an error.                     |
-| auth_req_result | u32      |AUTHORIZE_IMAGE (0xDEADC0DE), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB)
+| auth_req_result | u32      |AUTHORIZE_IMAGE (0xDEADC0DE), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB) |
 
 ### GET_IMAGE_INFO
 
@@ -1365,7 +1365,7 @@ Command Code: `0x494D_4530` ("IME0")
 | **Name** | **Type** | **Description**                                                                                                                                                                                   |
 | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | chksum         | u32            | Checksum over other input arguments, computed by the caller. Little endian.                                                                                                                             |
-| fw_id          | u32            | Firmware id of the image, in little-endian format
+| fw_id          | u32            | Firmware id of the image, in little-endian format |
 
 *Table: `GET_IMAGE_INFO` output arguments*
 
@@ -1373,15 +1373,15 @@ Command Code: `0x494D_4530` ("IME0")
 | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | chksum         | u32            | Checksum over other output arguments, computed by Caliptra. Little endian.                                                                                                                                    |
 | fips_status    | u32            | Indicates if the command is FIPS approved or an error.                                                                                                                                                        |
-| Component_id      | u32            | This corresponds to the `Component Id` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| flags          | u32            | This corresponds to the `flags` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Image Load Address High | u32          | This corresponds to the `Image Load Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Image Load Address Low  | u32          | This corresponds to the `Image Load Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Staging Address High    | u32          | This corresponds to the `Staging Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Staging Address Low     | u32          | This corresponds to the `Staging Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Classification          | u32          | This corresponds to the `Classification` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Version Number          | u32          | This corresponds to the `Version Number` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
-| Version String          | u8[32]       | This corresponds to the `Version String` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main-2.x/auth-manifest/README.md)
+| Component_id      | u32            | This corresponds to the `Component Id` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| flags          | u32            | This corresponds to the `flags` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Image Load Address High | u32          | This corresponds to the `Image Load Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Image Load Address Low  | u32          | This corresponds to the `Image Load Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Staging Address High    | u32          | This corresponds to the `Staging Address High` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Staging Address Low     | u32          | This corresponds to the `Staging Address Low` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Classification          | u32          | This corresponds to the `Classification` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Version Number          | u32          | This corresponds to the `Version Number` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
+| Version String          | u8[32]       | This corresponds to the `Version String` field in the [SoC Manifest](https://github.com/chipsalliance/caliptra-sw/blob/main/auth-manifest/README.md) |
 
 ### GET\_MCU\_FW\_SIZE
 
@@ -2568,15 +2568,15 @@ Command Code: `0x434D_4453` ("CMDS")
 
 *Table: `CM_DERIVE_STABLE_KEY` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 | key_type      | u32      | Source key to derive the stable key from. **0x0000_0001:** IDevId  <br> **0x0000_0002:** LDevId |
 | info          | u8[32]   | Data to use in the key derivation. |
 
 *Table: `CM_DERIVE_STABLE_KEY` output arguments*
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | cmk           | CMK      | CMK that stores the stable key material |
 
@@ -2663,13 +2663,13 @@ Command Code: `0x4944_4352` ("IDCR")
 
 *Table: `GET_IDEV_ECC384_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum      | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 
 *Table: `GET_IDEV_ECC384_CSR` output arguments*
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size    | u32      | Length in bytes of the valid data in the data field.                       |
 | data          | u8[...]  | DER-encoded ECC384 IDevID certificate signing request.                     |
@@ -2680,13 +2680,13 @@ Command Code: `0x4944_4d52` ("IDMR")
 
 *Table: `GET_IDEV_MLDSA87_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum      | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 
 *Table: `GET_IDEV_MLDSA87_CSR` output arguments*
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size    | u32      | Length in bytes of the valid data in the data field.                       |
 | data          | u8[...]  | DER-encoded MLDSA87 IDevID certificate signing request.                    |
@@ -2705,13 +2705,13 @@ Command Code: `0x464D_4352` ("FMCR")
 
 *Table: `GET_FMC_ALIAS_ECC384_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum      | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 
 *Table: `GET_FMC_ALIAS_ECC384_CSR` output arguments*
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size    | u32      | Length in bytes of the valid data in the data field.                       |
 | data          | u8[...]  | DER-encoded ECC384 FMC Alias certificate signing request.                  |
@@ -2722,13 +2722,13 @@ Command Code: `0x464d_4452` ("FMDR")
 
 *Table: `GET_FMC_ALIAS_MLDSA87_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum      | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 
 *Table: `GET_FMC_ALIAS_MLDSA87_CSR` output arguments*
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size    | u32      | Length in bytes of the valid data in the data field.                       |
 | data          | u8[...]  | DER-encoded MLDSA87 FMC Alias certificate signing request.                 |
@@ -2741,16 +2741,16 @@ Command Code: `0x4145_4352` ("AECR")
 
 *Table: `GET_ATTESTED_ECC384_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 | key_id        | u32      | Key ID for which CSR is requested.<br> **0x0000_0001:** LDevId <br> **0x0000_0002:** FMC Alias <br> **0x0000_0003:** RT Alias |
 | nonce         | u8[32]   | Nonce to be included in the CSR EAT.|
 
 *Table: `GET_ATTESTED_ECC384_CSR` output arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size     | u32      | Length in bytes of the valid data in the data field.                      |
 | data          | u8[...]  | DER-encoded ECC384 attested certificate signing request.            |
@@ -2763,16 +2763,16 @@ Command Code: `0x414D_4352` ("AMCR")
 
 *Table: `GET_ATTESTED_MLDSA87_CSR` input arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other input arguments, computed by the caller. Little endian.  |
 | key_id        | u32      | Key ID for which CSR is requested.<br> **0x0000_0001:** LDevId <br> **0x0000_0002:** FMC Alias <br> **0x0000_0003:** RT Alias |
 | nonce         | u8[32]   | Nonce to be included in the CSR EAT. |
 
 *Table: `GET_ATTESTED_MLDSA87_CSR` output arguments*
 
-| **Name**      | **Type** | **Description**
-| --------      | -------- | ---------------
+| **Name**      | **Type** | **Description** |
+| --------      | -------- | --------------- |
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | data\_size     | u32      | Length in bytes of the valid data in the data field.                      |
 | data          | u8[...]  | DER-encoded MLDSA87 attested certificate signing request.            |
@@ -2785,15 +2785,15 @@ Command Code: `0x5357_4545` ("SWEE")
 
 *Table: `SIGN_WITH_EXPORTED_ECDSA` input arguments*
 
-| **Name**             | **Type** | **Description**
-| --------             | -------- | ---------------
+| **Name**             | **Type** | **Description** |
+| --------             | -------- | --------------- |
 | chksum               | u32      | Checksum over other input arguments, computed by the caller. Little endian.         |
 | exported_cdi_handle  | u8[32]   | The Exported CDI handle returned by the DPE `DeriveContext` command. Little endian. |
 | tbs                  | u8[48]   | The bytes to be signed. Little endian.                                              |
 
 *Table: `SIGN_WITH_EXPORTED_ECDSA` output arguments*
-| **Name**           | **Type** | **Description**
-| --------           | -------- | ---------------
+| **Name**           | **Type** | **Description** |
+| --------           | -------- | --------------- |
 | derived_pubkey_x   | u8[48]   | The X BigNum of the ECDSA public key associated with the signing key.      |
 | derived_pubkey_y   | u8[48]   | The Y BigNum of the ECDSA public key associated with the signing key.      |
 | signature_r        | u8[48]   | The R BigNum of an ECDSA signature.                                        |
@@ -2809,8 +2809,8 @@ Command Code: `5256_4348` ("RVCH")
 
 *Table: `REVOKE_EXPORTED_CDI_HANDLE` input arguments*
 
-| **Name**             | **Type** | **Description**
-| --------             | -------- | ---------------
+| **Name**             | **Type** | **Description** |
+| --------             | -------- | --------------- |
 | chksum               | u32      | Checksum over other input arguments, computed by the caller. Little endian.         |
 | exported_cdi_handle  | u8[32]   | The Exported CDI handle returned by the DPE `DeriveContext` command. Little endian. |
 
@@ -2837,8 +2837,8 @@ That external command will still need its own checksum, if applicable.
 
 *Table: `EXTERNAL_MAILBOX_CMD` input arguments*
 
-| **Name**             | **Type** | **Description**
-| --------             | -------- | ---------------
+| **Name**             | **Type** | **Description** |
+| --------             | -------- | --------------- |
 | chksum               | u32      | Checksum over other input arguments, computed by the caller. Little endian.       |
 | command_id           | u32      | Command ID for the mailbox command to be executed. Little endian.                     |
 | command_size         | u32      | Size of the mailbox command to be executed. Little endian.                               |
@@ -2855,14 +2855,14 @@ Command Code: '5243_5458` ("RCTX")
 
 *Table: `REALLOCATE_DPE_CONTEXT_LIMITS` input arguments*
 
-| **Name**           | **Type** | **Description**
-| --------           | -------- | ---------------
+| **Name**           | **Type** | **Description** |
+| --------           | -------- | --------------- |
 | chksum             | u32      | Checksum over other input arguments, computed by the caller. Little endian.         |
 | pl0_context_limit  | u32      | Number of contexts to allocate to PL0. PL1 will receive remaining contexts. |
 
 *Table: `REALLOCATE_DPE_CONTEXT_LIMITS` output arguments*
-| **Name**              | **Type** | **Description**
-| --------              | -------- | ---------------
+| **Name**              | **Type** | **Description** |
+| --------              | -------- | --------------- |
 | chksum                | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | fips_status           | u32      | Indicates if the command is FIPS approved or an error.                     |
 | new_pl0_context_limit | u32      | Number of contexts assigned to PL0 after the reallocation                  |


### PR DESCRIPTION
Fix tables where header/separator rows and data rows had different numbers of | delimiters, which breaks mdbook rendering. Changes are minimal — only adding missing trailing (or leading) | to make rows consistent within each table.

Also fixes some links to the old main-2.x branch, which is no longer updated.