### PR TITLE
[fw_info] Add more information about how firmware was verified

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1453,6 +1453,9 @@ pub struct FwInfoResp {
     pub owner_pub_key_hash: [u32; 12],
     pub authman_sha384_digest: [u32; 12],
     pub most_recent_fw_error: u32,
+    pub image_manifest_pqc_type: u32,
+    pub vendor_ecc384_pub_key_index: u32,
+    pub vendor_pqc_pub_key_index: u32,
 }
 
 // CAPABILITIES

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -214,6 +214,9 @@ struct caliptra_fw_info_resp
     uint32_t owner_pub_key_hash[12];
     uint32_t authman_sha384_digest[12];
     uint32_t most_recent_fw_error;
+    uint32_t image_manifest_pqc_type;
+    uint32_t vendor_ecc384_pub_key_index;
+    uint32_t vendor_pqc_pub_key_index;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -46,6 +46,9 @@ impl FwInfoCmd {
         resp.runtime_sha384_digest = pdata.manifest1.runtime.digest;
         resp.owner_pub_key_hash = pdata.data_vault.owner_pk_hash().into();
         resp.authman_sha384_digest = pdata.auth_manifest_digest;
+        resp.image_manifest_pqc_type = pdata.manifest1.pqc_key_type as u32;
+        resp.vendor_ecc384_pub_key_index = handoff.data_vault.vendor_ecc_pk_index();
+        resp.vendor_pqc_pub_key_index = handoff.data_vault.vendor_pqc_pk_index();
         resp.most_recent_fw_error = match get_fw_error_non_fatal() {
             0 => drivers.persistent_data.get().cleared_non_fatal_fw_error,
             e => e,

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -187,6 +187,15 @@ fn test_fw_info() {
         assert_eq!(info.fmc_sha384_digest, image.manifest.fmc.digest);
         assert_eq!(info.runtime_sha384_digest, image.manifest.runtime.digest);
         assert_eq!(info.most_recent_fw_error, 0x0);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Make image with newer SVN.
         let mut image_opts20 = image_opts.clone();
@@ -204,6 +213,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 20);
         assert_eq!(info.min_fw_svn, 10);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Make image with older SVN.
         let mut image_opts5 = image_opts;
@@ -219,6 +237,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 5);
         assert_eq!(info.min_fw_svn, 5);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Go back to SVN 20
         update_to(&mut model, &image20);
@@ -226,6 +253,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 20);
         assert_eq!(info.min_fw_svn, 5);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
     }
 }
 


### PR DESCRIPTION
This adds the following fields to `FwInfoResp`:

* image_manifest_pqc_type
* vendor_ecc384_pub_key_index
* vendor_pqc_pub_key_index

These will be used by MCU key revocation APIs to make sure it is safe to revoke a key.