### PR TITLE
Add MRAC (Memory Region Access Control) emulation

### DIFF
--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -15,7 +15,7 @@ use caliptra_emu_bus::Clock;
 use caliptra_emu_bus::Device;
 use caliptra_emu_bus::Event;
 use caliptra_emu_bus::EventData;
-use caliptra_emu_bus::{Bus, BusMmio};
+use caliptra_emu_bus::{Bus, BusMmio, MracBus};
 #[cfg(feature = "coverage")]
 use caliptra_emu_cpu::CoverageBitmaps;
 use caliptra_emu_cpu::{Cpu, CpuArgs, InstrTracer, Pic};
@@ -52,7 +52,11 @@ pub struct EmulatedApbBus<'a> {
 impl Bus for EmulatedApbBus<'_> {
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
         let result = self.model.soc_to_caliptra_bus.read(size, addr);
-        self.model.cpu.bus.log_read("SoC", size, addr, result);
+        self.model
+            .cpu
+            .bus
+            .inner_mut()
+            .log_read("SoC", size, addr, result);
         result
     }
     fn write(
@@ -62,14 +66,18 @@ impl Bus for EmulatedApbBus<'_> {
         val: RvData,
     ) -> Result<(), caliptra_emu_bus::BusError> {
         let result = self.model.soc_to_caliptra_bus.write(size, addr, val);
-        self.model.cpu.bus.log_write("SoC", size, addr, val, result);
+        self.model
+            .cpu
+            .bus
+            .inner_mut()
+            .log_write("SoC", size, addr, val, result);
         result
     }
 }
 
 /// Emulated model
 pub struct ModelEmulated {
-    cpu: Cpu<BusLogger<CaliptraRootBus>>,
+    cpu: Cpu<MracBus<BusLogger<CaliptraRootBus>>>,
     soc_to_caliptra_bus: SocToCaliptraBus,
     output: Output,
     trace_fn: Option<Box<InstrTracer<'static>>>,
@@ -260,7 +268,14 @@ impl HwModel for ModelEmulated {
         }
         let soc_to_caliptra_bus = root_bus.soc_to_caliptra_bus(params.soc_user);
         let (events_to_caliptra, events_from_caliptra, cpu) = {
-            let mut cpu = Cpu::new(BusLogger::new(root_bus), clock, pic, args);
+            let mrac = Rc::new(Cell::new(0u32));
+            let mut cpu = Cpu::new(
+                MracBus::new(BusLogger::new(root_bus), mrac.clone(), true),
+                clock,
+                pic,
+                args,
+                mrac,
+            );
             if let Some(stack_info) = params.stack_info {
                 cpu.with_stack_info(stack_info);
             }
@@ -271,7 +286,7 @@ impl HwModel for ModelEmulated {
         let mut hasher = DefaultHasher::new();
         std::hash::Hash::hash_slice(params.rom, &mut hasher);
         let image_tag = hasher.finish();
-        let mci_regs = cpu.bus.bus.mci_external_regs();
+        let mci_regs = cpu.bus.inner().bus.mci_external_regs();
 
         let mut m = ModelEmulated {
             output,
@@ -332,12 +347,24 @@ impl HwModel for ModelEmulated {
         // do the bare minimum for the recovery flow: activating the recovery image
         const DEVICE_STATUS_PENDING: u32 = 0x4;
         const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
-        if DeviceStatus0ReadVal::from(self.cpu.bus.bus.dma.axi.recovery.device_status_0.reg.get())
-            .dev_status()
+        if DeviceStatus0ReadVal::from(
+            self.cpu
+                .bus
+                .inner_mut()
+                .bus
+                .dma
+                .axi
+                .recovery
+                .device_status_0
+                .reg
+                .get(),
+        )
+        .dev_status()
             == DEVICE_STATUS_PENDING
         {
             self.cpu
                 .bus
+                .inner_mut()
                 .bus
                 .dma
                 .axi
@@ -354,7 +381,7 @@ impl HwModel for ModelEmulated {
                 (event.dest, event.event)
             {
                 let addr = start_addr as usize;
-                let mcu_sram_data = self.cpu.bus.bus.dma.axi.mcu_sram.data_mut();
+                let mcu_sram_data = self.cpu.bus.inner_mut().bus.dma.axi.mcu_sram.data_mut();
                 let Some(dest) = mcu_sram_data.get_mut(addr..addr + len as usize) else {
                     continue;
                 };
@@ -389,7 +416,7 @@ impl HwModel for ModelEmulated {
             return;
         }
         self.trace_fn = None;
-        self.cpu.bus.log = None;
+        self.cpu.bus.inner_mut().log = None;
         let Some(trace_path) = &self.trace_path else {
             return;
         };
@@ -401,7 +428,7 @@ impl HwModel for ModelEmulated {
                 return;
             }
         };
-        self.cpu.bus.log = Some(log.clone());
+        self.cpu.bus.inner_mut().log = Some(log.clone());
         self.trace_fn = Some(Box::new(move |pc, _instr| {
             writeln!(log, "pc=0x{pc:x}").unwrap();
         }))
@@ -409,20 +436,34 @@ impl HwModel for ModelEmulated {
 
     fn dccm_read(&self, offset: u32, len: usize) -> Vec<u8> {
         let offset = offset as usize;
-        self.cpu.bus.bus.dccm.data()[offset..offset + len].to_vec()
+        self.cpu.bus.inner().bus.dccm.data()[offset..offset + len].to_vec()
     }
 
     fn ecc_error_injection(&mut self, mode: ErrorInjectionMode) {
         match mode {
             ErrorInjectionMode::None => {
-                self.cpu.bus.bus.iccm.ram().borrow_mut().error_injection = 0;
-                self.cpu.bus.bus.dccm.error_injection = 0;
+                self.cpu
+                    .bus
+                    .inner_mut()
+                    .bus
+                    .iccm
+                    .ram()
+                    .borrow_mut()
+                    .error_injection = 0;
+                self.cpu.bus.inner_mut().bus.dccm.error_injection = 0;
             }
             ErrorInjectionMode::IccmDoubleBitEcc => {
-                self.cpu.bus.bus.iccm.ram().borrow_mut().error_injection = 2;
+                self.cpu
+                    .bus
+                    .inner_mut()
+                    .bus
+                    .iccm
+                    .ram()
+                    .borrow_mut()
+                    .error_injection = 2;
             }
             ErrorInjectionMode::DccmDoubleBitEcc => {
-                self.cpu.bus.bus.dccm.error_injection = 8;
+                self.cpu.bus.inner_mut().bus.dccm.error_injection = 8;
             }
         }
     }
@@ -446,10 +487,11 @@ impl HwModel for ModelEmulated {
         soc_manifest: Option<&[u8]>,
         mcu_firmware: Option<&[u8]>,
     ) -> Result<(), ModelError> {
-        self.cpu.bus.bus.dma.axi.recovery.cms_data = vec![firmware.to_vec()];
+        self.cpu.bus.inner_mut().bus.dma.axi.recovery.cms_data = vec![firmware.to_vec()];
         if let Some(soc_manifest) = soc_manifest {
             self.cpu
                 .bus
+                .inner_mut()
                 .bus
                 .dma
                 .axi
@@ -459,6 +501,7 @@ impl HwModel for ModelEmulated {
             if let Some(mcu_fw) = mcu_firmware {
                 self.cpu
                     .bus
+                    .inner_mut()
                     .bus
                     .dma
                     .axi
@@ -493,6 +536,7 @@ impl HwModel for ModelEmulated {
         let payload_len = payload.len();
         self.cpu
             .bus
+            .inner_mut()
             .bus
             .dma
             .axi
@@ -509,7 +553,7 @@ impl HwModel for ModelEmulated {
             return Err(ModelError::SubsystemSramError);
         }
 
-        let mcu_sram_data = self.cpu.bus.bus.dma.axi.mcu_sram.data();
+        let mcu_sram_data = self.cpu.bus.inner_mut().bus.dma.axi.mcu_sram.data();
         let payload = mcu_sram_data
             .get(..length)
             .ok_or(ModelError::SubsystemSramError)?
@@ -527,7 +571,7 @@ impl HwModel for ModelEmulated {
 
     /// Get OCP LOCK Info
     fn ocp_lock_state(&mut self) -> Option<OcpLockState> {
-        if let Ok(mek) = self.cpu.bus.bus.aes_clp.latest_mek().try_into() {
+        if let Ok(mek) = self.cpu.bus.inner_mut().bus.aes_clp.latest_mek().try_into() {
             Some(OcpLockState { mek })
         } else {
             None

--- a/sw-emulator/app/src/gdb/gdb_target.rs
+++ b/sw-emulator/app/src/gdb/gdb_target.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use caliptra_emu_bus::MracBus;
 use caliptra_emu_cpu::xreg_file::XReg;
 use caliptra_emu_cpu::StepAction;
 use caliptra_emu_cpu::{Cpu, WatchPtrKind};
@@ -34,14 +35,14 @@ pub enum ExecMode {
 }
 
 pub struct GdbTarget {
-    cpu: Cpu<CaliptraRootBus>,
+    cpu: Cpu<MracBus<CaliptraRootBus>>,
     exec_mode: ExecMode,
     breakpoints: Vec<u32>,
 }
 
 impl GdbTarget {
     // Create new instance of GdbTarget
-    pub fn new(cpu: Cpu<CaliptraRootBus>) -> Self {
+    pub fn new(cpu: Cpu<MracBus<CaliptraRootBus>>) -> Self {
         Self {
             cpu,
             exec_mode: ExecMode::Continue,

--- a/sw-emulator/app/src/main.rs
+++ b/sw-emulator/app/src/main.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use caliptra_api_types::{DeviceLifecycle, SecurityState};
-use caliptra_emu_bus::{Clock, Device, Event, EventData};
+use caliptra_emu_bus::{Clock, Device, Event, EventData, MracBus};
 use caliptra_emu_cpu::{Cpu, CpuArgs, Pic, RvInstr, StepAction};
 use caliptra_emu_periph::dma::recovery::RecoveryControl;
 use caliptra_emu_periph::soc_reg::DebugManufService;
@@ -24,6 +24,7 @@ use caliptra_emu_periph::{
 use caliptra_hw_model::BusMmio;
 use caliptra_registers::i3ccsr::regs::DeviceStatus0ReadVal;
 use clap::{arg, value_parser, ArgAction};
+use std::cell::Cell;
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
@@ -52,7 +53,7 @@ const EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES: u64 = 20_000_000; // 20 million cyc
 
 // CPU Main Loop (free_run no GDB)
 fn free_run(
-    mut cpu: Cpu<CaliptraRootBus>,
+    mut cpu: Cpu<MracBus<CaliptraRootBus>>,
     trace_path: Option<PathBuf>,
     events_to_caliptra: mpsc::Sender<Event>,
     events_from_caliptra: mpsc::Receiver<Event>,
@@ -99,14 +100,16 @@ fn free_run(
     };
 }
 
-fn step_recovery_flow(cpu: &mut Cpu<CaliptraRootBus>) {
+fn step_recovery_flow(cpu: &mut Cpu<MracBus<CaliptraRootBus>>) {
     // do the bare minimum for the recovery flow: activating the recovery image
     const DEVICE_STATUS_PENDING: u32 = 0x4;
     const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
-    if DeviceStatus0ReadVal::from(cpu.bus.dma.axi.recovery.device_status_0.reg.get()).dev_status()
+    if DeviceStatus0ReadVal::from(cpu.bus.inner().dma.axi.recovery.device_status_0.reg.get())
+        .dev_status()
         == DEVICE_STATUS_PENDING
     {
         cpu.bus
+            .inner_mut()
             .dma
             .axi
             .recovery
@@ -117,7 +120,7 @@ fn step_recovery_flow(cpu: &mut Cpu<CaliptraRootBus>) {
 }
 
 fn handle_events(
-    cpu: &mut Cpu<CaliptraRootBus>,
+    cpu: &mut Cpu<MracBus<CaliptraRootBus>>,
     events_from_caliptra: &mpsc::Receiver<Event>,
     events_to_caliptra: &mpsc::Sender<Event>,
     collected_events_from_caliptra: &mut Vec<Event>,
@@ -128,7 +131,7 @@ fn handle_events(
         if let (Device::MCU, EventData::MemoryRead { start_addr, len }) = (event.dest, event.event)
         {
             let addr = start_addr as usize;
-            let mcu_sram_data = cpu.bus.dma.axi.mcu_sram.data_mut();
+            let mcu_sram_data = cpu.bus.inner_mut().dma.axi.mcu_sram.data_mut();
             let Some(dest) = mcu_sram_data.get_mut(addr..addr + len as usize) else {
                 continue;
             };
@@ -243,6 +246,11 @@ fn main() -> io::Result<()> {
         )
         .arg(
             arg!(--"subsystem-mode" ... "Subsystem mode: get image update via recovery register interface")
+                .required(false)
+                .action(ArgAction::SetTrue)
+        )
+        .arg(
+            arg!(--"mrac" ... "Enable MRAC (Memory Region Access Control) enforcement")
                 .required(false)
                 .action(ArgAction::SetTrue)
         )
@@ -506,7 +514,15 @@ fn main() -> io::Result<()> {
 
     let cpu_args = CpuArgs::default();
 
-    let mut cpu = Cpu::new(root_bus, clock.clone(), pic, cpu_args);
+    let mrac_enabled = args.get_flag("mrac");
+    let mrac = Rc::new(Cell::new(0u32));
+    let mut cpu = Cpu::new(
+        MracBus::new(root_bus, mrac.clone(), mrac_enabled),
+        clock.clone(),
+        pic,
+        cpu_args,
+        mrac,
+    );
     let (events_to_caliptra, events_from_caliptra) = cpu.register_events();
 
     // Check if Optional GDB Port is passed

--- a/sw-emulator/compliance-test/src/main.rs
+++ b/sw-emulator/compliance-test/src/main.rs
@@ -17,6 +17,7 @@ use caliptra_emu_bus::{Bus, Clock, Ram};
 use caliptra_emu_cpu::{Cpu, CpuArgs, Pic, StepAction};
 use caliptra_emu_types::RvSize;
 use clap::{arg, value_parser};
+use std::cell::Cell;
 use std::error::Error;
 use std::io::ErrorKind;
 use std::path::PathBuf;
@@ -166,7 +167,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let pic = Rc::new(Pic::new());
         let clock = Rc::new(Clock::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(Ram::new(binary), clock, pic, args);
+        let mut cpu = Cpu::new(Ram::new(binary), clock, pic, args, Rc::new(Cell::new(0)));
         cpu.write_pc(0x3000);
         while !is_test_complete(&mut cpu.bus) {
             match cpu.step(None) {
@@ -197,7 +198,13 @@ mod tests {
         ram_bytes.extend(vec![0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(Ram::new(ram_bytes), Rc::new(Clock::new()), pic, args);
+        let mut cpu = Cpu::new(
+            Ram::new(ram_bytes),
+            Rc::new(Clock::new()),
+            pic,
+            args,
+            Rc::new(Cell::new(0)),
+        );
 
         check_reference_data("03020100\n07060504\n", &mut cpu.bus).unwrap();
         assert_eq!(

--- a/sw-emulator/lib/bus/src/lib.rs
+++ b/sw-emulator/lib/bus/src/lib.rs
@@ -17,6 +17,7 @@ mod dynamic_bus;
 mod event;
 mod mem;
 mod mmio;
+pub mod mrac_bus;
 mod ram;
 mod register;
 mod register_array;
@@ -28,6 +29,7 @@ pub use crate::clock::{ActionHandle, Clock, Timer, TimerAction};
 pub use crate::dynamic_bus::DynamicBus;
 pub use crate::event::{Device, Event, EventData, RecoveryCommandCode};
 pub use crate::mmio::BusMmio;
+pub use crate::mrac_bus::MracBus;
 pub use crate::ram::{AlignedRam, Ram};
 pub use crate::register::{
     ReadOnlyMemory, ReadOnlyRegister, ReadWriteMemory, ReadWriteRegister, Register,

--- a/sw-emulator/lib/bus/src/mrac_bus.rs
+++ b/sw-emulator/lib/bus/src/mrac_bus.rs
@@ -1,0 +1,522 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    mrac_bus.rs
+
+Abstract:
+
+    Optional emulation of the VeeR EL2 MRAC (Memory Region Access Control)
+    register for LSU (data) accesses. Wraps an inner Bus and enforces
+    per-region access rules:
+
+    - Side-effect regions: only naturally aligned access allowed.
+    - Cacheable regions: reads are widened to 64-bit aligned double-word
+      fetches (two word reads from the inner bus).
+
+    IFU (instruction fetch) accesses are handled at the cpu side and bypass
+    this wrapper -- see Cpu::read_instr.
+
+    Ref: https://chipsalliance.github.io/Cores-VeeR-EL2/html/main/docs_rendered/html/memory-map.html#region-access-control-register-mrac
+
+--*/
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::mpsc;
+
+use crate::bus::{Bus, BusError};
+use crate::event::Event;
+use caliptra_emu_types::{RvAddr, RvData, RvSize};
+
+/// Bus wrapper that enforces VeeR EL2 MRAC region access rules for LSU
+/// (data load/store) accesses.
+///
+/// The 32-bit address space is split into 16 regions of 256MB each.
+/// Each region has a 2-bit field in the MRAC CSR (0x7C0):
+///   - bit Y*2:   cacheable
+///   - bit Y*2+1: sideeffect
+///
+/// When `enabled` is false, all accesses pass through unchanged.
+pub struct MracBus<TBus: Bus> {
+    inner: TBus,
+    mrac: Rc<Cell<u32>>,
+    enabled: bool,
+}
+
+impl<TBus: Bus> MracBus<TBus> {
+    pub fn new(inner: TBus, mrac: Rc<Cell<u32>>, enabled: bool) -> Self {
+        Self {
+            inner,
+            mrac,
+            enabled,
+        }
+    }
+
+    /// Extract the 2-bit region field for a given address.
+    ///
+    /// The address space is split into 16 regions of 256 MB each. The high
+    /// nibble of the address selects the region; each region has a 2-bit
+    /// field at `mrac[region*2 +: 2]` where bit 0 = cacheable and bit 1 =
+    /// sideeffect.
+    fn region_bits(&self, addr: RvAddr) -> u32 {
+        let region = (addr >> 28) & 0xF;
+        (self.mrac.get() >> (region * 2)) & 0b11
+    }
+
+    /// True if the region containing `addr` has the sideeffect bit set
+    /// (bit 1 of the region's 2-bit field).
+    fn is_sideeffect(&self, addr: RvAddr) -> bool {
+        self.region_bits(addr) & 0b10 != 0
+    }
+
+    /// True if the region containing `addr` has the cacheable bit set
+    /// (bit 0 of the region's 2-bit field).
+    fn is_cacheable(&self, addr: RvAddr) -> bool {
+        self.region_bits(addr) & 0b01 != 0
+    }
+
+    /// Return a mutable reference to the inner bus.
+    pub fn inner_mut(&mut self) -> &mut TBus {
+        &mut self.inner
+    }
+
+    /// Return a reference to the inner bus.
+    pub fn inner(&self) -> &TBus {
+        &self.inner
+    }
+
+    /// Perform a "widened" read that emulates VeeR's 64-bit cache-line fill:
+    /// the inner bus sees one or two aligned 8-byte fetches, and the
+    /// requested `size` bytes at `addr` are extracted from the result.
+    ///
+    /// If `[addr, addr+size)` lies entirely within a single 8-byte aligned
+    /// chunk, only one 8-byte fetch is issued. If it crosses the boundary
+    /// (possible for unaligned half-word/word loads), two 8-byte fetches
+    /// are issued and the result is stitched.
+    fn read_widened(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
+        let size_bytes = match size {
+            RvSize::Byte => 1usize,
+            RvSize::HalfWord => 2,
+            RvSize::Word => 4,
+            _ => return Err(BusError::LoadAccessFault),
+        };
+        let aligned_addr = addr & !0x7;
+        let byte_offset = (addr - aligned_addr) as usize;
+
+        // wrapping_add is defensive against pathological MRAC settings near
+        // the top of the u32 address space. Caliptra's cacheable region is
+        // region 0 so this never wraps in practice, but it is cheaper than
+        // a runtime overflow check.
+        let lo0 = self.inner.read(RvSize::Word, aligned_addr)?;
+        let hi0 = self
+            .inner
+            .read(RvSize::Word, aligned_addr.wrapping_add(4))?;
+        let dword0: u64 = (lo0 as u64) | ((hi0 as u64) << 32);
+
+        let combined: u128 = if byte_offset + size_bytes > 8 {
+            // Access crosses the 8-byte boundary; fetch the next chunk too.
+            let lo1 = self
+                .inner
+                .read(RvSize::Word, aligned_addr.wrapping_add(8))?;
+            let hi1 = self
+                .inner
+                .read(RvSize::Word, aligned_addr.wrapping_add(12))?;
+            let dword1: u64 = (lo1 as u64) | ((hi1 as u64) << 32);
+            (dword0 as u128) | ((dword1 as u128) << 64)
+        } else {
+            dword0 as u128
+        };
+
+        let mask: u128 = match size {
+            RvSize::Byte => 0xFF,
+            RvSize::HalfWord => 0xFFFF,
+            RvSize::Word => 0xFFFF_FFFF,
+            _ => unreachable!(),
+        };
+        Ok(((combined >> (byte_offset * 8)) & mask) as u32)
+    }
+}
+
+impl<TBus: Bus> Bus for MracBus<TBus> {
+    fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
+        if !self.enabled {
+            return self.inner.read(size, addr);
+        }
+
+        if self.is_sideeffect(addr) {
+            // LSU side-effect: reject misaligned access only.
+            // Per RTL (lsu_addrcheck.sv): byte is always aligned,
+            // halfword must be 2-byte aligned, word must be 4-byte aligned.
+            let is_aligned = match size {
+                RvSize::Byte => true,
+                RvSize::HalfWord => (addr & 0x1) == 0,
+                RvSize::Word => (addr & 0x3) == 0,
+                _ => false,
+            };
+            if !is_aligned {
+                return Err(BusError::LoadAddrMisaligned);
+            }
+            // Side-effect: exact-size pass-through (no widening)
+            self.inner.read(size, addr)
+        } else if self.is_cacheable(addr) {
+            // LSU cacheable: widen to 64-bit aligned read(s)
+            self.read_widened(size, addr)
+        } else {
+            // Neither side-effect nor cacheable: pass through
+            self.inner.read(size, addr)
+        }
+    }
+
+    fn write(&mut self, size: RvSize, addr: RvAddr, val: RvData) -> Result<(), BusError> {
+        if !self.enabled {
+            return self.inner.write(size, addr, val);
+        }
+
+        if self.is_sideeffect(addr) {
+            // LSU side-effect: reject misaligned access only.
+            let is_aligned = match size {
+                RvSize::Byte => true,
+                RvSize::HalfWord => (addr & 0x1) == 0,
+                RvSize::Word => (addr & 0x3) == 0,
+                _ => false,
+            };
+            if !is_aligned {
+                return Err(BusError::StoreAddrMisaligned);
+            }
+        }
+
+        // Cacheable/non-sideeffect writes pass through with original size
+        self.inner.write(size, addr, val)
+    }
+
+    fn poll(&mut self) {
+        self.inner.poll();
+    }
+
+    fn warm_reset(&mut self) {
+        self.inner.warm_reset();
+    }
+
+    fn update_reset(&mut self) {
+        self.inner.update_reset();
+    }
+
+    fn incoming_event(&mut self, event: Rc<Event>) {
+        self.inner.incoming_event(event);
+    }
+
+    fn register_outgoing_events(&mut self, sender: mpsc::Sender<Event>) {
+        self.inner.register_outgoing_events(sender);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::testing::FakeBus;
+
+    fn make_mrac_bus(mrac_val: u32, enabled: bool) -> MracBus<FakeBus> {
+        let mrac = Rc::new(Cell::new(mrac_val));
+        let fake = FakeBus::new();
+        MracBus::new(fake, mrac, enabled)
+    }
+
+    #[test]
+    fn test_disabled_passthrough() {
+        let mut bus = make_mrac_bus(0xFFFF_FFFF, false);
+        // Even with all regions side-effect, disabled should pass through
+        assert!(bus.read(RvSize::Byte, 0x3003_0001).is_ok());
+        assert!(bus.write(RvSize::Byte, 0x3003_0001, 0x42).is_ok());
+    }
+
+    #[test]
+    fn test_sideeffect_word_aligned_ok() {
+        // Region 3 (0x3xxx_xxxx): set sideeffect bit = bit 7 (region 3 * 2 + 1)
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert!(bus.read(RvSize::Word, 0x3003_0000).is_ok());
+        assert!(bus.write(RvSize::Word, 0x3003_0000, 0x42).is_ok());
+    }
+
+    #[test]
+    fn test_sideeffect_byte_aligned_ok() {
+        // Per VeeR EL2 RTL: byte accesses are always naturally aligned,
+        // so they always succeed in side-effect regions.
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert!(bus.read(RvSize::Byte, 0x3003_0001).is_ok());
+        assert!(bus.write(RvSize::Byte, 0x3003_0001, 0x42).is_ok());
+    }
+
+    #[test]
+    fn test_sideeffect_halfword_aligned_ok() {
+        // Per VeeR EL2 RTL: 2-byte aligned halfword access succeeds.
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert!(bus.read(RvSize::HalfWord, 0x3003_0000).is_ok());
+    }
+
+    #[test]
+    fn test_sideeffect_halfword_misaligned_rejected() {
+        // Per VeeR EL2 RTL: misaligned halfword access is rejected.
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert_eq!(
+            bus.read(RvSize::HalfWord, 0x3003_0001),
+            Err(BusError::LoadAddrMisaligned)
+        );
+    }
+
+    #[test]
+    fn test_sideeffect_misaligned_word_rejected() {
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert_eq!(
+            bus.read(RvSize::Word, 0x3003_0002),
+            Err(BusError::LoadAddrMisaligned)
+        );
+    }
+
+    #[test]
+    fn test_cacheable_read_widens() {
+        // Region 5 (0x5xxx_xxxx): set cacheable bit = bit 10 (region 5 * 2)
+        let mrac_val = 1 << 10; // cacheable for region 5
+        let mut bus = make_mrac_bus(mrac_val, true);
+        // FakeBus returns Ok(0) by default, so widened read should succeed
+        assert!(bus.read(RvSize::Byte, 0x5000_0001).is_ok());
+        assert!(bus.read(RvSize::HalfWord, 0x5000_0002).is_ok());
+        assert!(bus.read(RvSize::Word, 0x5000_0004).is_ok());
+    }
+
+    #[test]
+    fn test_no_flags_passthrough() {
+        // Region 2: no flags set
+        let mut bus = make_mrac_bus(0, true);
+        assert!(bus.read(RvSize::Byte, 0x2000_0001).is_ok());
+        assert!(bus.write(RvSize::Byte, 0x2000_0001, 0x42).is_ok());
+    }
+
+    #[test]
+    fn test_cacheable_widens_causes_spurious_lock() {
+        // Demonstrates the problem: reading USER (offset 0x04) in a
+        // cacheable region widens to 64-bit, causing a read at offset 0x00
+        // (LOCK) which has side effects (acquires the lock).
+        let mrac_val = 1 << 6; // cacheable for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+
+        // Read USER at 0x3002_0004 -- should widen to 64-bit aligned read
+        let _ = bus.read(RvSize::Word, 0x3002_0004);
+
+        // The widened read should have issued two word reads starting at
+        // the 64-bit aligned boundary (0x3002_0000)
+        let log = bus.inner().log.take();
+        assert!(
+            log.contains("read(RvSize::Word, 0x30020000)"),
+            "Cacheable read should widen to include LOCK addr 0x30020000, got: {log}"
+        );
+        assert!(
+            log.contains("read(RvSize::Word, 0x30020004)"),
+            "Cacheable read should also read USER addr 0x30020004, got: {log}"
+        );
+    }
+
+    #[test]
+    fn test_sideeffect_write_halfword_misaligned_rejected() {
+        // Write-side counterpart of the read-side misalignment test:
+        // RTL rejects misaligned stores into sideeffect regions with
+        // StoreAddrMisaligned.
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert_eq!(
+            bus.write(RvSize::HalfWord, 0x3003_0001, 0x42),
+            Err(BusError::StoreAddrMisaligned)
+        );
+    }
+
+    #[test]
+    fn test_sideeffect_write_word_misaligned_rejected() {
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert_eq!(
+            bus.write(RvSize::Word, 0x3003_0002, 0x42),
+            Err(BusError::StoreAddrMisaligned)
+        );
+    }
+
+    #[test]
+    fn test_eleven_case_behaves_as_sideeffect() {
+        // The CSR write path sanitizes the illegal 0b11 combination to
+        // 0b10 (sideeffect-only). MracBus itself, however, may receive a
+        // raw 0b11 if a caller writes the cell directly (e.g. tests, future
+        // callers). Verify that runtime behavior in that case still matches
+        // sideeffect semantics: misaligned LSU access is rejected and there
+        // is no widening.
+        let mrac_val = 0b11 << 6; // both bits set for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+        assert_eq!(
+            bus.read(RvSize::HalfWord, 0x3003_0001),
+            Err(BusError::LoadAddrMisaligned)
+        );
+        // Aligned access goes through with no widening.
+        let _ = bus.read(RvSize::Word, 0x3003_0004);
+        let log = bus.inner().log.take();
+        assert!(
+            !log.contains("0x30030000"),
+            "0b11 should behave as sideeffect (no widening to aligned dword), got: {log}"
+        );
+        assert!(
+            log.contains("read(RvSize::Word, 0x30030004)"),
+            "only the requested word should be read, got: {log}"
+        );
+    }
+
+    #[test]
+    fn test_sideeffect_prevents_spurious_lock() {
+        // With side-effect correctly set for region 3, only the exact
+        // register is read -- no widening, no spurious LOCK access.
+        let mrac_val = 1 << 7; // sideeffect for region 3
+        let mut bus = make_mrac_bus(mrac_val, true);
+
+        let _ = bus.read(RvSize::Word, 0x3002_0004);
+
+        let log = bus.inner().log.take();
+        assert!(
+            !log.contains("0x30020000"),
+            "Side-effect read should not touch LOCK addr, got: {log}"
+        );
+        assert!(
+            log.contains("read(RvSize::Word, 0x30020004)"),
+            "Only USER addr should be read, got: {log}"
+        );
+    }
+
+    #[test]
+    fn test_cacheable_word_no_boundary_cross_single_dword() {
+        // A 4-byte word at offset 0 inside an 8-byte aligned chunk lies
+        // entirely within that chunk; only one 64-bit fetch is issued.
+        let mrac_val = 1 << 10; // cacheable for region 5
+        let mut bus = make_mrac_bus(mrac_val, true);
+        let _ = bus.read(RvSize::Word, 0x5000_0000);
+        let log = bus.inner().log.take();
+        assert!(
+            log.contains("read(RvSize::Word, 0x50000000)"),
+            "lo word should be read, got: {log}"
+        );
+        assert!(
+            log.contains("read(RvSize::Word, 0x50000004)"),
+            "hi word should be read, got: {log}"
+        );
+        assert!(
+            !log.contains("0x50000008"),
+            "no second dword fetch expected (no boundary cross), got: {log}"
+        );
+    }
+
+    #[test]
+    fn test_cacheable_lsu_halfword_crossing_boundary_fetches_second_dword() {
+        // A 2-byte halfword at offset 7 in an 8-byte chunk straddles into
+        // the next chunk (byte 7 from chunk N, byte 0 from chunk N+1).
+        let mrac_val = 1; // cacheable for region 0
+        let mut bus = make_mrac_bus(mrac_val, true);
+        let _ = bus.read(RvSize::HalfWord, 0x0000_0007);
+        let log = bus.inner().log.take();
+        for expect in [
+            "read(RvSize::Word, 0x0)",
+            "read(RvSize::Word, 0x4)",
+            "read(RvSize::Word, 0x8)",
+            "read(RvSize::Word, 0xc)",
+        ] {
+            assert!(
+                log.contains(expect),
+                "expected `{expect}` in halfword cross-boundary fetch log, got: {log}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cacheable_write_does_not_widen() {
+        // Per VeeR EL2 spec, the cacheable bit affects reads (cache-line
+        // fill) but NOT writes. A byte write into a cacheable region must
+        // pass through to the inner bus with the original size; it must
+        // NOT be widened to a dword.
+        let mrac_val = 1; // cacheable for region 0
+        let mut bus = make_mrac_bus(mrac_val, true);
+        bus.write(RvSize::Byte, 0x0000_0004, 0x42).unwrap();
+        let log = bus.inner().log.take();
+        assert!(
+            log.contains("write(RvSize::Byte, 0x4, 0x42)"),
+            "byte write should pass through unchanged, got: {log}"
+        );
+        assert!(
+            !log.contains("0x0000_0000") && !log.contains("0x0)"),
+            "no spurious read at aligned dword base, got: {log}"
+        );
+    }
+
+    #[test]
+    fn test_mrac_cell_change_takes_effect_immediately() {
+        // Simulates the warm-reset path: the shared Rc<Cell<u32>> is
+        // updated externally (e.g. by CsrFile::reset re-syncing the cell
+        // to the post-reset CSR value of 0). MracBus must observe the new
+        // value on the very next access, with no caching of region rules.
+        let mrac = Rc::new(Cell::new(1u32)); // region 0 cacheable
+        let mut bus = MracBus::new(FakeBus::new(), mrac.clone(), true);
+
+        // First access: cacheable -> widened (two word reads)
+        let _ = bus.read(RvSize::Word, 0x0000_0000);
+        let log_before = bus.inner().log.take();
+        assert!(
+            log_before.contains("read(RvSize::Word, 0x0)")
+                && log_before.contains("read(RvSize::Word, 0x4)"),
+            "cacheable region should widen, got: {log_before}"
+        );
+
+        // Reset the cell to all-zero (passthrough) and re-issue the access.
+        mrac.set(0);
+        let _ = bus.read(RvSize::Word, 0x0000_0000);
+        let log_after = bus.inner().log.take();
+        assert!(
+            log_after.contains("read(RvSize::Word, 0x0)") && !log_after.contains("0x4"),
+            "after cell reset to 0, only the requested word should be read, got: {log_after}"
+        );
+    }
+
+    #[test]
+    fn test_cacheable_value_extracted_correctly_with_boundary_cross() {
+        // Verify the stitched value is correct when reading across the
+        // 8-byte boundary. Use a custom inner bus that returns address-keyed
+        // data so we can assert the extracted value.
+        struct AddrKeyedBus {
+            // Word value at each aligned word address
+            words: std::collections::HashMap<RvAddr, RvData>,
+        }
+        impl Bus for AddrKeyedBus {
+            fn read(&mut self, _size: RvSize, addr: RvAddr) -> Result<RvData, BusError> {
+                Ok(*self.words.get(&(addr & !0x3)).unwrap_or(&0))
+            }
+            fn write(&mut self, _: RvSize, _: RvAddr, _: RvData) -> Result<(), BusError> {
+                Ok(())
+            }
+        }
+        let mut words = std::collections::HashMap::new();
+        // Aligned dword at 0x0: bytes 0..7 = AA BB CC DD EE FF 11 22
+        words.insert(0x0, 0xDDCC_BBAA);
+        words.insert(0x4, 0x2211_FFEE);
+        // Aligned dword at 0x8: bytes 8..15 = 33 44 55 66 ...
+        words.insert(0x8, 0x6655_4433);
+        words.insert(0xC, 0x0);
+
+        let mrac = Rc::new(Cell::new(1u32)); // cacheable for region 0
+        let mut bus = MracBus::new(AddrKeyedBus { words }, mrac, true);
+
+        // Halfword at 0x7 spans bytes [7,8] -> 22 33 -> 0x3322
+        let result = bus.read(RvSize::HalfWord, 0x7).unwrap();
+        assert_eq!(
+            result, 0x3322,
+            "boundary-crossing halfword at 0x7 should stitch correctly"
+        );
+    }
+}

--- a/sw-emulator/lib/bus/src/ram.rs
+++ b/sw-emulator/lib/bus/src/ram.rs
@@ -179,7 +179,7 @@ mod tests {
     fn test_read_error() {
         let mut ram = Ram::new(vec![1, 2, 3, 4]);
         assert_eq!(
-            ram.read(RvSize::Byte, ram.len()).err(),
+            ram.read(RvSize::Byte, ram.len() as RvAddr).err(),
             Some(BusError::LoadAccessFault),
         )
     }

--- a/sw-emulator/lib/bus/src/rom.rs
+++ b/sw-emulator/lib/bus/src/rom.rs
@@ -119,7 +119,7 @@ mod tests {
     fn test_read_error() {
         let mut rom = Rom::new(vec![1, 2, 3, 4]);
         assert_eq!(
-            rom.read(RvSize::Byte, rom.len()).err(),
+            rom.read(RvSize::Byte, rom.len() as RvAddr).err(),
             Some(BusError::LoadAccessFault),
         )
     }

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -22,6 +22,7 @@ use crate::Pic;
 use bit_vec::BitVec;
 use caliptra_emu_bus::{Bus, BusError, Clock, Event, TimerAction};
 use caliptra_emu_types::{RvAddr, RvData, RvException, RvSize};
+use std::cell::Cell;
 use std::fs::File;
 use std::io::Write;
 use std::rc::Rc;
@@ -374,10 +375,16 @@ pub enum StepAction {
 
 impl<TBus: Bus> Cpu<TBus> {
     /// Create a new RISCV CPU
-    pub fn new(bus: TBus, clock: Rc<Clock>, pic: Rc<Pic>, args: CpuArgs) -> Self {
+    pub fn new(
+        bus: TBus,
+        clock: Rc<Clock>,
+        pic: Rc<Pic>,
+        args: CpuArgs,
+        mrac: Rc<Cell<u32>>,
+    ) -> Self {
         Self {
             xregs: XRegFile::new(),
-            csrs: CsrFile::new(clock.clone(), pic.clone()),
+            csrs: CsrFile::new(clock.clone(), pic.clone(), mrac),
             pc: args.org.reset_vector,
             next_pc: args.org.reset_vector,
             bus,
@@ -767,18 +774,48 @@ impl<TBus: Bus> Cpu<TBus> {
     pub fn read_instr(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, RvException> {
         self.check_mem_priv(addr, size, RvMemAccessType::Execute)?;
 
-        match size {
-            RvSize::Byte => Err(RvException::instr_access_fault(addr)),
-            _ => match self.bus.read(size, addr) {
-                Ok(val) => Ok(val),
-                Err(exception) => match exception {
-                    BusError::InstrAccessFault => Err(RvException::instr_access_fault(addr)),
-                    BusError::LoadAccessFault => Err(RvException::instr_access_fault(addr)),
-                    BusError::LoadAddrMisaligned => Err(RvException::instr_addr_misaligned(addr)),
-                    BusError::StoreAccessFault => Err(RvException::store_access_fault(addr)),
-                    BusError::StoreAddrMisaligned => Err(RvException::store_addr_misaligned(addr)),
-                },
-            },
+        // IFU is handled at the cpu side rather than threading an
+        // access-type flag through the Bus trait. Always issue word-aligned
+        // reads to the bus and slice the requested halfword/word out
+        // locally; this naturally bypasses MracBus's LSU alignment rules
+        // (which IFU does not have) without any special casing.
+        let size_bytes = match size {
+            RvSize::Byte => return Err(RvException::instr_access_fault(addr)),
+            RvSize::HalfWord => 2usize,
+            RvSize::Word => 4,
+            _ => return Err(RvException::instr_access_fault(addr)),
+        };
+        let aligned = addr & !0x3;
+        let byte_off = (addr - aligned) as usize;
+        let lo = self
+            .bus
+            .read(RvSize::Word, aligned)
+            .map_err(|e| Self::map_ifu_error(e, addr))?;
+        let combined: u64 = if byte_off + size_bytes > 4 {
+            // Access straddles the next word.
+            let hi = self
+                .bus
+                .read(RvSize::Word, aligned.wrapping_add(4))
+                .map_err(|e| Self::map_ifu_error(e, addr))?;
+            (lo as u64) | ((hi as u64) << 32)
+        } else {
+            lo as u64
+        };
+        let val = match size {
+            RvSize::HalfWord => ((combined >> (byte_off * 8)) & 0xFFFF) as u32,
+            RvSize::Word => ((combined >> (byte_off * 8)) & 0xFFFF_FFFF) as u32,
+            _ => unreachable!(),
+        };
+        Ok(val)
+    }
+
+    fn map_ifu_error(e: BusError, addr: RvAddr) -> RvException {
+        match e {
+            BusError::InstrAccessFault => RvException::instr_access_fault(addr),
+            BusError::LoadAccessFault => RvException::instr_access_fault(addr),
+            BusError::LoadAddrMisaligned => RvException::instr_addr_misaligned(addr),
+            BusError::StoreAccessFault => RvException::store_access_fault(addr),
+            BusError::StoreAddrMisaligned => RvException::store_addr_misaligned(addr),
         }
     }
 
@@ -1128,7 +1165,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let cpu = Cpu::new(DynamicBus::new(), clock, pic, args);
+        let cpu = Cpu::new(DynamicBus::new(), clock, pic, args, Rc::new(Cell::new(0)));
         assert_eq!(cpu.read_pc(), 0);
     }
 
@@ -1137,7 +1174,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args);
+        let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args, Rc::new(Cell::new(0)));
         cpu.write_pc(0xFF);
         assert_eq!(cpu.read_pc(), 0xFF);
     }
@@ -1147,7 +1184,7 @@ mod tests {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args);
+        let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args, Rc::new(Cell::new(0)));
         for reg in 1..32u32 {
             assert_eq!(cpu.write_xreg(reg.into(), 0xFF).ok(), Some(()));
             assert_eq!(cpu.read_xreg(reg.into()).ok(), Some(0xFF));
@@ -1169,7 +1206,7 @@ mod tests {
 
         let args = CpuArgs::default();
 
-        Cpu::new(bus, clock, pic, args)
+        Cpu::new(bus, clock, pic, args, Rc::new(Cell::new(0)))
     }
 
     #[test]
@@ -2022,7 +2059,7 @@ mod tests {
 
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(bus, clock.clone(), pic, args);
+        let mut cpu = Cpu::new(bus, clock.clone(), pic, args, Rc::new(Cell::new(0)));
         for i in 0..30 {
             assert_eq!(cpu.clock.now(), i);
             assert_eq!(cpu.step(None), StepAction::Continue);
@@ -2095,7 +2132,7 @@ mod tests {
 
         let pic = Rc::new(Pic::new());
         let args = CpuArgs::default();
-        let mut cpu = Cpu::new(bus, clock.clone(), pic, args);
+        let mut cpu = Cpu::new(bus, clock.clone(), pic, args, Rc::new(Cell::new(0)));
         cpu.csrs.internal_timers.write_mitcnt(0, 100);
         cpu.global_int_en = true;
         cpu.ext_int_en = true;

--- a/sw-emulator/lib/cpu/src/csr_file.rs
+++ b/sw-emulator/lib/cpu/src/csr_file.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use crate::internal_timers::InternalTimers;
@@ -77,6 +78,9 @@ impl Csr {
 
     /// Interrupt Pending CSR
     pub const MIP: RvAddr = 0x344;
+
+    /// Memory region access control CSR
+    pub const MRAC: RvAddr = 0x7C0;
 
     /// Power management const CSR
     pub const MPMC: RvAddr = 0x7C6;
@@ -230,6 +234,8 @@ pub struct CsrFile {
     pub(crate) internal_timers: InternalTimers,
     /// Reference to PIC
     pic: Rc<Pic>,
+    /// Shared MRAC value (synced with MracBus wrapper)
+    mrac: Rc<Cell<u32>>,
 }
 
 /// Initalise a CSR read/write function in the CSR table
@@ -295,6 +301,7 @@ impl CsrFile {
         );
         csr_fn!(table, Csr::MIP, CsrFile::mip_read, CsrFile::mip_write);
         csr_fn!(table, Csr::MIE, CsrFile::system_read, CsrFile::mie_write);
+        csr_fn!(table, Csr::MRAC, CsrFile::system_read, CsrFile::mrac_write);
         csr_fn!(table, Csr::MPMC, CsrFile::system_read, CsrFile::mpmc_write);
         csr_fn!(
             table,
@@ -372,7 +379,7 @@ impl CsrFile {
     };
 
     /// Create a new Configuration and status register file
-    pub fn new(clock: Rc<Clock>, pic: Rc<Pic>) -> Self {
+    pub fn new(clock: Rc<Clock>, pic: Rc<Pic>, mrac: Rc<Cell<u32>>) -> Self {
         let mut csrs = Box::new([Csr::default(); CsrFile::CSR_COUNT]);
 
         csr_val!(csrs, Csr::MISA, 0x4010_1104, 0x0000_0000);
@@ -389,6 +396,7 @@ impl CsrFile {
         csr_val!(csrs, Csr::MCAUSE, 0x0000_0000, 0xFFFF_FFFF);
         csr_val!(csrs, Csr::MTVAL, 0x0000_0000, 0xFFFF_FFFF);
         csr_val!(csrs, Csr::MIP, 0x0000_0000, 0xFFFF_FFFF);
+        csr_val!(csrs, Csr::MRAC, 0x0000_0000, 0xFFFF_FFFF);
         csr_val!(csrs, Csr::MPMC, 0x0000_0002, 0x0000_0002);
         csr_val!(csrs, Csr::MSECCFG, 0x0000_0000, 0x0000_0003);
         csr_val!(csrs, Csr::MCYCLE, 0x0000_0000, 0xFFFF_FFFF);
@@ -425,6 +433,7 @@ impl CsrFile {
             max_pmpcfgi: None,
             internal_timers: crate::internal_timers::InternalTimers::new(clock.clone()),
             pic,
+            mrac,
         }
     }
 
@@ -434,6 +443,10 @@ impl CsrFile {
             csr.reset();
         }
         self.max_pmpcfgi = None;
+        // Re-sync the shared MRAC cell with the post-reset CSR value so the
+        // MracBus wrapper does not enforce stale region rules between reset
+        // and the firmware's first write to CSR 0x7C0.
+        self.mrac.set(self.csrs[Csr::MRAC as usize].val);
     }
 
     /// Allow all reads from the given CSR
@@ -587,6 +600,28 @@ impl CsrFile {
         );
         // Let's see if the soc wants to interrupt
         self.timer.schedule_poll_in(2);
+        Ok(())
+    }
+
+    /// Perform a write to the MRAC CSR, syncing to the shared MracBus value.
+    fn mrac_write(
+        &mut self,
+        priv_mode: RvPrivMode,
+        addr: RvAddr,
+        val: RvData,
+    ) -> Result<(), RvException> {
+        // HW maps illegal combination 11 (cacheable+sideeffect) to 10 (sideeffect)
+        let mut sanitized = val;
+        for region in 0..16u32 {
+            let shift = region * 2;
+            let bits = (sanitized >> shift) & 0b11;
+            if bits == 0b11 {
+                sanitized = (sanitized & !(0b11 << shift)) | (0b10 << shift);
+            }
+        }
+        self.system_write(priv_mode, addr, sanitized)?;
+        let csr = self.csrs[addr as usize];
+        self.mrac.set(csr.val);
         Ok(())
     }
 
@@ -1061,6 +1096,7 @@ fn decode_napot_pmpaddr(addr: u32) -> (u64, u64) {
 mod tests {
 
     use super::*;
+    use std::cell::Cell;
     use std::rc::Rc;
 
     #[test]
@@ -1091,7 +1127,7 @@ mod tests {
     fn test_u_mode_read_m_mode_csr() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let csrs = CsrFile::new(clock, pic);
+        let csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(
             csrs.read(RvPrivMode::U, Csr::MSTATUS).err(),
@@ -1107,7 +1143,7 @@ mod tests {
     fn test_cycle() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let csrs = CsrFile::new(clock.clone(), pic);
+        let csrs = CsrFile::new(clock.clone(), pic, Rc::new(Cell::new(0)));
         clock.increment(0x1234_5678_9abc);
 
         assert_eq!(csrs.read(RvPrivMode::M, Csr::MCYCLE), Ok(0x5678_9abc));
@@ -1118,7 +1154,7 @@ mod tests {
     fn test_u_mode_write_m_mode_csr() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(
             csrs.write(RvPrivMode::U, Csr::MSTATUS, 0xFFFF_FFFF).err(),
@@ -1134,7 +1170,7 @@ mod tests {
     fn test_u_mode_read_write_pmp() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(
             csrs.write(RvPrivMode::U, Csr::PMPCFG_START, 0xFFFF_FFFF)
@@ -1197,7 +1233,7 @@ mod tests {
     fn test_m_mode_read_write_pmp() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::PMPCFG_START, 0x1717_1717)
@@ -1243,7 +1279,7 @@ mod tests {
     fn test_lock_pmp() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         // Lock PMPADDR1, but not PMPADDR0, 2, or 3.
         assert_eq!(
@@ -1343,7 +1379,7 @@ mod tests {
     fn test_pmp_tor_lock() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         // Set PMP2CFG to TOR and lock
         assert_eq!(
@@ -1398,7 +1434,7 @@ mod tests {
     fn test_read_only_csr() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(csrs.read(RvPrivMode::M, Csr::MISA).ok(), Some(0x4010_1104));
         assert_eq!(
@@ -1412,7 +1448,7 @@ mod tests {
     fn test_read_write_csr() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
         assert_eq!(csrs.read(RvPrivMode::M, Csr::MEPC).ok(), Some(0));
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MEPC, u32::MAX).ok(),
@@ -1425,7 +1461,7 @@ mod tests {
     fn test_mseccfg_csr_sticky() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MSECCFG, 0xFFFF_FFFF).ok(),
             Some(())
@@ -1448,7 +1484,7 @@ mod tests {
     fn test_mstatus_invalid_mpp() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
         assert_eq!(
             csrs.write(RvPrivMode::M, Csr::MSTATUS, 0x0000_1800).ok(),
             Some(())
@@ -1479,7 +1515,7 @@ mod tests {
     fn test_read_write_masked_csr() {
         let clock = Rc::new(Clock::new());
         let pic = Rc::new(Pic::new());
-        let mut csrs = CsrFile::new(clock, pic);
+        let mut csrs = CsrFile::new(clock, pic, Rc::new(Cell::new(0)));
 
         assert_eq!(
             csrs.read(RvPrivMode::M, Csr::MSTATUS).ok(),
@@ -1506,5 +1542,56 @@ mod tests {
             csrs.read(RvPrivMode::M, Csr::MCOUNTINHIBIT).ok(),
             Some(0x0000_007D)
         );
+    }
+
+    #[test]
+    fn test_mrac_write_sanitizes_all_regions() {
+        // Writing 0xFFFF_FFFF to MRAC must sanitize every region's illegal
+        // 0b11 combination to 0b10 (sideeffect-only). Result should be
+        // 0xAAAA_AAAA (all 16 regions = sideeffect).
+        let clock = Rc::new(Clock::new());
+        let pic = Rc::new(Pic::new());
+        let mrac_cell = Rc::new(Cell::new(0u32));
+        let mut csrs = CsrFile::new(clock, pic, mrac_cell.clone());
+        csrs.write(RvPrivMode::M, Csr::MRAC, 0xFFFF_FFFF).unwrap();
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MRAC).unwrap(), 0xAAAA_AAAA);
+        assert_eq!(mrac_cell.get(), 0xAAAA_AAAA);
+    }
+
+    #[test]
+    fn test_mrac_write_preserves_legal_combinations() {
+        // 0b00, 0b01, 0b10 are all legal and must pass through unchanged.
+        // Construct a mix across regions and verify nothing is rewritten.
+        let clock = Rc::new(Clock::new());
+        let pic = Rc::new(Pic::new());
+        let mrac_cell = Rc::new(Cell::new(0u32));
+        let mut csrs = CsrFile::new(clock, pic, mrac_cell.clone());
+        // Region pattern (LSB region 0): 00 01 10 00 01 10 00 01 ...
+        let val: u32 = 0b00_01_10_00_01_10_00_01_10_00_01_10_00_01_10_00;
+        csrs.write(RvPrivMode::M, Csr::MRAC, val).unwrap();
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MRAC).unwrap(), val);
+        assert_eq!(mrac_cell.get(), val);
+    }
+
+    #[test]
+    fn test_csr_reset_resyncs_mrac_cell() {
+        // The shared MRAC cell must follow the CSR's reset value so the
+        // MracBus does not enforce stale region rules immediately after a
+        // warm reset (before firmware re-writes CSR 0x7C0).
+        let clock = Rc::new(Clock::new());
+        let pic = Rc::new(Pic::new());
+        let mrac_cell = Rc::new(Cell::new(0u32));
+        let mut csrs = CsrFile::new(clock, pic, mrac_cell.clone());
+
+        csrs.write(RvPrivMode::M, Csr::MRAC, 0xAAAA_A0A9).unwrap();
+        assert_eq!(mrac_cell.get(), 0xAAAA_A0A9);
+
+        csrs.reset();
+        assert_eq!(
+            mrac_cell.get(),
+            0,
+            "warm reset must restore the cell to the post-reset CSR value"
+        );
+        assert_eq!(csrs.read(RvPrivMode::M, Csr::MRAC).unwrap(), 0);
     }
 }

--- a/sw-emulator/lib/cpu/src/instr/test_macros.rs
+++ b/sw-emulator/lib/cpu/src/instr/test_macros.rs
@@ -1180,6 +1180,7 @@ mod test {
             $data_addr:expr => $data:expr
         ) => {{
             use caliptra_emu_bus::{Clock, DynamicBus, Ram, Rom};
+            use std::cell::Cell;
             use std::rc::Rc;
             use $crate::cpu::Cpu;
             use $crate::pic::Pic;
@@ -1191,7 +1192,7 @@ mod test {
             let clock = Rc::new(Clock::new());
             let pic = Rc::new(Pic::new());
             let args = CpuArgs::default();
-            let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args);
+            let mut cpu = Cpu::new(DynamicBus::new(), clock, pic, args, Rc::new(Cell::new(0)));
             let rom = Rom::new($text.clone());
             cpu.bus
                 .attach_dev("ROM", text_range, Box::new(rom))


### PR DESCRIPTION
## Add MRAC (Memory Region Access Control) emulation

Emulate the VeeR EL2 MRAC CSR (0x7C0) so the sw-emulator and hw-model exhibit the same per-region access constraints as real hardware. Reference: [VeeR EL2 spec](https://chipsalliance.github.io/Cores-VeeR-EL2/html/main/docs_rendered/html/memory-map.html#region-access-control-register-mrac).

### What this does

The 32-bit address space is split into 16 fixed 256 MB regions; each region has two MRAC bits (`cacheable`, `sideeffect`) that gate LSU behavior:

- **LSU data load:**
  - `sideeffect`: misaligned access is rejected; aligned access goes through with the requested size (no widening).
  - `cacheable`: read is widened to a 64-bit aligned dword fetch; write goes through with the requested size.
  - neither: passthrough.
- **`0b11` (both bits set):** illegal in RTL; sanitized to `0b10` (sideeffect-only) on CSR write.

IFU (instruction fetch) is handled at the cpu side rather than in `MracBus`: `Cpu::read_instr` issues word-aligned reads to the bus and slices the requested halfword/word out locally, with a second word read only when an `RVC` instruction straddles a 4-byte boundary. This naturally bypasses MracBus's LSU rules (which IFU does not have) without needing to thread any access-type information through the `Bus` trait.

### Why this matters

Without MRAC enforcement the emulator does not catch access-pattern bugs that would fail on real hardware. Concrete example: reading a mailbox `USER` register at offset 4 in a non-side-effect region triggers a widened 64-bit read that *also* reads the adjacent `LOCK` register at offset 0, silently acquiring the lock. The `sideeffect` flag prevents this by restricting reads to the exact requested address.

### Implementation

1. New `MracBus<TBus: Bus>` wrapper in `sw-emulator/lib/bus` that intercepts LSU reads and writes and enforces the rules above before delegating to the inner bus. The widening helper handles accesses that straddle the 8-byte dword boundary.
2. MRAC CSR (0x7C0) added to `CsrFile` with a shared `Rc<Cell<u32>>`; CSR writes update the cell that `MracBus` reads on every access. `CsrFile::reset()` re-syncs the cell so warm reset cannot leave `MracBus` enforcing stale region rules.
3. `Cpu::read_instr` rewritten to do its own word-aligned bus reads + local slicing for IFU. The `Bus::read` trait signature is **unchanged** from `main` — no breaking change for downstream consumers.
4. `ModelEmulated` and the `sw-emulator` app both wrap their root bus in `MracBus`. The CLI gains a `--mrac` flag; `ModelEmulated` enables MRAC by default so existing integration tests exercise the new path. This matches real hardware, where the boot code unconditionally writes CSR 0x7C0 at startup.

### Tests

- `mrac_bus` unit tests cover disabled passthrough, all four region encodings, alignment enforcement for side-effect, cacheable LSU widening including boundary-crossing accesses, the mailbox-lock spurious-acquire case that motivated this work, that cacheable writes are not widened, and shared-cell update propagation.
- `csr_file` unit tests cover MRAC CSR write sanitization across all 16 regions, preservation of legal combinations, and the reset-time cell resync.
- The full `caliptra-drivers` integration test binary passes with MRAC enabled.

Closes #3601
