### PR TITLE
[fw_info] Add more information about how firmware was verified (2.0)

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1453,6 +1453,10 @@ pub struct FwInfoResp {
     pub owner_pub_key_hash: [u32; 12],
     pub authman_sha384_digest: [u32; 12],
     pub most_recent_fw_error: u32,
+    pub vendor_pub_key_hash: [u32; 12],
+    pub image_manifest_pqc_type: u32,
+    pub vendor_ecc384_pub_key_index: u32,
+    pub vendor_pqc_pub_key_index: u32,
 }
 
 // CAPABILITIES

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -214,6 +214,10 @@ struct caliptra_fw_info_resp
     uint32_t owner_pub_key_hash[12];
     uint32_t authman_sha384_digest[12];
     uint32_t most_recent_fw_error;
+    uint32_t vendor_pub_key_hash[12];
+    uint32_t image_manifest_pqc_type;
+    uint32_t vendor_ecc384_pub_key_index;
+    uint32_t vendor_pqc_pub_key_index;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1003,30 +1003,34 @@ Command Code: `0x494E_464F` ("INFO")
 
 *Table: `FW_INFO` input arguments*
 
-| **Name**     | **Type**      | **Description**
-| --------     | --------      | ---------------
-| chksum       | u32           | Checksum over other input arguments, computed by the caller. Little endian.
+| **Name** | **Type** | **Description**                                                             |
+| -------- | -------- | --------------------------------------------------------------------------- |
+| chksum   | u32      | Checksum over other input arguments, computed by the caller. Little endian. |
 
 *Table: `FW_INFO` output arguments*
 
