### PR TITLE
[fix] Address-based authorize-and-stash measurement

### DIFF
--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -81,6 +81,7 @@ impl AuthorizeAndStashCmd {
         let auth_manifest_image_metadata_col = &persistent_data.fw.auth_manifest_image_metadata_col;
 
         let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
+        let mut stash_measurement = cmd.measurement;
         let auth_result = if let Some(metadata_entry) =
             find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id)
         {
@@ -121,6 +122,7 @@ impl AuthorizeAndStashCmd {
                     .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?
                     .into();
                 if cfi_launder(metadata_entry.digest) == measurement {
+                    stash_measurement = measurement;
                     caliptra_cfi_lib::cfi_assert_eq_12_words(
                         &Array4x12::from(metadata_entry.digest).0,
                         &Array4x12::from(measurement).0,
@@ -142,7 +144,7 @@ impl AuthorizeAndStashCmd {
                 let dpe_result = StashMeasurementCmd::stash_measurement(
                     drivers,
                     &cmd.fw_id,
-                    &cmd.measurement,
+                    &stash_measurement,
                     cmd.svn,
                     drivers.caller_privilege_level(),
                     locality,

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -13,8 +13,8 @@ use caliptra_auth_man_types::{
 use caliptra_builder::firmware::APP_WITH_UART;
 use caliptra_builder::{firmware::FMC_WITH_UART, ImageOptions};
 use caliptra_common::mailbox_api::{
-    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
-    MailboxReqHeader, SetAuthManifestReq,
+    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetTaggedTciReq, GetTaggedTciResp,
+    ImageHashSource, MailboxReq, MailboxReqHeader, SetAuthManifestReq, TagTciReq,
 };
 use caliptra_hw_model::{DefaultHwModel, HwModel};
 use caliptra_image_types::FwVerificationPqcKeyType;
@@ -38,6 +38,7 @@ pub const IMAGE_DIGEST_BAD: [u8; 48] = [
 pub const FW_ID_1: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
 pub const FW_ID_2: [u8; 4] = [0x02, 0x00, 0x00, 0x00];
 pub const FW_ID_BAD: [u8; 4] = [0xDE, 0xED, 0xBE, 0xEF];
+const AUTH_AND_STASH_TCI_TAG: u32 = 0x4154_5348;
 
 #[cfg(feature = "fpga_subsystem")]
 pub const TEST_SRAM_SIZE: usize = 0x1000;
@@ -1107,6 +1108,37 @@ fn write_to_test_sram(model: &mut DefaultHwModel, address: Addr64, data: &[u8]) 
     }
 }
 
+fn tag_and_get_default_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
+    let mut tag_cmd = MailboxReq::TagTci(TagTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        handle: [0u8; 16],
+        tag: AUTH_AND_STASH_TCI_TAG,
+    });
+    tag_cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_TAG_TCI),
+            tag_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let mut get_cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        tag: AUTH_AND_STASH_TCI_TAG,
+    });
+    get_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_GET_TAGGED_TCI),
+            get_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap()
+}
+
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_authorize_from_load_address() {
@@ -1118,12 +1150,12 @@ fn test_authorize_from_load_address() {
 
     let mut hasher = Sha384::new();
     hasher.update(load_memory_contents);
-    let fw_digest = hasher.finalize();
+    let fw_digest: [u8; 48] = hasher.finalize().into();
 
     let image_metadata = AuthManifestImageMetadata {
         fw_id: u32::from_le_bytes(FW_ID_1),
         flags: flags.0,
-        digest: fw_digest.into(),
+        digest: fw_digest,
         image_load_address: Addr64 {
             lo: TEST_SRAM_BASE.lo,
             hi: TEST_SRAM_BASE.hi,
@@ -1170,6 +1202,9 @@ fn test_authorize_from_load_address() {
 
     let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
+
+    let tagged_tci = tag_and_get_default_tci(&mut model);
+    assert_eq!(tagged_tci.tci_current, fw_digest);
 }
 
 #[cfg_attr(feature = "fpga_realtime", ignore)]
@@ -1240,12 +1275,12 @@ fn test_authorize_from_staging_address() {
 
     let mut hasher = Sha384::new();
     hasher.update(load_memory_contents);
-    let fw_digest = hasher.finalize();
+    let fw_digest: [u8; 48] = hasher.finalize().into();
 
     let image_metadata = AuthManifestImageMetadata {
         fw_id: u32::from_le_bytes(FW_ID_1),
         flags: flags.0,
-        digest: fw_digest.into(),
+        digest: fw_digest,
         image_staging_address: Addr64 {
             lo: TEST_SRAM_BASE.lo,
             hi: TEST_SRAM_BASE.hi,
@@ -1285,6 +1320,9 @@ fn test_authorize_from_staging_address() {
 
     let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
+
+    let tagged_tci = tag_and_get_default_tci(&mut model);
+    assert_eq!(tagged_tci.tci_current, fw_digest);
 }
 
 #[cfg_attr(feature = "fpga_realtime", ignore)]


### PR DESCRIPTION
Fix AUTHORIZE_AND_STASH so LoadAddress and StagingAddress requests stash the SHA-384 digest computed and verified by Caliptra, rather than the caller-provided measurement from the request.

InRequest behavior is unchanged. Regression coverage now reads back the DPE TCI after address-based authorization and verifies it matches the computed digest.