### PR TITLE
[dpe] Use both RT PCRs in RT DPE context

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1558,6 +1558,11 @@ impl CaliptraError {
             0x000E0073,
             "Runtime Error: Reallocate DPE context requested fewer PL1 contexts than are used currently"
         ),
+        (
+            RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED,
+            0x000E0074,
+            "Runtime Error: RT current PCR validation failed"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2544,10 +2544,10 @@ this case, the new Runtime Firmware must:
 
 1. Validate DPE state in SRAM
     1. Ensure the TCI tree is well-formed
-    1. Ensure all nodes chain to the root (TYPE = RTJM, “Internal TCI” flag is set)
+    1. Ensure all nodes chain to the root (TYPE = RTMR, “Internal TCI” flag is set)
 1. Verify that the “Latest TCI” field of the TCI Node that contains the
-   Runtime Journey PCR (TYPE = RTJM, “Internal TCI” flag is set) matches the
-   “Latest” Runtime PCR value from PCRX
+   Runtime PCRs (TYPE = RTMR, “Internal TCI” flag is set) matches the
+   “Latest” and Journey Runtime PCR values.
     1. Ensure `SHA384_HASH(0x00..00, TCI from SRAM) == RT_FW_JOURNEY_PCR`
 1. Check that retired and inactive contexts do not have tags
 1. If any validations fail, Runtime Firmware executes the
@@ -2649,9 +2649,9 @@ Caliptra Runtime Firmware is responsible for initializing DPE’s default contex
 
 * Runtime Firmware SHALL initialize the default context in “internal-cdi” mode.
 * Perform the following initial measurements:
-  * Call DeriveContext with Caliptra Journey PCR
+  * Call DeriveContext with Caliptra RT PCRs
     * INPUT\_DATA = PCRX (RT journey PCR as defined in the FHT)
-    * TYPE = “RTJM”
+    * TYPE = “RTMR”
     * CONTEXT\_HANDLE = default context
     * TARGET\_LOCALITY = Caliptra locality (0xFFFFFFFF)
   * Call DeriveContext with mailbox valid PAUSERS

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -12,7 +12,7 @@ Updates Caliptra with a new firmware image and tests that runtime boots | **test
 Boots runtime using the Caliptra runtime test binary | **test_boot** | N/A
 Boots Caliptra and validates the firmware version | **test_fw_version** | N/A
 Tests the persistent data layout on a RISC-V CPU with the runtime flag enabled| **test_persistent_data** | N/A
-Checks that DPE contains the correct measurements upon booting runtime | **test_boot_tci_data** | N/A 
+Checks that DPE contains the correct measurements upon booting runtime | **test_boot_tci_data** | N/A
 Checks that measurements in the measurement log are added to DPE upon booting runtime | **test_measurement_in_measurement_log_added_to_dpe** | N/A
 
 <br><br>
@@ -148,7 +148,7 @@ Tags the default context, retires the default context, and checks that the dpe_g
 # **Update Reset Tests**
 Test Scenario| Test Name | Runtime Error Code
 ---|---|---
-Checks that the DPE root measurement is set to the RT_FW_JOURNEY_PCR upon update reset | **test_rt_journey_pcr_updated_in_dpe** | N/A
+Checks that the DPE root measurements are set to the RT_FW_CURERNT_PCR and RT_FW_JOURNEY_PCR upon update reset | **test_rt_pcr_updated_in_dpe** | N/A
 Checks that context tags are persisted across update resets | **test_tags_persistence** | N/A
 Corrupts the context tags and checks that an error is thrown upon update reset | **test_context_tags_validation** | RUNTIME_CONTEXT_TAGS_VALIDATION_FAILED
 Corrupts the shape of the DPE context tree and checks that an error is thrown upon update reset | **test_dpe_validation_deformed_structure** | RUNTIME_DPE_VALIDATION_FAILED
@@ -160,7 +160,8 @@ Checks that the pcr reset counter is persisted across update resets | **test_pcr
 # **Warm Reset Tests**
 Test Scenario| Test Name | Runtime Error Code
 ---|---|---
-Corrupts the DPE root measurement, triggers a warm reset, and checks that RT journey PCR validation fails | **test_rt_journey_pcr_validation** | RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED
+Corrupts the DPE root current measurement, triggers a warm reset, and checks that RT current PCR validation fails | **test_rt_current_pcr_validation** | RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED
+Corrupts the DPE root journey measurement, triggers a warm reset, and checks that RT journey PCR validation fails | **test_rt_journey_pcr_validation** | RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED
 Tests that there is a non-fatal error if runtime is executing a mailbox command during warm reset | **test_mbox_busy_during_warm_reset** | RUNTIME_CMD_BUSY_DURING_WARM_RESET
 
 <br><br>

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -33,7 +33,10 @@ use caliptra_common::cfi_check;
 use caliptra_common::dice::{copy_ldevid_ecc384_cert, copy_ldevid_mldsa87_cert};
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
 use caliptra_drivers::{
-    cprintln, hand_off::DataStore, pcr_log::RT_FW_JOURNEY_PCR, sha2_512_384::Sha2DigestOpTrait,
+    cprintln,
+    hand_off::DataStore,
+    pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
+    sha2_512_384::Sha2DigestOpTrait,
     Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms, Mldsa87,
     PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha1, Sha256, Sha256Alg, Sha2_512_384,
     Sha2_512_384Acc, SocIfc, Trng,
@@ -57,7 +60,6 @@ use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance},
-    DPE_PROFILE,
 };
 use ureg::MmioMut;
 
