### PR TITLE
Cherry pick emulator fixes to 2.0

### DIFF
--- a/sw-emulator/lib/bus/src/register.rs
+++ b/sw-emulator/lib/bus/src/register.rs
@@ -262,7 +262,8 @@ where
 
     /// Write data of specified size to given address
     fn write(&mut self, _size: RvSize, _val: RvData) -> Result<(), BusError> {
-        Err(BusError::StoreAccessFault)
+        // Silently ignore writes to read-only registers
+        Ok(())
     }
 }
 
@@ -584,18 +585,11 @@ mod tests {
             reg.read(RvSize::Word).err(),
             Some(BusError::LoadAccessFault)
         );
-        assert_eq!(
-            reg.write(RvSize::Byte, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::HalfWord, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::Word, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
+        // Writes to read-only registers should succeed but be ignored
+        assert_eq!(reg.write(RvSize::Byte, 0x00).ok(), Some(()));
+        assert_eq!(reg.read(RvSize::Byte).ok(), Some(u8::MAX as RvData)); // Value unchanged
+        assert_eq!(reg.write(RvSize::HalfWord, 0x00).ok(), Some(()));
+        assert_eq!(reg.write(RvSize::Word, 0x00).ok(), Some(()));
     }
 
     #[test]
@@ -612,18 +606,11 @@ mod tests {
             reg.read(RvSize::Word).err(),
             Some(BusError::LoadAccessFault)
         );
-        assert_eq!(
-            reg.write(RvSize::Byte, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::HalfWord, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::Word, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
+        // Writes to read-only registers should succeed but be ignored
+        assert_eq!(reg.write(RvSize::Byte, 0x00).ok(), Some(()));
+        assert_eq!(reg.write(RvSize::HalfWord, 0x00).ok(), Some(()));
+        assert_eq!(reg.read(RvSize::HalfWord).ok(), Some(u16::MAX as RvData)); // Value unchanged
+        assert_eq!(reg.write(RvSize::Word, 0x00).ok(), Some(()));
     }
 
     #[test]
@@ -640,18 +627,11 @@ mod tests {
             reg.read(RvSize::HalfWord).err(),
             Some(BusError::LoadAccessFault)
         );
-        assert_eq!(
-            reg.write(RvSize::Byte, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::HalfWord, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
-        assert_eq!(
-            reg.write(RvSize::Word, 0xFF).err(),
-            Some(BusError::StoreAccessFault)
-        );
+        // Writes to read-only registers should succeed but be ignored
+        assert_eq!(reg.write(RvSize::Byte, 0x00).ok(), Some(()));
+        assert_eq!(reg.write(RvSize::HalfWord, 0x00).ok(), Some(()));
+        assert_eq!(reg.write(RvSize::Word, 0x00).ok(), Some(()));
+        assert_eq!(reg.read(RvSize::Word).ok(), Some(u32::MAX)); // Value unchanged
     }
 
     #[test]

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -261,6 +261,9 @@ pub struct Cpu<TBus: Bus> {
     /// Machine External interrupt enabled
     ext_int_en: bool,
 
+    /// Tracks ExtInt events that were deferred while interrupts were masked.
+    deferred_ext_int: [bool; 256],
+
     /// Halted state
     halted: bool,
 
@@ -341,6 +344,7 @@ impl<TBus: Bus> Cpu<TBus> {
             ext_int_vec: 0,
             global_int_en: false,
             ext_int_en: false,
+            deferred_ext_int: [false; 256],
             halted: false,
             // TODO: Pass in code_coverage from the outside (as caliptra-emu-cpu
             // isn't supposed to know anything about the caliptra memory map)
@@ -775,11 +779,22 @@ impl<TBus: Bus> Cpu<TBus> {
                 TimerAction::SetNmiVec { addr } => self.nmivec = addr,
                 TimerAction::ExtInt { irq, can_wake } => {
                     if self.global_int_en && self.ext_int_en && (!self.halted || can_wake) {
-                        self.halted = false;
-                        step_action = Some(self.handle_external_int(irq));
-                        break;
+                        if self.deferred_ext_int[irq as usize] {
+                            self.deferred_ext_int[irq as usize] = false;
+
+                            if let Some(_active_irq) = self.pic.highest_priority_irq_total() {
+                                self.halted = false;
+                                step_action = Some(self.handle_external_int(_active_irq));
+                                break;
+                            }
+                        } else {
+                            self.halted = false;
+                            step_action = Some(self.handle_external_int(irq));
+                            break;
+                        }
                     } else {
                         save = true;
+                        self.deferred_ext_int[irq as usize] = true;
                     }
                 }
                 TimerAction::SetExtIntVec { addr } => self.ext_int_vec = addr,

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -741,6 +741,9 @@ impl<TBus: Bus> Cpu<TBus> {
         self.halted = false;
         self.priv_mode = RvPrivMode::M;
         self.csrs.reset();
+        // Disarm internal timers to prevent interrupts scheduled before reset from firing
+        self.csrs.internal_timers.disarm(0);
+        self.csrs.internal_timers.disarm(1);
         self.reset_pc();
     }
 


### PR DESCRIPTION
Ignore Write of Read Only Register in Emulator register.rs (#2937)
    
(cherry picked from commit 2751130531879918b17c75849592a9855124153e)

sw-emulator: Don't fire saved internal timers during reset (#3259)
    
These internal timers might be saved up during hitless update, where the
MCU processor is halted. When it comes out of reset, the timers would
immediately try to fire, which could trigger the wrong code to be
executed.
    
(cherry picked from commit 539381c9ceb41dd91e5123a6705176bc826f90e2)

CPU emulator interrupt robustness: deliver only active PIC IRQs (#3644)
    
* sw-emulator: fix CPU interrupt handling and SoC register behavior
    
* fix CPU test case failure
    
(cherry picked from commit d2fcbf47f87cca024bab0a40e6d4877589b2b8d6)
