### PR TITLE
DPE ML-DSA: hybrid feature, crypto trait, 32 contexts, dual profile c…

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 # Licensed under the Apache-2.0 license
 [env]
+ARBITRARY_MAX_HANDLES = "32"
 RUST_MIN_STACK="16777216" # 16MB
 
 [target.riscv32imc-unknown-none-elf]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive-git",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
 dependencies = [
  "bitflags 2.9.1",
  "caliptra-cfi-derive-git",
@@ -2317,7 +2317,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=4986ac50d82b415d69eb73a44dfff1d776d5f762#4986ac50d82b415d69eb73a44dfff1d776d5f762"
+source = "git+https://github.com/chipsalliance/caliptra-dpe?rev=a26db5b869f13f0d2c5762b75f8892b9fe2d8055#a26db5b869f13f0d2c5762b75f8892b9fe2d8055"
 dependencies = [
  "arrayvec",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ cbc = "0.1.2"
 const-gen = "1.6.6"
 const-oid = "0.9.6"
 ml-dsa = "0.0.4"
+ml-dsa-01 = { package = "ml-dsa", version = "=0.1.0-rc.0" }
 cbindgen = { version = "0.24.0", default-features = false }
 cfg-if = "1.0.0"
 chrono = "0.4"
@@ -164,12 +165,12 @@ convert_case = "0.6.0"
 cms = "0.2.2"
 ctr = "0.9.2"
 der = { version = "0.7.10", features = ["derive", "alloc"] }
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false, features = ["p384"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "4986ac50d82b415d69eb73a44dfff1d776d5f762", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false, features = ["hybrid", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe", rev = "a26db5b869f13f0d2c5762b75f8892b9fe2d8055", default-features = false }
 
 # local DPE dependency; useful when developing
-# dpe = { path = "../caliptra-dpe/dpe", default-features = false, features = ["p384"] }
+# dpe = { path = "../caliptra-dpe/dpe", default-features = false, features = ["hybrid", "arbitrary_max_handles"] }
 # crypto = { path = "../caliptra-dpe/crypto", default-features = false }
 # platform = { path = "../caliptra-dpe/platform", default-features = false }
 elf = "0.7.2"
@@ -254,3 +255,4 @@ opt-level = 3
 opt-level = 3
 [profile.test.package.caliptra-drivers]
 opt-level = 3
+

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -76,6 +76,8 @@ impl CommandId {
     pub const MLDSA87_SIGNATURE_VERIFY: Self = Self(0x4d4c5632); // "MLV2"
     pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
+    pub const INVOKE_DPE_ECC384: Self = Self(0x44504543); // "DPEC"
+    pub const INVOKE_DPE_MLDSA87: Self = Self(0x4450454D); // "DPEM"
     pub const DISABLE_ATTESTATION: Self = Self(0x4453424C); // "DSBL"
     pub const FW_INFO: Self = Self(0x494E464F); // "INFO"
     pub const DPE_TAG_TCI: Self = Self(0x54514754); // "TAGT"
@@ -86,6 +88,8 @@ impl CommandId {
     pub const EXTEND_PCR: Self = Self(0x50435245); // "PCRE"
     pub const ADD_SUBJECT_ALT_NAME: Self = Self(0x414C544E); // "ALTN"
     pub const CERTIFY_KEY_EXTENDED: Self = Self(0x434B4558); // "CKEX"
+    pub const CERTIFY_KEY_EXTENDED_ECC384: Self = Self(0x434B4558); // "CKEX"
+    pub const CERTIFY_KEY_EXTENDED_MLDSA87: Self = Self(0x434B584D); // "CKXM"
 
     /// FIPS module commands.
     /// The status command.
@@ -1275,16 +1279,31 @@ impl Response for StashMeasurementResp {}
 // CERTIFY_KEY_EXTENDED
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
-pub struct CertifyKeyExtendedReq {
+pub struct CertifyKeyExtendedEcc384Req {
     pub hdr: MailboxReqHeader,
     pub flags: CertifyKeyExtendedFlags,
-    pub certify_key_req: [u8; CertifyKeyExtendedReq::CERTIFY_KEY_REQ_SIZE],
+    pub certify_key_req: [u8; CertifyKeyExtendedEcc384Req::CERTIFY_KEY_REQ_SIZE],
 }
-impl CertifyKeyExtendedReq {
+impl CertifyKeyExtendedEcc384Req {
     pub const CERTIFY_KEY_REQ_SIZE: usize = 72;
 }
-impl Request for CertifyKeyExtendedReq {
-    const ID: CommandId = CommandId::CERTIFY_KEY_EXTENDED;
+impl Request for CertifyKeyExtendedEcc384Req {
+    const ID: CommandId = CommandId::CERTIFY_KEY_EXTENDED_ECC384;
+    type Resp = CertifyKeyExtendedResp;
+}
+
+pub type CertifyKeyExtendedReq = CertifyKeyExtendedEcc384Req;
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyExtendedMldsa87Req {
+    pub hdr: MailboxReqHeader,
+    pub flags: CertifyKeyExtendedFlags,
+    pub axi_response: AxiResponseInfo,
+    pub certify_key_req: [u8; CertifyKeyExtendedEcc384Req::CERTIFY_KEY_REQ_SIZE],
+}
+impl Request for CertifyKeyExtendedMldsa87Req {
+    const ID: CommandId = CommandId::CERTIFY_KEY_EXTENDED_MLDSA87;
     type Resp = CertifyKeyExtendedResp;
 }
 
@@ -1295,6 +1314,17 @@ pub struct CertifyKeyExtendedFlags(pub u32);
 bitflags! {
     impl CertifyKeyExtendedFlags: u32 {
         const DMTF_OTHER_NAME = 1u32 << 31;
+        const EXTERNAL_AXI_RESPONSE = 1u32 << 30;
+    }
+}
+
+impl CertifyKeyExtendedFlags {
+    pub fn dmtf_other_name(&self) -> bool {
+        self.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME)
+    }
+
+    pub fn external_axi_response(&self) -> bool {
+        self.contains(CertifyKeyExtendedFlags::EXTERNAL_AXI_RESPONSE)
     }
 }
 
@@ -1302,12 +1332,33 @@ bitflags! {
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct CertifyKeyExtendedResp {
     pub hdr: MailboxRespHeader,
+    pub size: u32,
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
 }
 impl CertifyKeyExtendedResp {
-    pub const CERTIFY_KEY_RESP_SIZE: usize = 8000;
+    pub const CERTIFY_KEY_RESP_SIZE: usize = 25152;
 }
 impl Response for CertifyKeyExtendedResp {}
+
+impl Default for CertifyKeyExtendedResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            size: 0,
+            certify_key_resp: [0u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
+        }
+    }
+}
+
+impl CertifyKeyExtendedResp {
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.size as usize > Self::CERTIFY_KEY_RESP_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::CERTIFY_KEY_RESP_SIZE - self.size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
 
 // INVOKE_DPE_COMMAND
 #[repr(C)]
@@ -1388,6 +1439,78 @@ impl Default for InvokeDpeResp {
         }
     }
 }
+
+// INVOKE_DPE_MLDSA87
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeMldsa87Flags(u32);
+
+bitflags! {
+    impl InvokeDpeMldsa87Flags: u32 {
+        const EXTERNAL_AXI_RESPONSE = 1u32 << 31;
+    }
+}
+
+impl InvokeDpeMldsa87Flags {
+    pub fn external_axi_response(&self) -> bool {
+        self.contains(InvokeDpeMldsa87Flags::EXTERNAL_AXI_RESPONSE)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct AxiResponseInfo {
+    pub addr_lo: u32,
+    pub addr_hi: u32,
+    pub max_size: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeMldsa87Req {
+    pub hdr: MailboxReqHeader,
+    pub flags: InvokeDpeMldsa87Flags,
+    pub axi_response: AxiResponseInfo,
+    pub data_size: u32,
+    pub data: [u8; InvokeDpeMldsa87Req::DATA_MAX_SIZE],
+}
+
+impl InvokeDpeMldsa87Req {
+    pub const DATA_MAX_SIZE: usize = InvokeDpeReq::DATA_MAX_SIZE;
+
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.data_size as usize > Self::DATA_MAX_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+
+    pub fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if self.data_size as usize > Self::DATA_MAX_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+impl Default for InvokeDpeMldsa87Req {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            flags: InvokeDpeMldsa87Flags::default(),
+            axi_response: AxiResponseInfo::default(),
+            data_size: 0,
+            data: [0u8; InvokeDpeMldsa87Req::DATA_MAX_SIZE],
+        }
+    }
+}
+impl Request for InvokeDpeMldsa87Req {
+    const ID: CommandId = CommandId::INVOKE_DPE_MLDSA87;
+    type Resp = InvokeDpeResp;
+}
+
+pub const SUBSYSTEM_MAILBOX_SIZE_LIMIT: usize = 512;
 
 // GET_FMC_ALIAS_ECC384_CERT
 #[repr(C)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -49,7 +49,7 @@ pub use pmp::lock_datavault_region;
 pub const FMC_ORG: u32 = 0x40000000;
 pub const FMC_SIZE: u32 = 32 * 1024; // Must be 4k aligned
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 156 * 1024;
+pub const RUNTIME_SIZE: u32 = 176 * 1024;
 
 pub use memory_layout::{DATA_ORG, PERSISTENT_DATA_ORG};
 pub use wdt::{restart_wdt, start_wdt, stop_wdt, WdtTimeout};

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -132,6 +132,8 @@ impl AuthorizeAndStashCmd {
                     &cmd.fw_id,
                     &cmd.measurement,
                     cmd.svn,
+                    drivers.caller_privilege_level(),
+                    drivers.mbox.id(),
                 )?;
                 if dpe_result != DpeErrorCode::NoError {
                     drivers

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,30 +12,135 @@ Abstract:
 
 --*/
 
-use crate::{mutrefbytes, with_dpe_env, Drivers, PauserPrivileges};
+use crate::{
+    invoke_dpe::invoke_dpe_cmd, mutrefbytes, CaliptraDpeProfile, Drivers, PauserPrivileges,
+};
 use arrayvec::ArrayVec;
+use caliptra_api::mailbox::{
+    populate_checksum, CertifyKeyExtendedMldsa87Req, SUBSYSTEM_MAILBOX_SIZE_LIMIT,
+};
 use caliptra_common::mailbox_api::{
-    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxRespHeader,
+    CertifyKeyExtendedEcc384Req, CertifyKeyExtendedFlags, CertifyKeyExtendedResp, MailboxRespHeader,
 };
+use caliptra_drivers::AxiAddr;
 use caliptra_error::{CaliptraError, CaliptraResult};
-use dpe::{
-    commands::{CertifyKeyP384Cmd as CertifyKeyCmd, CommandExecution},
-    response::Response,
-    DpeInstance, DpeProfile,
-};
-use zerocopy::FromBytes;
+use dpe::commands::{CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     #[inline(never)]
-    pub(crate) fn execute(
+    pub(crate) fn execute_ecc384(
         drivers: &mut Drivers,
         cmd_args: &[u8],
         mbox_resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        let cmd = CertifyKeyExtendedReq::ref_from_bytes(cmd_args)
+        let cmd = CertifyKeyExtendedEcc384Req::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        Self::execute(
+            drivers,
+            CaliptraDpeProfile::Ecc384,
+            &cmd.flags,
+            &cmd.certify_key_req,
+            mbox_resp,
+        )
+    }
 
+    #[inline(never)]
+    pub(crate) fn execute_mldsa87(
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        mbox_resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let cmd = CertifyKeyExtendedMldsa87Req::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        // External responses can only be done in subsystem mode
+        if cmd.flags.external_axi_response() && !drivers.soc_ifc.subsystem_mode() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        }
+
+        // Trim the response buffer to the correct size. If the response doesn't fit, it will fail
+        // during DPE execution and not at the transport layer. This is especially important for DPE
+        // handle rotation so the caller doesn't lose the handle.
+        let mbox_resp = if drivers.soc_ifc.subsystem_mode() {
+            let len = if cmd.flags.external_axi_response() {
+                usize::min(mbox_resp.len(), cmd.axi_response.max_size as usize)
+            } else {
+                // The mailbox size is smaller when subsystem is enabled
+                usize::min(mbox_resp.len(), SUBSYSTEM_MAILBOX_SIZE_LIMIT)
+            };
+            mbox_resp
+                .get_mut(..len)
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
+        } else {
+            mbox_resp
+        };
+
+        let len = Self::execute(
+            drivers,
+            CaliptraDpeProfile::Mldsa87,
+            &cmd.flags,
+            &cmd.certify_key_req,
+            mbox_resp,
+        )?;
+
+        // We are done if the response is going over the mailbox
+        let respond_to_mailbox = !cmd.flags.external_axi_response();
+        if respond_to_mailbox {
+            return Ok(len);
+        }
+
+        // Populate the checksum so the full response can be checked at the destination
+        // Make sure there is at least enough space for the response header
+        let len = usize::max(len, size_of::<MailboxRespHeader>());
+        populate_checksum(
+            mbox_resp
+                .get_mut(..len)
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
+        );
+
+        // Get the number of words to send by rounding up to nearest word
+        let num_words = len.next_multiple_of(4) / 4;
+        let len = num_words * 4;
+        if len > cmd.axi_response.max_size as usize {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+
+        // Get the buffer that will be sent over DMA. The DMA only supports sending words so we need
+        // to convert the response buffer to a &[u32].
+        let buffer = mbox_resp
+            .get(..len)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let buffer: &[u32] =
+            FromBytes::ref_from_bytes(buffer).map_err(|_| CaliptraError::ADDRESS_MISALIGNED)?;
+
+        // Send the response over DMA to the specified AXI address
+        let axi_addr = AxiAddr {
+            lo: cmd.axi_response.addr_lo,
+            hi: cmd.axi_response.addr_hi,
+        };
+        for (i, word) in buffer.iter().enumerate() {
+            drivers.dma.write_dword(
+                AxiAddr {
+                    lo: axi_addr.lo + (i as u32 * 4),
+                    hi: axi_addr.hi,
+                },
+                *word,
+            );
+        }
+
+        // Response is sent over DMA instead of the mailbox, so return 0 length
+        Ok(0)
+    }
+
+    #[inline(never)]
+    fn execute(
+        drivers: &mut Drivers,
+        profile: CaliptraDpeProfile,
+        flags: &CertifyKeyExtendedFlags,
+        certify_key_req: &[u8; CertifyKeyExtendedEcc384Req::CERTIFY_KEY_REQ_SIZE],
+        mbox_resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
         match drivers.caller_privilege_level() {
             // CERTIFY_KEY_EXTENDED MUST only be called from PL0
             PauserPrivileges::PL0 => (),
@@ -45,7 +150,7 @@ impl CertifyKeyExtendedCmd {
         }
 
         // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
-        let dmtf_device_info = if cmd.flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
+        let dmtf_device_info = if flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
             drivers.dmtf_device_info.as_ref().and_then(|info| {
                 let mut dmtf_device_info = ArrayVec::new();
                 dmtf_device_info.try_extend_from_slice(info).ok()?;
@@ -54,34 +159,59 @@ impl CertifyKeyExtendedCmd {
         } else {
             None
         };
-        let locality = drivers.mbox.id();
 
-        let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..]).or(Err(
-            CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
-        ))?;
-        let resp = with_dpe_env(drivers, dmtf_device_info, None, |env| {
-            let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
-            Ok(certify_key_cmd.execute(dpe, env, locality))
-        })?;
+        let certify_key_cmd = match profile {
+            CaliptraDpeProfile::Ecc384 => Command::from(
+                CertifyKeyP384Cmd::ref_from_bytes(&certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+            CaliptraDpeProfile::Mldsa87 => Command::from(
+                CertifyKeyMldsa87Cmd::ref_from_bytes(&certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+        };
+        let resp = mutrefbytes::<CertifyKeyExtendedResp>(mbox_resp)?;
+        resp.hdr = MailboxRespHeader::default();
+        let cmd = &certify_key_cmd;
+        let result = invoke_dpe_cmd(
+            profile,
+            drivers,
+            cmd,
+            dmtf_device_info,
+            None,
+            None,
+            &mut resp.certify_key_resp,
+        );
 
-        let certify_key_resp = match resp {
-            Ok(Response::CertifyKey(certify_key_resp)) => certify_key_resp,
-            Ok(_) => return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED),
+        match result {
+            Ok(dpe_resp_len) => {
+                let len = size_of::<CertifyKeyExtendedResp>()
+                    - CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE
+                    + dpe_resp_len;
+                resp.size = len as u32;
+                Ok(len)
+            }
             Err(e) => {
                 // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
                 if let Some(ext_err) = e.get_error_detail() {
                     drivers.soc_ifc.set_fw_extended_error(ext_err);
                 }
-                return Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED);
+                Err(CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED)
             }
-        };
-
-        let certify_key_extended_resp = mutrefbytes::<CertifyKeyExtendedResp>(mbox_resp)?;
-        certify_key_extended_resp.hdr = MailboxRespHeader::default();
-        certify_key_extended_resp.certify_key_resp = certify_key_resp
-            .as_bytes()
-            .try_into()
-            .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?;
-        Ok(core::mem::size_of::<CertifyKeyExtendedResp>())
+        }
     }
 }
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyExtendedRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub size: u32,
+}
+
+const _: () = assert!(
+    size_of::<CertifyKeyExtendedRespHeader>()
+        == size_of::<CertifyKeyExtendedResp>() - CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE
+);

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -18,36 +18,64 @@ use caliptra_common::keyids::{
     KEY_ID_DPE_CDI, KEY_ID_DPE_PRIV_KEY, KEY_ID_EXPORTED_DPE_CDI, KEY_ID_TMP,
 };
 use caliptra_drivers::{
-    hmac_kdf,
+    hmac_kdf, okref,
     sha2_512_384::{Sha2DigestOpTrait, Sha384},
     Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Scalar, Ecc384Seed, ExportedCdiEntry,
     ExportedCdiHandles, Hmac, HmacMode, KeyId, KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs,
-    Sha2DigestOp, Sha2_512_384, Trng,
+    Mldsa87, Mldsa87PubKey, Mldsa87Seed, Mldsa87SignRnd, Sha2DigestOp, Sha2_512_384, Trng,
 };
 use constant_time_eq::constant_time_eq;
+use core::marker::PhantomData;
 use crypto::{
     ecdsa::{
         curve_384::{Curve384, EcdsaPub384, EcdsaSignature384},
         EcdsaPubKey, EcdsaSignature,
     },
-    Crypto, CryptoError, CryptoSuite, Digest, DigestAlgorithm, DigestType, Hasher, PubKey,
-    SignData, Signature, SignatureAlgorithm, SignatureType,
+    ml_dsa::{ExternalMu, MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
+    Crypto, CryptoError, CryptoSuite, Digest, DigestAlgorithm, DigestType, Hasher, Mu, PubKey,
+    SignData, SignDataAlgorithm, SignDataType, Signature, SignatureAlgorithm, SignatureType,
 };
-use dpe::{ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
+use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
+use zerocopy::IntoBytes;
 
-pub struct DpeCrypto<'a> {
+pub type DpeEcCrypto<'a> = DpeCrypto<'a, Curve384, crypto::Sha384, crypto::Sha384>;
+impl CryptoSuite for DpeEcCrypto<'_> {}
+impl SignatureType for DpeEcCrypto<'_> {
+    const SIGNATURE_ALGORITHM: SignatureAlgorithm = Curve384::SIGNATURE_ALGORITHM;
+}
+impl DigestType for DpeEcCrypto<'_> {
+    const DIGEST_ALGORITHM: DigestAlgorithm = crypto::Sha384::DIGEST_ALGORITHM;
+}
+impl SignDataType for DpeEcCrypto<'_> {
+    const SIGN_DATA_ALGORITHM: SignDataAlgorithm = crypto::Sha384::SIGN_DATA_ALGORITHM;
+}
+
+pub type DpeMldsaCrypto<'a> = DpeCrypto<'a, ExternalMu, crypto::Sha384, Mu>;
+impl CryptoSuite for DpeMldsaCrypto<'_> {}
+impl SignatureType for DpeMldsaCrypto<'_> {
+    const SIGNATURE_ALGORITHM: SignatureAlgorithm = ExternalMu::SIGNATURE_ALGORITHM;
+}
+impl DigestType for DpeMldsaCrypto<'_> {
+    const DIGEST_ALGORITHM: DigestAlgorithm = crypto::Sha384::DIGEST_ALGORITHM;
+}
+impl SignDataType for DpeMldsaCrypto<'_> {
+    const SIGN_DATA_ALGORITHM: SignDataAlgorithm = Mu::SIGN_DATA_ALGORITHM;
+}
+
+pub struct DpeCrypto<'a, S: SignatureType, D: DigestType, SD: SignDataType> {
     sha2_512_384: &'a mut Sha2_512_384,
     trng: &'a mut Trng,
-    ecc384: &'a mut Ecc384,
     hmac: &'a mut Hmac,
     key_vault: &'a mut KeyVault,
-    rt_pub_key: &'a mut Ecc384PubKey,
+    signer: Signer<'a>,
+    rt_pub_key: PubKey,
     key_id_rt_cdi: KeyId,
     key_id_rt_priv_key: KeyId,
     exported_cdi_slots: &'a mut ExportedCdiHandles,
+    _pd: PhantomData<(S, D, SD)>,
 }
 
-impl<'a> DpeCrypto<'a> {
+impl<'a> DpeEcCrypto<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         sha2_512_384: &'a mut Sha2_512_384,
@@ -55,30 +83,68 @@ impl<'a> DpeCrypto<'a> {
         ecc384: &'a mut Ecc384,
         hmac: &'a mut Hmac,
         key_vault: &'a mut KeyVault,
-        rt_pub_key: &'a mut Ecc384PubKey,
+        rt_pub_key: PubKey,
         key_id_rt_cdi: KeyId,
         key_id_rt_priv_key: KeyId,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
-    ) -> Self {
-        Self {
+    ) -> DpeEcCrypto<'a> {
+        DpeEcCrypto {
             sha2_512_384,
             trng,
-            ecc384,
             hmac,
             key_vault,
+            signer: Signer::Ec(ecc384),
             rt_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
             exported_cdi_slots,
+            _pd: PhantomData,
         }
     }
+}
 
+impl<'a> DpeMldsaCrypto<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        sha2_512_384: &'a mut Sha2_512_384,
+        trng: &'a mut Trng,
+        mldsa: &'a mut Mldsa87,
+        hmac: &'a mut Hmac,
+        key_vault: &'a mut KeyVault,
+        rt_pub_key: PubKey,
+        key_id_rt_cdi: KeyId,
+        key_id_rt_priv_key: KeyId,
+        exported_cdi_slots: &'a mut ExportedCdiHandles,
+    ) -> DpeMldsaCrypto<'a> {
+        DpeMldsaCrypto {
+            sha2_512_384,
+            trng,
+            hmac,
+            key_vault,
+            signer: Signer::Mldsa(mldsa),
+            rt_pub_key,
+            key_id_rt_cdi,
+            key_id_rt_priv_key,
+            exported_cdi_slots,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<S: SignatureType, D: DigestType, SD: SignDataType> DpeCrypto<'_, S, D, SD> {
     fn derive_cdi_inner(
         &mut self,
         measurement: &Digest,
         info: &[u8],
         key_id: KeyId,
-    ) -> Result<<DpeCrypto<'a> as crypto::Crypto>::Cdi, CryptoError> {
+    ) -> Result<<Self as crypto::Crypto>::Cdi, CryptoError> {
+        let mut usage = KeyUsage::default().set_hmac_key_en();
+        let usage = match S::SIGNATURE_ALGORITHM {
+            SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => usage.set_ecc_key_gen_seed_en(),
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => usage.set_mldsa_key_gen_seed_en(),
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        };
+
         let mut hasher = self.hash_initialize()?;
         hasher.update(measurement.as_slice())?;
         hasher.update(info)?;
@@ -90,13 +156,7 @@ impl<'a> DpeCrypto<'a> {
             b"derive_cdi",
             Some(context.as_slice()),
             self.trng,
-            KeyWriteArgs::new(
-                key_id,
-                KeyUsage::default()
-                    .set_hmac_key_en()
-                    .set_ecc_key_gen_seed_en(),
-            )
-            .into(),
+            KeyWriteArgs::new(key_id, usage).into(),
             HmacMode::Hmac384,
         )
         .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
@@ -105,42 +165,64 @@ impl<'a> DpeCrypto<'a> {
 
     fn derive_key_pair_inner(
         &mut self,
-        cdi: &<DpeCrypto<'a> as crypto::Crypto>::Cdi,
+        cdi: &KeyId,
         label: &[u8],
         info: &[u8],
         key_id: KeyId,
-    ) -> Result<(<DpeCrypto<'a> as crypto::Crypto>::PrivKey, PubKey), CryptoError> {
+    ) -> Result<(KeyId, PubKey), CryptoError> {
+        let mut usage = KeyUsage::default();
+        let usage = match S::SIGNATURE_ALGORITHM {
+            SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => usage.set_ecc_key_gen_seed_en(),
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => usage.set_mldsa_key_gen_seed_en(),
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        };
         hmac_kdf(
             self.hmac,
             KeyReadArgs::new(*cdi).into(),
             label,
             Some(info),
             self.trng,
-            KeyWriteArgs::new(KEY_ID_TMP, KeyUsage::default().set_ecc_key_gen_seed_en()).into(),
+            KeyWriteArgs::new(KEY_ID_TMP, usage).into(),
             HmacMode::Hmac384,
         )
         .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
 
-        let pub_key = self
-            .ecc384
-            .key_pair(
-                Ecc384Seed::Key(KeyReadArgs::new(KEY_ID_TMP)),
-                &Array4x12::default(),
-                self.trng,
-                KeyWriteArgs::new(key_id, KeyUsage::default().set_ecc_private_key_en()).into(),
-            )
-            .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
-            &pub_key.x.into(),
-            &pub_key.y.into(),
-        )));
-        Ok((key_id, pub_key))
+        match (S::SIGNATURE_ALGORITHM, &mut self.signer) {
+            (SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384), Signer::Ec(ecc384)) => {
+                let pub_key = ecc384
+                    .key_pair(
+                        Ecc384Seed::Key(KeyReadArgs::new(KEY_ID_TMP)),
+                        &Array4x12::default(),
+                        self.trng,
+                        KeyWriteArgs::new(key_id, KeyUsage::default().set_ecc_private_key_en())
+                            .into(),
+                    )
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+                    &pub_key.x.into(),
+                    &pub_key.y.into(),
+                )));
+                Ok((key_id, pub_key))
+            }
+            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(mldsa87)) => {
+                let pub_key = mldsa87
+                    .key_pair(
+                        Mldsa87Seed::Key(KeyReadArgs::new(KEY_ID_TMP)),
+                        self.trng,
+                        None,
+                    )
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)));
+                let pub_key: &Mldsa87PubKey = okref(&pub_key)?;
+                Ok((KEY_ID_TMP, PubKey::MlDsa(MldsaPublicKey(pub_key.into()))))
+            }
+            _ => Err(CryptoError::MismatchedAlgorithm),
+        }
     }
 
     pub fn get_cdi_from_exported_handle(
         &mut self,
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
-    ) -> Option<<DpeCrypto<'a> as crypto::Crypto>::Cdi> {
+    ) -> Option<KeyId> {
         for cdi_slot in self.exported_cdi_slots.entries.iter() {
             match cdi_slot {
                 ExportedCdiEntry {
@@ -155,9 +237,98 @@ impl<'a> DpeCrypto<'a> {
         }
         None
     }
+
+    #[inline(never)]
+    fn sign_ec(
+        ecc384: &mut Ecc384,
+        sha2_512_384: &mut Sha2_512_384,
+        trng: &mut Trng,
+        data: &SignData,
+        priv_key: &KeyId,
+        pub_key: &PubKey,
+    ) -> Result<Signature, CryptoError> {
+        let priv_key_args = KeyReadArgs::new(*priv_key);
+        let ecc_priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
+
+        let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })) = pub_key else {
+            return Err(CryptoError::MismatchedAlgorithm);
+        };
+        let ecc_pub_key = Ecc384PubKey {
+            x: Ecc384Scalar::from(x),
+            y: Ecc384Scalar::from(y),
+        };
+        let digest = match data {
+            SignData::Digest(Digest::Sha384(crypto::Sha384(digest))) => Ecc384Scalar::from(digest),
+            SignData::Raw(msg) => sha2_512_384
+                .sha384_digest(msg)
+                .map_err(|_| CryptoError::HashError(0))?,
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        };
+        let sig = ecc384
+            .sign(ecc_priv_key, &ecc_pub_key, &digest, trng)
+            .map_err(|e| CryptoError::CryptoLibError(u32::from(e)));
+        let sig = okref(&sig)?;
+        Ok(Signature::Ecdsa(EcdsaSignature::Ecdsa384(
+            EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into()),
+        )))
+    }
+
+    #[inline(never)]
+    fn sign_mldsa(
+        mldsa: &mut Mldsa87,
+        trng: &mut Trng,
+        data: &SignData,
+        priv_key: &KeyId,
+        pub_key: &PubKey,
+    ) -> Result<Signature, CryptoError> {
+        let priv_key_args = KeyReadArgs::new(*priv_key);
+        let priv_key = Mldsa87Seed::Key(priv_key_args);
+
+        let PubKey::MlDsa(MldsaPublicKey(pub_key)) = pub_key else {
+            return Err(CryptoError::MismatchedAlgorithm);
+        };
+        let pub_key = Mldsa87PubKey::from(pub_key);
+
+        // Deterministic signing
+        let sign_rnd = Mldsa87SignRnd::default();
+
+        let sig = match data {
+            SignData::Raw(msg) => mldsa.sign_var(priv_key, &pub_key, msg, &sign_rnd, trng),
+            SignData::Mu(_) => {
+                // caliptra-2.0 does not support external-mu signing
+                return Err(CryptoError::NotImplemented);
+            }
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        };
+        let sig = okref(&sig).map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+
+        let mut dpe_sig = [0u8; 4627];
+        dpe_sig.copy_from_slice(&sig.as_bytes()[..4627]);
+        Ok(Signature::MlDsa(MldsaSignature(dpe_sig)))
+    }
+
+    fn sign_helper(
+        signer: &mut Signer,
+        sha2_512_384: &mut Sha2_512_384,
+        trng: &mut Trng,
+        data: &SignData,
+        priv_key: &KeyId,
+        pub_key: &PubKey,
+    ) -> Result<Signature, CryptoError> {
+        match (S::SIGNATURE_ALGORITHM, signer) {
+            (SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384), Signer::Ec(ecc384)) => {
+                Self::sign_ec(ecc384, sha2_512_384, trng, data, priv_key, pub_key)
+            }
+            (SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87), Signer::Mldsa(mldsa87)) => {
+                // mldsa87 already available
+                Self::sign_mldsa(mldsa87, trng, data, priv_key, pub_key)
+            }
+            _ => Err(CryptoError::MismatchedAlgorithm),
+        }
+    }
 }
 
