### PR TITLE
fpga: use strap UDS/FE for deterministic IDevID

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1808,8 +1808,8 @@ impl HwModel for ModelFpgaSubsystem {
             m.wrapper.regs().cptra_obf_field_entropy[i].set(fei);
         }
 
-        // Currently not using strap UDS and FE
-        m.set_secrets_valid(false);
+        // Use strap UDS and FE for deterministic IDevID on FPGA
+        m.set_secrets_valid(true);
 
         println!("Putting subsystem into reset");
         m.set_subsystem_reset(true);


### PR DESCRIPTION
Switch secrets_valid to true so DOE reads UDS and field entropy from strap registers instead of OTP. This gives deterministic IDevID on FPGA (required for tests) while keeping OTP blank (required by the test_uds).