@@ -224,13 +226,13 @@ impl Drivers {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::UpdateReset);
                 Self::validate_dpe_structure(self)?;
                 Self::validate_context_tags(self)?;
-                Self::update_dpe_rt_journey(self)?;
+                Self::update_dpe_rt_tci(self)?;
             }
             ResetReason::WarmReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::WarmReset);
                 Self::validate_dpe_structure(self)?;
                 Self::validate_context_tags(self)?;
-                Self::check_dpe_rt_journey_unchanged(self)?;
+                Self::check_dpe_rt_pcrs_unchanged(self)?;
                 Self::update_fw_version(self, true, true);
                 if self.soc_ifc.subsystem_mode() {
                     Self::release_mcu_sram(self)?;
@@ -335,12 +337,13 @@ impl Drivers {
 
     /// Update DPE root context's TCI measurement with RT_FW_JOURNEY_PCR
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn update_dpe_rt_journey(drivers: &mut Drivers) -> CaliptraResult<()> {
+    fn update_dpe_rt_tci(drivers: &mut Drivers) -> CaliptraResult<()> {
         let dpe = &mut drivers.persistent_data.get_mut().dpe;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
-        let latest_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR));
-        dpe.contexts[root_idx].tci.tci_current = TciMeasurement(latest_pcr);
-        dpe.contexts[root_idx].tci.tci_cumulative = TciMeasurement(latest_pcr);
+        let current_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR));
+        let journey_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR));
+        dpe.contexts[root_idx].tci.tci_current = TciMeasurement(current_pcr);
+        dpe.contexts[root_idx].tci.tci_cumulative = TciMeasurement(journey_pcr);
 
         Ok(())
     }
@@ -382,22 +385,28 @@ impl Drivers {
     }
 
     /// Check that RT_FW_JOURNEY_PCR == DPE Root Context's TCI measurement
-    fn check_dpe_rt_journey_unchanged(drivers: &mut Drivers) -> CaliptraResult<()> {
+    fn check_dpe_rt_pcrs_unchanged(drivers: &mut Drivers) -> CaliptraResult<()> {
         let dpe = &drivers.persistent_data.get().dpe;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
         let latest_tci = Array4x12::from(&dpe.contexts[root_idx].tci.tci_current.0);
-        let latest_pcr = drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR);
+        let latest_pcr = drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR);
+        let journey_tci = Array4x12::from(&dpe.contexts[root_idx].tci.tci_cumulative.0);
+        let journey_pcr = drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR);
 
