### PR TITLE
rom: Randomize AES ENTROPY_IF_SEED on reset (#3487) (2.0)

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-e755a14f7464c9d74a57765c7c07060ea4cd2c3fba0a72ecff87aaf34195bb06e6fa36f990912074906cd6a4fa2f836a  caliptra-rom-no-log.bin
-1d8f26024ac634c48e8c3c9a427e1e11c445b4777d3701e6765be3bf804672cdcf106624d3ce25f06e85adbd959f2ed4  caliptra-rom-with-log.bin
+be057d687480ece3235ea7b58b65dba83b41cfecf2f192867a75d02e7d4e58db578c75ff8c9cef17aca19e3d2367fc18  caliptra-rom-no-log.bin
+de9e908b719bdaa7a8ca86596d9c350527975109afcecf25b27a13bb135922aea335685d2c11897fe44d5e4f94bdb371  caliptra-rom-with-log.bin

--- a/drivers/src/aes.rs
+++ b/drivers/src/aes.rs
@@ -211,6 +211,22 @@ impl Aes {
         Self { aes, aes_clp }
     }
 
+    /// Seed the AES Trivium stream cipher primitive with fresh entropy.
+    ///
+    /// After reset, the Trivium primitive is initialized to a netlist constant
+    /// and produces deterministic output. Firmware must provide a new 288-bit
+    /// seed after every reset by writing all 9 `entropy_if_seed` registers.
+    pub fn seed_entropy_if(&mut self, trng: &mut Trng) -> CaliptraResult<()> {
+        let entropy = trng.generate()?;
+        self.with_aes(|_aes, aes_clp| {
+            let seeds = aes_clp.entropy_if_seed();
+            for i in 0..9 {
+                seeds.at(i).write(|_| entropy.0[i]);
+            }
+        });
+        Ok(())
+    }
+
     // Ensures that only one copy of the AES registers are used
     // in any given context to ensure exclusive access.
     fn with_aes<T>(

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -89,6 +89,10 @@ pub extern "C" fn rom_entry() -> ! {
 
     report_boot_status(RomBootStatus::CfiInitialized.into());
 
+    if let Err(err) = env.aes.seed_entropy_if(&mut env.trng) {
+        handle_fatal_error(err.into());
+    }
+
     // Check if HW version is supported.
     let cptra_gen = env.soc_ifc.caliptra_generation();
     if !is_supported_hw_version(&cptra_gen) {


### PR DESCRIPTION
I confirmed that this needs to be seeded by FW on reset, so we seed it from the entropy source when the AES driver is instantiated (so, on ROM reset, and also during runtime FW startup).

This register is used to randomize the HW masking of the AES engine, which is a countermeasure against timing and power analysis.

The RDL description of these registers states:

> After reset and whenever firmware wants to reseed the Trivium stream cipher primitive, it has to write every register once. The order in which the registers are written doesn't matter. Upon writing the last register, the provided 288-bit value is loaded into the Trivium primitive.
>
> It's fine to write the registers while AES is busy and even while it's performing a a reseed operation of the internal PRNGs via the EDN interface.
>
> Note: Upon reset, the state of the Trivium primitive is initialized to a netlist constant. The primitive thus always generates the same output after reset. It is the responsibility of firmware to provide a new state seed after reset.

(cherry picked from commit ae1f7f293f5a0277af42d8cf2910b705c9313e59)