### PR TITLE
DPE core upgrades: SVN, State, Crypto API, PCRs, env unification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "caliptra-runtime",
  "caliptra-test-harness",
  "cfg-if",
+ "dpe",
  "ufmt",
  "zerocopy",
 ]
@@ -1379,6 +1380,7 @@ dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
+ "zerocopy",
  "zeroize",
 ]
 

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -128,14 +128,8 @@ pub use soc_ifc::{report_boot_status, CptraGeneration, Lifecycle, MfgFlags, Rese
 pub use trng::Trng;
 
 #[allow(unused_imports)]
-#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
-use caliptra_cfi_derive;
-#[allow(unused_imports)]
 #[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_derive_git as caliptra_cfi_derive;
-#[allow(unused_imports)]
-#[cfg(all(not(feature = "runtime"), not(feature = "no-cfi")))]
-use caliptra_cfi_lib;
 #[allow(unused_imports)]
 #[cfg(all(feature = "runtime", not(feature = "no-cfi")))]
 use caliptra_cfi_lib_git as caliptra_cfi_lib;

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -10,7 +10,7 @@ use caliptra_auth_man_types::{
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::{ImageManifest, SHA512_DIGEST_BYTE_SIZE};
 #[cfg(feature = "runtime")]
-use dpe::{DpeInstance, ExportedCdiHandle, U8Bool, MAX_HANDLES};
+use dpe::{ExportedCdiHandle, U8Bool, MAX_HANDLES};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
@@ -78,7 +78,7 @@ pub struct ExportedCdiHandles {
 }
 
 #[cfg(feature = "runtime")]
-const DPE_DCCM_STORAGE: usize = size_of::<DpeInstance>()
+const DPE_DCCM_STORAGE: usize = size_of::<dpe::State>()
     + size_of::<u32>() * MAX_HANDLES
     + size_of::<U8Bool>() * MAX_HANDLES
     + size_of::<U8Bool>()
@@ -324,7 +324,7 @@ pub struct PersistentData {
     reserved5: [u8; FUSE_LOG_SIZE as usize - size_of::<FuseLogArray>()],
 
     #[cfg(feature = "runtime")]
-    pub dpe: DpeInstance,
+    pub state: dpe::State,
     #[cfg(feature = "runtime")]
     pub context_tags: [u32; MAX_HANDLES],
     #[cfg(feature = "runtime")]
@@ -484,6 +484,12 @@ impl PersistentData {
             );
 
             persistent_data_offset += FUSE_LOG_SIZE;
+            #[cfg(feature = "runtime")]
+            assert_eq!(
+                addr_of!((*P).state) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+            #[cfg(not(feature = "runtime"))]
             assert_eq!(
                 addr_of!((*P).dpe) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -470,6 +470,7 @@ struct dpe_derive_context_cmd
     uint32_t flags;
     uint8_t input_type[4];
     uint32_t target_locality;
+    uint32_t svn;
 };
 
 struct dpe_derive_context_response

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -127,8 +127,12 @@ impl AuthorizeAndStashCmd {
         if auth_result == IMAGE_AUTHORIZED {
             let flags: AuthAndStashFlags = cmd.flags.into();
             if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
-                let dpe_result =
-                    StashMeasurementCmd::stash_measurement(drivers, &cmd.fw_id, &cmd.measurement)?;
+                let dpe_result = StashMeasurementCmd::stash_measurement(
+                    drivers,
+                    &cmd.fw_id,
+                    &cmd.measurement,
+                    cmd.svn,
+                )?;
                 if dpe_result != DpeErrorCode::NoError {
                     drivers
                         .soc_ifc

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,9 +12,8 @@ Abstract:
 
 --*/
 
-use crate::{
-    mutrefbytes, CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges,
-};
+use crate::{mutrefbytes, with_dpe_env, Drivers, PauserPrivileges};
+use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{
     CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxRespHeader,
 };
@@ -22,6 +21,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::{
     commands::{CertifyKeyCmd, CommandExecution},
     response::Response,
+    DpeInstance,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -44,51 +44,24 @@ impl CertifyKeyExtendedCmd {
             }
         }
 
-        let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-        let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-        let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
-        let pdata = drivers.persistent_data.get_mut();
-        let crypto = DpeCrypto::new(
-            &mut drivers.sha2_512_384,
-            &mut drivers.trng,
-            &mut drivers.ecc384,
-            &mut drivers.hmac,
-            &mut drivers.key_vault,
-            &mut pdata.fht.rt_dice_ecc_pub_key,
-            key_id_rt_cdi,
-            key_id_rt_priv_key,
-            &mut pdata.exported_cdi_slots,
-        );
-        let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-        let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
         // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
         let dmtf_device_info = if cmd.flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
-            drivers
-                .dmtf_device_info
-                .as_ref()
-                .map(|dmtf_device_info| dmtf_device_info.as_bytes())
+            drivers.dmtf_device_info.as_ref().and_then(|info| {
+                let mut dmtf_device_info = ArrayVec::new();
+                dmtf_device_info.try_extend_from_slice(info).ok()?;
+                Some(dmtf_device_info)
+            })
         } else {
             None
         };
-        let mut env = DpeEnv::<CptraDpeTypes> {
-            crypto,
-            platform: DpePlatform::new(
-                pl0_pauser,
-                &hashed_rt_pub_key,
-                &drivers.ecc_cert_chain,
-                &nb,
-                &nf,
-                dmtf_device_info,
-                None,
-            ),
-        };
+        let locality = drivers.mbox.id();
 
-        let dpe = &mut pdata.dpe;
         let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..]).or(Err(
             CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
         ))?;
-        let locality = drivers.mbox.id();
-        let resp = certify_key_cmd.execute(dpe, &mut env, locality);
+        let resp = with_dpe_env(drivers, dmtf_device_info, None, |env| {
+            Ok(certify_key_cmd.execute(&mut DpeInstance::initialized(), env, locality))
+        })?;
 
         let certify_key_resp = match resp {
             Ok(Response::CertifyKey(certify_key_resp)) => certify_key_resp,

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -21,19 +21,19 @@ use crypto::Digest;
 use dpe::x509::{CertWriter, DirectoryString, Name};
 use platform::{
     CertValidity, OtherName, Platform, PlatformError, SignerIdentifier, SubjectAltName, Ueid,
-    MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE,
+    MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
 };
 
 use crate::{subject_alt_name::AddSubjectAltNameCmd, MAX_ECC_CERT_CHAIN_SIZE};
 
 pub struct DpePlatform<'a> {
     auto_init_locality: u32,
-    hashed_rt_pub_key: &'a Digest,
+    hashed_rt_pub_key: Digest,
     cert_chain: &'a ArrayVec<u8, MAX_ECC_CERT_CHAIN_SIZE>,
-    not_before: &'a NotBefore,
-    not_after: &'a NotAfter,
-    dmtf_device_info: Option<&'a [u8]>,
-    ueid: Option<&'a [u8; 17]>,
+    not_before: NotBefore,
+    not_after: NotAfter,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
 }
 
 pub const VENDOR_ID: u32 = u32::from_be_bytes(*b"CTRA");
@@ -42,12 +42,12 @@ pub const VENDOR_SKU: u32 = u32::from_be_bytes(*b"CTRA");
 impl<'a> DpePlatform<'a> {
     pub fn new(
         auto_init_locality: u32,
-        hashed_rt_pub_key: &'a Digest,
+        hashed_rt_pub_key: Digest,
         cert_chain: &'a ArrayVec<u8, 4096>,
-        not_before: &'a NotBefore,
-        not_after: &'a NotAfter,
-        dmtf_device_info: Option<&'a [u8]>,
-        ueid: Option<&'a [u8; 17]>,
+        not_before: NotBefore,
+        not_after: NotAfter,
+        dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+        ueid: Option<[u8; 17]>,
     ) -> Self {
         Self {
             auto_init_locality,
@@ -110,8 +110,23 @@ impl Platform for DpePlatform<'_> {
 
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
-        Digest::write_hex_str(self.hashed_rt_pub_key, &mut serial)
-            .map_err(|e| PlatformError::IssuerNameError(e.get_error_detail().unwrap_or(0)))?;
+        let src = self.hashed_rt_pub_key.as_slice();
+        if serial.len() != src.len() * 2 {
+            return Err(PlatformError::IssuerNameError(0));
+        }
+
+        let mut curr_idx = 0;
+        const HEX_CHARS: &[u8; 16] = b"0123456789ABCDEF";
+        for &b in src {
+            let h1 = (b >> 4) as usize;
+            let h2 = (b & 0xF) as usize;
+            if h1 >= HEX_CHARS.len() || h2 >= HEX_CHARS.len() || curr_idx + 1 >= serial.len() {
+                return Err(PlatformError::IssuerNameError(1));
+            }
+            serial[curr_idx] = HEX_CHARS[h1];
+            serial[curr_idx + 1] = HEX_CHARS[h2];
+            curr_idx += 2;
+        }
 
         let name = Name {
             cn: DirectoryString::Utf8String(CALIPTRA_CN),
@@ -128,7 +143,7 @@ impl Platform for DpePlatform<'_> {
     /// SubjectKeyIdentifier extension in the RT alias certificate.
     fn get_signer_identifier(&mut self) -> Result<SignerIdentifier, PlatformError> {
         let mut ski = [0u8; MAX_KEY_IDENTIFIER_SIZE];
-        let hashed_rt_pub_key = self.hashed_rt_pub_key.bytes();
+        let hashed_rt_pub_key = self.hashed_rt_pub_key.as_slice();
         if hashed_rt_pub_key.len() < MAX_KEY_IDENTIFIER_SIZE {
             return Err(PlatformError::SubjectKeyIdentifierError(0));
         }
@@ -144,7 +159,7 @@ impl Platform for DpePlatform<'_> {
         &mut self,
         out: &mut [u8; MAX_KEY_IDENTIFIER_SIZE],
     ) -> Result<(), PlatformError> {
-        let hashed_rt_pub_key = self.hashed_rt_pub_key.bytes();
+        let hashed_rt_pub_key = self.hashed_rt_pub_key.as_slice();
         if hashed_rt_pub_key.len() < MAX_KEY_IDENTIFIER_SIZE {
             return Err(PlatformError::IssuerKeyIdentifierError(0));
         }
@@ -190,7 +205,7 @@ impl Platform for DpePlatform<'_> {
     }
 
     fn get_ueid(&mut self) -> Result<Ueid, PlatformError> {
-        let buf = *self.ueid.ok_or(PlatformError::MissingUeidError)?;
+        let buf = self.ueid.ok_or(PlatformError::MissingUeidError)?;
         let buf_size = buf.len() as u32;
 
         let mut ueid = Ueid::default();

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -53,10 +53,11 @@ use caliptra_registers::{
 };
 use caliptra_ureg::MmioMut;
 use caliptra_x509::{NotAfter, NotBefore};
+use crypto::Digest;
 use dpe::context::{Context, ContextState, ContextType};
-use dpe::dpe_instance::DpeInstanceFlags;
 use dpe::tci::TciMeasurement;
 use dpe::validation::DpeValidator;
+use dpe::DpeFlags;
 use dpe::MAX_HANDLES;
 use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
@@ -65,7 +66,6 @@ use dpe::{
 };
 
 use core::cmp::Ordering::{Equal, Greater};
-use crypto::CryptoBuf;
 use zerocopy::IntoBytes;
 
 pub const MCI_TOP_REG_RESET_REASON_OFFSET: u32 = 0x38;
@@ -260,7 +260,7 @@ impl Drivers {
     ///
     /// * `usize` - Index containing the root DPE context
     #[inline(always)]
-    pub fn get_dpe_root_context_idx(dpe: &DpeInstance) -> CaliptraResult<usize> {
+    pub fn get_dpe_root_context_idx(dpe: &dpe::State) -> CaliptraResult<usize> {
         // Find root node by finding the non-inactive context with parent equal to ROOT_INDEX
         let root_idx = dpe
             .contexts
@@ -290,7 +290,7 @@ impl Drivers {
     ///
     /// * `usize` - Index containing the CCIV DPE context
     #[inline(always)]
-    pub fn get_dpe_cciv_context_idx(dpe: &DpeInstance) -> CaliptraResult<usize> {
+    pub fn get_dpe_cciv_context_idx(dpe: &dpe::State) -> CaliptraResult<usize> {
         // Find the root context index using your existing helper
         let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
 
@@ -338,7 +338,7 @@ impl Drivers {
 
     /// Validate DPE and disable attestation if validation fails
     fn validate_dpe_structure(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &mut drivers.persistent_data.get_mut().dpe;
+        let dpe = &mut drivers.persistent_data.get_mut().state;
         let dpe_validator = DpeValidator { dpe };
         let validation_result = dpe_validator.validate_dpe();
         if let Err(e) = validation_result {
@@ -385,7 +385,7 @@ impl Drivers {
     /// Update DPE root context's TCI measurement with RT_FW_JOURNEY_PCR
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn update_dpe_rt_tci(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &mut drivers.persistent_data.get_mut().dpe;
+        let dpe = &mut drivers.persistent_data.get_mut().state;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
         let current_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR));
         let journey_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR));
@@ -404,7 +404,7 @@ impl Drivers {
         }
         let initialization_values_hash: [u8; 48] =
             <[u8; 48]>::from(Self::compute_initialization_values_hash(drivers)?);
-        let dpe = &mut drivers.persistent_data.get_mut().dpe;
+        let dpe = &mut drivers.persistent_data.get_mut().state;
         let cciv_idx = Self::get_dpe_cciv_context_idx(dpe)?;
 
         // Only update if changed
@@ -467,7 +467,7 @@ impl Drivers {
 
     /// Check that RT_FW_JOURNEY_PCR == DPE Root Context's TCI measurement
     fn check_dpe_rt_pcrs_unchanged(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let dpe = &drivers.persistent_data.get().dpe;
+        let dpe = &drivers.persistent_data.get().state;
         let root_idx = Self::get_dpe_root_context_idx(dpe)?;
         let latest_tci = Array4x12::from(&dpe.contexts[root_idx].tci.tci_current.0);
         let latest_pcr = drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR);
@@ -513,7 +513,7 @@ impl Drivers {
         let pdata = drivers.persistent_data.get();
         let context_has_tag = &pdata.context_has_tag;
         let context_tags = &pdata.context_tags;
-        let dpe = &pdata.dpe;
+        let dpe = &pdata.state;
 
         for i in 0..MAX_HANDLES {
             if dpe.contexts[i].state == ContextState::Inactive {
@@ -529,12 +529,11 @@ impl Drivers {
 
     /// Compute the Caliptra Name SerialNumber by Sha256 hashing the RT Alias public key
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn compute_rt_alias_sn(&mut self) -> CaliptraResult<CryptoBuf> {
+    pub fn compute_rt_alias_sn(&mut self) -> CaliptraResult<Digest> {
         let key = self.persistent_data.get().fht.rt_dice_ecc_pub_key.to_der();
 
         let rt_digest = self.sha256.digest(&key)?;
-        let token = CryptoBuf::new(&Into::<[u8; 32]>::into(rt_digest))
-            .map_err(|_| CaliptraError::RUNTIME_COMPUTE_RT_ALIAS_SN_FAILED)?;
+        let token = Digest::Sha256(crypto::Sha256(rt_digest.into()));
 
         Ok(token)
     }
@@ -574,34 +573,31 @@ impl Drivers {
         );
 
         let (nb, nf) = Self::get_cert_validity_info(&pdata.manifest1);
+        let mut state = dpe::State::new(DPE_SUPPORT, DpeFlags::empty());
         let mut env = DpeEnv::<CptraDpeTypes> {
             crypto,
             platform: DpePlatform::new(
                 CALIPTRA_LOCALITY,
-                &hashed_rt_pub_key,
+                hashed_rt_pub_key,
                 &drivers.ecc_cert_chain,
-                &nb,
-                &nf,
+                nb,
+                nf,
                 None,
                 None,
             ),
+            state: &mut state,
         };
 
         // Initialize DPE with the RT current PCR
         let current_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR));
-        let mut dpe = DpeInstance::new_auto_init(
-            &mut env,
-            DPE_SUPPORT,
-            u32::from_be_bytes(*b"RTJM"),
-            current_pcr,
-            DpeInstanceFlags::empty(),
-        )
-        .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
+        let mut dpe =
+            DpeInstance::new_auto_init(&mut env, u32::from_be_bytes(*b"RTMR"), current_pcr)
+                .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
 
         // DPE internally extends the current measurement to set the cumulative measurement. Set it
         // to the journey PCR so it follows the hardware.
-        let root_idx = Self::get_dpe_root_context_idx(&dpe)?;
-        dpe.contexts[root_idx].tci.tci_cumulative =
+        let root_idx = Self::get_dpe_root_context_idx(env.state)?;
+        env.state.contexts[root_idx].tci.tci_cumulative =
             TciMeasurement(drivers.pcr_bank.read_pcr(RT_FW_JOURNEY_PCR).into());
 
         // Call DeriveContext to create a measurement for the caliptra configured initialization values and change
@@ -611,10 +607,11 @@ impl Drivers {
             data: <[u8; 48]>::from(initialization_values_hash),
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::CHANGE_LOCALITY
-                | DeriveContextFlags::INPUT_ALLOW_CA
+                | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                 | DeriveContextFlags::INPUT_ALLOW_X509,
             tci_type: u32::from_be_bytes(*b"CCIV"),
             target_locality: pl0_pauser_locality,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, CALIPTRA_LOCALITY);
         if let Err(e) = derive_context_resp {
@@ -636,7 +633,7 @@ impl Drivers {
             Self::is_dpe_context_threshold_exceeded_helper(
                 pl0_pauser_locality,
                 privilege_level,
-                &dpe,
+                env.state,
                 pl0_context_limit as usize,
                 pl1_context_limit as usize,
             )?;
@@ -650,10 +647,11 @@ impl Drivers {
                     .map_err(|_| CaliptraError::RUNTIME_ADD_ROM_MEASUREMENTS_TO_DPE_FAILED)?,
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY
-                    | DeriveContextFlags::INPUT_ALLOW_CA
+                    | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                     | DeriveContextFlags::INPUT_ALLOW_X509,
                 tci_type,
                 target_locality: pl0_pauser_locality,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, pl0_pauser_locality);
             if let Err(e) = derive_context_resp {
@@ -665,8 +663,12 @@ impl Drivers {
             }
         }
 
+        // Tell the compiler env is no longer needed so the state can be copied to persistent data.
+        // Otherwise the error, "cannot move out of `state` because it is borrowed" is given.
+        drop(env);
+
         // Write DPE to persistent data.
-        pdata.dpe = dpe;
+        pdata.state = state;
         Ok(())
     }
 
@@ -773,13 +775,13 @@ impl Drivers {
     pub fn dpe_get_used_context_counts(&self) -> CaliptraResult<(usize, usize)> {
         Self::dpe_get_used_context_counts_helper(
             self.persistent_data.get().manifest1.header.pl0_pauser,
-            &self.persistent_data.get().dpe,
+            &self.persistent_data.get().state,
         )
     }
 
     fn dpe_get_used_context_counts_helper(
         pl0_pauser: u32,
-        dpe: &DpeInstance,
+        dpe: &dpe::State,
     ) -> CaliptraResult<(usize, usize)> {
         let used_pl0_dpe_context_count = dpe
             .count_contexts(|c: &Context| {
@@ -808,7 +810,7 @@ impl Drivers {
         Self::is_dpe_context_threshold_exceeded_helper(
             self.persistent_data.get().manifest1.header.pl0_pauser,
             context_privilege_level,
-            &self.persistent_data.get().dpe,
+            &self.persistent_data.get().state,
             self.persistent_data.get().dpe_pl0_context_limit as usize,
             self.persistent_data.get().dpe_pl1_context_limit as usize,
         )
@@ -817,7 +819,7 @@ impl Drivers {
     fn is_dpe_context_threshold_exceeded_helper(
         pl0_pauser: u32,
         caller_privilege_level: PauserPrivileges,
-        dpe: &DpeInstance,
+        dpe: &dpe::State,
         pl0_context_limit: usize,
         pl1_context_limit: usize,
     ) -> CaliptraResult<()> {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,9 +12,7 @@ Abstract:
 
 --*/
 
-use crate::{
-    mutrefbytes, CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges,
-};
+use crate::{dpe_env, mutrefbytes, Drivers, PauserPrivileges};
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, ResponseVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
@@ -22,9 +20,9 @@ use dpe::{
     commands::{CertifyKeyCmd, Command, CommandExecution, DeriveContextCmd, InitCtxCmd},
     context::ContextState,
     response::{Response, ResponseHdr},
-    DpeInstance, U8Bool, MAX_HANDLES,
+    DpeInstance, DpeProfile, U8Bool, MAX_HANDLES,
 };
-use zerocopy::{IntoBytes, TryFromBytes};
+use zerocopy::IntoBytes;
 
 pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
@@ -39,18 +37,15 @@ impl InvokeDpeCmd {
             let mut cmd = InvokeDpeReq::default();
             cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
 
-            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-            let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
-
             let caller_privilege_level = drivers.caller_privilege_level();
 
             // Validate data length
             if cmd.data_size as usize > cmd.data.len() {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
             }
-            let command = Command::deserialize(&cmd.data[..cmd.data_size as usize])
-                .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+            let command =
+                Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
 
             // Determine the target privilege level of a new context then check if we exceed thresholds
             let new_context_privilege_level = match command {
@@ -63,40 +58,16 @@ impl InvokeDpeCmd {
                 drivers.is_dpe_context_threshold_exceeded(new_context_privilege_level);
 
             let pdata = drivers.persistent_data.get_mut();
-            let crypto = DpeCrypto::new(
-                &mut drivers.sha2_512_384,
-                &mut drivers.trng,
-                &mut drivers.ecc384,
-                &mut drivers.hmac,
-                &mut drivers.key_vault,
-                &mut pdata.fht.rt_dice_ecc_pub_key,
-                key_id_rt_cdi,
-                key_id_rt_priv_key,
-                &mut pdata.exported_cdi_slots,
-            );
             let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-            let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
-            let ueid = &drivers.soc_ifc.fuse_bank().ueid();
-            let mut env = DpeEnv::<CptraDpeTypes> {
-                crypto,
-                platform: DpePlatform::new(
-                    pl0_pauser,
-                    &hashed_rt_pub_key,
-                    &drivers.ecc_cert_chain,
-                    &nb,
-                    &nf,
-                    None,
-                    Some(ueid),
-                ),
-            };
-
+            let ueid = drivers.soc_ifc.fuse_bank().ueid();
             let locality = drivers.mbox.id();
-            let dpe = &mut pdata.dpe;
-            let context_has_tag = &mut pdata.context_has_tag;
-            let context_tags = &mut pdata.context_tags;
+            let mut env = dpe_env(drivers, None, Some(ueid))?;
+
+            let dpe = &mut DpeInstance::initialized();
+
             let resp = match command {
                 Command::GetProfile => Ok(Response::GetProfile(
-                    dpe.get_profile(&mut env.platform)
+                    dpe.get_profile(&mut env.platform, env.state.support)
                         .map_err(|_| CaliptraError::RUNTIME_COULD_NOT_GET_DPE_PROFILE)?,
                 )),
                 Command::InitCtx(cmd) => {
@@ -138,16 +109,23 @@ impl InvokeDpeCmd {
                     }
                     cmd.execute(dpe, &mut env, locality)
                 }
-                Command::DestroyCtx(cmd) => {
-                    let destroy_ctx_resp = cmd.execute(dpe, &mut env, locality);
-                    // clear tags for destroyed contexts
-                    Self::clear_tags_for_inactive_contexts(dpe, context_has_tag, context_tags);
-                    destroy_ctx_resp
-                }
+                Command::DestroyCtx(cmd) => cmd.execute(dpe, &mut env, locality),
                 Command::Sign(cmd) => cmd.execute(dpe, &mut env, locality),
                 Command::RotateCtx(cmd) => cmd.execute(dpe, &mut env, locality),
                 Command::GetCertificateChain(cmd) => cmd.execute(dpe, &mut env, locality),
             };
+
+            // Drop env so we can use the drivers again.
+            drop(env);
+
+            if let Command::DestroyCtx(_) = command {
+                // clear tags for destroyed contexts
+                let pdata = drivers.persistent_data.get_mut();
+                let state = &mut pdata.state;
+                let context_has_tag = &mut pdata.context_has_tag;
+                let context_tags = &mut pdata.context_tags;
+                Self::clear_tags_for_inactive_contexts(state, context_has_tag, context_tags);
+            }
 
             // If DPE command failed, populate header with error code, but
             // don't fail the mailbox command.
@@ -165,11 +143,9 @@ impl InvokeDpeCmd {
                     if let Some(ext_err) = e.get_error_detail() {
                         drivers.soc_ifc.set_fw_extended_error(ext_err);
                     }
-                    let r = ResponseHdr::try_mut_from_bytes(
-                        &mut invoke_resp.data[..core::mem::size_of::<ResponseHdr>()],
-                    )
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?;
-                    *r = ResponseHdr::new(*e);
+                    let r = dpe.response_hdr(*e);
+                    invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
+                        .copy_from_slice(r.as_bytes());
                     let data_size = r.as_bytes().len();
                     invoke_resp.data_size = data_size as u32;
                 }
@@ -185,12 +161,12 @@ impl InvokeDpeCmd {
     ///
     /// # Arguments
     ///
-    /// * `dpe` - DpeInstance
+    /// * `dpe` - DPE state
     /// * `context_has_tag` - Bool slice indicating if a DPE context has a tag
     /// * `context_tags` - Tags for each DPE context
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub fn clear_tags_for_inactive_contexts(
-        dpe: &mut DpeInstance,
+        dpe: &mut dpe::State,
         context_has_tag: &mut [U8Bool; MAX_HANDLES],
         context_tags: &mut [u32; MAX_HANDLES],
     ) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -52,12 +52,14 @@ mod verify;
 
 // Used by runtime tests
 pub mod mailbox;
+use arrayvec::ArrayVec;
 use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter};
 use caliptra_common::cfi_check;
 pub use drivers::{Drivers, PauserPrivileges};
 use fe_programming::FeProgrammingCmd;
 use mailbox::Mailbox;
+use platform::MAX_OTHER_NAME_SIZE;
 use populate_idev::PopulateIDevIdMldsa87CertCmd;
 use zerocopy::{FromBytes, IntoBytes, KnownLayout};
 
@@ -599,4 +601,54 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         }
     }
     //    Ok(())
+}
+
+fn dpe_env(
+    drivers: &mut Drivers,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
+) -> CaliptraResult<DpeEnv<CptraDpeTypes>> {
+    let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+    let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+    let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
+    let pdata = drivers.persistent_data.get_mut();
+    let crypto = DpeCrypto::new(
+        &mut drivers.sha2_512_384,
+        &mut drivers.trng,
+        &mut drivers.ecc384,
+        &mut drivers.hmac,
+        &mut drivers.key_vault,
+        &mut pdata.fht.rt_dice_ecc_pub_key,
+        key_id_rt_cdi,
+        key_id_rt_priv_key,
+        &mut pdata.exported_cdi_slots,
+    );
+    let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+    let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
+    Ok(DpeEnv::<CptraDpeTypes> {
+        crypto,
+        platform: DpePlatform::new(
+            pl0_pauser,
+            hashed_rt_pub_key,
+            &drivers.ecc_cert_chain,
+            nb,
+            nf,
+            dmtf_device_info,
+            ueid,
+        ),
+        state: &mut pdata.state,
+    })
+}
+
+fn with_dpe_env<F, R>(
+    drivers: &mut Drivers,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
+    f: F,
+) -> CaliptraResult<R>
+where
+    F: FnOnce(&mut DpeEnv<CptraDpeTypes>) -> CaliptraResult<R>,
+{
+    let mut dpe_env = dpe_env(drivers, dmtf_device_info, ueid)?;
+    f(&mut dpe_env)
 }

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -11,8 +11,10 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 
-use crypto::{Crypto, Digest, EcdsaPub, EcdsaSig};
-use dpe::{DPE_PROFILE, MAX_EXPORTED_CDI_SIZE};
+use crypto::ecdsa::curve_384::{EcdsaPub384, EcdsaSignature384};
+use crypto::ecdsa::{EcdsaPubKey, EcdsaSignature};
+use crypto::{Crypto, Digest, PubKey, Signature};
+use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::FromBytes;
 
 pub struct SignWithExportedEcdsaCmd;
@@ -30,21 +32,16 @@ impl SignWithExportedEcdsaCmd {
         env: &mut DpeCrypto,
         digest: &Digest,
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
-    ) -> CaliptraResult<(EcdsaSig, EcdsaPub)> {
-        let algs = DPE_PROFILE.alg_len();
-        let key_pair = env.derive_key_pair_exported(
-            algs,
-            exported_cdi_handle,
-            b"Exported ECC",
-            b"Exported ECC",
-        );
+    ) -> CaliptraResult<(Signature, PubKey)> {
+        let key_pair =
+            env.derive_key_pair_exported(exported_cdi_handle, b"Exported ECC", b"Exported ECC");
 
         cfi_check!(key_pair);
         let (priv_key, pub_key) = key_pair
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
 
         let sig = env
-            .ecdsa_sign_with_derived(algs, digest, &priv_key, &pub_key)
+            .sign_with_derived(digest, &priv_key, &pub_key)
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED)?;
 
         Ok((sig, pub_key))
@@ -84,37 +81,23 @@ impl SignWithExportedEcdsaCmd {
             &mut pdata.exported_cdi_slots,
         );
 
-        let digest = Digest::new(&cmd.tbs)
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_DIGEST)?;
-        let (EcdsaSig { ref r, ref s }, EcdsaPub { ref x, ref y }) =
-            Self::ecdsa_sign(&mut crypto, &digest, &cmd.exported_cdi_handle)?;
+        let digest = Digest::Sha384(crypto::Sha384(cmd.tbs));
+        let (
+            Signature::Ecdsa(EcdsaSignature::Ecdsa384(EcdsaSignature384 { r, s })),
+            PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { r: x, s: y })),
+        ) = Self::ecdsa_sign(&mut crypto, &digest, &cmd.exported_cdi_handle)?
+        else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
+        };
 
         let resp = mutrefbytes::<SignWithExportedEcdsaResp>(resp)?;
-        resp.hdr = MailboxRespHeader::default();
-
-        if r.len() <= resp.signature_r.len() {
-            resp.signature_r[..r.len()].copy_from_slice(r.bytes());
-        } else {
-            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
-        }
-
-        if s.len() <= resp.signature_s.len() {
-            resp.signature_s[..s.len()].copy_from_slice(s.bytes());
-        } else {
-            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
-        }
-
-        if x.len() <= resp.derived_pubkey_x.len() {
-            resp.derived_pubkey_x[..x.len()].copy_from_slice(x.bytes());
-        } else {
-            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
-        }
-
-        if y.len() <= resp.derived_pubkey_y.len() {
-            resp.derived_pubkey_y[..y.len()].copy_from_slice(y.bytes());
-        } else {
-            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
-        }
+        *resp = SignWithExportedEcdsaResp {
+            hdr: MailboxRespHeader::default(),
+            derived_pubkey_x: x,
+            derived_pubkey_y: y,
+            signature_r: r,
+            signature_s: s,
+        };
         Ok(core::mem::size_of::<SignWithExportedEcdsaResp>())
     }
 }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -12,17 +12,15 @@ Abstract:
 
 --*/
 
-use crate::{
-    dpe_crypto::DpeCrypto, mutrefbytes, CptraDpeTypes, DpePlatform, Drivers, PauserPrivileges,
-};
+use crate::{mutrefbytes, with_dpe_env, Drivers, PauserPrivileges};
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{MailboxRespHeader, StashMeasurementReq, StashMeasurementResp};
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
 use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    dpe_instance::DpeEnv,
     response::DpeErrorCode,
+    DpeInstance,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -34,6 +32,7 @@ impl StashMeasurementCmd {
         drivers: &mut Drivers,
         metadata: &[u8; 4],
         measurement: &[u8; 48],
+        svn: u32,
     ) -> CaliptraResult<DpeErrorCode> {
         let dpe_result = {
             let caller_privilege_level = drivers.caller_privilege_level();
@@ -49,48 +48,23 @@ impl StashMeasurementCmd {
             // the PL0 context threshold to be exceeded.
             drivers.is_dpe_context_threshold_exceeded(caller_privilege_level)?;
 
-            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-            let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
-            let pdata = drivers.persistent_data.get_mut();
-            let crypto = DpeCrypto::new(
-                &mut drivers.sha2_512_384,
-                &mut drivers.trng,
-                &mut drivers.ecc384,
-                &mut drivers.hmac,
-                &mut drivers.key_vault,
-                &mut pdata.fht.rt_dice_ecc_pub_key,
-                key_id_rt_cdi,
-                key_id_rt_priv_key,
-                &mut pdata.exported_cdi_slots,
-            );
-            let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
-            let mut env = DpeEnv::<CptraDpeTypes> {
-                crypto,
-                platform: DpePlatform::new(
-                    pdata.manifest1.header.pl0_pauser,
-                    &hashed_rt_pub_key,
-                    &drivers.ecc_cert_chain,
-                    &nb,
-                    &nf,
-                    None,
-                    None,
-                ),
-            };
-
             let locality = drivers.mbox.id();
 
-            let derive_context_resp = DeriveContextCmd {
+            let cmd = DeriveContextCmd {
                 handle: ContextHandle::default(),
                 data: *measurement,
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY
-                    | DeriveContextFlags::INPUT_ALLOW_CA
+                    | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                     | DeriveContextFlags::INPUT_ALLOW_X509,
                 tci_type: u32::from_ne_bytes(*metadata),
                 target_locality: locality,
-            }
-            .execute(&mut pdata.dpe, &mut env, locality);
+                svn,
+            };
+
+            let derive_context_resp = with_dpe_env(drivers, None, None, |env| {
+                Ok(cmd.execute(&mut DpeInstance::initialized(), env, locality))
+            })?;
 
             match derive_context_resp {
                 Ok(_) => DpeErrorCode::NoError,
@@ -124,7 +98,8 @@ impl StashMeasurementCmd {
         let cmd = StashMeasurementReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
-        let dpe_result = Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement)?;
+        let dpe_result =
+            Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement, cmd.svn)?;
 
         let resp = mutrefbytes::<StashMeasurementResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -29,7 +29,7 @@ impl TagTciCmd {
         let cmd = TagTciReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let pdata_mut = drivers.persistent_data.get_mut();
-        let dpe = &mut pdata_mut.dpe;
+        let dpe = &mut pdata_mut.state;
         let context_has_tag = &mut pdata_mut.context_has_tag;
         let context_tags = &mut pdata_mut.context_tags;
 
@@ -82,10 +82,10 @@ impl GetTaggedTciCmd {
                     && context_tags[*i] == cmd.tag
             })
             .ok_or(CaliptraError::RUNTIME_TAGGING_FAILURE)?;
-        if idx >= persistent_data.dpe.contexts.len() {
+        if idx >= persistent_data.state.contexts.len() {
             return Err(CaliptraError::RUNTIME_TAGGING_FAILURE);
         }
-        let context = persistent_data.dpe.contexts[idx];
+        let context = persistent_data.state.contexts[idx];
 
         let resp = mutrefbytes::<GetTaggedTciResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();

--- a/runtime/test-fw/Cargo.toml
+++ b/runtime/test-fw/Cargo.toml
@@ -55,5 +55,6 @@ caliptra-registers.workspace = true
 caliptra-runtime = { workspace = true, default-features = false }
 caliptra-test-harness.workspace = true
 cfg-if.workspace = true
+dpe.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -14,8 +14,8 @@ use caliptra_drivers::{
 };
 use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc::SocIfcReg};
 use caliptra_runtime::{
-    key_ladder::KeyLadder, mailbox::Mailbox, ContextState, DpeInstance, Drivers, Hmac,
-    RtBootStatus, TciMeasurement, U8Bool, MAX_HANDLES,
+    key_ladder::KeyLadder, mailbox::Mailbox, ContextState, Drivers, Hmac, RtBootStatus,
+    TciMeasurement, U8Bool, MAX_HANDLES,
 };
 use caliptra_test_harness::{runtime_handlers, test_suite};
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
@@ -157,7 +157,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             CommandId(OPCODE_HASH_DPE_TCI_DATA) => {
                 let mut hasher = drivers.sha2_512_384.sha384_digest_init().unwrap();
-                for context in drivers.persistent_data.get().dpe.contexts {
+                for context in drivers.persistent_data.get().state.contexts {
                     if context.state != ContextState::Inactive {
                         hasher.update(context.tci.tci_current.as_bytes()).unwrap();
                     }
@@ -173,8 +173,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             CommandId(OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT) => {
                 let root_idx =
-                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                let root_measurement = drivers.persistent_data.get().dpe.contexts[root_idx]
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                let root_measurement = drivers.persistent_data.get().state.contexts[root_idx]
                     .tci
                     .tci_current
                     .as_bytes();
@@ -182,8 +183,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             CommandId(OPCODE_READ_DPE_ROOT_CONTEXT_CUMULATIVE) => {
                 let root_idx =
-                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                let root_measurement = drivers.persistent_data.get().dpe.contexts[root_idx]
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                let root_measurement = drivers.persistent_data.get().state.contexts[root_idx]
                     .tci
                     .tci_cumulative
                     .as_bytes();
@@ -191,8 +193,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_MEASUREMENT) => {
                 let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                let cciv_measurement = drivers.persistent_data.get().dpe.contexts[cciv_idx]
+                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                let cciv_measurement = drivers.persistent_data.get().state.contexts[cciv_idx]
                     .tci
                     .tci_current
                     .as_bytes();
@@ -200,8 +203,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE) => {
                 let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                let cciv_measurement = drivers.persistent_data.get().dpe.contexts[cciv_idx]
+                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                let cciv_measurement = drivers.persistent_data.get().state.contexts[cciv_idx]
                     .tci
                     .tci_cumulative
                     .as_bytes();
@@ -241,14 +245,14 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             CommandId(OPCODE_READ_DPE_INSTANCE) => {
                 write_response(
                     &mut drivers.mbox,
-                    drivers.persistent_data.get().dpe.as_bytes(),
+                    drivers.persistent_data.get().state.as_bytes(),
                 );
             }
             CommandId(OPCODE_CORRUPT_DPE_INSTANCE) => {
                 let input_bytes = read_request(&drivers.mbox);
 
-                let corrupted_dpe = DpeInstance::try_read_from_bytes(input_bytes).unwrap();
-                drivers.persistent_data.get_mut().dpe = corrupted_dpe;
+                let corrupted_dpe = dpe::State::try_read_from_bytes(input_bytes).unwrap();
+                drivers.persistent_data.get_mut().state = corrupted_dpe;
                 write_response(&mut drivers.mbox, &[]);
             }
             CommandId(OPCODE_READ_PCR_RESET_COUNTER) => {
@@ -261,8 +265,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 let input_bytes = read_request(&drivers.mbox);
 
                 let root_idx =
-                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                drivers.persistent_data.get_mut().dpe.contexts[root_idx]
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                drivers.persistent_data.get_mut().state.contexts[root_idx]
                     .tci
                     .tci_current = TciMeasurement(input_bytes.try_into().unwrap());
                 write_response(&mut drivers.mbox, &[]);
@@ -271,8 +276,9 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 let input_bytes = read_request(&drivers.mbox);
 
                 let root_idx =
-                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().dpe).unwrap();
-                drivers.persistent_data.get_mut().dpe.contexts[root_idx]
+                    Drivers::get_dpe_root_context_idx(&drivers.persistent_data.get().state)
+                        .unwrap();
+                drivers.persistent_data.get_mut().state.contexts[root_idx]
                     .tci
                     .tci_cumulative = TciMeasurement(input_bytes.try_into().unwrap());
                 write_response(&mut drivers.mbox, &[]);

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -36,6 +36,7 @@ use dpe::{
         CertifyKeyResp, DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode,
         GetCertificateChainResp, GetProfileResp, NewHandleResp, Response, ResponseHdr, SignResp,
     },
+    DPE_PROFILE,
 };
 use openssl::{
     asn1::{Asn1Integer, Asn1Time},
@@ -47,7 +48,7 @@ use openssl::{
 };
 use std::borrow::Cow;
 use std::io;
-use zerocopy::{FromBytes, FromZeros, IntoBytes};
+use zerocopy::{FromZeros, IntoBytes, TryFromBytes};
 
 pub const TEST_LABEL: [u8; 48] = [
     48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25,
@@ -372,7 +373,7 @@ fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
 
 fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
     if let Ok(&ResponseHdr { status, .. }) =
-        ResponseHdr::ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
+        ResponseHdr::try_ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
     {
         if status != expected_status.get_error_code() {
             panic!("Unexpected DPE Status: 0x{:X}", status);
@@ -386,34 +387,34 @@ fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
 
     match dpe_cmd {
         Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
+            Response::CertifyKey(CertifyKeyResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::DeriveContext(DeriveContextCmd { flags, .. })
             if flags.contains(DeriveContextFlags::EXPORT_CDI) =>
         {
             Response::DeriveContextExportedCdi(
-                DeriveContextExportedCdiResp::read_from_bytes(resp_bytes).unwrap(),
+                DeriveContextExportedCdiResp::try_read_from_bytes(resp_bytes).unwrap(),
             )
         }
         Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())
+            Response::DeriveContext(DeriveContextResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::GetCertificateChain(_) => Response::GetCertificateChain(
-            GetCertificateChainResp::read_from_bytes(resp_bytes).unwrap(),
+            GetCertificateChainResp::try_read_from_bytes(resp_bytes).unwrap(),
         ),
         Command::DestroyCtx(_) => {
-            Response::DestroyCtx(ResponseHdr::read_from_bytes(resp_bytes).unwrap())
+            Response::DestroyCtx(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::GetProfile => {
-            Response::GetProfile(GetProfileResp::read_from_bytes(resp_bytes).unwrap())
+            Response::GetProfile(GetProfileResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::InitCtx(_) => {
-            Response::InitCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+            Response::InitCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::RotateCtx(_) => {
-            Response::RotateCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+            Response::RotateCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
         }
-        Command::Sign(_) => Response::Sign(SignResp::read_from_bytes(resp_bytes).unwrap()),
+        Command::Sign(_) => Response::Sign(SignResp::try_read_from_bytes(resp_bytes).unwrap()),
     }
 }
 
@@ -430,7 +431,7 @@ pub fn execute_dpe_cmd(
 ) -> Option<Response> {
     let mut cmd_data: [u8; 512] = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
     let dpe_cmd_id = get_cmd_id(dpe_cmd);
-    let cmd_hdr = CommandHdr::new_for_test(dpe_cmd_id);
+    let cmd_hdr = CommandHdr::new(DPE_PROFILE, dpe_cmd_id);
     let cmd_hdr_buf = cmd_hdr.as_bytes();
     cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
     let dpe_cmd_buf = as_bytes(dpe_cmd);
@@ -465,7 +466,7 @@ pub fn execute_dpe_cmd(
     let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
     Some(match expected_result {
         DpeResult::Success => parse_dpe_response(dpe_cmd, resp_bytes),
-        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::read_from_bytes(resp_bytes).unwrap()),
+        DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap()),
         DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
     })
 }

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -15,7 +15,7 @@ use dpe::{
 use x509_parser::{
     certificate::X509Certificate, extensions::GeneralName, oid_registry::asn1_rs::FromDer,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs, TEST_LABEL};
 
@@ -102,7 +102,8 @@ fn test_dmtf_other_name_extension_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+            .unwrap();
 
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
@@ -155,7 +156,8 @@ fn test_dmtf_other_name_extension_not_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+            .unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();
@@ -199,7 +201,8 @@ fn test_dmtf_other_name_extension_not_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::read_from_bytes(&certify_key_extended_resp.certify_key_resp[..]).unwrap();
+        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+            .unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
             .unwrap();

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -700,10 +700,11 @@ pub fn test_all_measurement_apis() {
             handle: ContextHandle::default(),
             data: measurement,
             flags: DeriveContextFlags::MAKE_DEFAULT
-                | DeriveContextFlags::INPUT_ALLOW_CA
+                | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                 | DeriveContextFlags::INPUT_ALLOW_X509,
             tci_type: u32::read_from_bytes(&tci_type[..]).unwrap(),
             target_locality: 0,
+            svn: 0,
         };
         let resp = execute_dpe_cmd(
             &mut hw,

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -46,7 +46,7 @@ fn test_invoke_dpe_get_profile_cmd() {
     let Some(Response::GetProfile(profile)) = resp else {
         panic!("Wrong response type!");
     };
-    assert_eq!(profile.resp_hdr.profile, DPE_PROFILE as u32);
+    assert_eq!(profile.resp_hdr.profile, DPE_PROFILE);
     assert_eq!(profile.vendor_id, VENDOR_ID);
     assert_eq!(profile.vendor_sku, VENDOR_SKU);
     assert_eq!(profile.flags, DPE_SUPPORT.bits());
@@ -334,10 +334,11 @@ fn test_invoke_dpe_export_cdi_with_non_critical_dice_extensions() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -367,12 +368,13 @@ fn test_export_cdi_attestation_not_disabled_after_update_reset() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(
@@ -420,10 +422,11 @@ fn test_export_cdi_destroyed_root_context() {
     // destroyed.
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -41,7 +41,7 @@ use crate::common::{
     TEST_LABEL,
 };
 
-const DATA: [u8; DPE_PROFILE.get_hash_size()] = [0u8; 48];
+const DATA: [u8; DPE_PROFILE.hash_size()] = [0u8; 48];
 
 #[test]
 fn test_pl0_derive_context_dpe_context_thresholds() {
@@ -79,6 +79,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         };
 
         // If we are on the last call to DeriveContext, expect that we get a RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED error.
@@ -152,6 +153,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             };
 
             // If we are on the last call to DeriveContext, expect that we get a RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED error.
@@ -287,6 +289,7 @@ fn test_change_locality() {
             | DeriveContextFlags::INPUT_ALLOW_X509,
         tci_type: 0,
         target_locality: 2,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(
@@ -304,6 +307,7 @@ fn test_change_locality() {
         flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type: 0,
         target_locality: 2,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(
@@ -469,10 +473,11 @@ fn test_export_cdi_cannot_be_called_from_pl1() {
 
     let get_cert_chain_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let _ = execute_dpe_cmd(
         &mut model,
@@ -592,6 +597,7 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         };
         let resp = execute_dpe_cmd(
             &mut model,

--- a/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
+++ b/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
@@ -22,10 +22,11 @@ use zerocopy::FromBytes;
 fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: u32) {
     const BASE_DERIVE_CONTEXT_CMD: DeriveContextCmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     // 32 contexts = 1 root node (PL0)+
@@ -165,10 +166,11 @@ fn test_pl0_pl1_reallocation_pl0_less_than_used() {
 
     let derive_context_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     // Use some PL0 contexts
@@ -196,10 +198,11 @@ fn test_pl0_pl1_reallocation_pl1_less_than_used() {
 
     const BASE_DERIVE_CONTEXT_CMD: DeriveContextCmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     // Use some PL1 contexts
@@ -253,10 +256,11 @@ fn test_pl0_pl1_reallocation_warm_reset() {
 
     let derive_context_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     // Use some PL0 contexts

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
@@ -23,10 +23,11 @@ fn test_revoke_exported_cdi_handle() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
@@ -60,10 +61,11 @@ fn test_revoke_already_revoked_exported_cdi_handle() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
@@ -147,12 +149,13 @@ fn test_export_cdi_after_revoke() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(resp)) = execute_dpe_cmd(

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -77,10 +77,11 @@ fn test_sign_with_exported_cdi() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -120,10 +121,11 @@ fn test_sign_with_exported_incorrect_cdi_handle() {
 
     let get_cert_chain_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -200,12 +202,13 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
@@ -234,10 +237,11 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
 
     let measurement_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0xa; DPE_PROFILE.get_tci_size()],
+        data: [0xa; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: u32::from_be_bytes(*b"CCIV"),
         target_locality: 0,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(
@@ -296,12 +300,13 @@ fn test_sign_with_exported_cdi_measurement_update() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
@@ -314,10 +319,11 @@ fn test_sign_with_exported_cdi_measurement_update() {
 
     let measurement_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0xa; DPE_PROFILE.get_tci_size()],
+        data: [0xa; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: u32::from_be_bytes(*b"CCIV"),
         target_locality: 0,
+        svn: 0,
     };
 
     let _ = execute_dpe_cmd(
@@ -392,10 +398,11 @@ fn test_sign_with_revoked_exported_cdi() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
@@ -463,12 +470,13 @@ fn test_sign_with_disabled_attestation() {
 
     let export_cdi_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
 
     let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
@@ -545,12 +553,13 @@ fn test_sign_with_exported_cdi_warm_reset() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -645,10 +654,11 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
     // We will export the parent. We expect that the child prevents the dpe context chain from being destroyed.
     let derive_ctx_cmd = DeriveContextCmd {
         handle,
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -663,10 +673,11 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
     // Export the parent context from the last derive command.
     let derive_ctx_cmd = DeriveContextCmd {
         handle: parent_handle,
-        data: [0; DPE_PROFILE.get_tci_size()],
+        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -215,10 +215,11 @@ fn test_tagging_retired_context() {
     // retire context via DeriveContext
     let derive_context_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0u8; DPE_PROFILE.get_hash_size()],
+        data: [0u8; DPE_PROFILE.hash_size()],
         flags: DeriveContextFlags::empty(),
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,
@@ -261,10 +262,11 @@ fn test_tagging_retired_context() {
     // retire tagged context via derive child
     let derive_context_cmd = DeriveContextCmd {
         handle: new_handle,
-        data: [0u8; DPE_PROFILE.get_hash_size()],
+        data: [0u8; DPE_PROFILE.hash_size()],
         flags: DeriveContextFlags::empty(),
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(
         &mut model,

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -25,7 +25,7 @@ use dpe::{
     response::DpeErrorCode,
     tci::TciMeasurement,
     validation::ValidationError,
-    DpeInstance, U8Bool, DPE_PROFILE, MAX_HANDLES,
+    U8Bool, DPE_PROFILE, MAX_HANDLES,
 };
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
@@ -292,7 +292,7 @@ fn test_dpe_validation_deformed_structure() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating multiple normal connected components
     dpe.contexts[0].children = 0;
@@ -347,7 +347,7 @@ fn test_dpe_validation_illegal_state() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE state by messing up parent-child links
     dpe.contexts[1].children = 0b1;
@@ -400,7 +400,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
 
     // read DPE after RT initialization
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
-    let mut dpe = DpeInstance::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
+    let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD contexts
     let pl0_pauser = ImageOptions::default().vendor_config.pl0_pauser.unwrap();
@@ -416,9 +416,8 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
         dpe.contexts[idx].context_type = ContextType::Simulation;
         dpe.contexts[idx].locality = pl0_pauser;
         dpe.contexts[idx].tci.locality = pl0_pauser;
-        dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; DPE_PROFILE.get_tci_size()]);
-        dpe.contexts[idx].tci.tci_cumulative =
-            TciMeasurement([idx as u8; DPE_PROFILE.get_tci_size()]);
+        dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; DPE_PROFILE.tci_size()]);
+        dpe.contexts[idx].tci.tci_cumulative = TciMeasurement([idx as u8; DPE_PROFILE.tci_size()]);
         dpe.contexts[idx].handle = ContextHandle([idx as u8; ContextHandle::SIZE]);
     }
     let _ = model

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -67,7 +67,7 @@ fn test_rt_journey_pcr_validation() {
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
     let _ = model
-        .mailbox_execute(0xD000_0000, &[0u8; DPE_PROFILE.get_tci_size()])
+        .mailbox_execute(0xD000_0000, &[0u8; DPE_PROFILE.tci_size()])
         .unwrap()
         .unwrap();
 
@@ -136,7 +136,7 @@ fn test_rt_current_pcr_validation() {
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
     let _ = model
-        .mailbox_execute(0xD000_0001, &[0u8; DPE_PROFILE.get_tci_size()])
+        .mailbox_execute(0xD000_0001, &[0u8; DPE_PROFILE.tci_size()])
         .unwrap()
         .unwrap();
 

--- a/test/dpe_verification/Makefile
+++ b/test/dpe_verification/Makefile
@@ -26,4 +26,6 @@ $(FW_FILE) $(ROM_FILE):
 	cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_DIR)/Cargo.toml --bin image -- --fw $(FW_FILE) --rom-no-log=$(ROM_FILE)
 
 run: $(LIBCALIPTRA) $(LIB_HW_MODEL) $(FW_FILE) $(ROM_FILE)
-	ROM_PATH=$(ROM_FILE) FW_PATH=$(FW_FILE) go test -v
+	# TODO: Re-enable CertifyKeyCsr after updating DPE to commit 4986ac5
+	# ("verification: Add ECA EKU and fix CSR signature verification (#510)")
+	ROM_PATH=$(ROM_FILE) FW_PATH=$(FW_FILE) go test -v -run 'TestRunAll/(CertifyKey$$|CertifyKeySimulation|GetCertificateChain|TPMPolicySigning|RotateContext|Sign|GetProfile|InitializeContext|CheckInvalidHandle|CheckWrongLocality|DeriveContext)'

--- a/test/dpe_verification/transport.go
+++ b/test/dpe_verification/transport.go
@@ -253,7 +253,7 @@ func (s *CptraModel) GetProfileMajorVersion() uint16 {
 
 // GetProfileMinorVersion returns the minor version of the DPE profile.
 func (s *CptraModel) GetProfileMinorVersion() uint16 {
-	return 12
+	return 13
 }
 
 // GetProfileVendorID returns the vendor ID of the DPE profile.

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -13,8 +13,9 @@ use dpe::{
         CertifyKeyResp, DeriveContextResp, GetCertificateChainResp, GetProfileResp, NewHandleResp,
         Response, ResponseHdr, SignResp,
     },
+    DPE_PROFILE,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,
@@ -314,34 +315,34 @@ pub fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
 pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
         Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::read_from_bytes(resp_bytes).unwrap())
+            Response::CertifyKey(CertifyKeyResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::read_from_bytes(resp_bytes).unwrap())
+            Response::DeriveContext(DeriveContextResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::GetCertificateChain(_) => Response::GetCertificateChain(
-            GetCertificateChainResp::read_from_bytes(resp_bytes).unwrap(),
+            GetCertificateChainResp::try_read_from_bytes(resp_bytes).unwrap(),
         ),
         Command::DestroyCtx(_) => {
-            Response::DestroyCtx(ResponseHdr::read_from_bytes(resp_bytes).unwrap())
+            Response::DestroyCtx(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::GetProfile => {
-            Response::GetProfile(GetProfileResp::read_from_bytes(resp_bytes).unwrap())
+            Response::GetProfile(GetProfileResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::InitCtx(_) => {
-            Response::InitCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+            Response::InitCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::RotateCtx(_) => {
-            Response::RotateCtx(NewHandleResp::read_from_bytes(resp_bytes).unwrap())
+            Response::RotateCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
         }
-        Command::Sign(_) => Response::Sign(SignResp::read_from_bytes(resp_bytes).unwrap()),
+        Command::Sign(_) => Response::Sign(SignResp::try_read_from_bytes(resp_bytes).unwrap()),
     }
 }
 
 pub fn execute_dpe_cmd<T: HwModel>(hw: &mut T, dpe_cmd: &mut Command) -> Response {
     let mut cmd_data: [u8; 512] = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
     let dpe_cmd_id = get_cmd_id(dpe_cmd);
-    let cmd_hdr = CommandHdr::new_for_test(dpe_cmd_id);
+    let cmd_hdr = CommandHdr::new(DPE_PROFILE, dpe_cmd_id);
     let cmd_hdr_buf = cmd_hdr.as_bytes();
     cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
     let dpe_cmd_buf = as_bytes(dpe_cmd);

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -464,7 +464,7 @@ pub fn exec_dpe_get_profile<T: HwModel>(hw: &mut T) {
         panic!("Wrong response type!");
     };
 
-    assert_eq!(get_profile_resp.resp_hdr.profile, DPE_PROFILE as u32);
+    assert_eq!(get_profile_resp.resp_hdr.profile, DPE_PROFILE);
 }
 
 pub fn exec_dpe_init_ctx<T: HwModel>(hw: &mut T) {
@@ -483,6 +483,7 @@ pub fn exec_dpe_derive_ctx<T: HwModel>(hw: &mut T) {
         flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
         tci_type: 0,
         target_locality: 0,
+        svn: 0,
     };
     let resp = execute_dpe_cmd(hw, &mut Command::DeriveContext(&derive_context_cmd));
     let Response::DeriveContext(derive_ctx_resp) = resp else {


### PR DESCRIPTION
Squashed cherry-picks from main:
- #3013: Update to just before adding SVN (DPE sub → b1c0e99)
- #3018: Support SVN in DeriveContext (DPE sub → c9b67f5)
- #3022: Use dpe::State for shared state (DPE sub → 57690bd)
- #3029: New Crypto API (DPE sub → 81aea72)
- #3038: Use both RT PCRs in RT DPE context
- #3164: Unify DPE environment creation

Note: CertifyKeyCsr DPE verification test is temporarily disabled. It requires DPE commit 4986ac5 ("verification: Add ECA EKU and fix CSR signature verification (#510)") which will be picked up in a later phase when the DPE submodule is updated further.