### PR TITLE
Add support for `SIGN_WITH_EXPORTED_MLDSA`

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -711,6 +711,7 @@ pub enum MailboxReq {
     VerifyAuthManifest(VerifyAuthManifestReq),
     AuthorizeAndStash(AuthorizeAndStashReq),
     SignWithExportedEcdsa(SignWithExportedEcdsaReq),
+    SignWithExportedMldsa(SignWithExportedMldsaReq),
     RevokeExportedCdiHandle(RevokeExportedCdiHandleReq),
     GetImageInfo(GetImageInfoReq),
     CmStatus(MailboxReqHeader),
@@ -819,6 +820,7 @@ impl MailboxReq {
             MailboxReq::VerifyAuthManifest(req) => Ok(req.as_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_bytes()),
+            MailboxReq::SignWithExportedMldsa(req) => Ok(req.as_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_bytes()),
             MailboxReq::GetImageInfo(req) => Ok(req.as_bytes()),
             MailboxReq::CmStatus(req) => Ok(req.as_bytes()),
@@ -925,6 +927,7 @@ impl MailboxReq {
             MailboxReq::VerifyAuthManifest(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::SignWithExportedMldsa(req) => Ok(req.as_mut_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_mut_bytes()),
             MailboxReq::GetImageInfo(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmStatus(req) => Ok(req.as_mut_bytes()),
@@ -1031,6 +1034,7 @@ impl MailboxReq {
             MailboxReq::VerifyAuthManifest(_) => CommandId::VERIFY_AUTH_MANIFEST,
             MailboxReq::AuthorizeAndStash(_) => CommandId::AUTHORIZE_AND_STASH,
             MailboxReq::SignWithExportedEcdsa(_) => CommandId::SIGN_WITH_EXPORTED_ECDSA,
+            MailboxReq::SignWithExportedMldsa(_) => CommandId::SIGN_WITH_EXPORTED_MLDSA,
             MailboxReq::RevokeExportedCdiHandle(_) => CommandId::REVOKE_EXPORTED_CDI_HANDLE,
             MailboxReq::GetImageInfo(_) => CommandId::GET_IMAGE_INFO,
             MailboxReq::CmStatus(_) => CommandId::CM_STATUS,
@@ -2481,13 +2485,40 @@ pub struct RevokeExportedCdiHandleResp {
     pub hdr: MailboxRespHeader,
 }
 
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MldsaSignType {
+    Mu = 0,
+    Raw = 1,
+}
+
+impl From<MldsaSignType> for u32 {
+    fn from(val: MldsaSignType) -> Self {
+        val as u32
+    }
+}
+
+impl TryFrom<u32> for MldsaSignType {
+    type Error = ();
+
+    fn try_from(val: u32) -> Result<Self, Self::Error> {
+        match val {
+            0 => Ok(MldsaSignType::Mu),
+            1 => Ok(MldsaSignType::Raw),
+            _ => Err(()),
+        }
+    }
+}
+
 // SIGN_WITH_EXPORTED_MLDSA
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct SignWithExportedMldsaReq {
     pub hdr: MailboxReqHeader,
     pub exported_cdi_handle: [u8; Self::EXPORTED_CDI_MAX_SIZE],
-    pub tbs: [u8; Self::MAX_DIGEST_SIZE],
+    pub sign_type: u32,
+    pub tbs_size: u32,
+    pub tbs: [u8; Self::MAX_TBS_SIZE],
 }
 
 impl Default for SignWithExportedMldsaReq {
@@ -2495,14 +2526,16 @@ impl Default for SignWithExportedMldsaReq {
         Self {
             hdr: MailboxReqHeader::default(),
             exported_cdi_handle: [0u8; Self::EXPORTED_CDI_MAX_SIZE],
-            tbs: [0u8; Self::MAX_DIGEST_SIZE],
+            sign_type: MldsaSignType::Mu as u32,
+            tbs_size: 0,
+            tbs: [0u8; Self::MAX_TBS_SIZE],
         }
     }
 }
 
 impl SignWithExportedMldsaReq {
     pub const EXPORTED_CDI_MAX_SIZE: usize = 32;
-    pub const MAX_DIGEST_SIZE: usize = 64;
+    pub const MAX_TBS_SIZE: usize = 1024;
 }
 
 impl Request for SignWithExportedMldsaReq {
@@ -2516,10 +2549,11 @@ pub struct SignWithExportedMldsaResp {
     pub hdr: MailboxRespHeader,
     pub derived_pubkey: [u8; Self::PUBKEY_SIZE],
     pub signature: [u8; Self::SIG_SIZE],
+    pub _padding: [u8; 1],
 }
 
 impl SignWithExportedMldsaResp {
-    pub const SIG_SIZE: usize = 4628;
+    pub const SIG_SIZE: usize = 4627;
     pub const PUBKEY_SIZE: usize = 2592;
 }
 
@@ -2531,6 +2565,7 @@ impl Default for SignWithExportedMldsaResp {
             hdr: MailboxRespHeader::default(),
             signature: [0u8; Self::SIG_SIZE],
             derived_pubkey: [0u8; Self::PUBKEY_SIZE],
+            _padding: [0u8; 1],
         }
     }
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1878,6 +1878,21 @@ impl CaliptraError {
             0x000E009B,
             "Runtime Error: Disable attestation failed during PCR validation"
         ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED,
+            0x000E009C,
+            "Runtime Error: Sign with exported MLDSA key derivation failed"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED,
+            0x000E009D,
+            "Runtime Error: Sign with exported MLDSA signature failed"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_SIGNATURE,
+            0x000E009E,
+            "Runtime Error: Sign with exported MLDSA invalid signature"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -82,6 +82,7 @@ pub use crate::hmac::Hmac;
 pub use crate::invoke_dpe::CaliptraDpeProfile;
 use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
+use crate::sign_with_exported_mldsa::SignWithExportedMldsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use activate_firmware::ActivateFirmwareCmd;
 pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
@@ -413,6 +414,9 @@ fn execute_command(
         CommandId::GET_PCR_LOG => GetPcrLogCmd::execute(drivers, resp),
         CommandId::SIGN_WITH_EXPORTED_ECDSA => {
             SignWithExportedEcdsaCmd::execute(drivers, cmd_bytes, resp)
+        }
+        CommandId::SIGN_WITH_EXPORTED_MLDSA => {
+            SignWithExportedMldsaCmd::execute(drivers, cmd_bytes, resp)
         }
         CommandId::REVOKE_EXPORTED_CDI_HANDLE => {
             RevokeExportedCdiHandleCmd::execute(drivers, cmd_bytes)

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -16,6 +16,8 @@ use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
 use caliptra_dpe_crypto::{Crypto, Mu, PubKey, SignData, Signature};
 use zerocopy::FromBytes;
 
+const PROFILE_DESC: &[u8] = b"Exported ML-DSA";
+
 pub struct SignWithExportedMldsaCmd;
 
 impl SignWithExportedMldsaCmd {
@@ -34,7 +36,7 @@ impl SignWithExportedMldsaCmd {
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
     ) -> CaliptraResult<(Signature, PubKey)> {
         let key_pair =
-            env.derive_key_pair_exported(exported_cdi_handle, b"Exported ECC", b"Exported ECC");
+            env.derive_key_pair_exported(exported_cdi_handle, PROFILE_DESC, PROFILE_DESC);
 
         cfi_check!(key_pair);
         let signer = key_pair

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,22 +1,125 @@
 // Licensed under the Apache-2.0 license
 
-use crate::Drivers;
+use crate::{dpe_crypto::DpeCrypto, mutrefbytes, Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
+
+use caliptra_common::cfi_check;
+use caliptra_common::mailbox_api::{
+    MailboxRespHeader, MldsaSignType, SignWithExportedMldsaReq, SignWithExportedMldsaResp,
+};
+use caliptra_drivers::okref;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
-#[allow(dead_code)]
+use caliptra_dpe::MAX_EXPORTED_CDI_SIZE;
+use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
+use caliptra_dpe_crypto::{Crypto, Mu, PubKey, SignData, Signature};
+use zerocopy::FromBytes;
+
 pub struct SignWithExportedMldsaCmd;
 
 impl SignWithExportedMldsaCmd {
-    #[allow(dead_code)]
+    /// SignWithExported signs a `digest` using an MLDSA keypair derived from a exported_cdi
+    /// handle and the CDI stored in DPE.
+    ///
+    /// # Arguments
+    ///
+    /// * `env` - DPE environment containing Crypto and Platform implementations
+    /// * `data` - The data to be signed
+    /// * `exported_cdi_handle` - A handle from DPE that is exchanged for a CDI.
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    fn mldsa_sign(
+        env: &mut DpeCrypto,
+        data: &SignData,
+        exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
+    ) -> CaliptraResult<(Signature, PubKey)> {
+        let key_pair =
+            env.derive_key_pair_exported(exported_cdi_handle, b"Exported ECC", b"Exported ECC");
+
+        cfi_check!(key_pair);
+        let signer = key_pair
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED)?;
+
+        let pub_key = signer.public_key();
+        let pub_key = okref(&pub_key)
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED)?;
+
+        let sig = signer.sign(data);
+        let sig = okref(&sig)
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED)?;
+
+        Ok((sig.clone(), pub_key.clone()))
+    }
+
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(
-        _drivers: &mut Drivers,
-        _cmd_args: &[u8],
-        _resp: &mut [u8],
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        // [TODO][CAP2]
-        Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_SUPPORTED)?
+        let cmd = SignWithExportedMldsaReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        match drivers.caller_privilege_level() {
+            // SIGN_WITH_EXPORTED_MLDSA MUST only be called from PL0
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+
+        let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+        let key_id_rt_priv_key = Drivers::get_key_id_rt_mldsa_keypair_seed(drivers)?;
+        let rt_pub_key = Drivers::get_key_id_rt_mldsa_pub_key(drivers)?;
+        let rt_pub_key = PubKey::Mldsa(MldsaPublicKey(rt_pub_key.into()));
+
+        let pdata = drivers.persistent_data.get_mut();
+
+        let mut crypto = DpeCrypto::new_mldsa87(
+            &mut drivers.sha2_512_384,
+            &mut drivers.trng,
+            drivers.abr.abr_reg(),
+            &mut drivers.hmac,
+            &mut drivers.key_vault,
+            rt_pub_key,
+            key_id_rt_cdi,
+            key_id_rt_priv_key,
+            &mut pdata.fw.dpe.exported_cdi_slots,
+        )?;
+
+        let sign_type = MldsaSignType::try_from(cmd.sign_type)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        let data = match sign_type {
+            MldsaSignType::Mu => {
+                if cmd.tbs_size != 64 {
+                    return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+                }
+                SignData::Mu(Mu(cmd.tbs[..64].try_into().unwrap()))
+            }
+            MldsaSignType::Raw => {
+                if cmd.tbs_size as usize > cmd.tbs.len() {
+                    return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+                }
+                SignData::Raw(&cmd.tbs[..cmd.tbs_size as usize])
+            }
+        };
+        let result = Self::mldsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle);
+        let (sig, pubkey) = okref(&result)?;
+        let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pubkey))) =
+            (sig, pubkey)
+        else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_SIGNATURE);
+        };
+
+        let resp = mutrefbytes::<SignWithExportedMldsaResp>(resp)?;
+        *resp = SignWithExportedMldsaResp {
+            hdr: MailboxRespHeader::default(),
+            derived_pubkey: *pubkey,
+            signature: *sig,
+            _padding: Default::default(),
+        };
+        Ok(core::mem::size_of::<SignWithExportedMldsaResp>())
     }
 }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -37,6 +37,7 @@ mod test_recovery_flow;
 mod test_revoke_exported_cdi_handle;
 mod test_set_auth_manifest;
 mod test_sign_with_export_ecdsa;
+mod test_sign_with_export_mldsa;
 mod test_stash_measurement;
 mod test_tagging;
 mod test_update_reset;

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_mldsa.rs
@@ -1,0 +1,807 @@
+// Licensed under the Apache-2.0 license
+
+use crate::common::{assert_error, execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs};
+use caliptra_api::{
+    mailbox::{MailboxRespHeader, RevokeExportedCdiHandleReq},
+    SocManager,
+};
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, MldsaSignType, SignWithExportedMldsaReq,
+    SignWithExportedMldsaResp,
+};
+use caliptra_dpe::{
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
+    context::ContextHandle,
+    response::{DeriveContextExportedCdiResp, NewHandleResp, Response},
+};
+use caliptra_dpe_crypto::MAX_EXPORTED_CDI_SIZE;
+use caliptra_hw_model::{HwModel, ModelError};
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus, TciMeasurement};
+use ml_dsa_01::{
+    signature::Verifier, EncodedSignature, EncodedVerifyingKey, Signature, VerifyingKey,
+};
+use x509_parser::certificate::X509Certificate;
+use x509_parser::prelude::*;
+use zerocopy::{FromBytes, IntoBytes};
+
+fn verify_mldsa_signature(
+    sig: &[u8; 4627],
+    exported_cdi_resp: &DeriveContextExportedCdiResp,
+    sign_type: MldsaSignType,
+    data: &[u8],
+) -> bool {
+    let (_, cert_parsed) = X509Certificate::from_der(
+        &exported_cdi_resp.new_certificate
+            [..exported_cdi_resp.certificate_size.try_into().unwrap()],
+    )
+    .unwrap();
+    let raw_pubkey = cert_parsed
+        .tbs_certificate
+        .subject_pki
+        .subject_public_key
+        .data;
+    let raw_pubkey: [u8; 2592] = raw_pubkey.as_ref().try_into().unwrap();
+    let encoded_vk = EncodedVerifyingKey::<ml_dsa_01::MlDsa87>::from(raw_pubkey);
+    let vk = VerifyingKey::<ml_dsa_01::MlDsa87>::decode(&encoded_vk);
+
+    let encoded_sig = EncodedSignature::<ml_dsa_01::MlDsa87>::from(*sig);
+    let sig = Signature::decode(&encoded_sig).unwrap();
+
+    match sign_type {
+        MldsaSignType::Mu => vk.verify_mu(&<[u8; 64]>::try_from(data).unwrap().into(), &sig),
+        MldsaSignType::Raw => vk.verify(data, &sig).is_ok(),
+    }
+}
+
+#[test]
+fn test_sign_with_exported_cdi_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let derive_resp = match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+}
+
+#[test]
+fn test_sign_with_exported_incorrect_cdi_handle_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let get_cert_chain_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&get_cert_chain_cmd),
+        DpeResult::Success,
+    );
+
+    match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFF; MAX_EXPORTED_CDI_SIZE],
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_eq!(
+        result.unwrap_err(),
+        ModelError::MailboxCmdFailed(
+            caliptra_drivers::CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED.into(),
+        )
+    );
+}
+
+#[test]
+fn test_sign_with_exported_never_derived_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFF; MAX_EXPORTED_CDI_SIZE],
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_eq!(
+        result.unwrap_err(),
+        ModelError::MailboxCmdFailed(
+            caliptra_drivers::CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED.into(),
+        )
+    );
+}
+
+#[test]
+fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT
+            | DeriveContextFlags::ALLOW_RECURSIVE,
+        ..Default::default()
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("expected derive context resp!")
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &original_cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+
+    let measurement_cmd = DeriveContextCmd {
+        data: TciMeasurement([0xa; caliptra_dpe::TCI_SIZE]),
+        flags: DeriveContextFlags::RECURSIVE,
+        tci_type: if model.subsystem_mode() {
+            u32::from_be_bytes(*b"MCFW")
+        } else {
+            u32::from_be_bytes(*b"CCIV")
+        },
+        ..Default::default()
+    };
+
+    let _ = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&measurement_cmd),
+        DpeResult::Success,
+    );
+
+    let Some(Response::Error(e)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::DpeCmdFailure,
+    ) else {
+        panic!("Expected the second export cdi command to fail.")
+    };
+    assert_eq!(
+        e.status,
+        caliptra_dpe::response::DpeErrorCode::Crypto(
+            caliptra_dpe_crypto::CryptoError::ExportedCdiHandleDuplicateCdi
+        )
+        .get_error_code()
+    );
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &original_cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+}
+
+#[test]
+fn test_sign_with_exported_cdi_measurement_update_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT
+            | DeriveContextFlags::ALLOW_RECURSIVE,
+        ..Default::default()
+    };
+
+    let Some(Response::DeriveContextExportedCdi(original_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("expected derive context resp!")
+    };
+
+    let measurement_cmd = DeriveContextCmd {
+        data: TciMeasurement([0xa; caliptra_dpe::TCI_SIZE]),
+        flags: DeriveContextFlags::RECURSIVE,
+        tci_type: if model.subsystem_mode() {
+            u32::from_be_bytes(*b"MCFW")
+        } else {
+            u32::from_be_bytes(*b"CCIV")
+        },
+        ..Default::default()
+    };
+
+    let _ = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&measurement_cmd),
+        DpeResult::Success,
+    );
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: original_cdi_resp.exported_cdi,
+    });
+    cmd.populate_chksum().unwrap();
+
+    match model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    ) {
+        Ok(_) => (),
+        Err(e) => panic!("REVOKE_EXPORTED_CDI_HANDLE failed with {:?}", e),
+    }
+
+    let Some(Response::DeriveContextExportedCdi(updated_cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("expected derive context resp!")
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: updated_cdi_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+    // The original CDI was revoked.
+    assert!(!verify_mldsa_signature(
+        &sign_resp.signature,
+        &original_cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &updated_cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+    assert_ne!(original_cdi_resp, updated_cdi_resp);
+    assert_ne!(
+        original_cdi_resp.exported_cdi,
+        updated_cdi_resp.exported_cdi
+    );
+    assert_ne!(
+        original_cdi_resp.new_certificate,
+        updated_cdi_resp.new_certificate
+    );
+}
+
+#[test]
+fn test_sign_with_revoked_exported_cdi_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        ..Default::default()
+    };
+
+    let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("expected derive context resp!")
+    };
+
+    let mut sign_cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: cdi_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    sign_cmd.populate_chksum().unwrap();
+
+    let result = model
+        .mailbox_execute(
+            CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+            sign_cmd.as_bytes().unwrap(),
+        )
+        .expect("SIGN_WITH_EXPORTED_MLDSA should not fail until the handle is revoked")
+        .unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(result.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+
+    let mut revoke_cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: cdi_resp.exported_cdi,
+    });
+    revoke_cmd.populate_chksum().unwrap();
+
+    match model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        revoke_cmd.as_bytes().unwrap(),
+    ) {
+        Ok(_) => (),
+        Err(e) => panic!("REVOKE_EXPORTED_CDI_HANDLE failed with {:?}", e),
+    }
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        sign_cmd.as_bytes().unwrap(),
+    );
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVIATION_FAILED,
+        result.err().unwrap(),
+    );
+}
+
+#[test]
+fn test_sign_with_disabled_attestation_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let export_cdi_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+        ..Default::default()
+    };
+
+    let Some(Response::DeriveContextExportedCdi(cdi_resp)) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&export_cdi_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("expected derive context resp!")
+    };
+
+    let mut sign_cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: cdi_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    sign_cmd.populate_chksum().unwrap();
+
+    let result = model
+        .mailbox_execute(
+            CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+            sign_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(result.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    let result = model
+        .mailbox_execute(
+            CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+            sign_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(result.as_bytes()).unwrap();
+    // Signature is still valid in terms of structure, but we can't verify it against the old cert.
+    // We just check that it completes successfully.
+    assert!(!verify_mldsa_signature(
+        &sign_resp.signature,
+        &cdi_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+}
+
+#[test]
+fn test_sign_with_exported_cdi_warm_reset_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        security_state: Some(
+            *caliptra_hw_model::SecurityState::default()
+                .set_device_lifecycle(caliptra_hw_model::DeviceLifecycle::Production)
+                .set_debug_locked(true),
+        ),
+        ..Default::default()
+    });
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let derive_resp = match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+
+    // Wait for command to finish
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().mailbox_flow_done());
+
+    // Triggering a warm reset while a command is being processed will disable attestation.
+    for _ in 0..1000 {
+        model.step();
+    }
+
+    model.warm_reset_flow().unwrap();
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+}
+
+#[test]
+fn test_sign_with_exported_cdi_warm_reset_parent_mldsa() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        security_state: Some(
+            *caliptra_hw_model::SecurityState::default()
+                .set_device_lifecycle(caliptra_hw_model::DeviceLifecycle::Production)
+                .set_debug_locked(true),
+        ),
+        ..Default::default()
+    });
+
+    // Rotate out the default handle so we can make multiple descendants.
+    let rotate_ctx_cmd = caliptra_dpe::commands::RotateCtxCmd {
+        handle: ContextHandle::default(),
+        flags: caliptra_dpe::commands::RotateCtxFlags::empty(),
+    };
+
+    let Some(Response::RotateCtx(NewHandleResp { handle, .. })) = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::RotateCtx(&rotate_ctx_cmd),
+        DpeResult::Success,
+    ) else {
+        panic!("Failed to rotate context!");
+    };
+
+    // Derive a new context and retain the parent.
+    // We will export the parent. We expect that the child prevents the dpe context chain from being destroyed.
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle,
+        flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+        tci_type: 1,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let Some(Response::DeriveContext(caliptra_dpe::response::DeriveContextResp {
+        parent_handle,
+        ..
+    })) = resp
+    else {
+        panic!("expected derive context resp!");
+    };
+
+    // Export the parent context from the last derive command.
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: parent_handle,
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 2,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let derive_resp = match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+
+    // Wait for command to finish
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().mailbox_flow_done());
+
+    // Triggering a warm reset while a command is being processed will disable attestation.
+    for _ in 0..1000 {
+        model.step();
+    }
+
+    model.warm_reset_flow().unwrap();
+
+    // Wait for boot
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Mu.into(),
+        tbs_size: 64,
+        tbs: [0u8; 1024],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Mu,
+        &[0u8; 64]
+    ));
+}
+
+#[test]
+fn test_sign_with_exported_cdi_mldsa_raw() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+
+    let derive_resp = match resp {
+        Some(Response::DeriveContextExportedCdi(resp)) => resp,
+        _ => panic!("expected derive context resp!"),
+    };
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: derive_resp.exported_cdi,
+        sign_type: MldsaSignType::Raw.into(),
+        tbs_size: 100,
+        tbs: {
+            let mut tbs = [0u8; 1024];
+            tbs[..100].copy_from_slice(&[0xa; 100]);
+            tbs
+        },
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let response = result.unwrap().unwrap();
+    let sign_resp = SignWithExportedMldsaResp::ref_from_bytes(response.as_bytes()).unwrap();
+    assert!(verify_mldsa_signature(
+        &sign_resp.signature,
+        &derive_resp,
+        MldsaSignType::Raw,
+        &[0xa; 100]
+    ));
+}


### PR DESCRIPTION
This adds similar functionality to `SIGN_WITH_EXPORTED_ECDSA`, but with ML-DSA-87. This adds similar tests to the legacy version as well.