### PR TITLE
drivers: handle mailbox FSM error state and unexpected DataReady (2.0) (#3393)

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-262d5ff5da77a8804e97309194e701baad6467b2276483b342fc5df4ee6b21cd2f3fc2ea19708a76398473316df8e1a8  caliptra-rom-no-log.bin
-e953daf4a8953053937a75b8ac7d7d8d4dc9e229cbe44e52b7dc8c9f539d529e18a4702c1beaf6a21a723f96b2b1045f  caliptra-rom-with-log.bin
+fbe16569809ff13a676d9c211bb35311525d88c7f2bf372ffcbf45103e00269e0dffff02bb49bf63b18b9d4feacc6d29  caliptra-rom-no-log.bin
+7eccdb97d5146f3e99978713101af105e7f9f2599cf47eab099ed7d9bed6e35d055e3bad43ade54421e8b5ea9ebda9ce  caliptra-rom-with-log.bin

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -288,6 +288,11 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
+    pub const MAILBOX_DRIVER_DATA_READY: FwId = FwId {
+        bin_name: "mailbox_driver_data_ready",
+        ..BASE_FWID
+    };
+
     pub const MBOX_SEND_TXN_DROP: FwId = FwId {
         bin_name: "mbox_send_txn_drop",
         ..BASE_FWID
@@ -582,6 +587,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::MAILBOX_DRIVER_RESPONDER,
     &driver_tests::MAILBOX_DRIVER_SENDER,
     &driver_tests::MAILBOX_DRIVER_NEGATIVE_TESTS,
+    &driver_tests::MAILBOX_DRIVER_DATA_READY,
     &driver_tests::MBOX_SEND_TXN_DROP,
     &driver_tests::ML_DSA87,
     &driver_tests::PCRBANK,

--- a/drivers/src/mailbox.rs
+++ b/drivers/src/mailbox.rs
@@ -230,12 +230,17 @@ impl MailboxSendTxn<'_> {
 
     /// Checks if receiver processed the request.
     pub fn is_response_ready(&self) -> bool {
-        // TODO: Handle MboxStatusE::DataReady
         let mbox = self.mbox.regs();
+        let status = mbox.status().read();
+
+        // If the FSM is in error state (SoC misbehaved), stop waiting.
+        if status.mbox_fsm_ps().mbox_error() {
+            return true;
+        }
 
         matches!(
-            mbox.status().read().status(),
-            MboxStatusE::CmdComplete | MboxStatusE::CmdFailure
+            status.status(),
+            MboxStatusE::DataReady | MboxStatusE::CmdComplete | MboxStatusE::CmdFailure
         )
     }
 
@@ -252,6 +257,17 @@ impl MailboxSendTxn<'_> {
             return Err(CaliptraError::DRIVER_MAILBOX_INVALID_STATE);
         }
         let mbox = self.mbox.regs_mut();
+        let status = mbox.status().read();
+
+        // If FSM is in error state, recover by writing to unlock register.
+        // Also, DataReady is not expected in any current firmware flow.
+        // Treat it as unexpected SoC behavior.
+        if status.mbox_fsm_ps().mbox_error() || status.status() == MboxStatusE::DataReady {
+            mbox.unlock().write(|w| w.unlock(true));
+            self.state = MailboxOpState::Idle;
+            return Err(CaliptraError::DRIVER_MAILBOX_FSM_ERROR);
+        }
+
         mbox.execute().write(|w| w.execute(false));
         self.state = MailboxOpState::Idle;
         Ok(())

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -100,6 +100,11 @@ path = "src/bin/mailbox_driver_negative_tests.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "mailbox_driver_data_ready"
+path = "src/bin/mailbox_driver_data_ready.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "keyvault"
 path = "src/bin/keyvault_tests.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/mailbox_driver_data_ready.rs
+++ b/drivers/test-fw/src/bin/mailbox_driver_data_ready.rs
@@ -1,0 +1,45 @@
+// Licensed under the Apache-2.0 license
+
+//! Test firmware that sends a mailbox request and verifies that a DataReady
+//! response is treated as an error by the driver.
+
+#![no_main]
+#![no_std]
+
+// Needed to bring in startup code
+#[allow(unused)]
+use caliptra_test_harness::{self, println};
+
+use caliptra_drivers::{self, CaliptraError, Mailbox};
+use caliptra_registers::mbox::MboxCsr;
+
+#[panic_handler]
+pub fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[no_mangle]
+extern "C" fn main() {
+    let mut mbox = unsafe { Mailbox::new(MboxCsr::new()) };
+
+    // Send a request; the SoC will respond with DataReady
+    let mut txn = mbox.try_start_send_txn().unwrap();
+    txn.send_request(0xd000_0000, b"Hello").unwrap();
+    while !txn.is_response_ready() {}
+
+    // complete() should return an error since DataReady is unexpected
+    let result = txn.complete();
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        CaliptraError::DRIVER_MAILBOX_FSM_ERROR
+    ));
+    drop(txn);
+
+    // Mailbox should be back to idle after the unlock; send another request
+    // to prove recovery worked
+    let mut txn = mbox.wait_until_start_send_txn();
+    txn.send_request(0xd000_1000, b"").unwrap();
+    while !txn.is_response_ready() {}
+    txn.complete().unwrap();
+}

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -739,6 +739,24 @@ fn test_uc_to_soc_error_state() {
 }
 
 #[test]
+fn test_mailbox_uc_to_soc_data_ready() {
+    let mut model = start_driver_test(&firmware::driver_tests::MAILBOX_DRIVER_DATA_READY).unwrap();
+
+    // Firmware sends request with cmd 0xd000_0000 and data "Hello"
+    let txn = model.wait_for_mailbox_receive().unwrap();
+    assert_eq!(txn.req.cmd, 0xd000_0000);
+    assert_eq!(txn.req.data, b"Hello");
+    // Respond with DataReady - firmware should treat this as an error and unlock
+    txn.respond_with_data(&[0x12, 0x34, 0x56, 0x78]).unwrap();
+
+    // After error recovery, firmware retries with a second request
+    let txn = model.wait_for_mailbox_receive().unwrap();
+    assert_eq!(txn.req.cmd, 0xd000_1000);
+    assert_eq!(txn.req.data, b"");
+    txn.respond_success();
+}
+
+#[test]
 fn test_pcrbank() {
     run_driver_test(&firmware::driver_tests::PCRBANK);
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -384,6 +384,11 @@ impl CaliptraError {
             "Mailbox Error: Uncorrectable ECC"
         ),
         (
+            DRIVER_MAILBOX_FSM_ERROR,
+            0x00080006,
+            "Mailbox Error: FSM entered error state"
+        ),
+        (
             DRIVER_SHA2_512_384ACC_INDEX_OUT_OF_BOUNDS,
             0x00090003,
             "SHA2_512_384ACC Error: Index out of bounds"


### PR DESCRIPTION
Fix mailbox driver to detect and recover from the MBOX_ERROR FSM state during uC→SoC transactions. When the SoC misbehaves (e.g., writing to execute register when it doesn't own the lock), the FSM enters the error state. Previously, is_response_ready() would loop forever.

Also, while we're here, we handle the unexpected DataReady case, where additional data is attempted to be sent through the mailbox after the initial response. We don't support this kind of flow in the firmware today, so we have abort the transaction in this case.

Fixes #718

(cherry picked from commit 537f3913e424f14428ff26cbc7692d716671db99)