### PR TITLE
ci: set FIPS_TEST_ROM_EXP_VERSION for frozen ROM 2.1 tests

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -349,6 +349,11 @@ jobs:
 
           if [[ "${{ inputs.workflow_call }}" && "${{ inputs.rom-version }}" != "latest" ]]; then
             VARS+=" CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}""
+            # Map rom-version to the expected FIPS test ROM version
+            case "${{ inputs.rom-version }}" in
+              "2.1") VARS+=" FIPS_TEST_ROM_EXP_VERSION=2_1_0" ;;
+              *) echo "Unknown rom-version ${{ inputs.rom-version }} for FIPS_TEST_ROM_EXP_VERSION"; exit 1 ;;
+            esac
           fi
 
           echo VARS=${VARS}

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -292,6 +292,11 @@ jobs:
 
           if [[ "${{ inputs.workflow_call }}" && "${{ inputs.rom-version }}" != "latest" ]]; then
             VARS+=" CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}""
+            # Map rom-version to the expected FIPS test ROM version
+            case "${{ inputs.rom-version }}" in
+              "2.1") VARS+=" FIPS_TEST_ROM_EXP_VERSION=2_1_0" ;;
+              *) echo "Unknown rom-version ${{ inputs.rom-version }} for FIPS_TEST_ROM_EXP_VERSION"; exit 1 ;;
+            esac
           fi
 
           echo VARS=${VARS}

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -61,6 +61,11 @@ jobs:
           export CALIPTRA_PREBUILT_FW_DIR=/tmp/caliptra-test-firmware
           if [ "${{ inputs.rom-version }}" != "latest" ]; then
             export CPTRA_CI_ROM_VERSION="${{ inputs.rom-version }}"
+            # Map rom-version to the expected FIPS test ROM version
+            case "${{ inputs.rom-version }}" in
+              "2.1") export FIPS_TEST_ROM_EXP_VERSION="2_1_0" ;;
+              *) echo "Unknown rom-version ${{ inputs.rom-version }} for FIPS_TEST_ROM_EXP_VERSION"; exit 1 ;;
+            esac
           fi
 
           if [ "${{ inputs.rom-logging }}" == "true" ] || [ -z "${{ inputs.rom-logging }}" ]; then


### PR DESCRIPTION
When running tests against the frozen ROM 2.1 binary (version 0x1040), the FIPS test suite defaults to ROM_EXP_CURRENT (0x1041) since the ROM version was bumped to 2.1.1. This causes services::execute_all_services_rom, services::execute_all_services_rt, and services::version_info_update to fail with version assertion mismatches in all rom-2.1 CI variants.