### PR TITLE
DPE hybrid build, submodule removal, DPE update

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 # Licensed under the Apache-2.0 license
 [env]
-ARBITRARY_MAX_HANDLES = "32"
 RUST_MIN_STACK="16777216" # 16MB
 
 [target.riscv32imc-unknown-none-elf]

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,10 +34,6 @@ jobs:
         run: |
           echo "Build-Test: release_ref=$(git rev-parse HEAD)"
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Install required packages
         run: |
           sudo apt-get update -qy && sudo apt-get install libftdi1-dev libusb-1.0-0-dev golang-1.21-go

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,10 +26,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Configure actions-cache environment variables
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Check that the ROM hash matches the frozen one
         run: ./ci.sh check_frozen_images
 

--- a/.github/workflows/size-history.yml
+++ b/.github/workflows/size-history.yml
@@ -28,10 +28,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Pull dpe submodule
-        run: |
-          git submodule update --init dpe
-
       - name: Configure actions-cache environment variables
         uses: actions/github-script@v7
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,10 +5,6 @@
 	path = hw/latest/rtl
 	url = https://github.com/chipsalliance/caliptra-rtl
 	branch = main
-[submodule "dpe"]
-	path = dpe
-	url = https://github.com/chipsalliance/caliptra-dpe.git
-	branch = main
 [submodule "hw/latest/i3c-core-rtl"]
 	path = hw/latest/i3c-core-rtl
 	url = https://github.com/chipsalliance/i3c-core.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,10 +1376,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
+ "constant_time_eq",
  "zerocopy",
  "zeroize",
 ]
@@ -1519,6 +1521,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -2314,6 +2317,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -3417,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,6 @@ resolver = "2"
 exclude = [
   # Uses a custom .cargo/config
   "sw-emulator/example",
-  "dpe/dpe",
-  "dpe/crypto",
-  "dpe/platform",
-  "dpe/simulator",
-  "dpe/tools",
 
   # fpga-boss depends on crates with annoying system deps like libusb and
   # libftdi, so keep it in its own workspace
@@ -169,9 +164,14 @@ convert_case = "0.6.0"
 cms = "0.2.2"
 ctr = "0.9.2"
 der = { version = "0.7.10", features = ["derive", "alloc"] }
-dpe = { path = "dpe/dpe", default-features = false, features = ["dpe_profile_p384_sha384"] }
-crypto = { path = "dpe/crypto", default-features = false }
-platform = { path = "dpe/platform", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false, features = ["p384"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false }
+
+# local DPE dependency; useful when developing
+# dpe = { path = "../caliptra-dpe/dpe", default-features = false, features = ["p384"] }
+# crypto = { path = "../caliptra-dpe/crypto", default-features = false }
+# platform = { path = "../caliptra-dpe/platform", default-features = false }
 elf = "0.7.2"
 fips204 = "0.4.6"
 fslock = "0.2.1"

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1305,7 +1305,7 @@ pub struct CertifyKeyExtendedResp {
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
 }
 impl CertifyKeyExtendedResp {
-    pub const CERTIFY_KEY_RESP_SIZE: usize = 6272;
+    pub const CERTIFY_KEY_RESP_SIZE: usize = 8000;
 }
 impl Response for CertifyKeyExtendedResp {}
 
@@ -1375,7 +1375,7 @@ pub struct InvokeDpeResp {
     pub data: [u8; InvokeDpeResp::DATA_MAX_SIZE], // variable length
 }
 impl InvokeDpeResp {
-    pub const DATA_MAX_SIZE: usize = 6556;
+    pub const DATA_MAX_SIZE: usize = 8000;
 }
 impl ResponseVarSize for InvokeDpeResp {}
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1598,6 +1598,11 @@ impl CaliptraError {
             0x000E0094,
             "Runtime Error: Multiple CCIV contexts found"
         ),
+        (
+            RUNTIME_INVOKE_DPE_RESPONSE_TOO_LARGE,
+            0x000E008D,
+            "Runtime Error: DPE response too large"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -293,7 +293,7 @@ struct caliptra_certify_key_extended_req
 struct caliptra_certify_key_extended_resp
 {
     struct caliptra_resp_header hdr;
-    uint8_t certify_key_resp[6272];
+    uint8_t certify_key_resp[8000];
 };
 
 struct caliptra_fips_version_resp
@@ -417,7 +417,7 @@ struct dpe_resp_hdr
 };
 
 #define DPE_HANDLE_SIZE 16
-#define DPE_CERT_SIZE 6144
+#define DPE_CERT_SIZE 7872
 
 #ifndef DPE_PROFILE
 #define DPE_PROFILE DPE_PROFILE_384

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,7 +26,7 @@ caliptra-kat.workspace = true
 caliptra-lms-types.workspace = true
 caliptra-registers.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
-dpe = { workspace = true, features = ["arbitrary_max_handles"] }
+dpe = { workspace = true }
 constant_time_eq.workspace = true
 crypto.workspace = true
 platform.workspace = true

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -19,11 +19,11 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::{
-    commands::{CertifyKeyCmd, CommandExecution},
+    commands::{CertifyKeyP384Cmd as CertifyKeyCmd, CommandExecution},
     response::Response,
-    DpeInstance,
+    DpeInstance, DpeProfile,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
@@ -60,7 +60,8 @@ impl CertifyKeyExtendedCmd {
             CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
         ))?;
         let resp = with_dpe_env(drivers, dmtf_device_info, None, |env| {
-            Ok(certify_key_cmd.execute(&mut DpeInstance::initialized(), env, locality))
+            let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
+            Ok(certify_key_cmd.execute(dpe, env, locality))
         })?;
 
         let certify_key_resp = match resp {

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -31,7 +31,7 @@ use crypto::{
         EcdsaPubKey, EcdsaSignature,
     },
     Crypto, CryptoError, CryptoSuite, Digest, DigestAlgorithm, DigestType, Hasher, PubKey,
-    Signature, SignatureAlgorithm, SignatureType,
+    SignData, Signature, SignatureAlgorithm, SignatureType,
 };
 use dpe::{ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 
@@ -130,10 +130,10 @@ impl<'a> DpeCrypto<'a> {
                 KeyWriteArgs::new(key_id, KeyUsage::default().set_ecc_private_key_en()).into(),
             )
             .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(
-            EcdsaPub384::from_slice(&pub_key.x.into(), &pub_key.y.into())
-                .map_err(|_| CryptoError::Size)?,
-        ));
+        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+            &pub_key.x.into(),
+            &pub_key.y.into(),
+        )));
         Ok((key_id, pub_key))
     }
 
@@ -318,24 +318,24 @@ impl Crypto for DpeCrypto<'_> {
         self.derive_key_pair_inner(&cdi, label, info, KEY_ID_TMP)
     }
 
-    fn sign_with_alias(&mut self, digest: &Digest) -> Result<Signature, CryptoError> {
-        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(
-            EcdsaPub384::from_slice(&self.rt_pub_key.x.into(), &self.rt_pub_key.y.into())
-                .map_err(|_| CryptoError::Size)?,
-        ));
-        self.sign_with_derived(digest, &self.key_id_rt_priv_key.clone(), &pub_key)
+    fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
+        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+            &self.rt_pub_key.x.into(),
+            &self.rt_pub_key.y.into(),
+        )));
+        self.sign_with_derived(data, &self.key_id_rt_priv_key.clone(), &pub_key)
     }
 
     fn sign_with_derived(
         &mut self,
-        digest: &Digest,
+        data: &SignData,
         priv_key: &Self::PrivKey,
         pub_key: &PubKey,
     ) -> Result<Signature, CryptoError> {
         let priv_key_args = KeyReadArgs::new(*priv_key);
         let ecc_priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
 
-        let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { r: x, s: y })) = pub_key else {
+        let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })) = pub_key else {
             return Err(CryptoError::MismatchedAlgorithm);
         };
         let ecc_pub_key = Ecc384PubKey {
@@ -343,23 +343,22 @@ impl Crypto for DpeCrypto<'_> {
             y: Ecc384Scalar::from(y),
         };
 