-impl Drop for DpeCrypto<'_> {
+impl<S: SignatureType, D: DigestType, SD: SignDataType> Drop for DpeCrypto<'_, S, D, SD> {
     fn drop(&mut self) {
         let _ = self.key_vault.erase_key(KEY_ID_DPE_CDI);
         let _ = self.key_vault.erase_key(KEY_ID_DPE_PRIV_KEY);
@@ -191,16 +362,7 @@ impl Hasher for DpeHasher<'_> {
     }
 }
 
-impl CryptoSuite for DpeCrypto<'_> {}
-impl SignatureType for DpeCrypto<'_> {
-    const SIGNATURE_ALGORITHM: SignatureAlgorithm = Curve384::SIGNATURE_ALGORITHM;
-}
-
-impl DigestType for DpeCrypto<'_> {
-    const DIGEST_ALGORITHM: DigestAlgorithm = crypto::Sha384::DIGEST_ALGORITHM;
-}
-
-impl Crypto for DpeCrypto<'_> {
+impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for DpeCrypto<'_, S, D, SD> {
     type Cdi = KeyId;
     type Hasher<'b>
         = DpeHasher<'b>
@@ -319,11 +481,14 @@ impl Crypto for DpeCrypto<'_> {
     }
 
     fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
-        let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
-            &self.rt_pub_key.x.into(),
-            &self.rt_pub_key.y.into(),
-        )));
-        self.sign_with_derived(data, &self.key_id_rt_priv_key.clone(), &pub_key)
+        Self::sign_helper(
+            &mut self.signer,
+            self.sha2_512_384,
+            self.trng,
+            data,
+            &self.key_id_rt_priv_key,
+            &self.rt_pub_key,
+        )
     }
 
     fn sign_with_derived(
@@ -332,33 +497,18 @@ impl Crypto for DpeCrypto<'_> {
         priv_key: &Self::PrivKey,
         pub_key: &PubKey,
     ) -> Result<Signature, CryptoError> {
-        let priv_key_args = KeyReadArgs::new(*priv_key);
-        let ecc_priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
-
-        let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })) = pub_key else {
-            return Err(CryptoError::MismatchedAlgorithm);
-        };
-        let ecc_pub_key = Ecc384PubKey {
-            x: Ecc384Scalar::from(x),
-            y: Ecc384Scalar::from(y),
-        };
-
-        let digest = match data {
-            SignData::Digest(Digest::Sha384(crypto::Sha384(digest))) => Ecc384Scalar::from(digest),
-            SignData::Raw(msg) => self
-                .sha2_512_384
-                .sha384_digest(msg)
-                .map_err(|_| CryptoError::HashError(0))?,
-            _ => return Err(CryptoError::MismatchedAlgorithm),
-        };
-
-        let sig = self
-            .ecc384
-            .sign(ecc_priv_key, &ecc_pub_key, &digest, self.trng)
-            .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-
-        Ok(Signature::Ecdsa(EcdsaSignature::Ecdsa384(
-            EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into()),
-        )))
+        Self::sign_helper(
+            &mut self.signer,
+            self.sha2_512_384,
+            self.trng,
+            data,
+            priv_key,
+            pub_key,
+        )
     }
