### PR TITLE
Feature/optimize zeroize impls

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-76900995d321429428eba826bcf1596f7f978e0a9c309e145fdf70c80ca2045a3c3de2b79c71a47d87681b4ee5be13ec  caliptra-rom-no-log.bin
-1c424923bf2991d615ce98f552a57a6bc408791adfaf6b210aaab771a66f9e5ea7ecf6de6f3bec6ea675ca26dc2670bf  caliptra-rom-with-log.bin
+aadd589c1ce483542a93dcc162eaf908edde2cea9fd145d16c66a33869b3c4fb302a6316448c6ce377e4fff9fcb60a0c  caliptra-rom-no-log.bin
+d3b16fb2051edf9ef2e18d2189946fb7811f652a205266ba8ac08094f3bf6470e8c9e6520f5921eb53dec3a20e3fbf2c  caliptra-rom-with-log.bin

--- a/auth-manifest/types/src/lib.rs
+++ b/auth-manifest/types/src/lib.rs
@@ -160,12 +160,19 @@ impl Default for AuthManifestImageMetadata {
 
 /// Caliptra Authorization Manifest Image Metadata Collection
 #[repr(C)]
-#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AuthManifestImageMetadataCollection {
     pub entry_count: u32,
 
     pub image_metadata_list: [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT],
+}
+
+impl ZeroizeWithByteScrub for AuthManifestImageMetadataCollection {}
+impl zeroize::Zeroize for AuthManifestImageMetadataCollection {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
 }
 
 impl Default for AuthManifestImageMetadataCollection {

--- a/drivers/src/bounded_address.rs
+++ b/drivers/src/bounded_address.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use caliptra_error::CaliptraError;
-use zerocopy::{FromBytes, Immutable, IntoBytes, TryFromBytes, Unalign};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, Unalign};
 use zeroize::Zeroize;
 
 use crate::memory_layout;
