### PR TITLE
[fix] Reference the correct response for `CmEcdsaSignReq`

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -4734,7 +4734,7 @@ impl CmEcdsaSignReq {
 
 impl Request for CmEcdsaSignReq {
     const ID: CommandId = CommandId::CM_ECDSA_SIGN;
-    type Resp = CmMldsaSignResp;
+    type Resp = CmEcdsaSignResp;
 }
 
 #[repr(C)]


### PR DESCRIPTION
The implementation for the `Request` trait for `CmEcdsaSignReq` was incorrectly referencing `CmMldsaSignResp`. This fixes it.