-        // Ensure TCI from SRAM == RT_FW_JOURNEY_PCR
-        if latest_pcr != latest_tci {
-            // If latest pcr validation fails, disable attestation
+        // Ensure TCIs from SRAM == PCRs
+        if latest_pcr != latest_tci || journey_pcr != journey_tci {
+            // If pcr validation fails, disable attestation
             let result = DisableAttestationCmd::execute(drivers);
             cfi_check!(result);
             match result {
                 Ok(_) => {
-                    caliptra_drivers::report_fw_error_non_fatal(
-                        CaliptraError::RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED.into(),
-                    );
+                    let error = if latest_pcr != latest_tci {
+                        CaliptraError::RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED
+                    } else {
+                        CaliptraError::RUNTIME_RT_JOURNEY_PCR_VALIDATION_FAILED
+                    };
+
+                    caliptra_drivers::report_fw_error_non_fatal(error.into());
                 }
                 Err(e) => {
                     cprintln!("{}", e.0);
@@ -408,7 +417,11 @@ impl Drivers {
             cfi_assert_eq_12_words(
                 &<[u32; 12]>::from(latest_tci),
                 &<[u32; 12]>::from(latest_pcr),
-            )
+            );
+            cfi_assert_eq_12_words(
+                &<[u32; 12]>::from(journey_tci),
+                &<[u32; 12]>::from(journey_pcr),
+            );
         }
 
         Ok(())
@@ -502,18 +515,22 @@ impl Drivers {
             ),
         };
 
-        // Initialize DPE with the RT journey PCR
-        let rt_journey_measurement = <[u8; DPE_PROFILE.get_hash_size()]>::from(
-            &drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR),
-        );
+        // Initialize DPE with the RT current PCR
+        let current_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR));
         let mut dpe = DpeInstance::new_auto_init(
             &mut env,
             DPE_SUPPORT,
             u32::from_be_bytes(*b"RTJM"),
-            rt_journey_measurement,
+            current_pcr,
             DpeInstanceFlags::empty(),
         )
         .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
+
+        // DPE internally extends the current measurement to set the cumulative measurement. Set it
+        // to the journey PCR so it follows the hardware.
+        let root_idx = Self::get_dpe_root_context_idx(&dpe)?;
+        dpe.contexts[root_idx].tci.tci_cumulative =
+            TciMeasurement(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR).into());
 
         // Call DeriveContext to create a measurement for the mailbox valid pausers and change locality to the pl0 pauser locality
         let derive_context_resp = DeriveContextCmd {

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -8,7 +8,7 @@ use core::mem::size_of;
 use caliptra_common::{handle_fatal_error, keyids::KEY_ID_TMP, mailbox_api::CommandId};
 use caliptra_drivers::{
     cprintln,
-    pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_JOURNEY_PCR},
+    pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
     Array4x12, CaliptraError, CaliptraResult, ResetReason,
 };
@@ -21,17 +21,20 @@ use caliptra_test_harness::{runtime_handlers, test_suite};
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 const OPCODE_READ_RT_FW_JOURNEY: u32 = 0x1000_0000;
+const OPCODE_READ_RT_FW_CURRENT: u32 = 0x1000_0001;
 const OPCODE_READ_MBOX_PAUSER_HASH: u32 = 0x2000_0000;
 const OPCODE_HASH_DPE_TCI_DATA: u32 = 0x3000_0000;
 const OPCODE_READ_STASHED_MEASUREMENT_PCR: u32 = 0x5000_0000;
 const OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT: u32 = 0x6000_0000;
+const OPCODE_READ_DPE_ROOT_CONTEXT_CUMULATIVE: u32 = 0x6000_0001;
 const OPCODE_READ_DPE_TAGS: u32 = 0x7000_0000;
 const OPCODE_CORRUPT_CONTEXT_TAGS: u32 = 0x8000_0000;
 const OPCODE_CORRUPT_CONTEXT_HAS_TAG: u32 = 0x9000_0000;
 const OPCODE_READ_DPE_INSTANCE: u32 = 0xA000_0000;
 const OPCODE_CORRUPT_DPE_INSTANCE: u32 = 0xB000_0000;
 const OPCODE_READ_PCR_RESET_COUNTER: u32 = 0xC000_0000;