@@ -24,7 +24,7 @@ impl MemBounds for RomBounds {
 pub type RomAddr<T> = BoundedAddr<T, RomBounds>;
 
 #[repr(C)]
-#[derive(TryFromBytes, IntoBytes, Immutable)]
+#[derive(FromZeros, IntoBytes, Immutable)]
 pub struct BoundedAddr<T: IntoBytes + FromBytes, B: MemBounds> {
     addr: Unalign<u32>,
     _phantom: PhantomData<(T, B)>,

--- a/drivers/src/hand_off.rs
+++ b/drivers/src/hand_off.rs
@@ -10,7 +10,7 @@ use bitfield::{bitfield_bitrange, bitfield_fields};
 use caliptra_error::CaliptraError;
 use caliptra_image_types::RomInfo;
 use core::mem::size_of;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const FHT_MARKER: u32 = 0x54484643;
@@ -178,7 +178,7 @@ impl From<DataStore> for HandOffDataHandle {
 /// to pass parameters and configuration information from one firmware layer to the next.
 const _: () = assert!(size_of::<FirmwareHandoffTable>() == 2048);
 #[repr(C)]
-#[derive(Clone, Debug, IntoBytes, TryFromBytes, Immutable, KnownLayout, Zeroize)]
+#[derive(Clone, Debug, IntoBytes, FromZeros, Immutable, KnownLayout, Zeroize)]
 pub struct FirmwareHandoffTable {
     /// Magic Number marking start of table. Value must be 0x54484643
     /// (‘CFHT’ when viewed as little-endian ASCII).

--- a/drivers/src/key_vault.rs
+++ b/drivers/src/key_vault.rs
@@ -17,10 +17,10 @@ use bitfield::bitfield;
 use crate::{CaliptraError, CaliptraResult};
 use caliptra_registers::kv::KvReg;
 
-use zerocopy::{IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromZeros, IntoBytes, KnownLayout};
 
 /// Key Identifier
-#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromBytes, IntoBytes, KnownLayout)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromZeros, IntoBytes, KnownLayout)]
 #[repr(u8)]
 pub enum KeyId {
     KeyId0 = 0,

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -11,7 +11,8 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
 #[cfg(feature = "runtime")]
 use dpe::{DpeInstance, ExportedCdiHandle, U8Bool, MAX_HANDLES};
-use zerocopy::{IntoBytes, KnownLayout, TryFromBytes};
+use caliptra_image_types::ZeroizeWithByteScrub;
+use zerocopy::{FromZeros, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
 #[cfg(feature = "runtime")]
@@ -56,7 +57,7 @@ pub const MEASUREMENT_MAX_COUNT: usize = 8;
 // CDI handles at the cost of using more KeyVault slots.
 pub const EXPORTED_HANDLES_NUM: usize = 1;
 #[cfg(feature = "runtime")]
-#[derive(Clone, TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
+#[derive(Clone, FromZeros, IntoBytes, KnownLayout)]
 pub struct ExportedCdiEntry {
     pub key: KeyId,
     pub handle: ExportedCdiHandle,
@@ -64,9 +65,27 @@ pub struct ExportedCdiEntry {
 }
 
 #[cfg(feature = "runtime")]
-#[derive(Clone, TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
+impl ZeroizeWithByteScrub for ExportedCdiEntry {}
+#[cfg(feature = "runtime")]
+impl Zeroize for ExportedCdiEntry {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
+}
+
+#[cfg(feature = "runtime")]
+#[derive(Clone, FromZeros, IntoBytes, KnownLayout)]
 pub struct ExportedCdiHandles {
     pub entries: [ExportedCdiEntry; EXPORTED_HANDLES_NUM],
+}
+
+#[cfg(feature = "runtime")]
+impl ZeroizeWithByteScrub for ExportedCdiHandles {}
+#[cfg(feature = "runtime")]
+impl Zeroize for ExportedCdiHandles {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
 }
 
 #[cfg(feature = "runtime")]
@@ -90,7 +109,7 @@ pub type AuthManifestImageMetadataList =
 const _: () = assert!(MAX_IDEVID_CSR_SIZE < IDEVID_CSR_SIZE as usize);
 const _: () = assert!(MAX_FMC_ALIAS_CSR_SIZE < FMC_ALIAS_CSR_SIZE as usize);
 
-#[derive(Clone, TryFromBytes, IntoBytes, Zeroize)]
+#[derive(Clone, FromZeros, IntoBytes, Zeroize)]
 #[repr(C)]
 pub struct IdevIdCsr {
     csr_len: u32,
@@ -102,7 +121,7 @@ pub mod fmc_alias_csr {
 
     const _: () = assert!(size_of::<FmcAliasCsr>() < FMC_ALIAS_CSR_SIZE as usize);
 
-    #[derive(Clone, TryFromBytes, IntoBytes, Zeroize)]
+    #[derive(Clone, FromZeros, IntoBytes, Zeroize)]
     #[repr(C)]
     pub struct FmcAliasCsr {
         csr_len: u32,
@@ -225,7 +244,7 @@ const _: () = assert!(
 );
 const _: () = assert!(size_of::<IdevIdCsr>() <= IDEVID_CSR_SIZE as usize);
 
-#[derive(TryFromBytes, IntoBytes, KnownLayout, Zeroize)]
+#[derive(FromZeros, IntoBytes, KnownLayout)]
 #[repr(C)]
 pub struct PersistentData {
     pub manifest1: ImageManifest,
@@ -301,6 +320,13 @@ pub struct PersistentData {
     // New objects should always source memory from this range.
     // Taking memory from this reserve does NOT break hitless updates.
     pub reserved_memory: [u8; RESERVED_MEMORY_SIZE as usize],
+}
+
+impl ZeroizeWithByteScrub for PersistentData {}
+impl Zeroize for PersistentData {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
 }
 
 impl PersistentData {

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -9,9 +9,9 @@ use caliptra_auth_man_types::{
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use caliptra_image_types::ImageManifest;
+use caliptra_image_types::ZeroizeWithByteScrub;
 #[cfg(feature = "runtime")]
 use dpe::{DpeInstance, ExportedCdiHandle, U8Bool, MAX_HANDLES};
-use caliptra_image_types::ZeroizeWithByteScrub;
 use zerocopy::{FromZeros, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -872,6 +872,12 @@ pub trait HwModel: SocManager {
 
     fn ecc_error_injection(&mut self, _mode: ErrorInjectionMode) {}
 
+    /// Read a region of DCCM (Data Closely Coupled Memory).
+    /// `offset` is relative to the DCCM base address and `len` is the number of bytes to read.
+    fn dccm_read(&self, _offset: u32, _len: usize) -> Vec<u8> {
+        unimplemented!("direct DCCM reads are not supported on this model")
+    }
+
     fn set_apb_pauser(&mut self, pauser: u32);
 
     /// Executes a typed request and (if success), returns the typed response.

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -105,6 +105,16 @@ impl ModelEmulated {
     }
 }
 
+impl ModelEmulated {
+    /// Read a slice of the DCCM (Data Closely Coupled Memory) by absolute address.
+    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
+    pub fn dccm_read(&self, addr: u32, len: usize) -> &[u8] {
+        const DCCM_BASE: u32 = 0x5000_0000;
+        let offset = (addr - DCCM_BASE) as usize;
+        &self.cpu.bus.bus.dccm.data()[offset..offset + len]
+    }
+}
+
 fn hash_slice(slice: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     std::hash::Hash::hash_slice(slice, &mut hasher);

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -105,16 +105,6 @@ impl ModelEmulated {
     }
 }
 
-impl ModelEmulated {
-    /// Read a slice of the DCCM (Data Closely Coupled Memory) by absolute address.
-    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
-    pub fn dccm_read(&self, addr: u32, len: usize) -> &[u8] {
-        const DCCM_BASE: u32 = 0x5000_0000;
-        let offset = (addr - DCCM_BASE) as usize;
-        &self.cpu.bus.bus.dccm.data()[offset..offset + len]
-    }
-}
-
 fn hash_slice(slice: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     std::hash::Hash::hash_slice(slice, &mut hasher);
@@ -299,6 +289,11 @@ impl HwModel for ModelEmulated {
                 self.cpu.bus.bus.dccm.error_injection = 8;
             }
         }
+    }
+
+    fn dccm_read(&self, offset: u32, len: usize) -> Vec<u8> {
+        let offset = offset as usize;
+        self.cpu.bus.bus.dccm.data()[offset..offset + len].to_vec()
     }
 
     fn set_apb_pauser(&mut self, pauser: u32) {

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -531,12 +531,6 @@ impl HwModel for ModelFpgaRealtime {
 }
 
 impl ModelFpgaRealtime {
-    /// Read a region of DCCM (Data Closely Coupled Memory) by absolute address.
-    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
-    pub fn dccm_read(&self, _addr: u32, _len: usize) -> Vec<u8> {
-        unimplemented!("direct DCCM reads are not supported against the hardware model")
-    }
-
     pub fn launch_openocd(&mut self) -> Result<(), OpenOcdError> {
         let _ = Command::new("sudo")
             .arg("pkill")

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -531,6 +531,12 @@ impl HwModel for ModelFpgaRealtime {
 }
 
 impl ModelFpgaRealtime {
+    /// Read a region of DCCM (Data Closely Coupled Memory) by absolute address.
+    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
+    pub fn dccm_read(&self, _addr: u32, _len: usize) -> Vec<u8> {
+        unimplemented!("direct DCCM reads are not supported against the hardware model")
+    }
+
     pub fn launch_openocd(&mut self) -> Result<(), OpenOcdError> {
         let _ = Command::new("sudo")
             .arg("pkill")

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -102,12 +102,6 @@ impl ModelVerilated {
     pub fn corrupt_mailbox_ecc_double_bit(&mut self) {
         self.v.corrupt_mailbox_ecc_double_bit();
     }
-
-    /// Read a region of DCCM (Data Closely Coupled Memory) by absolute address.
-    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
-    pub fn dccm_read(&self, _addr: u32, _len: usize) -> Vec<u8> {
-        unimplemented!("direct DCCM reads are not supported against the hardware model")
-    }
 }
 
 fn ahb_txn_size(ty: AhbTxnType) -> RvSize {

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -102,6 +102,12 @@ impl ModelVerilated {
     pub fn corrupt_mailbox_ecc_double_bit(&mut self) {
         self.v.corrupt_mailbox_ecc_double_bit();
     }
+
+    /// Read a region of DCCM (Data Closely Coupled Memory) by absolute address.
+    /// The `addr` and `len` are in the CPU address space (starting at 0x5000_0000).
+    pub fn dccm_read(&self, _addr: u32, _len: usize) -> Vec<u8> {
+        unimplemented!("direct DCCM reads are not supported against the hardware model")
+    }
 }
 
 fn ahb_txn_size(ty: AhbTxnType) -> RvSize {

--- a/image/types/src/lib.rs
+++ b/image/types/src/lib.rs
@@ -23,8 +23,33 @@ use core::ops::Range;
 use memoffset::{offset_of, span_of};
 #[cfg(feature = "std")]
 use serde_derive::Deserialize;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
+
+/// Types implementing this trait can be securely zeroized via a single
+/// byte-slice volatile write, without per-field recursion.
+///
+/// # Invariants (enforced by trait bounds)
+///
+/// - `IntoBytes`: the value has a contiguous byte representation with no
+///   uninitialized padding, so casting `&mut Self` to `&mut [u8]` is valid.
+/// - `FromZeros`: all-zeros is a valid bit pattern for `Self`, so zeroing
+///   every byte produces a valid value.
+///
+/// The default `zeroize` method passes the byte slice to `[u8]::zeroize()`
+/// from the `zeroize` crate, which uses volatile writes to prevent the
+/// compiler from eliding the zeroing as a dead store.
+pub trait ZeroizeWithByteScrub: FromZeros + IntoBytes + Sized {
+    fn zeroize_scrub(&mut self) {
+        // SAFETY: `Self: IntoBytes` guarantees a contiguous byte representation
+        // with no uninitialized padding. `Self: FromZeros` guarantees all-zeros
+        // is a valid bit pattern. `self` is a valid mutable reference.
+        let bytes = unsafe {
+            core::slice::from_raw_parts_mut(self as *mut Self as *mut u8, size_of::<Self>())
+        };
+        bytes.zeroize();
+    }
+}
 
 pub const MANIFEST_MARKER: u32 = 0x4E414D43;
 pub const VENDOR_ECC_KEY_COUNT: u32 = 4;
@@ -159,7 +184,7 @@ impl ImageBundle {
 
 /// Calipatra Image Manifest
 #[repr(C)]
-#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Clone, Copy, Debug, Zeroize)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Clone, Copy, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageManifest {
     /// Marker
@@ -179,6 +204,13 @@ pub struct ImageManifest {
 
     /// Runtime TOC Entry
     pub runtime: ImageTocEntry,
+}
+
+impl ZeroizeWithByteScrub for ImageManifest {}
+impl zeroize::Zeroize for ImageManifest {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
 }
 
 impl Default for ImageManifest {
@@ -389,7 +421,7 @@ impl From<ImageTocEntryId> for u32 {
 
 /// Caliptra Table of contents entry
 #[repr(C)]
-#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug, Zeroize)]
+#[derive(IntoBytes, Clone, Copy, FromBytes, Immutable, KnownLayout, Default, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ImageTocEntry {
     /// ID
@@ -424,6 +456,13 @@ pub struct ImageTocEntry {
 
     /// Digest
     pub digest: ImageDigest,
+}
+
+impl ZeroizeWithByteScrub for ImageTocEntry {}
+impl zeroize::Zeroize for ImageTocEntry {
+    fn zeroize(&mut self) {
+        self.zeroize_scrub();
+    }
 }
 
 impl ImageTocEntry {

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -109,6 +109,8 @@ fn test_fips_shutdown() {
     );
 }
 
+#[cfg_attr(feature = "verilator", ignore)]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_fips_shutdown_zeroizes_persistent_data() {
     const PERSISTENT_DATA_ADDR: u32 = caliptra_drivers::memory_layout::PERSISTENT_DATA_ORG;

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -108,3 +108,37 @@ fn test_fips_shutdown() {
         resp,
     );
 }
+
+#[test]
+fn test_fips_shutdown_zeroizes_persistent_data() {
+    const PERSISTENT_DATA_ADDR: u32 = caliptra_drivers::memory_layout::PERSISTENT_DATA_ORG;
+    const PERSISTENT_DATA_SIZE: usize =
+        caliptra_drivers::memory_layout::PERSISTENT_DATA_SIZE as usize;
+
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
+
+    let nonzero = model
+        .dccm_read(PERSISTENT_DATA_ADDR, PERSISTENT_DATA_SIZE)
+        .iter()
+        .any(|b| *b != 0);
+    assert!(nonzero, "The persistent data was not initialized");
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::SHUTDOWN), &[]),
+    };
+
+    model
+        .mailbox_execute(u32::from(CommandId::SHUTDOWN), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+
+    let dccm = model.dccm_read(PERSISTENT_DATA_ADDR, PERSISTENT_DATA_SIZE);
+    for (offset, &byte) in dccm.iter().enumerate() {
+        assert_eq!(
+            byte, 0,
+            "PersistentData not zeroed at offset 0x{offset:x}: got 0x{byte:02x}"
+        );
+    }
+}

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -113,7 +113,8 @@ fn test_fips_shutdown() {
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_fips_shutdown_zeroizes_persistent_data() {
-    const PERSISTENT_DATA_ADDR: u32 = caliptra_drivers::memory_layout::PERSISTENT_DATA_ORG;
+    const PERSISTENT_DATA_OFFSET: u32 = caliptra_drivers::memory_layout::PERSISTENT_DATA_ORG
+        - caliptra_drivers::memory_layout::DCCM_ORG;
     const PERSISTENT_DATA_SIZE: usize =
         caliptra_drivers::memory_layout::PERSISTENT_DATA_SIZE as usize;
 
@@ -122,7 +123,7 @@ fn test_fips_shutdown_zeroizes_persistent_data() {
     model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
 
     let nonzero = model
-        .dccm_read(PERSISTENT_DATA_ADDR, PERSISTENT_DATA_SIZE)
+        .dccm_read(PERSISTENT_DATA_OFFSET, PERSISTENT_DATA_SIZE)
         .iter()
         .any(|b| *b != 0);
     assert!(nonzero, "The persistent data was not initialized");
@@ -136,7 +137,7 @@ fn test_fips_shutdown_zeroizes_persistent_data() {
         .unwrap()
         .unwrap();
 
-    let dccm = model.dccm_read(PERSISTENT_DATA_ADDR, PERSISTENT_DATA_SIZE);
+    let dccm = model.dccm_read(PERSISTENT_DATA_OFFSET, PERSISTENT_DATA_SIZE);
     for (offset, &byte) in dccm.iter().enumerate() {
         assert_eq!(
             byte, 0,


### PR DESCRIPTION
Implement custom zeroization logic for large data structures which relies on the byte slice zeroization implemented by the zeroization crate.  This reduces instruction usage, since a single zeroization method can be called rather than recursively calling each individual field's zeroize.

This is guaranteed to be safe, since the various structures implement ZeroCopy traits which guarantee their layout as well as all 0s being a safe value.

Add a unit test to verify the data is cleared.