+}
+
+enum Signer<'a> {
+    Ec(&'a mut Ecc384),
+    Mldsa(&'a mut Mldsa87),
 }

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -18,21 +18,19 @@ use arrayvec::ArrayVec;
 use caliptra_drivers::cprintln;
 use caliptra_x509::{NotAfter, NotBefore};
 use crypto::Digest;
-use dpe::{
-    x509::{CertWriter, DirectoryString, Name},
-    DpeProfile,
-};
+use dpe::x509::{CertWriter, DirectoryString, Name};
 use platform::{
     CertValidity, OtherName, Platform, PlatformError, SignerIdentifier, SubjectAltName, Ueid,
     MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
 };
 
-use crate::{subject_alt_name::AddSubjectAltNameCmd, MAX_ECC_CERT_CHAIN_SIZE};
+use crate::{subject_alt_name::AddSubjectAltNameCmd, CaliptraDpeProfile};
 
 pub struct DpePlatform<'a> {
+    profile: CaliptraDpeProfile,
     auto_init_locality: u32,
     hashed_rt_pub_key: Digest,
-    cert_chain: &'a ArrayVec<u8, MAX_ECC_CERT_CHAIN_SIZE>,
+    cert_chain: &'a [u8],
     not_before: NotBefore,
     not_after: NotAfter,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
@@ -43,16 +41,19 @@ pub const VENDOR_ID: u32 = u32::from_be_bytes(*b"CTRA");
 pub const VENDOR_SKU: u32 = u32::from_be_bytes(*b"CTRA");
 
 impl<'a> DpePlatform<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        profile: CaliptraDpeProfile,
         auto_init_locality: u32,
         hashed_rt_pub_key: Digest,
-        cert_chain: &'a ArrayVec<u8, 4096>,
+        cert_chain: &'a [u8],
         not_before: NotBefore,
         not_after: NotAfter,
         dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
         ueid: Option<[u8; 17]>,
     ) -> Self {
         Self {
+            profile,
             auto_init_locality,
             hashed_rt_pub_key,
             cert_chain,
@@ -108,8 +109,9 @@ impl Platform for DpePlatform<'_> {
         &mut self,
         out: &mut [u8; MAX_ISSUER_NAME_SIZE],
     ) -> Result<usize, PlatformError> {
-        const CALIPTRA_CN: &[u8] = b"Caliptra 2.0 Ecc384 Rt Alias";
-        let mut issuer_writer = CertWriter::new(out, DpeProfile::P384Sha384, true);
+        const CN_ECC384: &[u8] = b"Caliptra 2.0 Ecc384 Rt Alias";
+        const CN_MLDSA87: &[u8] = b"Caliptra 2.0 MlDsa87 Rt Alias";
+        let mut issuer_writer = CertWriter::new(out, self.profile.into(), true);
 
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
@@ -117,8 +119,12 @@ impl Platform for DpePlatform<'_> {
             .write_hex_str(&mut serial)
             .map_err(|_| PlatformError::IssuerNameError(1))?;
 
+        let cn = match self.profile {
+            CaliptraDpeProfile::Ecc384 => CN_ECC384,
+            CaliptraDpeProfile::Mldsa87 => CN_MLDSA87,
+        };
         let name = Name {
-            cn: DirectoryString::Utf8String(CALIPTRA_CN),
+            cn: DirectoryString::Utf8String(cn),
             serial: DirectoryString::PrintableString(&serial),
         };
         let issuer_len = issuer_writer

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -20,8 +20,8 @@ use crate::debug_unlock::ProductionDebugUnlock;
 pub use crate::fips::fips_self_test_cmd::SelfTestStatus;
 use crate::recovery_flow::RecoveryFlow;
 use crate::{
-    dice, CptraDpeTypes, DisableAttestationCmd, DpeCrypto, DpePlatform, Mailbox, CALIPTRA_LOCALITY,
-    DPE_SUPPORT, MAX_ECC_CERT_CHAIN_SIZE, MAX_MLDSA_CERT_CHAIN_SIZE,
+    dice, CaliptraDpeProfile, CptraDpeEcTypes, DisableAttestationCmd, DpeEcCrypto, DpePlatform,
+    Mailbox, CALIPTRA_LOCALITY, DPE_SUPPORT, MAX_ECC_CERT_CHAIN_SIZE, MAX_MLDSA_CERT_CHAIN_SIZE,
     PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD, PL0_PAUSER_FLAG,
     PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
@@ -53,7 +53,7 @@ use caliptra_registers::{
 };
 use caliptra_ureg::MmioMut;
 use caliptra_x509::{NotAfter, NotBefore};
-use crypto::Digest;
+use crypto::{Digest, PubKey};
 use dpe::commands::DeriveContextCmd;
 use dpe::context::{Context, ContextState, ContextType};
 use dpe::tci::TciMeasurement;
@@ -528,12 +528,24 @@ impl Drivers {
         Ok(())
     }
 
-    /// Compute the Caliptra Name SerialNumber by Sha256 hashing the RT Alias public key
+    /// Compute the Caliptra Name SerialNumber by Sha256 hashing the ECC RT Alias public key
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn compute_rt_alias_sn(&mut self) -> CaliptraResult<Digest> {
+    pub fn compute_ecc_rt_alias_sn(&mut self) -> CaliptraResult<Digest> {
         let key = self.persistent_data.get().fht.rt_dice_ecc_pub_key.to_der();
 
         let rt_digest = self.sha256.digest(&key)?;
+        let token = Digest::Sha256(crypto::Sha256(rt_digest.into()));
+
+        Ok(token)
+    }
+
+    /// Compute the Caliptra Name SerialNumber by Sha256 hashing the ML-DSA RT Alias public key
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    pub fn compute_mldsa_rt_alias_sn(&mut self) -> CaliptraResult<Digest> {
+        let key_id = Self::get_key_id_rt_mldsa_keypair_seed(self)?;
+        let pub_key = Self::get_key_id_rt_mldsa_pub_key(self)?;
+        let rt_digest = self.sha256.digest(pub_key.0.as_bytes())?;
+        let _ = key_id; // used for key derivation
         let token = Digest::Sha256(crypto::Sha256(rt_digest.into()));
 
         Ok(token)
@@ -544,7 +556,7 @@ impl Drivers {
     fn initialize_dpe(drivers: &mut Drivers) -> CaliptraResult<()> {
         let manifest = drivers.persistent_data.get().manifest1;
         let pl0_pauser_locality = manifest.header.pl0_pauser;
-        let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+        let hashed_rt_pub_key = drivers.compute_ecc_rt_alias_sn()?;
         let privilege_level = drivers.caller_privilege_level();
 
         // Set context limits in persistent data as we init DPE
@@ -561,13 +573,18 @@ impl Drivers {
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
         let pdata = drivers.persistent_data.get_mut();
-        let crypto = DpeCrypto::new(
+        let crypto = DpeEcCrypto::new(
             &mut drivers.sha2_512_384,
             &mut drivers.trng,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.key_vault,
-            &mut pdata.fht.rt_dice_ecc_pub_key,
+            PubKey::Ecdsa(crypto::ecdsa::EcdsaPubKey::Ecdsa384(
+                crypto::ecdsa::curve_384::EcdsaPub384::from_slice(
+                    &pdata.fht.rt_dice_ecc_pub_key.x.into(),
+                    &pdata.fht.rt_dice_ecc_pub_key.y.into(),
+                ),
+            )),
             key_id_rt_cdi,
             key_id_rt_priv_key,
             &mut pdata.exported_cdi_slots,
@@ -575,9 +592,10 @@ impl Drivers {
 
         let (nb, nf) = Self::get_cert_validity_info(&pdata.manifest1);
         let mut state = dpe::State::new(DPE_SUPPORT, DpeFlags::empty());
-        let mut env = DpeEnv::<CptraDpeTypes> {
+        let mut env = DpeEnv::<CptraDpeEcTypes> {
             crypto,
             platform: DpePlatform::new(
+                CaliptraDpeProfile::Ecc384,
                 CALIPTRA_LOCALITY,
                 hashed_rt_pub_key,
                 &drivers.ecc_cert_chain,

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,148 +12,264 @@ Abstract:
 
 --*/
 
-use crate::{dpe_env, mutrefbytes, Drivers, PauserPrivileges};
+use crate::{ec_dpe_env, mldsa_dpe_env, AxiAddr, Drivers, PauserPrivileges};
+use arrayvec::ArrayVec;
+use caliptra_api::mailbox::{
+    populate_checksum, AxiResponseInfo, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req,
+    MailboxReqHeader, MailboxRespHeader, SUBSYSTEM_MAILBOX_SIZE_LIMIT,
+};
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, ResponseVarSize};
-use caliptra_drivers::{CaliptraError, CaliptraResult};
+use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp};
+use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult};
 use dpe::{
     commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
     context::ContextState,
-    response::ResponseHdr,
+    response::{DpeErrorCode, ResponseHdr},
     DpeInstance, DpeProfile, U8Bool, MAX_HANDLES,
 };
-use zerocopy::IntoBytes;
+use platform::MAX_OTHER_NAME_SIZE;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CaliptraDpeProfile {
+    Ecc384,
+    Mldsa87,
+}
+
+impl From<CaliptraDpeProfile> for DpeProfile {
+    fn from(profile: CaliptraDpeProfile) -> Self {
+        match profile {
+            CaliptraDpeProfile::Ecc384 => DpeProfile::P384Sha384,
+            CaliptraDpeProfile::Mldsa87 => DpeProfile::Mldsa87,
+        }
+    }
+}
 pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(
+    pub(crate) fn execute_ecc384(
         drivers: &mut Drivers,
         cmd_args: &[u8],
         mbox_resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        if cmd_args.len() <= core::mem::size_of::<InvokeDpeReq>() {
-            let mut cmd = InvokeDpeReq::default();
-            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
-
-            let caller_privilege_level = drivers.caller_privilege_level();
-
-            // Validate data length
-            if cmd.data_size as usize > cmd.data.len() {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-            }
-            let command =
-                &Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-
-            // Determine the target privilege level of a new context then check if we exceed thresholds
-            let new_context_privilege_level = match command {
-                Command::DeriveContext(cmd) if cmd.flags.changes_locality() => {
-                    drivers.privilege_level_from_locality(cmd.target_locality)
-                }
-                _ => caller_privilege_level,
-            };
-            let dpe_context_threshold_err =
-                drivers.is_dpe_context_threshold_exceeded(new_context_privilege_level);
-
-            let pdata = drivers.persistent_data.get_mut();
-            let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-            let ueid = drivers.soc_ifc.fuse_bank().ueid();
-            let locality = drivers.mbox.id();
-            let mut env = dpe_env(drivers, None, Some(ueid))?;
-
-            let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
-            let resp = match command {
-                Command::GetProfile(cmd) => cmd.execute(dpe, &mut env, locality),
-                Command::InitCtx(cmd) => {
-                    // InitCtx can only create new contexts if they are simulation contexts.
-                    if InitCtxCmd::flag_is_simulation(cmd) {
-                        dpe_context_threshold_err?;
-                    }
-                    cmd.execute(dpe, &mut env, locality)
-                }
-                Command::DeriveContext(cmd) => {
-                    let flags = cmd.flags;
-                    // If the recursive flag is not set, DeriveContext will generate a new context.
-                    // If recursive _is_ set, it will extend the existing one, which will not count
-                    // against the context threshold.
-                    if !flags.is_recursive() {
-                        // Takes target locality into consideration if applicable. See above
-                        dpe_context_threshold_err?;
-                    }
-                    if flags.changes_locality()
-                        && cmd.target_locality == pl0_pauser
-                        && caller_privilege_level != PauserPrivileges::PL0
-                    {
-                        return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                    }
-
-                    if flags.exports_cdi() && caller_privilege_level != PauserPrivileges::PL0 {
-                        return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                    }
-
-                    cmd.execute(dpe, &mut env, locality)
-                }
-                Command::CertifyKey(cmd) => {
-                    // PL1 cannot request X509
-                    if cmd.format() == CertifyKeyCommand::FORMAT_X509
-                        && caller_privilege_level != PauserPrivileges::PL0
-                    {
-                        return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                    }
-                    cmd.execute(dpe, &mut env, locality)
-                }
-                Command::DestroyCtx(cmd) => cmd.execute(dpe, &mut env, locality),
-                Command::Sign(cmd) => cmd.execute(dpe, &mut env, locality),
-                Command::RotateCtx(cmd) => cmd.execute(dpe, &mut env, locality),
-                Command::GetCertificateChain(cmd) => cmd.execute(dpe, &mut env, locality),
-            };
-
-            // Drop env so we can use the drivers again.
-            drop(env);
-
-            if let Command::DestroyCtx(_) = command {
-                // clear tags for destroyed contexts
-                let pdata = drivers.persistent_data.get_mut();
-                let state = &mut pdata.state;
-                let context_has_tag = &mut pdata.context_has_tag;
-                let context_tags = &mut pdata.context_tags;
-                Self::clear_tags_for_inactive_contexts(state, context_has_tag, context_tags);
-            }
-
-            // If DPE command failed, populate header with error code, but
-            // don't fail the mailbox command.
-            let invoke_resp = mutrefbytes::<InvokeDpeResp>(mbox_resp)?;
-
-            match resp {
-                Ok(ref r) => {
-                    let resp_bytes = r.as_bytes();
-                    let data_size = resp_bytes.len();
-                    let buf = invoke_resp
-                        .data
-                        .get_mut(..data_size)
-                        .ok_or(CaliptraError::RUNTIME_INVOKE_DPE_RESPONSE_TOO_LARGE)?;
-                    buf.copy_from_slice(resp_bytes);
-                    invoke_resp.data_size = data_size as u32;
-                }
-                Err(ref e) => {
-                    // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                    if let Some(ext_err) = e.get_error_detail() {
-                        drivers.soc_ifc.set_fw_extended_error(ext_err);
-                    }
-                    let r = dpe.response_hdr(*e);
-                    invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
-                        .copy_from_slice(r.as_bytes());
-                    let data_size = r.as_bytes().len();
-                    invoke_resp.data_size = data_size as u32;
-                }
-            };
-
-            Ok(invoke_resp.partial_len()?)
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
+        // The mailbox SRAM has to be accessed in word alignment, copying the command locally to
+        // avoid unaligned accesses.
+        let mut staging_buffer_buf = [0u32; size_of::<InvokeDpeReq>() / 4];
+        let staging_buffer = staging_buffer_buf.as_mut_bytes();
+        if cmd_args.len() > staging_buffer.len() {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
         }
+        staging_buffer[..cmd_args.len()].copy_from_slice(cmd_args);
+
+        // Parse the header to get the DPE command size and buffer
+        let (cmd, dpe_cmd_buf) = InvokeDpeEcc384Header::ref_from_prefix(staging_buffer)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let dpe_cmd_buf = dpe_cmd_buf
+            .get(..cmd.data_size as usize)
+            .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        Self::execute(drivers, dpe_cmd_buf, mbox_resp, CaliptraDpeProfile::Ecc384)
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute_mldsa87(
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        mbox_resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        // The mailbox SRAM has to be accessed in word alignment, copying the command locally to
+        // avoid unaligned accesses.
+        let mut staging_buffer_buf = [0u32; size_of::<InvokeDpeMldsa87Req>() / 4];
+        let staging_buffer = staging_buffer_buf.as_mut_bytes();
+        if cmd_args.len() > staging_buffer.len() {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+        staging_buffer[..cmd_args.len()].copy_from_slice(cmd_args);
+
+        // Parse the header to get the DPE command size and buffer
+        let (cmd, dpe_cmd_buf) = InvokeDpeMldsa87Header::ref_from_prefix(staging_buffer)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        let dpe_cmd_buf = dpe_cmd_buf
+            .get(..cmd.data_size as usize)
+            .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        // External responses can only be done in subsystem mode
+        if cmd.flags.external_axi_response() && !drivers.soc_ifc.subsystem_mode() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        }
+
+        // Trim the response buffer to the correct size. If the response doesn't fit, it will fail
+        // during DPE execution and not at the transport layer. This is especially important for DPE
+        // handle rotation so the caller doesn't lose the handle.
+        let mbox_resp = if drivers.soc_ifc.subsystem_mode() {
+            let len = if cmd.flags.external_axi_response() {
+                usize::min(mbox_resp.len(), cmd.axi_response.max_size as usize)
+            } else {
+                // The mailbox size is smaller when subsystem is enabled
+                usize::min(mbox_resp.len(), SUBSYSTEM_MAILBOX_SIZE_LIMIT)
+            };
+            mbox_resp
+                .get_mut(..len)
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?
+        } else {
+            mbox_resp
+        };
+
+        // Execute the DPE command and get the length of the response that was written
+        let len = Self::execute(drivers, dpe_cmd_buf, mbox_resp, CaliptraDpeProfile::Mldsa87)?;
+
+        // We are done if the response is going over the mailbox
+        let respond_to_mailbox = !cmd.flags.external_axi_response();
+        if respond_to_mailbox {
+            return Ok(len);
+        }
+
+        // Populate the checksum so the full response can be checked at the destination
+        // Make sure there is at least enough space for the response header
+        let len = usize::max(len, size_of::<MailboxRespHeader>());
+        populate_checksum(
+            mbox_resp
+                .get_mut(..len)
+                .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
+        );
+
+        // Get the number of words to send by rounding up to nearest word
+        let num_words = len.next_multiple_of(4) / 4;
+        let len = num_words * 4;
+        if len > cmd.axi_response.max_size as usize {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+
+        // Get the buffer that will be sent over DMA. The DMA only supports sending words so we need
+        // to convert the response buffer to a &[u32].
+        let buffer = mbox_resp
+            .get(..len)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let buffer: &[u32] =
+            FromBytes::ref_from_bytes(buffer).map_err(|_| CaliptraError::ADDRESS_MISALIGNED)?;
+
+        // Send the response over DMA to the specified AXI address
+        let axi_addr = AxiAddr {
+            lo: cmd.axi_response.addr_lo,
+            hi: cmd.axi_response.addr_hi,
+        };
+        for (i, word) in buffer.iter().enumerate() {
+            drivers.dma.write_dword(
+                AxiAddr {
+                    lo: axi_addr.lo + (i as u32 * 4),
+                    hi: axi_addr.hi,
+                },
+                *word,
+            );
+        }
+
+        // Response is sent over DMA instead of the mailbox, so return 0 length
+        Ok(0)
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
+    fn execute(
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        mbox_resp: &mut [u8],
+        profile: CaliptraDpeProfile,
+    ) -> CaliptraResult<usize> {
+        let caller_privilege_level = drivers.caller_privilege_level();
+
+        let command = &Command::deserialize(profile.into(), cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+
+        // Determine the target privilege level of a new context then check if we exceed thresholds
+        let new_context_privilege_level = match command {
+            Command::DeriveContext(cmd) if cmd.flags.changes_locality() => {
+                drivers.privilege_level_from_locality(cmd.target_locality)
+            }
+            _ => caller_privilege_level,
+        };
+        let dpe_context_threshold_err =
+            drivers.is_dpe_context_threshold_exceeded(new_context_privilege_level);
+
+        let pdata = drivers.persistent_data.get_mut();
+        let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+
+        // Check if command can be executed
+        match command {
+            Command::InitCtx(cmd) => {
+                // InitCtx can only create new contexts if they are simulation contexts.
+                if InitCtxCmd::flag_is_simulation(cmd) {
+                    dpe_context_threshold_err?;
+                }
+            }
+            Command::DeriveContext(cmd) => {
+                let flags = cmd.flags;
+                // If the recursive flag is not set, DeriveContext will generate a new context.
+                // If recursive _is_ set, it will extend the existing one, which will not count
+                // against the context threshold.
+                if !flags.is_recursive() {
+                    // Takes target locality into consideration if applicable. See above
+                    dpe_context_threshold_err?;
+                }
+                if flags.changes_locality()
+                    && cmd.target_locality == pl0_pauser
+                    && caller_privilege_level != PauserPrivileges::PL0
+                {
+                    return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+                }
+
+                if flags.exports_cdi() && caller_privilege_level != PauserPrivileges::PL0 {
+                    return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+                }
+            }
+            Command::CertifyKey(cmd) => {
+                // PL1 cannot request X509
+                if cmd.format() == CertifyKeyCommand::FORMAT_X509
+                    && caller_privilege_level != PauserPrivileges::PL0
+                {
+                    return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+                }
+            }
+            _ => (),
+        };
+
+        let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
+        let (invoke_resp, data) = InvokeDpeRespHeader::mut_from_prefix(mbox_resp)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        if data.len() < core::mem::size_of::<ResponseHdr>() {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+        let result = invoke_dpe_cmd(profile, drivers, command, None, ueid, None, data);
+
+        if let Command::DestroyCtx(_) = command {
+            // clear tags for destroyed contexts
+            let pdata = drivers.persistent_data.get_mut();
+            let state = &mut pdata.state;
+            let context_has_tag = &mut pdata.context_has_tag;
+            let context_tags = &mut pdata.context_tags;
+            Self::clear_tags_for_inactive_contexts(state, context_has_tag, context_tags);
+        }
+
+        // If DPE command failed, populate header with error code, but
+        // don't fail the mailbox command.
+        match result {
+            Ok(data_size) => {
+                invoke_resp.data_size = data_size as u32;
+            }
+            Err(ref e) => {
+                // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+                if let Some(ext_err) = e.get_error_detail() {
+                    drivers.soc_ifc.set_fw_extended_error(ext_err);
+                }
+                let r = ResponseHdr::new(profile.into(), *e);
+                data[..core::mem::size_of::<ResponseHdr>()].copy_from_slice(r.as_bytes());
+                invoke_resp.data_size = r.as_bytes().len() as u32;
+            }
+        };
+
+        Ok(size_of::<InvokeDpeResp>() - InvokeDpeResp::DATA_MAX_SIZE
+            + invoke_resp.data_size as usize)
     }
 
     /// Remove context tags for all inactive DPE contexts
@@ -181,3 +297,93 @@ impl InvokeDpeCmd {
         });
     }
 }
+
+pub fn invoke_dpe_cmd(
+    profile: CaliptraDpeProfile,
+    drivers: &mut Drivers,
+    command: &Command,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
+    locality: Option<u32>,
+    out: &mut [u8],
+) -> Result<usize, DpeErrorCode> {
+    let locality = if let Some(locality) = locality {
+        locality
+    } else {
+        drivers.mbox.id()
+    };
+    match profile {
+        CaliptraDpeProfile::Ecc384 => {
+            invoke_ecc_dpe_cmd(drivers, command, dmtf_device_info, ueid, locality, out)
+        }
+        CaliptraDpeProfile::Mldsa87 => {
+            invoke_mldsa_dpe_cmd(drivers, command, dmtf_device_info, ueid, locality, out)
+        }
+    }
+}
+
+#[inline(never)]
+fn invoke_ecc_dpe_cmd(
+    drivers: &mut Drivers,
+    command: &Command,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
+    locality: u32,
+    out: &mut [u8],
+) -> Result<usize, DpeErrorCode> {
+    let mut env = ec_dpe_env(drivers, dmtf_device_info, ueid);
+    let env = okmutref(&mut env).map_err(|_| DpeErrorCode::InternalError)?;
+    let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
+    command.execute_serialized(dpe, env, locality, out)
+}
+
+#[inline(never)]
+fn invoke_mldsa_dpe_cmd(
+    drivers: &mut Drivers,
+    command: &Command,
+    dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
+    ueid: Option<[u8; 17]>,
+    locality: u32,
+    out: &mut [u8],
+) -> Result<usize, DpeErrorCode> {
+    let mut env = mldsa_dpe_env(drivers, dmtf_device_info, ueid);
+    let env = okmutref(&mut env).map_err(|_| DpeErrorCode::InternalError)?;
+    let dpe = &mut DpeInstance::initialized(DpeProfile::Mldsa87);
+    command.execute_serialized(dpe, env, locality, out)
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+struct InvokeDpeEcc384Header {
+    pub hdr: MailboxReqHeader,
+    pub data_size: u32,
+}
+
+const _: () = assert!(
+    size_of::<InvokeDpeEcc384Header>() == size_of::<InvokeDpeReq>() - InvokeDpeReq::DATA_MAX_SIZE
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+struct InvokeDpeMldsa87Header {
+    pub hdr: MailboxReqHeader,
+    pub flags: InvokeDpeMldsa87Flags,
+    pub axi_response: AxiResponseInfo,
+    pub data_size: u32,
+}
+
+const _: () = assert!(
+    size_of::<InvokeDpeMldsa87Header>()
+        == size_of::<InvokeDpeMldsa87Req>() - InvokeDpeMldsa87Req::DATA_MAX_SIZE
+);
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeRespHeader {
+    pub hdr: MailboxRespHeader,
+    pub data_size: u32,
+}
+
+const _: () = assert!(
+    size_of::<InvokeDpeRespHeader>() == size_of::<InvokeDpeResp>() - InvokeDpeResp::DATA_MAX_SIZE
+);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -56,6 +56,11 @@ use arrayvec::ArrayVec;
 use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter};
 use caliptra_common::cfi_check;
+use caliptra_common::mailbox_api::MailboxReqHeader;
+use crypto::ecdsa::curve_384::EcdsaPub384;
+use crypto::ecdsa::EcdsaPubKey;
+use crypto::ml_dsa::MldsaPublicKey;
+use crypto::PubKey;
 pub use drivers::{Drivers, PauserPrivileges};
 use fe_programming::FeProgrammingCmd;
 use mailbox::Mailbox;
@@ -65,7 +70,9 @@ use zerocopy::{FromBytes, IntoBytes, KnownLayout};
 
 use crate::capabilities::CapabilitiesCmd;
 pub use crate::certify_key_extended::CertifyKeyExtendedCmd;
+use crate::dpe_crypto::{DpeEcCrypto, DpeMldsaCrypto};
 pub use crate::hmac::Hmac;
+pub use crate::invoke_dpe::CaliptraDpeProfile;
 use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
@@ -75,7 +82,6 @@ pub use caliptra_common::fips::FipsVersionCmd;
 use caliptra_common::mailbox_api::{populate_checksum, FipsVersionResp, MAX_RESP_SIZE};
 pub use dice::{GetFmcAliasCertCmd, GetLdevCertCmd, IDevIdCertCmd};
 pub use disable::DisableAttestationCmd;
-use dpe_crypto::DpeCrypto;
 pub use dpe_platform::{DpePlatform, VENDOR_ID, VENDOR_SKU};
 pub use fips::FipsShutdownCmd;
 #[cfg(feature = "fips_self_test")]
@@ -101,7 +107,7 @@ use tagging::{GetTaggedTciCmd, TagTciCmd};
 
 use caliptra_common::cprintln;
 
-use caliptra_drivers::{CaliptraError, CaliptraResult, ResetReason};
+use caliptra_drivers::{okref, AxiAddr, CaliptraError, CaliptraResult, ResetReason};
 use caliptra_registers::mbox::enums::MboxStatusE;
 pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 use dpe::{
@@ -135,7 +141,7 @@ impl From<RtBootStatus> for u32 {
 
 pub const DPE_SUPPORT: Support = Support::all();
 pub const MAX_ECC_CERT_CHAIN_SIZE: usize = 4096;
-pub const MAX_MLDSA_CERT_CHAIN_SIZE: usize = 31_000;
+pub const MAX_MLDSA_CERT_CHAIN_SIZE: usize = 32 * 1024;
 
 pub const PL0_PAUSER_FLAG: u32 = 1;
 pub const PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD: usize = 16;
@@ -154,10 +160,17 @@ pub(crate) fn mutrefbytes<R: FromBytes + IntoBytes + KnownLayout>(
     Ok(resp)
 }
 
-pub struct CptraDpeTypes;
+pub struct CptraDpeEcTypes;
 
-impl DpeTypes for CptraDpeTypes {
-    type Crypto<'a> = DpeCrypto<'a>;
+impl DpeTypes for CptraDpeEcTypes {
+    type Crypto<'a> = DpeEcCrypto<'a>;
+    type Platform<'a> = DpePlatform<'a>;
+}
+
+pub struct CptraDpeMldsaTypes;
+
+impl DpeTypes for CptraDpeMldsaTypes {
+    type Crypto<'a> = DpeMldsaCrypto<'a>;
     type Platform<'a> = DpePlatform<'a>;
 }
 
@@ -185,6 +198,15 @@ fn enter_idle(drivers: &mut Drivers) {
     caliptra_cpu::csr::mpmc_halt_and_enable_interrupts();
 }
 
+fn human_readable_command(bytes: &[u8]) -> Option<&str> {
+    if bytes.len() == 4 && bytes.iter().all(|c| c.is_ascii_alphanumeric()) {
+        // Safety: we just checked that all bytes are ASCII.
+        Some(unsafe { core::str::from_utf8_unchecked(bytes) })
+    } else {
+        None
+    }
+}
+
 /// Handles the pending mailbox command and writes the repsonse back to the mailbox
 ///
 /// # Returns
@@ -198,37 +220,37 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
 
     // For firmware update, don't read data from the mailbox
     if drivers.mbox.cmd() == CommandId::FIRMWARE_LOAD {
-        cfi_assert_eq(drivers.mbox.cmd(), CommandId::FIRMWARE_LOAD);
+        cfi_assert_eq(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_LOAD),
+        );
         update::handle_impactless_update(drivers)?;
 
         // If the handler succeeds but does not invoke reset that is
         // unexpected. Denote that the update failed.
         return Err(CaliptraError::RUNTIME_UNEXPECTED_UPDATE_RETURN);
     } else {
-        cfi_assert_ne(drivers.mbox.cmd(), CommandId::FIRMWARE_LOAD);
+        cfi_assert_ne(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_LOAD),
+        );
     }
 
     if drivers.mbox.cmd() == CommandId::FIRMWARE_VERIFY {
         return firmware_verify::FirmwareVerifyCmd::execute(drivers);
     } else {
-        cfi_assert_ne(drivers.mbox.cmd(), CommandId::FIRMWARE_VERIFY);
+        cfi_assert_ne(
+            u32::from(drivers.mbox.cmd()),
+            u32::from(CommandId::FIRMWARE_VERIFY),
+        );
     }
 
     // Get the command bytes
     let req_packet = Packet::get_from_mbox(drivers)?;
     let cmd_bytes = req_packet.as_bytes()?;
+    let cmd_id = req_packet.cmd;
 
-    // Create human-readable name of command.
-    let bytes = req_packet.cmd.to_be_bytes();
-    let ascii = {
-        if bytes.len() != 4 || bytes.iter().any(|c| !c.is_ascii_alphanumeric()) {
-            None
-        } else {
-            core::str::from_utf8(&bytes).ok()
-        }
-    };
-
-    if let Some(ascii) = ascii {
+    if let Some(ascii) = human_readable_command(&cmd_id.to_be_bytes()) {
         cprintln!(
             "[rt] Received command=0x{:x} ({}), len={}",
             req_packet.cmd,
@@ -243,10 +265,18 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         );
     }
 
+    execute_command(drivers, cmd_id, cmd_bytes)
+}
+
+fn execute_command(
+    drivers: &mut Drivers,
+    cmd_id: u32,
+    cmd_bytes: &[u8],
+) -> CaliptraResult<MboxStatusE> {
     // stage the response once on the stack
     let resp = &mut [0u8; MAX_RESP_SIZE][..];
 
-    let len = match CommandId::from(req_packet.cmd) {
+    let len = match CommandId::from(cmd_id) {
         CommandId::ACTIVATE_FIRMWARE => {
             activate_firmware::ActivateFirmwareCmd::execute(drivers, cmd_bytes, resp)
         }
@@ -272,7 +302,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::GET_LDEV_MLDSA87_CERT => {
             GetLdevCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
-        CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers, cmd_bytes, resp),
+        CommandId::INVOKE_DPE_ECC384 => InvokeDpeCmd::execute_ecc384(drivers, cmd_bytes, resp),
+        CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeCmd::execute_mldsa87(drivers, cmd_bytes, resp),
         CommandId::ECDSA384_SIGNATURE_VERIFY => {
             caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)
         }
@@ -307,7 +338,12 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             GetRtAliasCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
         CommandId::ADD_SUBJECT_ALT_NAME => AddSubjectAltNameCmd::execute(drivers, cmd_bytes),
-        CommandId::CERTIFY_KEY_EXTENDED => CertifyKeyExtendedCmd::execute(drivers, cmd_bytes, resp),
+        CommandId::CERTIFY_KEY_EXTENDED_ECC384 => {
+            CertifyKeyExtendedCmd::execute_ecc384(drivers, cmd_bytes, resp)
+        }
+        CommandId::CERTIFY_KEY_EXTENDED_MLDSA87 => {
+            CertifyKeyExtendedCmd::execute_mldsa87(drivers, cmd_bytes, resp)
+        }
         CommandId::INCREMENT_PCR_RESET_COUNTER => {
             IncrementPcrResetCounterCmd::execute(drivers, cmd_bytes)
         }
@@ -480,6 +516,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         // should be impossible
         return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
     }
+
     let mbox = &mut drivers.mbox;
     let resp = &mut resp[..len];
     // Generate response checksum
@@ -491,6 +528,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     Ok(MboxStatusE::DataReady)
 }
 
+/// Handles an external mailbox command. If a valid external command was parsed,
+/// then Some is returned and the external mailbox command will be copied into
+#[inline(never)]
 #[cfg(feature = "riscv")]
 // TODO implement in emulator
 fn setup_mailbox_wfi(drivers: &mut Drivers) {
@@ -603,34 +643,40 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
     //    Ok(())
 }
 
-fn dpe_env(
+fn ec_dpe_env(
     drivers: &mut Drivers,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
-) -> CaliptraResult<DpeEnv<CptraDpeTypes>> {
-    let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+) -> CaliptraResult<DpeEnv<CptraDpeEcTypes>> {
+    let hashed_rt_pub_key = drivers.compute_ecc_rt_alias_sn()?;
     let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
     let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
     let pdata = drivers.persistent_data.get_mut();
-    let crypto = DpeCrypto::new(
+    let rt_pub_key = &mut pdata.fht.rt_dice_ecc_pub_key;
+    let rt_pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+        &rt_pub_key.x.into(),
+        &rt_pub_key.y.into(),
+    )));
+    let crypto = DpeEcCrypto::new(
         &mut drivers.sha2_512_384,
         &mut drivers.trng,
         &mut drivers.ecc384,
         &mut drivers.hmac,
         &mut drivers.key_vault,
-        &mut pdata.fht.rt_dice_ecc_pub_key,
+        rt_pub_key,
         key_id_rt_cdi,
         key_id_rt_priv_key,
         &mut pdata.exported_cdi_slots,
     );
     let pl0_pauser = pdata.manifest1.header.pl0_pauser;
     let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
-    Ok(DpeEnv::<CptraDpeTypes> {
+    Ok(DpeEnv::<CptraDpeEcTypes> {
         crypto,
         platform: DpePlatform::new(
+            CaliptraDpeProfile::Ecc384,
             pl0_pauser,
             hashed_rt_pub_key,
-            &drivers.ecc_cert_chain,
+            drivers.ecc_cert_chain.as_slice(),
             nb,
             nf,
             dmtf_device_info,
@@ -640,15 +686,43 @@ fn dpe_env(
     })
 }
 
-fn with_dpe_env<F, R>(
+fn mldsa_dpe_env(
     drivers: &mut Drivers,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
-    f: F,
-) -> CaliptraResult<R>
-where
-    F: FnOnce(&mut DpeEnv<CptraDpeTypes>) -> CaliptraResult<R>,
-{
-    let mut dpe_env = dpe_env(drivers, dmtf_device_info, ueid)?;
-    f(&mut dpe_env)
+) -> CaliptraResult<DpeEnv<CptraDpeMldsaTypes>> {
+    let hashed_rt_pub_key = drivers.compute_mldsa_rt_alias_sn()?;
+    let rt_pub_key = Drivers::get_key_id_rt_mldsa_pub_key(drivers);
+    let rt_pub_key = okref(&rt_pub_key)?;
+    let rt_pub_key = PubKey::MlDsa(MldsaPublicKey((*rt_pub_key).into()));
+    let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+    let key_id_rt_priv_key = Drivers::get_key_id_rt_mldsa_keypair_seed(drivers)?;
+    let pdata = drivers.persistent_data.get_mut();
+    let crypto = DpeMldsaCrypto::new(
+        &mut drivers.sha2_512_384,
+        &mut drivers.trng,
+        &mut drivers.mldsa87,
+        &mut drivers.hmac,
+        &mut drivers.key_vault,
+        rt_pub_key,
+        key_id_rt_cdi,
+        key_id_rt_priv_key,
+        &mut pdata.exported_cdi_slots,
+    );
+    let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+    let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
+    Ok(DpeEnv::<CptraDpeMldsaTypes> {
+        crypto,
+        platform: DpePlatform::new(
+            CaliptraDpeProfile::Mldsa87,
+            pl0_pauser,
+            hashed_rt_pub_key,
+            drivers.mldsa_cert_chain.as_slice(),
+            nb,
+            nf,
+            dmtf_device_info,
+            ueid,
+        ),
+        state: &mut pdata.state,
+    })
 }

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{dpe_crypto::DpeCrypto, mutrefbytes, Drivers, PauserPrivileges};
+use crate::{dpe_crypto::DpeEcCrypto, mutrefbytes, Drivers, PauserPrivileges};
 
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_lib_git::{cfi_assert, cfi_launder};
 
 use caliptra_common::cfi_check;
 use caliptra_common::mailbox_api::{
@@ -29,14 +29,14 @@ impl SignWithExportedEcdsaCmd {
     /// * `exported_cdi_handle` - A handle from DPE that is exchanged for a CDI.
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn ecdsa_sign(
-        env: &mut DpeCrypto,
+        env: &mut DpeEcCrypto,
         data: &SignData,
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
     ) -> CaliptraResult<(Signature, PubKey)> {
         let key_pair =
             env.derive_key_pair_exported(exported_cdi_handle, b"Exported ECC", b"Exported ECC");
 
-        cfi_check!(key_pair);
+        let _ = &key_pair;
         let (priv_key, pub_key) = key_pair
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
 
@@ -68,14 +68,19 @@ impl SignWithExportedEcdsaCmd {
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
         let pdata = drivers.persistent_data.get_mut();
+        let rt_pub_key = &mut pdata.fht.rt_dice_ecc_pub_key;
+        let rt_pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+            &rt_pub_key.x.into(),
+            &rt_pub_key.y.into(),
+        )));
 
-        let mut crypto = DpeCrypto::new(
+        let mut crypto = DpeEcCrypto::new(
             &mut drivers.sha2_512_384,
             &mut drivers.trng,
             &mut drivers.ecc384,
             &mut drivers.hmac,
             &mut drivers.key_vault,
-            &mut pdata.fht.rt_dice_ecc_pub_key,
+            rt_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,
             &mut pdata.exported_cdi_slots,

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -12,44 +12,47 @@ Abstract:
 
 --*/
 
-use crate::{mutrefbytes, with_dpe_env, Drivers, PauserPrivileges};
+use crate::{
+    invoke_dpe::invoke_dpe_cmd, mutrefbytes, CaliptraDpeProfile, Drivers, PauserPrivileges,
+};
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{MailboxRespHeader, StashMeasurementReq, StashMeasurementResp};
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
 use dpe::{
-    commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    response::DpeErrorCode,
+    response::{DeriveContextResp, DpeErrorCode},
     tci::TciMeasurement,
-    DpeInstance, DpeProfile,
 };
 use zerocopy::{FromBytes, IntoBytes};
+
+const MCU_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
 
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
+    /// This function MUST ONLY be called by Caliptra.
+    /// Mailbox commands MUST use the `execute` function.
     pub(crate) fn stash_measurement(
         drivers: &mut Drivers,
         metadata: &[u8; 4],
         measurement: &[u8; 48],
         svn: u32,
+        caller_privilege_level: PauserPrivileges,
+        locality: u32,
     ) -> CaliptraResult<DpeErrorCode> {
         let dpe_result = {
-            let caller_privilege_level = drivers.caller_privilege_level();
-            match caller_privilege_level {
-                // Only PL0 can call STASH_MEASUREMENT
-                PauserPrivileges::PL0 => (),
-                PauserPrivileges::PL1 => {
-                    return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                }
-            }
+            // Check for MCU FW ID and swap it's TCI type
+            let tci_type = if metadata == &[2, 0, 0, 0] {
+                MCU_TCI_TYPE
+            } else {
+                u32::from_ne_bytes(*metadata)
+            };
 
             // Check that adding this measurement to DPE doesn't cause
             // the PL0 context threshold to be exceeded.
             drivers.is_dpe_context_threshold_exceeded(caller_privilege_level)?;
-
-            let locality = drivers.mbox.id();
 
             let cmd = DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -58,24 +61,25 @@ impl StashMeasurementCmd {
                     | DeriveContextFlags::CHANGE_LOCALITY
                     | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
                     | DeriveContextFlags::INPUT_ALLOW_X509,
-                tci_type: u32::from_ne_bytes(*metadata),
+                tci_type,
                 target_locality: locality,
                 svn,
             };
 
-            let derive_context_resp = with_dpe_env(drivers, None, None, |env| {
-                let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
-                Ok(cmd.execute(dpe, env, locality))
-            })?;
-
-            match derive_context_resp {
+            let profile = CaliptraDpeProfile::Ecc384;
+            let cmd = &Command::from(&cmd);
+            let mut resp_buf = [0u32; size_of::<DeriveContextResp>() / 4];
+            let resp = resp_buf.as_mut_bytes();
+            let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
+            let result = &invoke_dpe_cmd(profile, drivers, cmd, None, ueid, Some(locality), resp);
+            match result {
                 Ok(_) => DpeErrorCode::NoError,
                 Err(e) => {
                     // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
                     if let Some(ext_err) = e.get_error_detail() {
                         drivers.soc_ifc.set_fw_extended_error(ext_err);
                     }
-                    e
+                    *e
                 }
             }
         };
@@ -97,11 +101,27 @@ impl StashMeasurementCmd {
         cmd_args: &[u8],
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        let caller_privilege_level = drivers.caller_privilege_level();
+        match caller_privilege_level {
+            // Only PL0 can call STASH_MEASUREMENT
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+
         let cmd = StashMeasurementReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        let locality = drivers.mbox.id();
 
-        let dpe_result =
-            Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement, cmd.svn)?;
+        let dpe_result = Self::stash_measurement(
+            drivers,
+            &cmd.metadata,
+            &cmd.measurement,
+            cmd.svn,
+            caller_privilege_level,
+            locality,
+        )?;
 
         let resp = mutrefbytes::<StashMeasurementResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -295,7 +295,7 @@ fn test_dpe_validation_deformed_structure() {
     let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE structure by creating multiple normal connected components
-    dpe.contexts[0].children = 0.into();
+    dpe.contexts[0].children = 0u64.into();
     dpe.contexts[0].state = ContextState::Active;
     dpe.contexts[1].parent_idx = Context::ROOT_INDEX;
     let _ = model
@@ -350,7 +350,7 @@ fn test_dpe_validation_illegal_state() {
     let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
     // corrupt DPE state by messing up parent-child links
-    dpe.contexts[1].children = 0b1u32.into();
+    dpe.contexts[1].children = 0b1u64.into();
     let _ = model
         .mailbox_execute(0xB000_0000, dpe.as_bytes())
         .unwrap()

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -321,6 +321,7 @@ pub fn parse_dpe_response(dpe_cmd: &mut Command, resp_bytes: &[u8]) -> Response 
         Command::Sign(SignCommand::P384(_)) => Response::Sign(SignResp::P384(
             SignP384Resp::try_read_from_bytes(resp_bytes).unwrap(),
         )),
+        _ => panic!("Unsupported DPE command variant"),
     }
 }
 


### PR DESCRIPTION
…ommands

Squashed backport of:
- [dpe] Enable hybrid DPE feature (#3243)
- [dpe] Add ML-DSA DPE Crypto trait (#3315)
- [dpe] Add support for 64 DPE contexts (#3246)
- [dpe] Add ML-DSA DPE command (#3326)
- [dpe] Test ML-DSA CertifyKey (#3357)
- [dpe] Test using external mu with ML-DSA profile (#3371)
- [dpe] reduce nesting of InvokeDpeCmd::execute (#3386)
- [dpe] Add optional ML-DSA response over DMA (#3391)
- [dpe] Add HW model support for large DPE responses (#3403)
- [dpe] Support both DPE profiles in more tests (#3407)
- [dpe] Add a test for worst case scenario certs and CSRs (#3417)
- [dpe] Fail early for response sizing (#3415)
- [dpe] Add ML-DSA support to CertifyKeyExtended (#3426)
- [dpe] Test ML-DSA profile with golang verification (#3454)
- [dpe] Add comment that initialization is profile agnostic (#3460)

DPE rev: a26db5b — last rev bumped by PRs in this list (#3371). Not updated to caliptra-dpe main (cfc9a71) because DPE commit 337f7e4 (Update CFI #531) renamed caliptra-cfi packages from caliptra-cfi-*-git to caliptra-cfi-*, which conflicts with caliptra-2.0 CFI. Updating 2.0 CFI to match would be a ROM change.

Using 32 DPE contexts (not 64 from #3246) because 64 contexts requires DPE_SIZE=10KB which changes PersistentData layout and breaks the frozen ROM hash. 32 contexts keeps DPE_SIZE=5KB.

caliptra-2.0 adaptations:
- DpeMldsaCrypto uses MldsaReg (2.0 has dedicated ML-DSA HW register; main uses AbrReg shared Adams Bridge register for ML-DSA and ML-KEM)
- SignData::Mu returns CryptoError::NotImplemented (no external-mu on 2.0)
- Removed ML-KEM commands (no ML-KEM HW on 2.0)
- Removed main-only commands (ocp_lock, shake256)
- Flat PersistentData paths (2.0 uses single struct, not rom/fw split)
- Kept 2.0 caliptra-cfi-*-git package names to avoid ROM recompilation
- RUNTIME_SIZE=176KB (main uses 210KB; 2.0 has fewer runtime features)

Known issue: firmware stack overflow (~8KB over 140KB budget) during initialize_dpe. The hybrid DPE Response enum is ~25KB (MAX_CERT_SIZE = 22KB) and is allocated on the stack by CommandExecution::execute(). Needs stack space or DCCM space resolution.