### PR TITLE
[nightly-1.x]: Publish release as draft

### DIFF
--- a/.github/workflows/nightly-release-1.x.yml
+++ b/.github/workflows/nightly-release-1.x.yml
@@ -169,7 +169,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.find-latest-release.outputs.new_release_tag }}
-          draft: false
+          draft: true
           prerelease: true
 
       - name: Write artifact to workflow with release info


### PR DESCRIPTION
So it can be modified before being published.

This is required for immutable releases