### PR TITLE
[OCP-LOCK] Enable encryption engine interacting tests on subsystem FPGA

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -1176,11 +1176,19 @@ bitfield! {
     command_code, set_command_code: 5, 2;
     error_code, _: 19, 16;
     ready_bit, _: 31;
+
+    #[cfg(any(feature = "fpga_realtime", feature = "fpga_subsystem"))]
+    _, set_ready_bit: 31;
 }
 impl EncryptionEngineCtrl {
     fn clear() -> Self {
         let mut ctrl = Self(0);
         ctrl.set_done_bit(true);
+
+        // To maintain the RDY bit to be set
+        #[cfg(any(feature = "fpga_realtime", feature = "fpga_subsystem"))]
+        ctrl.set_ready_bit(true);
+
         ctrl
     }
 
@@ -1188,6 +1196,11 @@ impl EncryptionEngineCtrl {
         let mut ctrl = Self(0);
         ctrl.set_command_code(cmd.into());
         ctrl.set_execute_bit(true);
+
+        // To maintain the RDY bit to be set
+        #[cfg(any(feature = "fpga_realtime", feature = "fpga_subsystem"))]
+        ctrl.set_ready_bit(true);
+
         ctrl
     }
 }

--- a/hw-model/src/fpga_regs.rs
+++ b/hw-model/src/fpga_regs.rs
@@ -69,6 +69,27 @@ register_bitfields! {
     pub FlashCtrlRegwen [
         EN OFFSET(0) NUMBITS(1) [],
     ],
+    pub EncryptionEngineControl [
+        EXE OFFSET(0) NUMBITS(1) [
+            IDLE = 0,
+            RUN = 1,
+        ],
+        DONE OFFSET(1) NUMBITS(1) [
+            DONE = 1,
+        ],
+        CMD OFFSET(2) NUMBITS(4) [
+            LOAD_MEK = 1,
+            UNLOAD_MEK = 2,
+            ZEROIZE = 3,
+        ],
+        ERR OFFSET(16) NUMBITS(4) [
+            NO_ERROR = 0,
+            INVALID_COMMAND = 1,
+        ],
+        RDY OFFSET(31) NUMBITS(1) [
+            READY = 1,
+        ]
+    ],
 }
 
 register_structs! {
@@ -131,6 +152,10 @@ register_structs! {
         (0x14c => pub cptr_ss_raw_unlock_token_hash: [ReadWrite<u32>; 4]),
         (0x15c => _reserved1),
         (0x200 => pub ocp_lock_key_release_reg: [ReadWrite<u32>; 16]),
-        (0x240 => @END),
+        (0x240 => pub ocp_lock_metadata_reg: [ReadWrite<u32>; 5]),
+        (0x254 => _reserved2),
+        (0x260 => pub ocp_lock_auxiliary_data_reg: [ReadWrite<u32>; 8]),
+        (0x280 => pub ocp_lock_control_reg: ReadWrite<u32, EncryptionEngineControl::Register>),
+        (0x284 => @END),
     }
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -6,8 +6,8 @@
 use crate::api_types::{DeviceLifecycle, Fuses};
 use crate::bmc::Bmc;
 use crate::fpga_regs::{
-    Control, FifoData, FifoRegs, FifoStatus, FlashControl, FlashCtrlRegs, FlashOpStatus,
-    ItrngFifoStatus, WrapperRegs,
+    Control, EncryptionEngineControl, FifoData, FifoRegs, FifoStatus, FlashControl, FlashCtrlRegs,
+    FlashOpStatus, ItrngFifoStatus, WrapperRegs,
 };
 use crate::keys::{DEFAULT_LIFECYCLE_RAW_TOKENS, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN};
 use crate::mcu_boot_status::McuBootMilestones;
@@ -23,12 +23,17 @@ use crate::{
 };
 use crate::{OcpLockState, SecurityState};
 use anyhow::Result;
+use caliptra_api::mailbox::{
+    OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE, OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE,
+    OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE,
+};
 use caliptra_api::SocManager;
 use caliptra_emu_bus::{Bus, BusError, BusMmio, Device, Event, EventData, RecoveryCommandCode};
 use caliptra_emu_types::{RvAddr, RvData, RvSize};
 use caliptra_hw_model_types::HexSlice;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use sensitive_mmio::{SensitiveMmio, SensitiveMmioArgs};
+use std::collections::HashMap;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -469,6 +474,11 @@ pub struct ModelFpgaSubsystem {
     saved_ocp_lock_en: bool,
     saved_security_state: SecurityState,
     saved_lc_state: Option<LifecycleControllerState>,
+
+    // OCP LOCK encryption engine FPGA emulator
+    pub realtime_encryption_engine: Option<thread::JoinHandle<()>>,
+    pub realtime_encryption_engine_exit_flag: Arc<AtomicBool>,
+    pub realtime_encryption_engine_paused: Arc<AtomicBool>,
 }
 
 impl ModelFpgaSubsystem {
@@ -899,6 +909,118 @@ impl ModelFpgaSubsystem {
             while running.load(Ordering::Relaxed) && Instant::now() < end_time {
                 thread::sleep(Duration::from_millis(1));
             }
+        }
+    }
+
+    fn realtime_encryption_engine_register_handler(
+        wrapper: Arc<Wrapper>,
+        running: Arc<AtomicBool>,
+        paused: Arc<AtomicBool>,
+    ) {
+        type Mek = [u32; OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE / size_of::<u32>()];
+        type Metadata = [u32; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE / size_of::<u32>()];
+        type Aux = [u32; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE / size_of::<u32>()];
+
+        enum EncryptionEngineState {
+            WaitCommand,
+            WaitClear,
+        }
+
+        let mut key_cache: HashMap<Metadata, (Aux, Mek)> = HashMap::new();
+        let mut internal_state: EncryptionEngineState = EncryptionEngineState::WaitCommand;
+        let mut prev_cmd: u32 = 0;
+
+        wrapper
+            .regs()
+            .ocp_lock_control_reg
+            .write(EncryptionEngineControl::RDY::READY);
+
+        // Small delay to allow reset to complete
+        thread::sleep(Duration::from_millis(1));
+
+        while running.load(Ordering::Relaxed) {
+            // To maintain the ready bit
+            wrapper
+                .regs()
+                .ocp_lock_control_reg
+                .modify(EncryptionEngineControl::RDY::READY);
+
+            // If paused, sleep and check again
+            if paused.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(1));
+                continue;
+            }
+
+            match internal_state {
+                EncryptionEngineState::WaitCommand => {
+                    let mut cmd = wrapper.regs().ocp_lock_control_reg.extract();
+                    if cmd.is_set(EncryptionEngineControl::EXE) {
+                        match cmd.read_as_enum::<EncryptionEngineControl::CMD::Value>(
+                            EncryptionEngineControl::CMD,
+                        ) {
+                            Some(EncryptionEngineControl::CMD::Value::LOAD_MEK) => {
+                                let metadata: Metadata = wrapper
+                                    .regs()
+                                    .ocp_lock_metadata_reg
+                                    .each_ref()
+                                    .map(|r| r.get());
+                                let aux: Aux = wrapper
+                                    .regs()
+                                    .ocp_lock_auxiliary_data_reg
+                                    .each_ref()
+                                    .map(|r| r.get());
+                                let mek: Mek = wrapper
+                                    .regs()
+                                    .ocp_lock_key_release_reg
+                                    .each_ref()
+                                    .map(|r| r.get());
+                                key_cache.insert(metadata, (aux, mek));
+
+                                cmd.modify(EncryptionEngineControl::ERR::NO_ERROR);
+                            }
+                            Some(EncryptionEngineControl::CMD::Value::UNLOAD_MEK) => {
+                                let metadata: Metadata = wrapper
+                                    .regs()
+                                    .ocp_lock_metadata_reg
+                                    .each_ref()
+                                    .map(|r| r.get());
+                                key_cache.remove(&metadata);
+
+                                cmd.modify(EncryptionEngineControl::ERR::NO_ERROR);
+                            }
+                            Some(EncryptionEngineControl::CMD::Value::ZEROIZE) => {
+                                key_cache.clear();
+
+                                cmd.modify(EncryptionEngineControl::ERR::NO_ERROR);
+                            }
+                            _ => {
+                                cmd.modify(EncryptionEngineControl::ERR::INVALID_COMMAND);
+                            }
+                        };
+                        cmd.modify(
+                            EncryptionEngineControl::DONE::DONE
+                                + EncryptionEngineControl::EXE::IDLE
+                                + EncryptionEngineControl::RDY::READY,
+                        );
+
+                        prev_cmd = cmd.get();
+                        wrapper.regs().ocp_lock_control_reg.set(prev_cmd);
+                        internal_state = EncryptionEngineState::WaitClear;
+                    }
+                }
+                EncryptionEngineState::WaitClear => {
+                    let cmd = wrapper.regs().ocp_lock_control_reg.extract();
+                    if cmd.get() != prev_cmd && cmd.is_set(EncryptionEngineControl::DONE) {
+                        wrapper
+                            .regs()
+                            .ocp_lock_control_reg
+                            .write(EncryptionEngineControl::RDY::READY);
+                        internal_state = EncryptionEngineState::WaitCommand;
+                    }
+                }
+            }
+
+            thread::sleep(Duration::from_millis(1));
         }
     }
 