-const OPCODE_CORRUPT_DPE_ROOT_TCI: u32 = 0xD000_0000;
+const OPCODE_CORRUPT_DPE_ROOT_JOURNEY_TCI: u32 = 0xD000_0000;
+const OPCODE_CORRUPT_DPE_ROOT_CURRENT_TCI: u32 = 0xD000_0001;
 const OPCODE_HOLD_COMMAND_BUSY: u32 = 0xE000_0000;
 const OPCODE_READ_KEY_LADDER_MAX_SVN: u32 = 0xF000_0000;
 const OPCODE_READ_KEY_LADDER_DIGEST: u32 = 0x1000_1000;
@@ -131,6 +134,10 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 let rt_journey_pcr: [u8; 48] = drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR).into();
                 write_response(&mut drivers.mbox, &rt_journey_pcr);
             }
+            CommandId(OPCODE_READ_RT_FW_CURRENT) => {
+                let rt_journey_pcr: [u8; 48] = drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR).into();
+                write_response(&mut drivers.mbox, &rt_journey_pcr);
+            }
             CommandId(OPCODE_READ_MBOX_PAUSER_HASH) => {
                 const PAUSER_COUNT: usize = 5;
                 let mbox_valid_pauser: [u32; PAUSER_COUNT] = drivers.soc_ifc.mbox_valid_pauser();
@@ -168,6 +175,15 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 let root_measurement = drivers.persistent_data.get().dpe.contexts[root_idx]
                     .tci
                     .tci_current
+                    .as_bytes();
+                write_response(&mut drivers.mbox, root_measurement);
+            }
+            CommandId(OPCODE_READ_DPE_ROOT_CONTEXT_CUMULATIVE) => {
+                let root_idx =
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
+                let root_measurement = drivers.persistent_data.get().dpe.contexts[root_idx]
+                    .tci
+                    .tci_cumulative
                     .as_bytes();
                 write_response(&mut drivers.mbox, root_measurement);
             }
@@ -221,7 +237,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     drivers.persistent_data.get().pcr_reset.as_bytes(),
                 );
             }
