### PR TITLE
Add emulator check for ABR_ENTROPY

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-cb192f868e929b2953535083c503b343f88cbb76aaa4acac167c2fc553170baf4cffc60424c68ec21ee7bc924c46b936  caliptra-rom-no-log.bin
-0c7cd2729ee7c7956a39a9eaa6b6d63486243f3d90e8d5d2f0d22b6aaa8b8b6111e4d2606328a01574daee287044ad2d  caliptra-rom-with-log.bin
+7524bc58025a0a5d648dbd908042e6215eda70a9f5320144272799516b57e045bcda8ff355b8cb189f8fe9877e2a3c70  caliptra-rom-no-log.bin
+62b9b858cbfbe1818ae6fd2544f9d2557dbaea07a41be25e60a37acde4ffb2de41d242c4d134e31114c2514d0662e9e7  caliptra-rom-with-log.bin

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -115,11 +115,6 @@ impl<'a> Mldsa87<'a> {
         Self { mldsa87 }
     }
 
-    fn generate_iv(trng: &mut Trng) -> CaliptraResult<LEArray4x16> {
-        let iv = trng.generate16()?;
-        Ok(LEArray4x16::from(iv))
-    }
-
     // Wait on the provided condition OR the error condition defined in this function
     // In the event of the error condition being set, clear the error bits and return an error
     fn wait<F>(regs: RegisterBlock<ureg::RealMmioMut>, condition: F) -> CaliptraResult<()>
@@ -181,9 +176,8 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Seed::PrivKey(_) => Err(CaliptraError::DRIVER_MLDSA87_KEY_GEN_SEED_BAD_USAGE)?,
         }
 
-        // Generate an IV.
-        let iv = Self::generate_iv(trng)?;
-        iv.write_to_reg(mldsa.entropy());
+        // Generate randomness for SCA protection.
+        trng.generate16()?.write_to_reg(mldsa.entropy());
 
         // Program the command register for key generation
         mldsa.mldsa_ctrl().write(|w| w.ctrl(KEYGEN));
