### PR TITLE
fix(emulator): correct flow status handling in soc_reg

### DIFF
--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1217,7 +1217,7 @@ impl SocRegistersImpl {
         // READY_FOR_FUSES (bit 30) is HW-driven and read-only per spec.
         // Preserve this bit across SW writes to match RTL behavior.
         const READY_FOR_FUSES_MASK: u32 = 1 << 30;
-        
+
         let current = self.cptra_flow_status.reg.get();
         let preserved = current & READY_FOR_FUSES_MASK;
 

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -1214,8 +1214,17 @@ impl SocRegistersImpl {
             Err(BusError::StoreAccessFault)?
         }
 
+        // READY_FOR_FUSES (bit 30) is HW-driven and read-only per spec.
+        // Preserve this bit across SW writes to match RTL behavior.
+        const READY_FOR_FUSES_MASK: u32 = 1 << 30;
+        
+        let current = self.cptra_flow_status.reg.get();
+        let preserved = current & READY_FOR_FUSES_MASK;
+
+        let new_val = (val & !READY_FOR_FUSES_MASK) | preserved;
+
         // Set the flow status register.
-        self.cptra_flow_status.reg.set(val);
+        self.cptra_flow_status.reg.set(new_val);
 
         // If ready_for_fw bit is set, run the op_fn_write_complete_cb.
         if self.cptra_flow_status.reg.is_set(FlowStatus::READY_FOR_FW) {


### PR DESCRIPTION

The ready_for_fuses bit is driven by hardware (Boot FSM) and should not be overwritten
by software writes in the emulator.

Previously, writes to the SOC register would overwrite all bits, including
ready_for_fuses. This resulted in incorrect behavior where firmware could
observe the bit being cleared unintentionally.

This change preserves the ready_for_fuses bit during register writes by:
- retaining the existing value of the bit from the current register state
- applying all other bits from the incoming write value

This aligns emulator behavior with RTL, where ready_for_fuses is hardware-driven.