@@ -1852,6 +1974,12 @@ impl HwModel for ModelFpgaSubsystem {
         let realtime_thread_paused2 = realtime_thread_paused.clone();
         let realtime_wrapper = wrapper.clone();
 
+        let realtime_encryption_engine_exit_flag = Arc::new(AtomicBool::new(true));
+        let realtime_encryption_engine_exit_flag2 = realtime_encryption_engine_exit_flag.clone();
+        let realtime_encryption_engine_paused = Arc::new(AtomicBool::new(false));
+        let realtime_encryption_engine_paused2 = realtime_encryption_engine_paused.clone();
+        let realtime_wrapper_for_encryption_engine = wrapper.clone();
+
         let xi3c_config = xi3c::Config {
             device_id: 0,
             base_address: i3c_controller_mmio,
@@ -1954,6 +2082,10 @@ impl HwModel for ModelFpgaSubsystem {
             saved_ocp_lock_en: params.ocp_lock_en,
             saved_security_state: params.security_state,
             saved_lc_state: params.ss_init_params.lc_state,
+
+            realtime_encryption_engine: None,
+            realtime_encryption_engine_exit_flag,
+            realtime_encryption_engine_paused,
         };
 
         println!("AXI reset");
@@ -1967,6 +2099,14 @@ impl HwModel for ModelFpgaSubsystem {
                 realtime_thread_exit_flag2,
                 realtime_thread_paused2,
                 params.itrng_nibbles,
+            )
+        }));
+
+        m.realtime_encryption_engine = Some(std::thread::spawn(move || {
+            Self::realtime_encryption_engine_register_handler(
+                realtime_wrapper_for_encryption_engine,
+                realtime_encryption_engine_exit_flag2,
+                realtime_encryption_engine_paused2,
             )
         }));
 
