### PR TITLE
rom: Seed ABR_ENTROPY on startup for SCA

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-edfe34e867ec6be9bed2bc0a027ca87716c3d8874ed4d7a91c78c377e3bbe6786f19a0f8e048e646b27d835f9079274e  caliptra-rom-no-log.bin
-64de7987581bfffa673b5bc03539c0bfa5ccbbe892d9c457691da52d26c98ef50706fd80ea52567665208c4a9f6cd2c6  caliptra-rom-with-log.bin
+72243c191a46d14bf5650b25c6d633ca0218a024a2f48228892c8e66cd7330d3b555794dceef37e85defd52320cd8629  caliptra-rom-no-log.bin
+248be6b227a494d4dee2c3ef0479f7d557069e4b8a68fb53a4eacb2310b1070c6238dcfc7931b5bb6e847f2b47abdf71  caliptra-rom-with-log.bin

--- a/drivers/src/abr.rs
+++ b/drivers/src/abr.rs
@@ -15,7 +15,7 @@ Abstract:
 
 use caliptra_registers::abr::AbrReg;
 
-use crate::{MlKem1024, Mldsa87};
+use crate::{CaliptraResult, MlKem1024, Mldsa87, Trng};
 
 /// ABR (Adams Bridge) hardware driver.
 ///
@@ -36,6 +36,14 @@ impl Abr {
     /// * `abr` - The ABR register block
     pub fn new(abr: AbrReg) -> Self {
         Self { abr }
+    }
+
+    /// Seed the ABR entropy registers with fresh randomness to
+    /// provide side-channel attack countermeasures.
+    pub fn seed_entropy(&mut self, trng: &mut Trng) -> CaliptraResult<()> {
+        let entropy = trng.generate16()?;
+        entropy.write_to_reg(self.abr.regs_mut().entropy());
+        Ok(())
     }
 
     /// Get a mutable reference to the ABR register block.

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -98,6 +98,11 @@ pub extern "C" fn rom_entry() -> ! {
         Err(e) => handle_fatal_error(e.into()),
     };
 
+    // Seed the ABR entropy registers for SCA countermeasures
+    if let Err(e) = env.abr.seed_entropy(&mut env.trng) {
+        handle_fatal_error(e.into());
+    }
+
     // Check if TRNG is correctly sourced as per hw config.
     validate_trng_config(&mut env);
 


### PR DESCRIPTION
ROM needs to seed these registers with random values for SCA protection.