### PR TITLE
[1.x-nightly]: Make nightly release a draft

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -161,7 +161,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.find-latest-release.outputs.new_release_tag }}
-          draft: false
+          draft: true
           prerelease: true
 
       - name: Write artifact to workflow with release info


### PR DESCRIPTION
This is required for immutable releases.