### PR TITLE
fpga: use strap UDS/FE for deterministic IDevID for tests

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -196,6 +196,11 @@ pub struct SubsystemInitParams<'a> {
     // Override the lifecycle state provisioned into OTP. When set, this
     // takes priority over the security_state-derived lifecycle mapping.
     pub lc_state: Option<LifecycleControllerState>,
+
+    // When true, set secrets_valid so DOE reads UDS and field entropy
+    // from strap registers instead of OTP. This gives deterministic
+    // IDevID on FPGA, required for attestation tests.
+    pub use_strap_secrets: bool,
 }
 
 impl Default for SubsystemInitParams<'_> {
@@ -209,6 +214,7 @@ impl Default for SubsystemInitParams<'_> {
             prod_dbg_unlock_pk_hashes_offset: Default::default(),
             primary_flash_initial_contents: None,
             lc_state: None,
+            use_strap_secrets: false,
         }
     }
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1808,8 +1808,8 @@ impl HwModel for ModelFpgaSubsystem {
             m.wrapper.regs().cptra_obf_field_entropy[i].set(fei);
         }
 
-        // Currently not using strap UDS and FE
-        m.set_secrets_valid(false);
+        // Use strap UDS and FE for deterministic IDevID on FPGA when requested
+        m.set_secrets_valid(params.ss_init_params.use_strap_secrets);
 
         println!("Putting subsystem into reset");
         m.set_subsystem_reset(true);


### PR DESCRIPTION
 Switch `secrets_valid` to True so DOE reads UDS and FE from strap registers
 instead of OTP. This gives deterministic and identical IdevID on FPGA and emulator
 for SPDM attestation tests