-| **Name**               | **Type**       | **Description**
-| --------               | --------       | ---------------
-| chksum                 | u32            | Checksum over other input arguments, computed by the caller. Little endian.
-| fips\_status           | u32            | Indicates if the command is FIPS approved or an error.
-| pl0_pauser             | u32            | PAUSER with PL0 privileges (from image header).
-| firmware_svn           | u32            | Firmware SVN.
-| min_firmware_svn       | u32            | Min Firmware SVN.
-| cold_boot_fw_svn       | u32            | Cold-boot Firmware SVN.
-| attestation_disabled   | u32            | State of attestation disable.
-| rom_revision           | u8[20]         | Revision (Git commit ID) of ROM build.
-| fmc_revision           | u8[20]         | Revision (Git commit ID) of FMC build.
-| runtime_revision       | u8[20]         | Revision (Git commit ID) of runtime build.
-| rom_sha256_digest      | u32[8]         | Digest of ROM binary.
-| fmc_sha384_digest      | u32[12]        | Digest of FMC binary.
-| runtime_sha384_digest  | u32[12]        | Digest of runtime binary.
-| owner_pub_key_hash     | u32[12]        | Hash of the owner public keys provided in the image bundle manifest.
-| authman_sha384_digest  | u32[12]        | Hash of the authorization manifest provided by SET_AUTH_MANIFEST.
-| most_recent_fw_error   | u32            | Most recent FW non-fatal error (shows current non-fatal error if non-zero)
+| **Name**                    | **Type** | **Description**                                                                                                                                     |
+| --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| chksum                      | u32      | Checksum over other input arguments, computed by the caller. Little endian.                                                                         |
+| fips\_status                | u32      | Indicates if the command is FIPS approved or an error.                                                                                              |
+| pl0_pauser                  | u32      | PAUSER with PL0 privileges (from image header).                                                                                                     |
+| firmware_svn                | u32      | Firmware SVN.                                                                                                                                       |
+| min_firmware_svn            | u32      | Min Firmware SVN.                                                                                                                                   |
+| cold_boot_fw_svn            | u32      | Cold-boot Firmware SVN.                                                                                                                             |
+| attestation_disabled        | u32      | State of attestation disable.                                                                                                                       |
+| rom_revision                | u8[20]   | Revision (Git commit ID) of ROM build.                                                                                                              |
+| fmc_revision                | u8[20]   | Revision (Git commit ID) of FMC build.                                                                                                              |
+| runtime_revision            | u8[20]   | Revision (Git commit ID) of runtime build.                                                                                                          |
+| rom_sha256_digest           | u32[8]   | Digest of ROM binary. See [Byte order of cryptographic fields](#byte-order-of-cryptographic-fields).                                                |
+| fmc_sha384_digest           | u32[12]  | Digest of FMC binary. See [Byte order of cryptographic fields](#byte-order-of-cryptographic-fields).                                                |
+| runtime_sha384_digest       | u32[12]  | Digest of runtime binary. See [Byte order of cryptographic fields](#byte-order-of-cryptographic-fields).                                            |
+| owner_pub_key_hash          | u32[12]  | Hash of the owner public keys provided in the image bundle manifest. See [Byte order of cryptographic fields](#byte-order-of-cryptographic-fields). |
+| authman_sha384_digest       | u32[12]  | Hash of the authorization manifest provided by SET_AUTH_MANIFEST. See [Byte order of cryptographic fields](#byte-order-of-cryptographic-fields).    |
+| most_recent_fw_error        | u32      | Most recent FW non-fatal error (shows current non-fatal error if non-zero)                                                                          |
+| vendor_pub_key_hash         | u32[12]  | Hash of the vendor public key used to verify firmware. **Only present in FW 2.0.2+ and 2.1.1+.**                                                    |
+| image_manifest_pqc_type     | u32      | PQC key type from image manifest. **Only present in FW 2.0.2+ and 2.1.1+.**                                                                         |
+| vendor_ecc384_pub_key_index | u32      | Index of the vendor ECC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
+| vendor_pqc_pub_key_index    | u32      | Index of the vendor PQC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
 
 ### VERSION
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -46,6 +46,14 @@ impl FwInfoCmd {
         resp.runtime_sha384_digest = pdata.manifest1.runtime.digest;
         resp.owner_pub_key_hash = pdata.data_vault.owner_pk_hash().into();
         resp.authman_sha384_digest = pdata.auth_manifest_digest;
+        resp.vendor_pub_key_hash = drivers
+            .soc_ifc
+            .fuse_bank()
+            .vendor_pub_key_info_hash()
+            .into();
+        resp.image_manifest_pqc_type = pdata.manifest1.pqc_key_type as u32;
+        resp.vendor_ecc384_pub_key_index = handoff.data_vault.vendor_ecc_pk_index();
+        resp.vendor_pqc_pub_key_index = handoff.data_vault.vendor_pqc_pk_index();
         resp.most_recent_fw_error = match get_fw_error_non_fatal() {
             0 => drivers.persistent_data.get().cleared_non_fatal_fw_error,
             e => e,

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -100,13 +100,18 @@ fn test_fw_info() {
             caliptra_builder::build_and_sign_image(&FMC_WITH_UART, app, image_opts10).unwrap();
 
         // Set fuses
-        let owner_pub_key_hash = ImageGenerator::new(Crypto::default())
+        let image_generator = ImageGenerator::new(Crypto::default());
+        let owner_pub_key_hash = image_generator
             .owner_pubkey_digest(&image.manifest.preamble)
+            .unwrap();
+        let vendor_pub_key_hash = image_generator
+            .vendor_pubkey_info_digest(&image.manifest.preamble)
             .unwrap();
 
         let fuses = Fuses {
             fuse_pqc_key_type: *pqc_key_type as u32,
             owner_pk_hash: owner_pub_key_hash,
+            vendor_pk_hash: vendor_pub_key_hash,
             ..Default::default()
         };
 
@@ -187,6 +192,17 @@ fn test_fw_info() {
         assert_eq!(info.fmc_sha384_digest, image.manifest.fmc.digest);
         assert_eq!(info.runtime_sha384_digest, image.manifest.runtime.digest);
         assert_eq!(info.most_recent_fw_error, 0x0);
+        assert_eq!(info.owner_pub_key_hash, owner_pub_key_hash);
+        assert_eq!(info.vendor_pub_key_hash, vendor_pub_key_hash);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Make image with newer SVN.
         let mut image_opts20 = image_opts.clone();
@@ -204,6 +220,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 20);
         assert_eq!(info.min_fw_svn, 10);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Make image with older SVN.
         let mut image_opts5 = image_opts;
@@ -219,6 +244,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 5);
         assert_eq!(info.min_fw_svn, 5);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
 
         // Go back to SVN 20
         update_to(&mut model, &image20);
@@ -226,6 +260,15 @@ fn test_fw_info() {
         assert_eq!(info.fw_svn, 20);
         assert_eq!(info.min_fw_svn, 5);
         assert_eq!(info.cold_boot_fw_svn, 10);
+        assert_eq!(info.image_manifest_pqc_type, *pqc_key_type as u32);
+        assert_eq!(
+            info.vendor_ecc384_pub_key_index,
+            image.manifest.preamble.vendor_ecc_pub_key_idx
+        );
+        assert_eq!(
+            info.vendor_pqc_pub_key_index,
+            image.manifest.preamble.vendor_pqc_pub_key_idx
+        );
     }
 }
 


### PR DESCRIPTION
This adds the following fields to `FwInfoResp`:

* vendor_pub_key_hash
* image_manifest_pqc_type
* vendor_ecc384_pub_key_index
* vendor_pqc_pub_key_index

These will be used by MCU key revocation APIs to make sure it is safe to revoke a key.