### PR TITLE
[nightly]: Don't run FPGA subsystem nightlies with logs

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -128,7 +128,6 @@ jobs:
         rng:
           - { name: "itrng", fpga_itrng: true, extra: "slow_tests,itrng" }
         log:
-          - { name: "log", rom_logging: true }
           - { name: "nolog", rom_logging: false }
         ocp_lock:
           - { name: "", ocp_lock: false }


### PR DESCRIPTION
We have a huge amount of subsystem jobs, and we already run PRs with logs enabled. We can reduce the amount of work by just always running the nightlies with no logs.