### PR TITLE
rom: Randomize AES ENTROPY_IF_SEED on reset

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-ce9218a2f5a29bd369c0b531efe1e30187164f739b32af64828cea7980a5139f32c5b033919a018428791f856bf7688b  caliptra-rom-no-log.bin
-be37c582ac78dfc5b625f5a474e8aeea3dfebef7cc9335d582a527447eb37f0ba10a0523bdc45f1d0dd881dad1cd97e9  caliptra-rom-with-log.bin
+edfe34e867ec6be9bed2bc0a027ca87716c3d8874ed4d7a91c78c377e3bbe6786f19a0f8e048e646b27d835f9079274e  caliptra-rom-no-log.bin
+64de7987581bfffa673b5bc03539c0bfa5ccbbe892d9c457691da52d26c98ef50706fd80ea52567665208c4a9f6cd2c6  caliptra-rom-with-log.bin

--- a/drivers/src/aes.rs
+++ b/drivers/src/aes.rs
@@ -212,6 +212,22 @@ impl Aes {
         Self { aes, aes_clp }
     }
 
+    /// Seed the AES Trivium stream cipher primitive with fresh entropy.
+    ///
+    /// After reset, the Trivium primitive is initialized to a netlist constant
+    /// and produces deterministic output. Firmware must provide a new 288-bit
+    /// seed after every reset by writing all 9 `entropy_if_seed` registers.
+    pub fn seed_entropy_if(&mut self, trng: &mut Trng) -> CaliptraResult<()> {
+        let entropy = trng.generate()?;
+        self.with_aes(|_aes, aes_clp| {
+            let seeds = aes_clp.entropy_if_seed();
+            for i in 0..9 {
+                seeds.at(i).write(|_| entropy.0[i]);
+            }
+        });
+        Ok(())
+    }
+
     // Ensures that only one copy of the AES registers are used
     // in any given context to ensure exclusive access.
     fn with_aes<T>(
@@ -1452,17 +1468,21 @@ pub struct AesGcm {
 impl AesGcm {
     /// Create a new AesGcm driver after running the GCM KAT.
     ///
+    /// Seeds the AES Trivium stream cipher with fresh entropy from the TRNG,
+    /// then runs the GCM and CMAC-KDF KATs.
+    ///
     /// # Arguments
     ///
     /// * `aes` - AES register block
     /// * `aes_clp` - AES CLP register block
-    /// * `trng` - TRNG driver (used for KAT only)
+    /// * `trng` - TRNG driver (used for entropy seeding and KATs)
     ///
     /// # Returns
     ///
     /// * `CaliptraResult<Self>` - The AesGcm driver if KATs pass
     pub fn new(aes: AesReg, aes_clp: AesClpReg, trng: &mut Trng) -> CaliptraResult<Self> {
         let mut aes = Aes::new_gcm(aes, aes_clp);
+        aes.seed_entropy_if(trng)?;
         crate::kats::execute_gcm_kat(&mut aes, trng)?;
         crate::kats::execute_cmackdf_kat(&mut aes)?;
         Ok(Self { aes })


### PR DESCRIPTION
I confirmed that this needs to be seeded by FW on reset, so we seed it from the entropy source when the AES driver is instantiated (so, on ROM reset, and also during runtime FW startup).

This register is used to randomize the HW masking of the AES engine, which is a countermeasure against timing and power analysis.

The RDL description of these registers states:

> After reset and whenever firmware wants to reseed the Trivium stream cipher primitive, it has to write every register once. The order in which the registers are written doesn't matter. Upon writing the last register, the provided 288-bit value is loaded into the Trivium primitive.
>
> It's fine to write the registers while AES is busy and even while it's performing a a reseed operation of the internal PRNGs via the EDN interface.
>
> Note: Upon reset, the state of the Trivium primitive is initialized to a netlist constant. The primitive thus always generates the same output after reset. It is the responsibility of firmware to provide a new state seed after reset.