### PR TITLE
Fix the issue in ACTIVATE_FIRMWARE that uses fw_id instead of exec_bit

### DIFF
--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -108,7 +108,7 @@ impl ActivateFirmwareCmd {
             if exec_bit == 0 || exec_bit == 1 || exec_bit > MAX_EXEC_GO_BIT_INDEX {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
             }
-            Self::set_bit(&mut images_to_activate_bitmap, fw_id as usize);
+            Self::set_bit(&mut images_to_activate_bitmap, exec_bit as usize);
         }
 
         Self::activate_fw(drivers, &images_to_activate_bitmap, mcu_image_size as u32)


### PR DESCRIPTION
Fixed https://github.com/chipsalliance/caliptra-sw/issues/3605