### PR TITLE
[ci]: Split junit.xml upload into separate step

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -378,6 +378,9 @@ jobs:
               --test-threads=1 \
               --no-fail-fast
 
+      - name: Copy junit.xml
+        if: success() || failure()
+        run: |
           sudo mv /tmp/junit.xml /tmp/junit-${{ matrix.partition }}.xml
 
       - name: 'Upload test results'

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -320,6 +320,9 @@ jobs:
               --test-threads=1 \
               --no-fail-fast
 
+      - name: Copy junit.xml
+        if: success() || failure()
+        run: |
           sudo mv /tmp/junit.xml /tmp/junit-${{ matrix.partition }}.xml
 
       - name: 'Upload test results'


### PR DESCRIPTION
GHA `run` exits early on failure, skipping the junit.xml copy.

This ensures that tests that the test printer can output test failures.