@@ -245,9 +239,8 @@ impl<'a> Mldsa87<'a> {
         // Sign RND, TODO do we want deterministic?
         sign_rnd.write_to_reg(mldsa.mldsa_sign_rnd());
 
-        // Generate an IV.
-        let iv = Self::generate_iv(trng)?;
-        iv.write_to_reg(mldsa.entropy());
+        // Generate randomness for SCA protection.
+        trng.generate16()?.write_to_reg(mldsa.entropy());
 
         // Program the command register for key generation
         mldsa.mldsa_ctrl().write(|w| {
@@ -386,9 +379,8 @@ impl<'a> Mldsa87<'a> {
         // Sign RND.
         sign_rnd.write_to_reg(mldsa.mldsa_sign_rnd());
 
-        // Generate an IV.
-        let iv = Self::generate_iv(trng)?;
-        iv.write_to_reg(mldsa.entropy());
+        // Generate randomness for SCA protection.
+        trng.generate16()?.write_to_reg(mldsa.entropy());
 
         // Copy seed or the private key to the hardware
         match seed {
@@ -574,9 +566,8 @@ impl<'a> Mldsa87<'a> {
         // Wait for hardware ready
         Mldsa87::wait(mldsa, || mldsa.mldsa_status().read().ready())?;
 
-        // Generate an IV.
-        let iv = Self::generate_iv(trng)?;
-        iv.write_to_reg(mldsa.entropy());
+        // Generate randomness for SCA protection.
+        trng.generate16()?.write_to_reg(mldsa.entropy());
 
         mldsa
             .mldsa_ctrl()

--- a/drivers/test-fw/src/bin/hpke_tests.rs
+++ b/drivers/test-fw/src/bin/hpke_tests.rs
@@ -64,6 +64,7 @@ test_suite! {
 fn test_ml_kem_1024_test_vector() {
     CfiCounter::reset(&mut || Ok((0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef)));
     let mut regs = TestRegisters::default();
+    regs.abr.seed_entropy(&mut regs.trng).unwrap();
 
     // SAFETY: This API is unsafe to discourage usage in firmware. It's used here to verify the
     // HPKE implementation against a known test vector.
@@ -108,6 +109,7 @@ fn test_ml_kem_1024_test_vector() {
 fn test_ml_kem_1024_self_talk() {
     CfiCounter::reset(&mut || Ok((0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef)));
     let mut regs = TestRegisters::default();
+    regs.abr.seed_entropy(&mut regs.trng).unwrap();
 
     let hpke = HpkeMlKemContext::generate(&mut regs.trng).unwrap();
     let mut kem = {
@@ -283,6 +285,7 @@ fn test_p384_public_key_curve_validation() {
 fn test_hybrid_test_vector() {
     CfiCounter::reset(&mut || Ok((0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef)));
     let mut regs = TestRegisters::default();
+    regs.abr.seed_entropy(&mut regs.trng).unwrap();
 
     let trad_priv_key = Ecc384Scalar::from(<[u8; 48]>::try_from(HYBRID_TRAD_DK).unwrap());
     let trad_pub_key = Ecc384PubKey {
@@ -352,6 +355,7 @@ fn test_hybrid_test_vector() {
 fn test_hybrid_self_talk() {
     CfiCounter::reset(&mut || Ok((0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef)));
     let mut regs = TestRegisters::default();
+    regs.abr.seed_entropy(&mut regs.trng).unwrap();
 
     let hpke = HpkeHybridContext::generate(&mut regs.trng).unwrap();
 

--- a/drivers/test-fw/src/bin/mlkem_tests.rs
+++ b/drivers/test-fw/src/bin/mlkem_tests.rs
@@ -45,6 +45,25 @@ const MESSAGE: [u32; 8] = [
 
 const KEY_ID: KeyId = KeyId::KeyId2;
 
+/// Seed the ABR entropy registers with fresh randomness.
+/// This must be called before any MLKEM (or MLDSA) operation.
+fn seed_abr_entropy() {
+    let mut trng = unsafe {
+        Trng::new(
+            CsrngReg::new(),
+            EntropySrcReg::new(),
+            SocIfcTrngReg::new(),
+            &SocIfcReg::new(),
+            PersistentDataAccessor::new(),
+        )
+        .unwrap()
+    };
+    let mut abr_reg = unsafe { AbrReg::new() };
+    let regs = abr_reg.regs_mut();
+    let entropy = trng.generate16().unwrap();
+    entropy.write_to_reg(regs.entropy());
+}
+
 fn test_mlkem_name() {
     let mut trng = unsafe {
         Trng::new(
@@ -74,6 +93,7 @@ fn test_mlkem_name() {
 }
 
 fn test_key_pair_generation() {
+    seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
     let mut mlkem = MlKem1024::new(&mut abr_reg);
 
@@ -270,6 +290,7 @@ fn test_key_pair_generation() {
 }
 
 fn test_key_pair_generation_from_kv() {
+    seed_abr_entropy();
     let mut trng = unsafe {
         Trng::new(
             CsrngReg::new(),
@@ -373,6 +394,7 @@ fn test_key_pair_generation_from_kv() {
 }
 
 fn test_encapsulate_and_decapsulate() {
+    seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
     let mut mlkem = MlKem1024::new(&mut abr_reg);
 
@@ -413,6 +435,7 @@ fn test_encapsulate_and_decapsulate() {
 }
 
 fn test_encapsulate_with_kv_message() {
+    seed_abr_entropy();
     let mut trng = unsafe {
         Trng::new(
             CsrngReg::new(),
@@ -603,6 +626,7 @@ fn test_encapsulate_with_kv_message() {
 }
 
 fn test_encapsulate_with_kv_output() {
+    seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
     let mut mlkem = MlKem1024::new(&mut abr_reg);
 
@@ -635,6 +659,7 @@ fn test_encapsulate_with_kv_output() {
 }
 
 fn test_keygen_decapsulate() {
+    seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
     let mut mlkem = MlKem1024::new(&mut abr_reg);
 
@@ -673,6 +698,7 @@ fn test_keygen_decapsulate() {
 }
 
 fn test_keygen_decapsulate_with_kv() {
+    seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
     let mut mlkem = MlKem1024::new(&mut abr_reg);
 

--- a/sw-emulator/lib/periph/src/abr.rs
+++ b/sw-emulator/lib/periph/src/abr.rs
@@ -519,8 +519,14 @@ impl Abr {
         match self.mldsa_ctrl.reg.read_as_enum(MlDsaControl::CTRL) {
             Some(MlDsaControl::CTRL::Value::KEYGEN)
             | Some(MlDsaControl::CTRL::Value::SIGNING)
-            | Some(MlDsaControl::CTRL::Value::VERIFYING)
             | Some(MlDsaControl::CTRL::Value::KEYGEN_AND_SIGN) => {
+                // Entropy must be written with non-zero values before these operations
+                // to provide SCA countermeasures.
+                assert!(
+                    self.abr_entropy.iter().any(|&v| v != 0),
+                    "ABR_ENTROPY registers must be written with non-zero values before KEYGEN/SIGNING/KEYGEN_AND_SIGN operations"
+                );
+
                 // Reset the Ready and Valid status bits
                 self.mldsa_status
                     .reg
@@ -532,10 +538,28 @@ impl Abr {
                     && (self.mldsa_ctrl.reg.read_as_enum(MlDsaControl::CTRL)
                         == Some(MlDsaControl::CTRL::Value::SIGNING)
                         || self.mldsa_ctrl.reg.read_as_enum(MlDsaControl::CTRL)
-                            == Some(MlDsaControl::CTRL::Value::VERIFYING)
-                        || self.mldsa_ctrl.reg.read_as_enum(MlDsaControl::CTRL)
                             == Some(MlDsaControl::CTRL::Value::KEYGEN_AND_SIGN))
                 {
+                    // Clear any previous streamed message
+                    self.mldsa_streamed_msg.clear();
+                    self.mldsa_status
+                        .reg
+                        .modify(MlDsaStatus::MSG_STREAM_READY::CLEAR);
+                    // Schedule an action to set the MSG_STREAM_READY bit after a short delay
+                    self.mldsa_op_msg_stream_ready_action = Some(self.timer.schedule_poll_in(10));
+                } else {
+                    // Not waiting for message streaming, proceed with operation
+                    self.mldsa_op_complete_action =
+                        Some(self.timer.schedule_poll_in(ML_DSA87_OP_TICKS));
+                }
+            }
+            Some(MlDsaControl::CTRL::Value::VERIFYING) => {
+                // Reset the Ready and Valid status bits
+                self.mldsa_status
+                    .reg
+                    .modify(MlDsaStatus::READY::CLEAR + MlDsaStatus::VALID::CLEAR);
+
+                if self.mldsa_ctrl.reg.is_set(MlDsaControl::STREAM_MSG) {
                     // Clear any previous streamed message
                     self.mldsa_streamed_msg.clear();
                     self.mldsa_status
@@ -974,6 +998,13 @@ impl Abr {
             | Some(MlKemControl::CTRL::Value::ENCAPS)
             | Some(MlKemControl::CTRL::Value::DECAPS)
             | Some(MlKemControl::CTRL::Value::KEYGEN_DECAPS) => {
+                // Entropy must be written with non-zero values before these operations
+                // to provide SCA countermeasures.
+                assert!(
+                    self.abr_entropy.iter().any(|&v| v != 0),
+                    "ABR_ENTROPY registers must be written with non-zero values before MLKEM operations"
+                );
+
                 // Reset the Ready and Valid status bits
                 self.mlkem_status.reg.modify(
                     MlKemStatus::READY::CLEAR
@@ -1410,6 +1441,7 @@ mod tests {
     const OFFSET_MLDSA_VERSION1: RvAddr = 0xC;
     const OFFSET_MLDSA_CONTROL: RvAddr = 0x10;
     const OFFSET_MLDSA_STATUS: RvAddr = 0x14;
+    const OFFSET_ABR_ENTROPY: RvAddr = 0x18;
     const OFFSET_MLDSA_SEED: RvAddr = 0x58;
     const OFFSET_MLDSA_SIGN_RND: RvAddr = 0x78;
     const OFFSET_MLDSA_MSG: RvAddr = 0x98;
@@ -1432,6 +1464,18 @@ mod tests {
     const OFFSET_MLKEM_DECAPS_KEY: RvAddr = 0xA000;
     const OFFSET_MLKEM_ENCAPS_KEY: RvAddr = 0xB000;
     const OFFSET_MLKEM_CIPHERTEXT: RvAddr = 0xB800;
+
+    /// Write non-zero entropy to the ABR_ENTROPY registers (shared by MLDSA and MLKEM).
+    fn write_abr_entropy(abr: &mut Abr) {
+        for i in 0..(ML_DSA87_IV_SIZE / 4) {
+            abr.write(
+                RvSize::Word,
+                OFFSET_ABR_ENTROPY + (i * 4) as RvAddr,
+                rand::thread_rng().gen::<u32>() | 1, // ensure non-zero
+            )
+            .unwrap();
+        }
+    }
 
     #[test]
     fn test_mldsa_name() {
@@ -1509,6 +1553,8 @@ mod tests {
                 .unwrap();
         }
 
+        write_abr_entropy(&mut ml_dsa87);
+
         ml_dsa87
             .write(
                 RvSize::Word,
@@ -1584,6 +1630,8 @@ mod tests {
                 )
                 .unwrap();
         }
+
+        write_abr_entropy(&mut ml_dsa87);
 
         ml_dsa87
             .write(
@@ -1819,6 +1867,8 @@ mod tests {
                 clock.increment_and_process_timer_actions(1, &mut ml_dsa87);
             }
 
+            write_abr_entropy(&mut ml_dsa87);
+
             ml_dsa87
                 .write(
                     RvSize::Word,
@@ -1884,6 +1934,8 @@ mod tests {
         // Save public key for later verification
         let mut keygen_rng = SeedOnlyRng::new(seed);
         let (pk, _sk) = try_keygen_with_rng(&mut keygen_rng).unwrap();
+
+        write_abr_entropy(&mut ml_dsa87);
 
         // Enable key generation and signing with streaming message mode in one operation
         let ctrl_value =
@@ -2035,6 +2087,8 @@ mod tests {
                 .unwrap();
         }
 
+        write_abr_entropy(&mut ml_dsa87);
+
         // Start signing operation with streaming mode
         let ctrl_value = MlDsaControl::CTRL::SIGNING.value | MlDsaControl::STREAM_MSG::SET.value;
         ml_dsa87
@@ -2125,6 +2179,165 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before KEYGEN/SIGNING/KEYGEN_AND_SIGN operations"
+    )]
+    fn test_mldsa_keygen_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut ml_dsa87 = Abr::new(&clock, key_vault, sha512);
+
+        let seed = rand::thread_rng().gen::<[u8; 32]>();
+        for (i, chunk) in seed.chunks_exact(4).enumerate() {
+            ml_dsa87
+                .write(
+                    RvSize::Word,
+                    OFFSET_MLDSA_SEED + (i * 4) as RvAddr,
+                    u32::from_le_bytes(chunk.try_into().unwrap()),
+                )
+                .unwrap();
+        }
+
+        // Do NOT write entropy — this should panic
+        ml_dsa87
+            .write(
+                RvSize::Word,
+                OFFSET_MLDSA_CONTROL,
+                MlDsaControl::CTRL::KEYGEN.into(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before KEYGEN/SIGNING/KEYGEN_AND_SIGN operations"
+    )]
+    fn test_mldsa_signing_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut ml_dsa87 = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        ml_dsa87
+            .write(
+                RvSize::Word,
+                OFFSET_MLDSA_CONTROL,
+                MlDsaControl::CTRL::SIGNING.into(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before KEYGEN/SIGNING/KEYGEN_AND_SIGN operations"
+    )]
+    fn test_mldsa_keygen_and_sign_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut ml_dsa87 = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        ml_dsa87
+            .write(
+                RvSize::Word,
+                OFFSET_MLDSA_CONTROL,
+                MlDsaControl::CTRL::KEYGEN_AND_SIGN.into(),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_mldsa_verify_without_entropy_succeeds() {
+        // Verify operations should NOT require entropy
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut ml_dsa87 = Abr::new(&clock, key_vault, sha512);
+
+        let msg: [u8; 64] = {
+            let part0 = rand::thread_rng().gen::<[u8; 32]>();
+            let part1 = rand::thread_rng().gen::<[u8; 32]>();
+            let concat: Vec<u8> = part0.iter().chain(part1.iter()).copied().collect();
+            concat.as_slice().try_into().unwrap()
+        };
+
+        let seed = rand::thread_rng().gen::<[u8; 32]>();
+        let mut keygen_rng = SeedOnlyRng::new(seed);
+        let (pk_from_lib, sk_from_lib) = try_keygen_with_rng(&mut keygen_rng).unwrap();
+        let signature_from_lib = sk_from_lib
+            .try_sign_with_seed(&[0u8; 32], &msg, &[])
+            .unwrap();
+
+        for (i, chunk) in msg.chunks_exact(4).enumerate() {
+            ml_dsa87
+                .write(
+                    RvSize::Word,
+                    OFFSET_MLDSA_MSG + (i * 4) as RvAddr,
+                    u32::from_le_bytes(chunk.try_into().unwrap()),
+                )
+                .unwrap();
+        }
+
+        let pk_for_hw = pk_from_lib.into_bytes();
+        for (i, chunk) in pk_for_hw.chunks_exact(4).enumerate() {
+            ml_dsa87
+                .write(
+                    RvSize::Word,
+                    OFFSET_MLDSA_PK + (i * 4) as RvAddr,
+                    u32::from_le_bytes(chunk.try_into().unwrap()),
+                )
+                .unwrap();
+        }
+
+        let sig_for_hw = {
+            let mut sig = [0; SIG_LEN + 1];
+            sig[..SIG_LEN].copy_from_slice(&signature_from_lib);
+            sig
+        };
+
+        for (i, chunk) in sig_for_hw.chunks_exact(4).enumerate() {
+            ml_dsa87
+                .write(
+                    RvSize::Word,
+                    OFFSET_MLDSA_SIGNATURE + (i * 4) as RvAddr,
+                    u32::from_le_bytes(chunk.try_into().unwrap()),
+                )
+                .unwrap();
+        }
+
+        // Do NOT write entropy — verify should still work
+        ml_dsa87
+            .write(
+                RvSize::Word,
+                OFFSET_MLDSA_CONTROL,
+                MlDsaControl::CTRL::VERIFYING.into(),
+            )
+            .unwrap();
+
+        loop {
+            let status = InMemoryRegister::<u32, MlDsaStatus::Register>::new(
+                ml_dsa87.read(RvSize::Word, OFFSET_MLDSA_STATUS).unwrap(),
+            );
+
+            if status.is_set(MlDsaStatus::VALID) && status.is_set(MlDsaStatus::READY) {
+                break;
+            }
+
+            clock.increment_and_process_timer_actions(1, &mut ml_dsa87);
+        }
+
+        let result = bytes_from_words_le(&ml_dsa87.mldsa_verify_res);
+        assert_eq!(result, &sig_for_hw[..ML_DSA87_VERIFICATION_SIZE_BYTES]);
+    }
+
+    #[test]
     fn test_mlkem_keygen() {
         let clock = Clock::new();
         let key_vault = KeyVault::new();
@@ -2153,6 +2366,8 @@ mod tests {
             )
             .unwrap();
         }
+
+        write_abr_entropy(&mut abr);
 
         // Trigger keygen
         abr.write(
@@ -2221,6 +2436,8 @@ mod tests {
             .unwrap();
         }
 
+        write_abr_entropy(&mut abr);
+
         // Trigger encapsulation
         abr.write(
             RvSize::Word,
@@ -2281,6 +2498,8 @@ mod tests {
             )
             .unwrap();
         }
+
+        write_abr_entropy(&mut abr);
 
         // Trigger decapsulation (ciphertext should already be set from encaps)
         abr.write(
@@ -2361,6 +2580,8 @@ mod tests {
             .unwrap();
         }
 
+        write_abr_entropy(&mut abr);
+
         // Trigger keygen + decapsulation
         abr.write(
             RvSize::Word,
@@ -2393,5 +2614,85 @@ mod tests {
         let encaps_key_hw = bytes_from_words_le(&abr.mlkem_encaps_key);
         let expected_ek_bytes = ek.as_bytes();
         assert_eq!(encaps_key_hw, expected_ek_bytes);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before MLKEM operations"
+    )]
+    fn test_mlkem_keygen_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut abr = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        abr.write(
+            RvSize::Word,
+            OFFSET_MLKEM_CONTROL,
+            MlKemControl::CTRL::KEYGEN.into(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before MLKEM operations"
+    )]
+    fn test_mlkem_encaps_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut abr = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        abr.write(
+            RvSize::Word,
+            OFFSET_MLKEM_CONTROL,
+            MlKemControl::CTRL::ENCAPS.into(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before MLKEM operations"
+    )]
+    fn test_mlkem_decaps_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut abr = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        abr.write(
+            RvSize::Word,
+            OFFSET_MLKEM_CONTROL,
+            MlKemControl::CTRL::DECAPS.into(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ABR_ENTROPY registers must be written with non-zero values before MLKEM operations"
+    )]
+    fn test_mlkem_keygen_decaps_without_entropy_panics() {
+        let clock = Clock::new();
+        let key_vault = KeyVault::new();
+        let sha512 = HashSha512::new(&clock, key_vault.clone());
+
+        let mut abr = Abr::new(&clock, key_vault, sha512);
+
+        // Do NOT write entropy — this should panic
+        abr.write(
+            RvSize::Word,
+            OFFSET_MLKEM_CONTROL,
+            MlKemControl::CTRL::KEYGEN_DECAPS.into(),
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
This also removes an unnecessary byte swap in the mldsa87 driver and clarifies the names and comments around the entropy.

This is a cherry pick of the relevant changes from the 2.0 PR #3521