-            CommandId(OPCODE_CORRUPT_DPE_ROOT_TCI) => {
+            CommandId(OPCODE_CORRUPT_DPE_ROOT_CURRENT_TCI) => {
                 let input_bytes = read_request(&drivers.mbox);
 
                 let root_idx =
@@ -229,6 +245,16 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 drivers.persistent_data.get_mut().dpe.contexts[root_idx]
                     .tci
                     .tci_current = TciMeasurement(input_bytes.try_into().unwrap());
+                write_response(&mut drivers.mbox, &[]);
+            }
+            CommandId(OPCODE_CORRUPT_DPE_ROOT_JOURNEY_TCI) => {
+                let input_bytes = read_request(&drivers.mbox);
+
+                let root_idx =
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
+                drivers.persistent_data.get_mut().dpe.contexts[root_idx]
+                    .tci
+                    .tci_cumulative = TciMeasurement(input_bytes.try_into().unwrap());
                 write_response(&mut drivers.mbox, &[]);
             }
             CommandId(OPCODE_READ_KEY_LADDER_MAX_SVN) => {

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -214,15 +214,15 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // We don't expect the image_digest to be part of the stash
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     let expected_measurement_hash = hasher.finalize();
 
@@ -274,15 +274,15 @@ fn test_authorize_and_stash_cmd_success() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order to check that stashed measurement was added to DPE
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     hasher.update(IMAGE_DIGEST1);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -172,15 +172,15 @@ fn test_boot_tci_data() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     let expected_measurement_hash = hasher.finalize();
 
@@ -248,15 +248,15 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
 
         model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
-        let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-        let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+        let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+        let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
         let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
         let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
         // hash expected DPE measurements in order
         let mut hasher = Sha384::new();
-        hasher.update(rt_journey_pcr);
+        hasher.update(rt_current_pcr);
         hasher.update(valid_pauser_hash);
         hasher.update(measurement);
         let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -71,15 +71,15 @@ fn test_stash_measurement() {
         .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
         .unwrap();
 
-    let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
-    let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
 
     let valid_pauser_hash_resp = model.mailbox_execute(0x2000_0000, &[]).unwrap().unwrap();
     let valid_pauser_hash: [u8; 48] = valid_pauser_hash_resp.as_bytes().try_into().unwrap();
 
     // hash expected DPE measurements in order to check that stashed measurement was added to DPE
     let mut hasher = Sha384::new();
-    hasher.update(rt_journey_pcr);
+    hasher.update(rt_current_pcr);
     hasher.update(valid_pauser_hash);
     hasher.update(measurement);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -50,7 +50,7 @@ pub fn mbox_test_image() -> &'static FwId<'static> {
 }
 
 #[test]
-fn test_rt_journey_pcr_updated_in_dpe() {
+fn test_rt_pcr_updated_in_dpe() {
     let image_options = ImageOptions {
         pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
@@ -71,10 +71,18 @@ fn test_rt_journey_pcr_updated_in_dpe() {
     let rt_journey_pcr_resp = model.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
     let rt_journey_pcr: [u8; 48] = rt_journey_pcr_resp.as_bytes().try_into().unwrap();
 
-    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0000, &[]).unwrap().unwrap();
+    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0001, &[]).unwrap().unwrap();
     let dpe_root_measurement: [u8; 48] = dpe_root_measurement_resp.as_bytes().try_into().unwrap();
 
     assert_eq!(dpe_root_measurement, rt_journey_pcr);
+
+    let rt_current_pcr_resp = model.mailbox_execute(0x1000_0001, &[]).unwrap().unwrap();
+    let rt_current_pcr: [u8; 48] = rt_current_pcr_resp.as_bytes().try_into().unwrap();
+
+    let dpe_root_measurement_resp = model.mailbox_execute(0x6000_0000, &[]).unwrap().unwrap();
+    let dpe_root_measurement: [u8; 48] = dpe_root_measurement_resp.as_bytes().try_into().unwrap();
+
+    assert_eq!(dpe_root_measurement, rt_current_pcr);
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -81,6 +81,75 @@ fn test_rt_journey_pcr_validation() {
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 }
 
+#[test]
+fn test_rt_current_pcr_validation() {
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+
+    let fw_svn = 9;
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        crate::test_update_reset::mbox_test_image(),
+        ImageOptions {
+            fw_svn,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let (vendor_pk_desc_hash, owner_pk_hash) = image_pk_desc_hash(&image.manifest);
+
+    let binding = image.to_bytes().unwrap();
+    let soc_manifest = crate::common::default_soc_manifest_bytes(Default::default(), fw_svn);
+    let boot_params = BootParams {
+        fw_image: Some(&binding),
+        soc_manifest: Some(&soc_manifest),
+        mcu_fw_image: Some(crate::common::DEFAULT_MCU_FW),
+        ..Default::default()
+    };
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            fuses: Fuses {
+                vendor_pk_hash: vendor_pk_desc_hash,
+                owner_pk_hash,
+                ..Default::default()
+            },
+            rom: &rom,
+            security_state,
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        boot_params.clone(),
+    )
+    .unwrap();
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+
+    let _ = model
+        .mailbox_execute(0xD000_0001, &[0u8; DPE_PROFILE.get_tci_size()])
+        .unwrap()
+        .unwrap();
+
+    // Perform warm reset
+    model.warm_reset_flow().unwrap();
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_fw_error_non_fatal().read()
+            == u32::from(CaliptraError::RUNTIME_RT_CURRENT_PCR_VALIDATION_FAILED)
+    });
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+}
+
 // TODO: https://github.com/chipsalliance/caliptra-sw/issues/2225
 #[test]
 #[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]


### PR DESCRIPTION
Fixes #2775

The original design for DPE only considered only having one measurement per context. Later a design change added another to accomodate current and journey measurements. This was not reflected in the RT DPE context so journey was used for both measurements. This was partially due to the fact that the RT current measurement is also already reported in the RT alias certificate.

This changes 2.x to report both current and journey measurements in its DPE context. A similar change will be added to 1.x as tracked in #3027.