@@ -2498,6 +2638,8 @@ impl HwModel for ModelFpgaSubsystem {
 
         // Pause the TRNG thread so it doesn't access the AXI bus during reset
         self.realtime_thread_paused.store(true, Ordering::Relaxed);
+        self.realtime_encryption_engine_paused
+            .store(true, Ordering::Relaxed);
         std::thread::sleep(Duration::from_millis(2));
 
         // Full AXI reset to clear all subsystem state including MCU
@@ -2509,6 +2651,8 @@ impl HwModel for ModelFpgaSubsystem {
 
         // Resume the TRNG thread
         self.realtime_thread_paused.store(false, Ordering::Relaxed);
+        self.realtime_encryption_engine_paused
+            .store(false, Ordering::Relaxed);
     }
 
     fn fuses(&self) -> &Fuses {
@@ -2619,6 +2763,13 @@ impl Drop for ModelFpgaSubsystem {
             .lock()
             .unwrap()
             .off();
+        self.realtime_encryption_engine_exit_flag
+            .store(false, Ordering::Relaxed);
+        self.realtime_encryption_engine
+            .take()
+            .unwrap()
+            .join()
+            .unwrap();
 
         self.set_subsystem_reset(true);
 

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_clear_key_cache.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_clear_key_cache.rs
@@ -12,7 +12,7 @@ use super::{
     boot_ocp_lock_runtime, validate_ocp_lock_response, InitializeMekSecretParams, OcpLockBootParams,
 };
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_clear_key_cache_success() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -60,7 +60,7 @@ fn test_clear_key_cache_success() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_clear_key_cache_command_timeout() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
@@ -44,7 +44,7 @@ static EXPECTED_MEK: LazyLock<Mek> = LazyLock::new(|| {
 });
 
 // TODO(clundin): Make tests work on emulator.
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_hitless_update() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -63,7 +63,7 @@ fn test_derive_mek_hitless_update() {
     verify_derive_mek(&mut model, &EXPECTED_MEK);
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_mix_mpk_hitless_update() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -261,7 +261,7 @@ fn mix_mpk_flow(
     result_mpks
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -297,7 +297,7 @@ fn test_derive_mek() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_mix_mpk() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -383,7 +383,7 @@ fn test_derive_mek_mix_mpk() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 /// Verifies MEK does not change after a warm reset.
 fn test_derive_mek_warm_reset() {
@@ -454,7 +454,7 @@ fn test_derive_mek_warm_reset() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_warm_reset_wipes_intermediate_secret() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -492,7 +492,7 @@ fn test_derive_mek_warm_reset_wipes_intermediate_secret() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_debug_unlocked() {
     let debug_unlocked_doe_out = DoeOutput::generate(&DoeInput::debug_unlocked());
@@ -544,7 +544,7 @@ fn test_derive_mek_debug_unlocked() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_corrupted_sek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -579,7 +579,7 @@ fn test_derive_corrupted_sek() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_corrupted_sek_no_checksum() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -613,7 +613,7 @@ fn test_derive_corrupted_sek_no_checksum() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_missing_secret_seed() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -646,7 +646,7 @@ fn test_derive_missing_secret_seed() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_consumed_secret_seed() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -696,7 +696,7 @@ fn test_derive_consumed_secret_seed() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_derive_mek_missing_hek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
@@ -97,7 +97,7 @@ fn update_reset(model: &mut DefaultHwModel) {
     update_fw(model, &APP_WITH_UART_OCP_LOCK_FPGA, ImageOptions::default());
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_timeout() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -129,7 +129,7 @@ fn test_load_mek_timeout() {
     validate_failure_response(&mut model, response, CaliptraError::OCP_LOCK_ENGINE_TIMEOUT);
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_success_with_fresh_wrapped_mek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -179,7 +179,7 @@ fn test_load_mek_command_success_with_fresh_wrapped_mek() {
     validate_success_response(&mut model, response, None);
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_success_with_stored_wrapped_mek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -285,7 +285,7 @@ fn test_load_mek_request_with_trailing_zero() {
     );
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_invalid_tag() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -322,7 +322,7 @@ fn test_load_mek_invalid_tag() {
     );
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_without_init_mek() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -354,7 +354,7 @@ fn test_load_mek_without_init_mek() {
     );
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_success_after_warm_reset() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -403,7 +403,7 @@ fn test_load_mek_command_success_after_warm_reset() {
     validate_success_response(&mut model, response, Some(&expected_mek));
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_impersistent_mek_secret_across_warm_reset() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -456,7 +456,7 @@ fn test_load_mek_command_impersistent_mek_secret_across_warm_reset() {
     );
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_success_after_update_reset() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -505,7 +505,7 @@ fn test_load_mek_command_success_after_update_reset() {
     validate_success_response(&mut model, response, Some(&expected_mek));
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_load_mek_command_impersistent_mek_secret_across_update_reset() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_unload_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_unload_mek.rs
@@ -21,7 +21,7 @@ const TEST_METADATA: [u8; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE] =
 const TEST_AUX: [u8; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE] =
     [0xFE; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE];
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_unload_mek_success() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -134,7 +134,7 @@ fn test_unload_mek_success() {
     });
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_unload_mek_without_loading() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
@@ -200,7 +200,7 @@ fn test_unload_mek_without_loading() {
     }
 }
 
-#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[cfg(not(feature = "fpga_realtime"))]
 #[test]
 fn test_unload_mek_command_timeout() {
     let mut model = boot_ocp_lock_runtime(OcpLockBootParams {


### PR DESCRIPTION
- Enable DERIVE_MEK tests (#3362)
- Enable CLEAR_KEY_CACHE tests
- Enable LOAD_MEK tests
- Enable UNLOAD_MEK tests