-        let Digest::Sha384(crypto::Sha384(digest)) = digest else {
-            return Err(CryptoError::MismatchedAlgorithm);
+        let digest = match data {
+            SignData::Digest(Digest::Sha384(crypto::Sha384(digest))) => Ecc384Scalar::from(digest),
+            SignData::Raw(msg) => self
+                .sha2_512_384
+                .sha384_digest(msg)
+                .map_err(|_| CryptoError::HashError(0))?,
+            _ => return Err(CryptoError::MismatchedAlgorithm),
         };
 
         let sig = self
             .ecc384
-            .sign(
-                ecc_priv_key,
-                &ecc_pub_key,
-                &Ecc384Scalar::from(digest),
-                self.trng,
-            )
+            .sign(ecc_priv_key, &ecc_pub_key, &digest, self.trng)
             .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
 
         Ok(Signature::Ecdsa(EcdsaSignature::Ecdsa384(
-            EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into())
-                .map_err(|_| CryptoError::Size)?,
+            EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into()),
         )))
     }
 }

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -18,7 +18,10 @@ use arrayvec::ArrayVec;
 use caliptra_drivers::cprintln;
 use caliptra_x509::{NotAfter, NotBefore};
 use crypto::Digest;
-use dpe::x509::{CertWriter, DirectoryString, Name};
+use dpe::{
+    x509::{CertWriter, DirectoryString, Name},
+    DpeProfile,
+};
 use platform::{
     CertValidity, OtherName, Platform, PlatformError, SignerIdentifier, SubjectAltName, Ueid,
     MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
@@ -106,27 +109,13 @@ impl Platform for DpePlatform<'_> {
         out: &mut [u8; MAX_ISSUER_NAME_SIZE],
     ) -> Result<usize, PlatformError> {
         const CALIPTRA_CN: &[u8] = b"Caliptra 2.0 Ecc384 Rt Alias";
-        let mut issuer_writer = CertWriter::new(out, true);
+        let mut issuer_writer = CertWriter::new(out, DpeProfile::P384Sha384, true);
 
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
-        let src = self.hashed_rt_pub_key.as_slice();
-        if serial.len() != src.len() * 2 {
-            return Err(PlatformError::IssuerNameError(0));
-        }
-
-        let mut curr_idx = 0;
-        const HEX_CHARS: &[u8; 16] = b"0123456789ABCDEF";
-        for &b in src {
-            let h1 = (b >> 4) as usize;
-            let h2 = (b & 0xF) as usize;
-            if h1 >= HEX_CHARS.len() || h2 >= HEX_CHARS.len() || curr_idx + 1 >= serial.len() {
-                return Err(PlatformError::IssuerNameError(1));
-            }
-            serial[curr_idx] = HEX_CHARS[h1];
-            serial[curr_idx + 1] = HEX_CHARS[h2];
-            curr_idx += 2;
-        }
+        self.hashed_rt_pub_key
+            .write_hex_str(&mut serial)
+            .map_err(|_| PlatformError::IssuerNameError(1))?;
 
         let name = Name {
             cn: DirectoryString::Utf8String(CALIPTRA_CN),

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -54,16 +54,17 @@ use caliptra_registers::{
 use caliptra_ureg::MmioMut;
 use caliptra_x509::{NotAfter, NotBefore};
 use crypto::Digest;
+use dpe::commands::DeriveContextCmd;
 use dpe::context::{Context, ContextState, ContextType};
 use dpe::tci::TciMeasurement;
 use dpe::validation::DpeValidator;
-use dpe::DpeFlags;
 use dpe::MAX_HANDLES;
 use dpe::{
-    commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
+    commands::{CommandExecution, DeriveContextFlags},
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance},
 };
+use dpe::{DpeFlags, DpeProfile};
 
 use core::cmp::Ordering::{Equal, Greater};
 use zerocopy::IntoBytes;
@@ -589,10 +590,14 @@ impl Drivers {
         };
 
         // Initialize DPE with the RT current PCR
-        let current_pcr = <[u8; 48]>::from(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR));
-        let mut dpe =
-            DpeInstance::new_auto_init(&mut env, u32::from_be_bytes(*b"RTMR"), current_pcr)
-                .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
+        let current_pcr = TciMeasurement(drivers.pcr_bank.read_pcr(RT_FW_CURRENT_PCR).into());
+        let mut dpe = DpeInstance::new_auto_init(
+            &mut env,
+            DpeProfile::P384Sha384,
+            u32::from_be_bytes(*b"RTMR"),
+            &current_pcr,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_INITIALIZE_DPE_FAILED)?;
 
         // DPE internally extends the current measurement to set the cumulative measurement. Set it
         // to the journey PCR so it follows the hardware.
@@ -602,9 +607,10 @@ impl Drivers {
 
         // Call DeriveContext to create a measurement for the caliptra configured initialization values and change
         // locality to the pl0 pauser locality
+        let initialization_values_hash: [u8; 48] = <[u8; 48]>::from(initialization_values_hash);
         let derive_context_resp = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: <[u8; 48]>::from(initialization_values_hash),
+            data: TciMeasurement(initialization_values_hash),
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::CHANGE_LOCALITY
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
@@ -642,9 +648,11 @@ impl Drivers {
             let tci_type = u32::from_ne_bytes(measurement_log_entry.metadata);
             let derive_context_resp = DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: measurement_data
-                    .try_into()
-                    .map_err(|_| CaliptraError::RUNTIME_ADD_ROM_MEASUREMENTS_TO_DPE_FAILED)?,
+                data: TciMeasurement(
+                    measurement_data
+                        .try_into()
+                        .map_err(|_| CaliptraError::RUNTIME_ADD_ROM_MEASUREMENTS_TO_DPE_FAILED)?,
+                ),
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY
                     | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -17,9 +17,9 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, ResponseVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use dpe::{
-    commands::{CertifyKeyCmd, Command, CommandExecution, DeriveContextCmd, InitCtxCmd},
+    commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
     context::ContextState,
-    response::{Response, ResponseHdr},
+    response::ResponseHdr,
     DpeInstance, DpeProfile, U8Bool, MAX_HANDLES,
 };
 use zerocopy::IntoBytes;
@@ -44,12 +44,12 @@ impl InvokeDpeCmd {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
             }
             let command =
-                Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
+                &Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
                     .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
 
             // Determine the target privilege level of a new context then check if we exceed thresholds
             let new_context_privilege_level = match command {
-                Command::DeriveContext(cmd) if DeriveContextCmd::changes_locality(cmd) => {
+                Command::DeriveContext(cmd) if cmd.flags.changes_locality() => {
                     drivers.privilege_level_from_locality(cmd.target_locality)
                 }
                 _ => caller_privilege_level,
@@ -63,13 +63,9 @@ impl InvokeDpeCmd {
             let locality = drivers.mbox.id();
             let mut env = dpe_env(drivers, None, Some(ueid))?;
 
-            let dpe = &mut DpeInstance::initialized();
-
+            let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
             let resp = match command {
-                Command::GetProfile => Ok(Response::GetProfile(
-                    dpe.get_profile(&mut env.platform, env.state.support)
-                        .map_err(|_| CaliptraError::RUNTIME_COULD_NOT_GET_DPE_PROFILE)?,
-                )),
+                Command::GetProfile(cmd) => cmd.execute(dpe, &mut env, locality),
                 Command::InitCtx(cmd) => {
                     // InitCtx can only create new contexts if they are simulation contexts.
                     if InitCtxCmd::flag_is_simulation(cmd) {
@@ -78,23 +74,22 @@ impl InvokeDpeCmd {
                     cmd.execute(dpe, &mut env, locality)
                 }
                 Command::DeriveContext(cmd) => {
+                    let flags = cmd.flags;
                     // If the recursive flag is not set, DeriveContext will generate a new context.
                     // If recursive _is_ set, it will extend the existing one, which will not count
                     // against the context threshold.
-                    if !DeriveContextCmd::is_recursive(cmd) {
+                    if !flags.is_recursive() {
                         // Takes target locality into consideration if applicable. See above
                         dpe_context_threshold_err?;
                     }
-                    if DeriveContextCmd::changes_locality(cmd)
+                    if flags.changes_locality()
                         && cmd.target_locality == pl0_pauser
                         && caller_privilege_level != PauserPrivileges::PL0
                     {
                         return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
                     }
 
-                    if DeriveContextCmd::exports_cdi(cmd)
-                        && caller_privilege_level != PauserPrivileges::PL0
-                    {
+                    if flags.exports_cdi() && caller_privilege_level != PauserPrivileges::PL0 {
                         return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
                     }
 
@@ -102,7 +97,7 @@ impl InvokeDpeCmd {
                 }
                 Command::CertifyKey(cmd) => {
                     // PL1 cannot request X509
-                    if cmd.format == CertifyKeyCmd::FORMAT_X509
+                    if cmd.format() == CertifyKeyCommand::FORMAT_X509
                         && caller_privilege_level != PauserPrivileges::PL0
                     {
                         return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
@@ -135,7 +130,11 @@ impl InvokeDpeCmd {
                 Ok(ref r) => {
                     let resp_bytes = r.as_bytes();
                     let data_size = resp_bytes.len();
-                    invoke_resp.data[..data_size].copy_from_slice(resp_bytes);
+                    let buf = invoke_resp
+                        .data
+                        .get_mut(..data_size)
+                        .ok_or(CaliptraError::RUNTIME_INVOKE_DPE_RESPONSE_TOO_LARGE)?;
+                    buf.copy_from_slice(resp_bytes);
                     invoke_resp.data_size = data_size as u32;
                 }
                 Err(ref e) => {

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -13,7 +13,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::ecdsa::curve_384::{EcdsaPub384, EcdsaSignature384};
 use crypto::ecdsa::{EcdsaPubKey, EcdsaSignature};
-use crypto::{Crypto, Digest, PubKey, Signature};
+use crypto::{Crypto, Digest, PubKey, SignData, Signature};
 use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::FromBytes;
 
@@ -25,12 +25,12 @@ impl SignWithExportedEcdsaCmd {
     /// # Arguments
     ///
     /// * `env` - DPE environment containing Crypto and Platform implementations
-    /// * `digest` - The data to be signed
+    /// * `data` - The data to be signed
     /// * `exported_cdi_handle` - A handle from DPE that is exchanged for a CDI.
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn ecdsa_sign(
         env: &mut DpeCrypto,
-        digest: &Digest,
+        data: &SignData,
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
     ) -> CaliptraResult<(Signature, PubKey)> {
         let key_pair =
@@ -41,7 +41,7 @@ impl SignWithExportedEcdsaCmd {
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
 
         let sig = env
-            .sign_with_derived(digest, &priv_key, &pub_key)
+            .sign_with_derived(data, &priv_key, &pub_key)
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED)?;
 
         Ok((sig, pub_key))
@@ -81,11 +81,11 @@ impl SignWithExportedEcdsaCmd {
             &mut pdata.exported_cdi_slots,
         );
 
-        let digest = Digest::Sha384(crypto::Sha384(cmd.tbs));
+        let data = Digest::Sha384(crypto::Sha384(cmd.tbs)).into();
         let (
             Signature::Ecdsa(EcdsaSignature::Ecdsa384(EcdsaSignature384 { r, s })),
-            PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { r: x, s: y })),
-        ) = Self::ecdsa_sign(&mut crypto, &digest, &cmd.exported_cdi_handle)?
+            PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })),
+        ) = Self::ecdsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle)?
         else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         };

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -20,7 +20,8 @@ use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
     response::DpeErrorCode,
-    DpeInstance,
+    tci::TciMeasurement,
+    DpeInstance, DpeProfile,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -52,7 +53,7 @@ impl StashMeasurementCmd {
 
             let cmd = DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: *measurement,
+                data: TciMeasurement(*measurement),
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY
                     | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
@@ -63,7 +64,8 @@ impl StashMeasurementCmd {
             };
 
             let derive_context_resp = with_dpe_env(drivers, None, None, |env| {
-                Ok(cmd.execute(&mut DpeInstance::initialized(), env, locality))
+                let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
+                Ok(cmd.execute(dpe, env, locality))
             })?;
 
             match derive_context_resp {

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -31,12 +31,9 @@ use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
 use caliptra_test::image_pk_desc_hash;
 use dpe::{
-    commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags},
-    response::{
-        CertifyKeyResp, DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode,
-        GetCertificateChainResp, GetProfileResp, NewHandleResp, Response, ResponseHdr, SignResp,
-    },
-    DPE_PROFILE,
+    commands::{Command, CommandHdr},
+    response::{DpeErrorCode, Response, ResponseHdr},
+    DpeProfile,
 };
 use openssl::{
     asn1::{Asn1Integer, Asn1Time},
@@ -345,32 +342,6 @@ pub fn generate_test_x509_cert(private_key: &PKey<Private>) -> X509 {
     cert_builder.build()
 }
 
-fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
-    match dpe_cmd {
-        Command::GetProfile => Command::GET_PROFILE,
-        Command::InitCtx(_) => Command::INITIALIZE_CONTEXT,
-        Command::DeriveContext(_) => Command::DERIVE_CONTEXT,
-        Command::CertifyKey(_) => Command::CERTIFY_KEY,
-        Command::Sign(_) => Command::SIGN,
-        Command::RotateCtx(_) => Command::ROTATE_CONTEXT_HANDLE,
-        Command::DestroyCtx(_) => Command::DESTROY_CONTEXT,
-        Command::GetCertificateChain(_) => Command::GET_CERTIFICATE_CHAIN,
-    }
-}
-
-fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
-    match dpe_cmd {
-        Command::CertifyKey(cmd) => cmd.as_bytes(),
-        Command::DeriveContext(cmd) => cmd.as_bytes(),
-        Command::GetCertificateChain(cmd) => cmd.as_bytes(),
-        Command::DestroyCtx(cmd) => cmd.as_bytes(),
-        Command::GetProfile => &[],
-        Command::InitCtx(cmd) => cmd.as_bytes(),
-        Command::RotateCtx(cmd) => cmd.as_bytes(),
-        Command::Sign(cmd) => cmd.as_bytes(),
-    }
-}
-
 fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
     if let Ok(&ResponseHdr { status, .. }) =
         ResponseHdr::try_ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
@@ -378,43 +349,6 @@ fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
         if status != expected_status.get_error_code() {
             panic!("Unexpected DPE Status: 0x{:X}", status);
         }
-    }
-}
-
-fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
-    // Peek response header so we can panic with an error code in case the command failed.
-    check_dpe_status(resp_bytes, DpeErrorCode::NoError);
-
-    match dpe_cmd {
-        Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::DeriveContext(DeriveContextCmd { flags, .. })
-            if flags.contains(DeriveContextFlags::EXPORT_CDI) =>
-        {
-            Response::DeriveContextExportedCdi(
-                DeriveContextExportedCdiResp::try_read_from_bytes(resp_bytes).unwrap(),
-            )
-        }
-        Command::DeriveContext(_) => {
-            Response::DeriveContext(DeriveContextResp::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::GetCertificateChain(_) => Response::GetCertificateChain(
-            GetCertificateChainResp::try_read_from_bytes(resp_bytes).unwrap(),
-        ),
-        Command::DestroyCtx(_) => {
-            Response::DestroyCtx(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::GetProfile => {
-            Response::GetProfile(GetProfileResp::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::InitCtx(_) => {
-            Response::InitCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::RotateCtx(_) => {
-            Response::RotateCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
-        }
-        Command::Sign(_) => Response::Sign(SignResp::try_read_from_bytes(resp_bytes).unwrap()),
     }
 }
 
@@ -430,11 +364,10 @@ pub fn execute_dpe_cmd(
     expected_result: DpeResult,
 ) -> Option<Response> {
     let mut cmd_data: [u8; 512] = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
-    let dpe_cmd_id = get_cmd_id(dpe_cmd);
-    let cmd_hdr = CommandHdr::new(DPE_PROFILE, dpe_cmd_id);
+    let cmd_hdr = CommandHdr::new(DpeProfile::P384Sha384, dpe_cmd.id());
     let cmd_hdr_buf = cmd_hdr.as_bytes();
     cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
-    let dpe_cmd_buf = as_bytes(dpe_cmd);
+    let dpe_cmd_buf = dpe_cmd.as_bytes();
     cmd_data[cmd_hdr_buf.len()..cmd_hdr_buf.len() + dpe_cmd_buf.len()].copy_from_slice(dpe_cmd_buf);
     let mut mbox_cmd = MailboxReq::InvokeDpeCommand(InvokeDpeReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -465,7 +398,11 @@ pub fn execute_dpe_cmd(
 
     let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
     Some(match expected_result {
-        DpeResult::Success => parse_dpe_response(dpe_cmd, resp_bytes),
+        DpeResult::Success => {
+            // Peek response header so we can panic with an error code in case the command failed.
+            check_dpe_status(resp_bytes, DpeErrorCode::NoError);
+            Response::try_read_from_bytes(dpe_cmd, resp_bytes).unwrap()
+        },
         DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap()),
         DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
     })

--- a/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
+++ b/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
@@ -2,9 +2,9 @@
 
 use caliptra_hw_model::DefaultHwModel;
 use dpe::{
-    commands::{CertifyKeyCmd, CertifyKeyFlags, Command},
+    commands::{CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command},
     context::ContextHandle,
-    response::Response,
+    response::{CertifyKeyResp, Response},
 };
 use openssl::x509::X509;
 
@@ -17,14 +17,14 @@ fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
         handle: ContextHandle::default(),
         flags: CertifyKeyFlags::empty(),
         label: TEST_LABEL,
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
     X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -8,9 +8,9 @@ use caliptra_common::mailbox_api::{
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::{AddSubjectAltNameCmd, RtBootStatus};
 use dpe::{
-    commands::{CertifyKeyCmd, CertifyKeyFlags},
+    commands::{CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd},
     context::ContextHandle,
-    response::CertifyKeyResp,
+    response::CertifyKeyP384Resp,
 };
 use x509_parser::{
     certificate::X509Certificate, extensions::GeneralName, oid_registry::asn1_rs::FromDer,
@@ -83,7 +83,7 @@ fn test_dmtf_other_name_extension_present() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let mut cmd = MailboxReq::CertifyKeyExtended(CertifyKeyExtendedReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -102,7 +102,7 @@ fn test_dmtf_other_name_extension_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+        CertifyKeyP384Resp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
             .unwrap();
 
     let (_, cert) =
@@ -135,7 +135,7 @@ fn test_dmtf_other_name_extension_not_present() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
 
     // Check that otherName extension is not present if not provided by ADD_SUBJECT_ALT_NAME
@@ -156,7 +156,7 @@ fn test_dmtf_other_name_extension_not_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+        CertifyKeyP384Resp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
             .unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
@@ -201,7 +201,7 @@ fn test_dmtf_other_name_extension_not_present() {
     let certify_key_extended_resp =
         CertifyKeyExtendedResp::read_from_bytes(resp.as_slice()).unwrap();
     let certify_key_resp =
-        CertifyKeyResp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
+        CertifyKeyP384Resp::try_read_from_bytes(&certify_key_extended_resp.certify_key_resp[..])
             .unwrap();
     let (_, cert) =
         X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -19,9 +19,13 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, DefaultHwModel, Fuses, HwModel, InitParams};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::{
-    commands::{CertifyKeyCmd, CertifyKeyFlags, Command, DeriveContextCmd, DeriveContextFlags},
+    commands::{
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command,
+        DeriveContextCmd, DeriveContextFlags,
+    },
     context::ContextHandle,
-    response::{CertifyKeyResp, Response},
+    response::{CertifyKeyP384Resp, CertifyKeyResp, Response},
+    tci::TciMeasurement,
 };
 use openssl::{
     asn1::Asn1Time,
@@ -441,14 +445,14 @@ fn test_dpe_leaf_cert() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
     let dpe_leaf_cert: X509 =
@@ -535,19 +539,19 @@ fn test_full_cert_chain_mldsa87() {
         .unwrap();
 }
 
-fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyResp {
+fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyP384Resp {
     let certify_key_cmd = CertifyKeyCmd {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
     certify_key_resp
@@ -698,7 +702,7 @@ pub fn test_all_measurement_apis() {
         // Send derive context call
         let derive_context_cmd = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: measurement,
+            data: TciMeasurement(measurement),
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                 | DeriveContextFlags::INPUT_ALLOW_X509,
@@ -708,7 +712,7 @@ pub fn test_all_measurement_apis() {
         };
         let resp = execute_dpe_cmd(
             &mut hw,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(_derive_ctx_resp)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -8,9 +8,12 @@ use caliptra_common::mailbox_api::{CommandId, FwInfoResp, MailboxReqHeader, Mail
 use caliptra_hw_model::HwModel;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::{
-    commands::{CertifyKeyCmd, CertifyKeyFlags, Command, SignCmd, SignFlags},
+    commands::{
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command, SignFlags,
+        SignP384Cmd as SignCmd,
+    },
     context::ContextHandle,
-    response::Response,
+    response::{CertifyKeyResp, Response, SignResp},
 };
 use openssl::{
     bn::BigNum,
@@ -39,10 +42,10 @@ fn test_disable_attestation_cmd() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::Sign(&sign_cmd),
+        &mut Command::from(&sign_cmd),
         DpeResult::Success,
     );
-    let Some(Response::Sign(sign_resp)) = resp else {
+    let Some(Response::Sign(SignResp::P384(sign_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -70,14 +73,14 @@ fn test_disable_attestation_cmd() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -154,14 +157,14 @@ fn test_attestation_disabled_flag_after_update_reset() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
     let dpe_leaf_cert: X509 =

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -18,12 +18,13 @@ use cms::{
 };
 use dpe::{
     commands::{
-        CertifyKeyCmd, CertifyKeyFlags, Command, DeriveContextCmd, DeriveContextFlags,
-        GetCertificateChainCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags, SignCmd, SignFlags,
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command,
+        DeriveContextCmd, DeriveContextFlags, GetCertificateChainCmd, GetProfileCmd, InitCtxCmd,
+        RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd as SignCmd,
     },
     context::ContextHandle,
-    response::{DpeErrorCode, Response},
-    DPE_PROFILE,
+    response::{CertifyKeyResp, DpeErrorCode, Response, SignResp},
+    DpeProfile,
 };
 use openssl::{
     bn::BigNum,
@@ -42,11 +43,15 @@ fn test_invoke_dpe_get_profile_cmd() {
 
     model.step_until_ready_for_runtime();
 
-    let resp = execute_dpe_cmd(&mut model, &mut Command::GetProfile, DpeResult::Success);
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::GetProfile(&GetProfileCmd),
+        DpeResult::Success,
+    );
     let Some(Response::GetProfile(profile)) = resp else {
         panic!("Wrong response type!");
     };
-    assert_eq!(profile.resp_hdr.profile, DPE_PROFILE);
+    assert_eq!(profile.resp_hdr.profile, DpeProfile::P384Sha384);
     assert_eq!(profile.vendor_id, VENDOR_ID);
     assert_eq!(profile.vendor_sku, VENDOR_SKU);
     assert_eq!(profile.flags, DPE_SUPPORT.bits());
@@ -102,10 +107,10 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::Sign(&sign_cmd),
+        &mut Command::from(&sign_cmd),
         DpeResult::Success,
     );
-    let Some(Response::Sign(sign_resp)) = resp else {
+    let Some(Response::Sign(SignResp::P384(sign_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -113,14 +118,14 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -153,10 +158,10 @@ fn test_invoke_dpe_asymmetric_sign() {
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::Sign(&sign_cmd),
+        &mut Command::from(&sign_cmd),
         DpeResult::Success,
     );
-    let Some(Response::Sign(sign_resp)) = resp else {
+    let Some(Response::Sign(SignResp::P384(sign_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -196,14 +201,14 @@ fn test_invoke_dpe_certify_key_csr() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_CSR,
+        format: CertifyKeyCommand::FORMAT_CSR,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -211,10 +216,9 @@ fn test_invoke_dpe_certify_key_csr() {
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
     // parse CMS ContentInfo
-    let content_info = ContentInfo::from_der(
-        &certify_key_resp.cert[..certify_key_resp.cert_size.try_into().unwrap()],
-    )
-    .unwrap();
+    let content_info =
+        ContentInfo::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
+            .unwrap();
     // parse SignedData
     let mut signed_data = SignedData::from_der(&content_info.content.to_der().unwrap()).unwrap();
     assert_eq!(signed_data.version, CmsVersion::V3);
@@ -313,17 +317,17 @@ fn test_invoke_dpe_certify_key_with_non_critical_dice_extensions() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::Success,
     );
-    let Some(Response::CertifyKey(resp)) = resp else {
+    let Some(Response::CertifyKey(CertifyKeyResp::P384(resp))) = resp else {
         panic!("Wrong response type!");
     };
-    check_dice_extension_criticality(&resp.cert[..resp.cert_size.try_into().unwrap()], false);
+    check_dice_extension_criticality(&resp.cert[..resp.cert_size as usize], false);
 }
 
 #[test]
@@ -334,15 +338,12 @@ fn test_invoke_dpe_export_cdi_with_non_critical_dice_extensions() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 
@@ -368,18 +369,15 @@ fn test_export_cdi_attestation_not_disabled_after_update_reset() {
 
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 
@@ -422,16 +420,13 @@ fn test_export_cdi_destroyed_root_context() {
     // destroyed.
     let derive_ctx_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -27,12 +27,11 @@ use caliptra_runtime::{
 
 use dpe::{
     commands::{
-        CertifyKeyCmd, CertifyKeyFlags, Command, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
-        RotateCtxCmd, RotateCtxFlags,
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command,
+        DeriveContextCmd, DeriveContextFlags, InitCtxCmd, RotateCtxCmd, RotateCtxFlags,
     },
     context::ContextHandle,
     response::Response,
-    DPE_PROFILE,
 };
 use zerocopy::IntoBytes;
 
@@ -40,8 +39,6 @@ use crate::common::{
     assert_error, execute_dpe_cmd, run_rt_test, run_rt_test_pqc, DpeResult, RuntimeTestArgs,
     TEST_LABEL,
 };
-
-const DATA: [u8; DPE_PROFILE.hash_size()] = [0u8; 48];
 
 #[test]
 fn test_pl0_derive_context_dpe_context_thresholds() {
@@ -75,18 +72,15 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     for i in 0..num_iterations {
         let derive_context_cmd = DeriveContextCmd {
             handle,
-            data: DATA,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-            tci_type: 0,
-            target_locality: 0,
-            svn: 0,
+            ..Default::default()
         };
 
         // If we are on the last call to DeriveContext, expect that we get a RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED error.
         if i == num_iterations - 1 {
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(&derive_context_cmd),
+                &mut Command::from(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -97,7 +91,7 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
 
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::Success,
         );
         let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -149,18 +143,15 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
         for i in 0..num_iterations {
             let derive_context_cmd = DeriveContextCmd {
                 handle,
-                data: DATA,
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-                tci_type: 0,
-                target_locality: 0,
-                svn: 0,
+                ..Default::default()
             };
 
             // If we are on the last call to DeriveContext, expect that we get a RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED error.
             if i == num_iterations - 1 {
                 let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(&derive_context_cmd),
+                &mut Command::from(&derive_context_cmd),
                 DpeResult::MboxCmdFailure(
                     caliptra_drivers::CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED,
                 ),
@@ -171,7 +162,7 @@ fn test_pl1_derive_context_dpe_context_thresholds() {
 
             let resp = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(&derive_context_cmd),
+                &mut Command::from(&derive_context_cmd),
                 DpeResult::Success,
             );
             let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -283,18 +274,16 @@ fn test_change_locality() {
 
     let derive_context_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: DATA,
         flags: DeriveContextFlags::CHANGE_LOCALITY
             | DeriveContextFlags::MAKE_DEFAULT
             | DeriveContextFlags::INPUT_ALLOW_X509,
-        tci_type: 0,
         target_locality: 2,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_context_cmd),
+        &mut Command::from(&derive_context_cmd),
         DpeResult::Success,
     )
     .unwrap();
@@ -303,16 +292,14 @@ fn test_change_locality() {
 
     let derive_context_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: DATA,
         flags: DeriveContextFlags::MAKE_DEFAULT,
-        tci_type: 0,
         target_locality: 2,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_context_cmd),
+        &mut Command::from(&derive_context_cmd),
         DpeResult::Success,
     )
     .unwrap();
@@ -473,15 +460,12 @@ fn test_export_cdi_cannot_be_called_from_pl1() {
 
     let get_cert_chain_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&get_cert_chain_cmd),
+        &mut Command::from(&get_cert_chain_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
 }
@@ -508,11 +492,11 @@ fn test_certify_key_x509_cannot_be_called_from_pl1() {
             handle: ContextHandle::default(),
             label: TEST_LABEL,
             flags: CertifyKeyFlags::empty(),
-            format: CertifyKeyCmd::FORMAT_X509,
+            format: CertifyKeyCommand::FORMAT_X509,
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::CertifyKey(&certify_key_cmd),
+            &mut Command::from(&certify_key_cmd),
             DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
         );
         assert!(resp.is_none());
@@ -593,15 +577,12 @@ fn test_derive_context_cannot_be_called_from_pl1_if_changes_locality_to_pl0() {
 
         let derive_context_cmd = DeriveContextCmd {
             handle: init_ctx_resp.handle,
-            data: DATA,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
-            tci_type: 0,
-            target_locality: 0,
-            svn: 0,
+            ..Default::default()
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::MboxCmdFailure(
                 caliptra_drivers::CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
             ),
@@ -792,11 +773,11 @@ fn test_pl0_unset_in_header() {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_X509,
+        format: CertifyKeyCommand::FORMAT_X509,
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::CertifyKey(&certify_key_cmd),
+        &mut Command::from(&certify_key_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
     );
     assert!(resp.is_none());
@@ -845,11 +826,11 @@ fn test_user_not_pl0() {
             handle: ContextHandle::default(),
             label: TEST_LABEL,
             flags: CertifyKeyFlags::empty(),
-            format: CertifyKeyCmd::FORMAT_X509,
+            format: CertifyKeyCommand::FORMAT_X509,
         };
         let resp = execute_dpe_cmd(
             &mut model,
-            &mut Command::CertifyKey(&certify_key_cmd),
+            &mut Command::from(&certify_key_cmd),
             DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
         );
         assert!(resp.is_none());

--- a/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
+++ b/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
@@ -12,21 +12,13 @@ use caliptra_common::mailbox_api::{MailboxReq, MailboxReqHeader};
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
 use caliptra_image_types::FwVerificationPqcKeyType;
-use dpe::{
-    commands::{Command, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
-    DPE_PROFILE,
-};
+use dpe::commands::{Command, DeriveContextCmd, DeriveContextFlags};
 use zerocopy::FromBytes;
 
 fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: u32) {
-    const BASE_DERIVE_CONTEXT_CMD: DeriveContextCmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
+    let base_derive_context_cmd = DeriveContextCmd {
         flags: DeriveContextFlags::MAKE_DEFAULT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     // 32 contexts = 1 root node (PL0)+
@@ -40,7 +32,7 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
     for _ in 0..(pl0_limit - 2) {
         let _ = execute_dpe_cmd(
             model,
-            &mut Command::DeriveContext(&BASE_DERIVE_CONTEXT_CMD),
+            &mut Command::from(&base_derive_context_cmd),
             DpeResult::Success,
         );
     }
@@ -49,7 +41,7 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
     // Trigger failure by trying to derive one more context to PL0
     let _ = execute_dpe_cmd(
         model,
-        &mut Command::DeriveContext(&BASE_DERIVE_CONTEXT_CMD),
+        &mut Command::from(&base_derive_context_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED),
     );
 
@@ -61,11 +53,11 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
             let derive_ctx_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
                 target_locality: 2,
-                ..BASE_DERIVE_CONTEXT_CMD
+                ..base_derive_context_cmd
             };
             let _ = execute_dpe_cmd(
                 model,
-                &mut Command::DeriveContext(&derive_ctx_cmd),
+                &mut Command::from(&derive_ctx_cmd),
                 DpeResult::Success,
             );
 
@@ -73,7 +65,7 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
         } else {
             let _ = execute_dpe_cmd(
                 model,
-                &mut Command::DeriveContext(&BASE_DERIVE_CONTEXT_CMD),
+                &mut Command::from(&base_derive_context_cmd),
                 DpeResult::Success,
             );
         }
@@ -83,7 +75,7 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
     // Trigger failure by trying to derive one more context to PL1
     let _ = execute_dpe_cmd(
         model,
-        &mut Command::DeriveContext(&BASE_DERIVE_CONTEXT_CMD),
+        &mut Command::from(&base_derive_context_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_PL1_USED_DPE_CONTEXT_THRESHOLD_REACHED),
     );
 }
@@ -165,19 +157,15 @@ fn test_pl0_pl1_reallocation_pl0_less_than_used() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     let derive_context_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     // Use some PL0 contexts
     for _ in 0..12 {
         let _ = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::Success,
         );
     }
@@ -196,13 +184,9 @@ fn test_pl0_pl1_reallocation_pl0_less_than_used() {
 fn test_pl0_pl1_reallocation_pl1_less_than_used() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    const BASE_DERIVE_CONTEXT_CMD: DeriveContextCmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
+    let base_derive_context_cmd = DeriveContextCmd {
         flags: DeriveContextFlags::MAKE_DEFAULT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     // Use some PL1 contexts
@@ -212,11 +196,11 @@ fn test_pl0_pl1_reallocation_pl1_less_than_used() {
             let derive_ctx_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
                 target_locality: 2,
-                ..BASE_DERIVE_CONTEXT_CMD
+                ..base_derive_context_cmd
             };
             let _ = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(&derive_ctx_cmd),
+                &mut Command::from(&derive_ctx_cmd),
                 DpeResult::Success,
             );
 
@@ -224,7 +208,7 @@ fn test_pl0_pl1_reallocation_pl1_less_than_used() {
         } else {
             let _ = execute_dpe_cmd(
                 &mut model,
-                &mut Command::DeriveContext(&BASE_DERIVE_CONTEXT_CMD),
+                &mut Command::from(&base_derive_context_cmd),
                 DpeResult::Success,
             );
         }
@@ -255,19 +239,15 @@ fn test_pl0_pl1_reallocation_warm_reset() {
     let mut model = run_rt_test(runtime_test_args);
 
     let derive_context_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::MAKE_DEFAULT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     // Use some PL0 contexts
     for _ in 0..12 {
         let _ = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::Success,
         );
     }
@@ -292,7 +272,7 @@ fn test_pl0_pl1_reallocation_warm_reset() {
     for _ in 0..10 {
         let _ = execute_dpe_cmd(
             &mut model,
-            &mut Command::DeriveContext(&derive_context_cmd),
+            &mut Command::from(&derive_context_cmd),
             DpeResult::Success,
         );
     }
@@ -300,7 +280,7 @@ fn test_pl0_pl1_reallocation_warm_reset() {
     // Trigger failure by trying to derive one more context to PL0
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_context_cmd),
+        &mut Command::from(&derive_context_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED),
     );
 }

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
@@ -7,9 +7,7 @@ use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
     response::Response,
-    DPE_PROFILE,
 };
 
 use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs};
@@ -22,17 +20,13 @@ fn test_revoke_exported_cdi_handle() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -60,17 +54,13 @@ fn test_revoke_already_revoked_exported_cdi_handle() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -148,19 +138,15 @@ fn test_export_cdi_after_revoke() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -181,7 +167,7 @@ fn test_export_cdi_after_revoke() {
 
     let Some(Response::DeriveContextExportedCdi(_)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -9,7 +9,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError, SecurityState};
-use caliptra_runtime::RtBootStatus;
+use caliptra_runtime::{RtBootStatus, TciMeasurement};
 use crypto::{CryptoError, MAX_EXPORTED_CDI_SIZE};
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags, RotateCtxCmd, RotateCtxFlags},
@@ -17,7 +17,7 @@ use dpe::{
     response::{
         DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, NewHandleResp, Response,
     },
-    DPE_PROFILE,
+    TCI_SIZE,
 };
 use openssl::{
     bn::BigNum,
@@ -76,16 +76,12 @@ fn test_sign_with_exported_cdi() {
     });
 
     let derive_ctx_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 
@@ -120,16 +116,12 @@ fn test_sign_with_exported_incorrect_cdi_handle() {
     });
 
     let get_cert_chain_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&get_cert_chain_cmd),
+        &mut Command::from(&get_cert_chain_cmd),
         DpeResult::Success,
     );
 
@@ -201,19 +193,15 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -236,23 +224,21 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
     assert!(check_certificate_signature(sign_resp, &original_cdi_resp));
 
     let measurement_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0xa; DPE_PROFILE.tci_size()],
+        data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: u32::from_be_bytes(*b"CCIV"),
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&measurement_cmd),
+        &mut Command::from(&measurement_cmd),
         DpeResult::Success,
     );
 
     let Some(Response::Error(e)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::DpeCmdFailure,
     ) else {
         panic!("Expected the second export cdi command to fail.")
@@ -299,36 +285,30 @@ fn test_sign_with_exported_cdi_measurement_update() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
     };
 
     let measurement_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0xa; DPE_PROFILE.tci_size()],
+        data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: u32::from_be_bytes(*b"CCIV"),
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let _ = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&measurement_cmd),
+        &mut Command::from(&measurement_cmd),
         DpeResult::Success,
     );
 
@@ -348,7 +328,7 @@ fn test_sign_with_exported_cdi_measurement_update() {
 
     let Some(Response::DeriveContextExportedCdi(updated_cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -397,17 +377,13 @@ fn test_sign_with_revoked_exported_cdi() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -469,19 +445,15 @@ fn test_sign_with_disabled_attestation() {
     });
 
     let export_cdi_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
 
     let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&export_cdi_cmd),
+        &mut Command::from(&export_cdi_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected derive context resp!")
@@ -552,18 +524,14 @@ fn test_sign_with_exported_cdi_warm_reset() {
     });
 
     let derive_ctx_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI
             | DeriveContextFlags::CREATE_CERTIFICATE
             | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 
@@ -654,15 +622,12 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
     // We will export the parent. We expect that the child prevents the dpe context chain from being destroyed.
     let derive_ctx_cmd = DeriveContextCmd {
         handle,
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 
@@ -673,15 +638,12 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
     // Export the parent context from the last derive command.
     let derive_ctx_cmd = DeriveContextCmd {
         handle: parent_handle,
-        data: [0; DPE_PROFILE.tci_size()],
         flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
+        &mut Command::from(&derive_ctx_cmd),
         DpeResult::Success,
     );
 

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -9,7 +9,6 @@ use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags, DestroyCtxCmd},
     context::ContextHandle,
     response::Response,
-    DPE_PROFILE,
 };
 use zerocopy::FromBytes;
 
@@ -213,17 +212,10 @@ fn test_tagging_retired_context() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     // retire context via DeriveContext
-    let derive_context_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0u8; DPE_PROFILE.hash_size()],
-        flags: DeriveContextFlags::empty(),
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
-    };
+    let derive_context_cmd = DeriveContextCmd::default();
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_context_cmd),
+        &mut Command::from(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(derive_context_resp)) = resp else {
@@ -262,15 +254,12 @@ fn test_tagging_retired_context() {
     // retire tagged context via derive child
     let derive_context_cmd = DeriveContextCmd {
         handle: new_handle,
-        data: [0u8; DPE_PROFILE.hash_size()],
         flags: DeriveContextFlags::empty(),
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
     let resp = execute_dpe_cmd(
         &mut model,
-        &mut Command::DeriveContext(&derive_context_cmd),
+        &mut Command::from(&derive_context_cmd),
         DpeResult::Success,
     );
     let Some(Response::DeriveContext(_)) = resp else {

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -25,7 +25,7 @@ use dpe::{
     response::DpeErrorCode,
     tci::TciMeasurement,
     validation::ValidationError,
-    U8Bool, DPE_PROFILE, MAX_HANDLES,
+    U8Bool, MAX_HANDLES, TCI_SIZE,
 };
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
@@ -295,7 +295,7 @@ fn test_dpe_validation_deformed_structure() {
     let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating multiple normal connected components
-    dpe.contexts[0].children = 0;
+    dpe.contexts[0].children = 0.into();
     dpe.contexts[0].state = ContextState::Active;
     dpe.contexts[1].parent_idx = Context::ROOT_INDEX;
     let _ = model
@@ -350,7 +350,7 @@ fn test_dpe_validation_illegal_state() {
     let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE state by messing up parent-child links
-    dpe.contexts[1].children = 0b1;
+    dpe.contexts[1].children = 0b1u32.into();
     let _ = model
         .mailbox_execute(0xB000_0000, dpe.as_bytes())
         .unwrap()
@@ -416,8 +416,8 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
         dpe.contexts[idx].context_type = ContextType::Simulation;
         dpe.contexts[idx].locality = pl0_pauser;
         dpe.contexts[idx].tci.locality = pl0_pauser;
-        dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; DPE_PROFILE.tci_size()]);
-        dpe.contexts[idx].tci.tci_cumulative = TciMeasurement([idx as u8; DPE_PROFILE.tci_size()]);
+        dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; TCI_SIZE]);
+        dpe.contexts[idx].tci.tci_cumulative = TciMeasurement([idx as u8; TCI_SIZE]);
         dpe.contexts[idx].handle = ContextHandle([idx as u8; ContextHandle::SIZE]);
     }
     let _ = model

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -10,7 +10,7 @@ use caliptra_hw_model::{
     BootParams, DeviceLifecycle, Fuses, HwModel, InitParams, SecurityState, SubsystemInitParams,
 };
 use caliptra_test::image_pk_desc_hash;
-use dpe::DPE_PROFILE;
+use dpe::TCI_SIZE;
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 
@@ -67,7 +67,7 @@ fn test_rt_journey_pcr_validation() {
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
     let _ = model
-        .mailbox_execute(0xD000_0000, &[0u8; DPE_PROFILE.tci_size()])
+        .mailbox_execute(0xD000_0000, &[0u8; TCI_SIZE])
         .unwrap()
         .unwrap();
 
@@ -136,7 +136,7 @@ fn test_rt_current_pcr_validation() {
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
     let _ = model
-        .mailbox_execute(0xD000_0001, &[0u8; DPE_PROFILE.tci_size()])
+        .mailbox_execute(0xD000_0001, &[0u8; TCI_SIZE])
         .unwrap()
         .unwrap();
 

--- a/test/dpe_verification/go.mod
+++ b/test/dpe_verification/go.mod
@@ -1,20 +1,17 @@
 module dpe
 
-go 1.20
+go 1.22.0
 
-replace github.com/chipsalliance/caliptra-dpe/verification/testing => ../../dpe/verification/testing
-
-replace github.com/chipsalliance/caliptra-dpe/verification/client => ../../dpe/verification/client
-
-replace github.com/chipsalliance/caliptra-dpe/verification/sim => ../../dpe/verification/sim
+toolchain go1.24.8
 
 require (
-	github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20240305022518-f4e3dd792a5c
-	github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20240227181801-29d5ca397c66
+	github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260131044809-4986ac50d82b
+	github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260131044809-4986ac50d82b
 )
 
 require (
-	github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20240305022518-f4e3dd792a5c // indirect
+	github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20260131044809-4986ac50d82b // indirect
+	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/github/smimesign v0.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-configfs-tsm v0.2.2 // indirect

--- a/test/dpe_verification/go.sum
+++ b/test/dpe_verification/go.sum
@@ -2,7 +2,15 @@ cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1h
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260131044809-4986ac50d82b h1:IIMPxeF9Y2cGlhP8dKA1KBrOPQsWcnT9sBD8Ic4YxzM=
+github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260131044809-4986ac50d82b/go.mod h1:HTEbUOJXYocmlvNJ8i0arjW/XQA7QYnCGQHi/8kwnAg=
+github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20260131044809-4986ac50d82b h1:gIFl/mTgSULIVWfYZ/l3/LJXMI87EgEV+7jEyt/QnHE=
+github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20260131044809-4986ac50d82b/go.mod h1:tCF7Q+jyiox85doSbjd2pFsdlFbzhdYQngIAJa85iHU=
+github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260131044809-4986ac50d82b h1:av1OryQFclG4xa1wDGJnYmAcAo7/TynMupoiAS32Ztg=
+github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260131044809-4986ac50d82b/go.mod h1:Fss82bN29Ry/nbhOo7Htk4sY8j5s+4M5S2FxLrO+hpo=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,7 +22,9 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/certificate-transparency-go v1.1.2 h1:4hE0GEId6NAW28dFpC+LrRGwQX5dtmXQGDbg8+/MZOM=
+github.com/google/certificate-transparency-go v1.1.2/go.mod h1:3OL+HKDqHPUfdKrHVQxO6T8nDLO0HF7LRTlkIWXaWvQ=
 github.com/google/go-attestation v0.5.0 h1:jXtAWT2sw2Yu8mYU0BC7FDidR+ngxFPSE+pl6IUu3/0=
+github.com/google/go-attestation v0.5.0/go.mod h1:0Tik9y3rzV649Jcr7evbljQHQAsIlJucyqQjYDBqktU=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -33,6 +43,7 @@ github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47
 github.com/google/go-tpm-tools v0.4.3 h1:L5dc34fttMIREoKRmnIJfv2NSZDSZ+RfBD+izN0EZoA=
 github.com/google/go-tpm-tools v0.4.3/go.mod h1:T8jXkp2s+eltnCDIsXR84/MTcVU9Ja7bh3Mit0pa4AY=
 github.com/google/go-tspi v0.3.0 h1:ADtq8RKfP+jrTyIWIZDIYcKOMecRqNJFOew2IT0Inus=
+github.com/google/go-tspi v0.3.0/go.mod h1:xfMGI3G0PhxCdNVcYr1C4C+EizojDg/TXuX5by8CiHI=
 github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=
 github.com/google/logger v1.1.1/go.mod h1:BkeJZ+1FhQ+/d087r4dzojEg1u2ZX+ZqG1jTUrLM+zQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -44,6 +55,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/mreiferson/go-httpclient v0.0.0-20201222173833-5e475fde3a4d/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
@@ -67,6 +79,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weppos/publicsuffix-go v0.13.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.30.2-0.20230730094716-a20f9abcc222 h1:h2JizvZl9aIj6za9S5AyrkU+OzIS4CetQthH/ejO+lg=
 github.com/weppos/publicsuffix-go v0.30.2-0.20230730094716-a20f9abcc222/go.mod h1:s41lQh6dIsDWIC1OWh7ChWJXLH0zkJ9KHZVqA7vHyuQ=
@@ -177,3 +190,4 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -7,13 +7,14 @@ use caliptra_common::mailbox_api::*;
 use caliptra_drivers::FipsTestHook;
 use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams, ModelError};
 use caliptra_image_types::FwVerificationPqcKeyType;
+use dpe::response::{CertifyKeyP384Resp, DeriveContextExportedCdiResp, SignP384Resp};
+use dpe::DpeProfile;
 use dpe::{
     commands::*,
     response::{
         CertifyKeyResp, DeriveContextResp, GetCertificateChainResp, GetProfileResp, NewHandleResp,
         Response, ResponseHdr, SignResp,
     },
-    DPE_PROFILE,
 };
 use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
@@ -287,35 +288,17 @@ pub fn mbx_send_and_check_resp_hdr<T: HwModel, U: FromBytes + IntoBytes>(
     //Ok(U::read_from_bytes(resp_bytes.as_bytes()).unwrap())
 }
 
-fn get_cmd_id(dpe_cmd: &mut Command) -> u32 {
-    match dpe_cmd {
-        Command::GetProfile => Command::GET_PROFILE,
-        Command::InitCtx(_) => Command::INITIALIZE_CONTEXT,
-        Command::DeriveContext(_) => Command::DERIVE_CONTEXT,
-        Command::CertifyKey(_) => Command::CERTIFY_KEY,
-        Command::Sign(_) => Command::SIGN,
-        Command::RotateCtx(_) => Command::ROTATE_CONTEXT_HANDLE,
-        Command::DestroyCtx(_) => Command::DESTROY_CONTEXT,
-        Command::GetCertificateChain(_) => Command::GET_CERTIFICATE_CHAIN,
-    }
-}
-pub fn as_bytes<'a>(dpe_cmd: &'a mut Command) -> &'a [u8] {
-    match dpe_cmd {
-        Command::CertifyKey(cmd) => cmd.as_bytes(),
-        Command::DeriveContext(cmd) => cmd.as_bytes(),
-        Command::GetCertificateChain(cmd) => cmd.as_bytes(),
-        Command::DestroyCtx(cmd) => cmd.as_bytes(),
-        Command::GetProfile => &[],
-        Command::InitCtx(cmd) => cmd.as_bytes(),
-        Command::RotateCtx(cmd) => cmd.as_bytes(),
-        Command::Sign(cmd) => cmd.as_bytes(),
-    }
-}
-
 pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response {
     match dpe_cmd {
-        Command::CertifyKey(_) => {
-            Response::CertifyKey(CertifyKeyResp::try_read_from_bytes(resp_bytes).unwrap())
+        Command::CertifyKey(CertifyKeyCommand::P384(_)) => Response::CertifyKey(
+            CertifyKeyResp::P384(CertifyKeyP384Resp::try_read_from_bytes(resp_bytes).unwrap()),
+        ),
+        Command::DeriveContext(DeriveContextCmd { flags, .. })
+            if flags.contains(DeriveContextFlags::EXPORT_CDI) =>
+        {
+            Response::DeriveContextExportedCdi(
+                DeriveContextExportedCdiResp::try_read_from_bytes(resp_bytes).unwrap(),
+            )
         }
         Command::DeriveContext(_) => {
             Response::DeriveContext(DeriveContextResp::try_read_from_bytes(resp_bytes).unwrap())
@@ -326,7 +309,7 @@ pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response 
         Command::DestroyCtx(_) => {
             Response::DestroyCtx(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap())
         }
-        Command::GetProfile => {
+        Command::GetProfile(_) => {
             Response::GetProfile(GetProfileResp::try_read_from_bytes(resp_bytes).unwrap())
         }
         Command::InitCtx(_) => {
@@ -335,17 +318,18 @@ pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response 
         Command::RotateCtx(_) => {
             Response::RotateCtx(NewHandleResp::try_read_from_bytes(resp_bytes).unwrap())
         }
-        Command::Sign(_) => Response::Sign(SignResp::try_read_from_bytes(resp_bytes).unwrap()),
+        Command::Sign(SignCommand::P384(_)) => Response::Sign(SignResp::P384(
+            SignP384Resp::try_read_from_bytes(resp_bytes).unwrap(),
+        )),
     }
 }
 
 pub fn execute_dpe_cmd<T: HwModel>(hw: &mut T, dpe_cmd: &mut Command) -> Response {
     let mut cmd_data: [u8; 512] = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
-    let dpe_cmd_id = get_cmd_id(dpe_cmd);
-    let cmd_hdr = CommandHdr::new(DPE_PROFILE, dpe_cmd_id);
+    let cmd_hdr = CommandHdr::new(DpeProfile::P384Sha384, dpe_cmd.id());
     let cmd_hdr_buf = cmd_hdr.as_bytes();
     cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
-    let dpe_cmd_buf = as_bytes(dpe_cmd);
+    let dpe_cmd_buf = dpe_cmd.as_bytes();
     cmd_data[cmd_hdr_buf.len()..cmd_hdr_buf.len() + dpe_cmd_buf.len()].copy_from_slice(dpe_cmd_buf);
 
     let mut payload = MailboxReq::InvokeDpeCommand(InvokeDpeReq {

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -10,7 +10,12 @@ use caliptra_drivers::FipsTestHook;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, ModelError};
 use caliptra_image_types::ImageManifest;
 use common::*;
-use dpe::{commands::*, context::ContextHandle, response::Response, DPE_PROFILE};
+use dpe::{
+    commands::*,
+    context::ContextHandle,
+    response::{CertifyKeyResp, Response, SignResp},
+    DpeProfile,
+};
 use openssl::sha::sha384;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -458,13 +463,13 @@ pub fn exec_cmd_extend_pcr<T: HwModel>(hw: &mut T) {
 }
 
 pub fn exec_dpe_get_profile<T: HwModel>(hw: &mut T) {
-    let resp = execute_dpe_cmd(hw, &mut Command::GetProfile);
+    let resp = execute_dpe_cmd(hw, &mut Command::GetProfile(&GetProfileCmd));
 
     let Response::GetProfile(get_profile_resp) = resp else {
         panic!("Wrong response type!");
     };
 
-    assert_eq!(get_profile_resp.resp_hdr.profile, DPE_PROFILE);
+    assert_eq!(get_profile_resp.resp_hdr.profile, DpeProfile::P384Sha384);
 }
 
 pub fn exec_dpe_init_ctx<T: HwModel>(hw: &mut T) {
@@ -478,14 +483,10 @@ pub fn exec_dpe_init_ctx<T: HwModel>(hw: &mut T) {
 
 pub fn exec_dpe_derive_ctx<T: HwModel>(hw: &mut T) {
     let derive_context_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: [0u8; 48],
         flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
-        tci_type: 0,
-        target_locality: 0,
-        svn: 0,
+        ..Default::default()
     };
-    let resp = execute_dpe_cmd(hw, &mut Command::DeriveContext(&derive_context_cmd));
+    let resp = execute_dpe_cmd(hw, &mut Command::from(&derive_context_cmd));
     let Response::DeriveContext(derive_ctx_resp) = resp else {
         panic!("Wrong response type!");
     };
@@ -499,15 +500,15 @@ pub fn exec_dpe_certify_key<T: HwModel>(hw: &mut T) {
         25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
     ];
 
-    let certify_key_cmd = CertifyKeyCmd {
+    let certify_key_cmd = CertifyKeyP384Cmd {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCmd::FORMAT_CSR,
+        format: CertifyKeyCommand::FORMAT_CSR,
     };
-    let resp = execute_dpe_cmd(hw, &mut Command::CertifyKey(&certify_key_cmd));
+    let resp = execute_dpe_cmd(hw, &mut Command::from(&certify_key_cmd));
 
-    let Response::CertifyKey(certify_key_resp) = resp else {
+    let Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -530,16 +531,16 @@ pub fn exec_dpe_sign<T: HwModel>(hw: &mut T) {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
-    let sign_cmd = SignCmd {
+    let sign_cmd = SignP384Cmd {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: SignFlags::empty(),
         digest: TEST_DIGEST,
     };
 
-    let resp = execute_dpe_cmd(hw, &mut Command::Sign(&sign_cmd));
+    let resp = execute_dpe_cmd(hw, &mut Command::from(&sign_cmd));
 
-    let Response::Sign(sign_resp) = resp else {
+    let Response::Sign(SignResp::P384(sign_resp)) = resp else {
         panic!("Wrong response type!");
     };
 


### PR DESCRIPTION
Squashed backport of:
- [dpe] Update DPE to hybrid build feature (#3070)
- [dpe] Remove DPE submodule and references (#3217)
- [dpe] Update DPE submodule to latest commit (#3216)