### PR TITLE
CPU emulator interrupt robustness: deliver only active PIC IRQs

### DIFF
--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -304,6 +304,9 @@ pub struct Cpu<TBus: Bus> {
     /// Machine External interrupt enabled
     ext_int_en: bool,
 
+    /// Tracks ExtInt events that were deferred while interrupts were masked.
+    deferred_ext_int: [bool; 256],
+
     /// Halted state
     halted: bool,
 
@@ -387,6 +390,7 @@ impl<TBus: Bus> Cpu<TBus> {
             ext_int_vec: 0,
             global_int_en: false,
             ext_int_en: false,
+            deferred_ext_int: [false; 256],
             halted: false,
             // TODO: Pass in code_coverage from the outside (as caliptra-emu-cpu
             // isn't supposed to know anything about the caliptra memory map)
@@ -824,13 +828,22 @@ impl<TBus: Bus> Cpu<TBus> {
                 TimerAction::SetNmiVec { addr } => self.nmivec = addr,
                 TimerAction::ExtInt { irq, can_wake } => {
                     if self.global_int_en && self.ext_int_en && (!self.halted || can_wake) {
-                        if let Some(_active_irq) = self.pic.highest_priority_irq_total() {
+                        if self.deferred_ext_int[irq as usize] {
+                            self.deferred_ext_int[irq as usize] = false;
+
+                            if let Some(_active_irq) = self.pic.highest_priority_irq_total() {
+                                self.halted = false;
+                                step_action = Some(self.handle_external_int(_active_irq));
+                                break;
+                            }
+                        } else {
                             self.halted = false;
                             step_action = Some(self.handle_external_int(irq));
                             break;
                         }
                     } else {
                         save = true;
+                        self.deferred_ext_int[irq as usize] = true;
                     }
                 }
                 TimerAction::SetExtIntVec { addr } => self.ext_int_vec = addr,

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -824,9 +824,11 @@ impl<TBus: Bus> Cpu<TBus> {
                 TimerAction::SetNmiVec { addr } => self.nmivec = addr,
                 TimerAction::ExtInt { irq, can_wake } => {
                     if self.global_int_en && self.ext_int_en && (!self.halted || can_wake) {
-                        self.halted = false;
-                        step_action = Some(self.handle_external_int(irq));
-                        break;
+                        if let Some(_active_irq) = self.pic.highest_priority_irq_total() {
+                            self.halted = false;
+                            step_action = Some(self.handle_external_int(irq));
+                            break;
+                        }
                     } else {
                         save = true;
                     }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -791,10 +791,10 @@ struct SocRegistersImpl {
     ss_uds_seed_base_addr_h: ReadWriteRegister<u32>,
 
     #[register(offset = 0x528)]
-    ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: ReadOnlyRegister<u32>,
+    ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: ReadWriteRegister<u32>,
 
     #[register(offset = 0x52c)]
-    ss_num_of_prod_debug_unlock_auth_pk_hashes: ReadOnlyRegister<u32>,
+    ss_num_of_prod_debug_unlock_auth_pk_hashes: ReadWriteRegister<u32>,
 
     #[register(offset = 0x530)]
     ss_debug_intent: ReadOnlyRegister<u32, SsDebugIntent::Register>,
@@ -1122,10 +1122,10 @@ impl SocRegistersImpl {
             ss_uds_seed_base_addr_h: ReadWriteRegister::new((uds_seed_offset >> 32) as u32),
             ss_recovery_mci_base_addr_l: ReadWriteRegister::new(mci_base as u32),
             ss_recovery_mci_base_addr_h: ReadWriteRegister::new((mci_base >> 32) as u32),
-            ss_num_of_prod_debug_unlock_auth_pk_hashes: ReadOnlyRegister::new(
+            ss_num_of_prod_debug_unlock_auth_pk_hashes: ReadWriteRegister::new(
                 ss_prod_dbg_unlock_number_of_fuses as u32,
             ),
-            ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: ReadOnlyRegister::new(
+            ss_prod_debug_unlock_auth_pk_hash_reg_bank_offset: ReadWriteRegister::new(
                 ss_prod_dbg_unlock_fuse_offset as u32,
             ),
             ss_soc_dbg_unlock_level: [0; 2],


### PR DESCRIPTION
Problem:
Unhandled interrupt failures were seen when deferred external interrupt events were replayed after interrupt state transitions.

**What changed:**

ExtInt handling now checks PIC pending state at delivery time.
Delivery uses the active highest-priority pending IRQ, not the stale queued IRQ.
Deferred events with no active pending source are ignored.
save=true deferral path remains unchanged.

**Behavioral impact:**

Valid interrupts are still delivered normally.
Spurious stale deferred events no longer trigger trap handling.
Reduces intermittent interrupt-related test flakiness.

Before this fix we are observing Unhandled interrupt 38
[MCI_TIMER_BEFORE_CPU_FIX.txt](https://github.com/user-attachments/files/26950512/MCI_TIMER_BEFORE_CPU_FIX.txt)

After this fix the test passed. 
[MCI_TIMER_AFTER_CPU_FIX.txt](https://github.com/user-attachments/files/26950517/MCI_TIMER_AFTER_CPU_FIX.txt)

Apart from cpu fix, I have added another register fix which says read/write register but code is written as readonly. 
<img width="1521" height="889" alt="image" src="https://github.com/user-attachments/assets/8f8f3491-c66c-4184-9b92-f135981ebd12" />
