### PR TITLE
[fix] Bind debug unlock token to device UDI

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-602ffeec3a70a86b0df1510c72c03c58b19a20ceb01864a024aa326d0abe05dc58ef8c204b1456769327200796c933ca  caliptra-rom-no-log.bin
-baeaebcaeed31422491c274205d28b3987c6fbddf9963c9228c7863e70fbcbf169d94b4159dc1287d398fb86bcdd7928  caliptra-rom-with-log.bin
+74e8f78d5a151a7c937cb83565aa0af808fe8c558a0b1287ed3780bc0e2656287ed1ea5fdbfe1b2ed9e5c42e58eba7d2  caliptra-rom-no-log.bin
+5e098276e2f07506a9dd51077c2c77e0b31a37ec6cf5dce4bd268f47e44745fd8bd30a827bf5c38a0f3321b3e71fb7d4  caliptra-rom-with-log.bin

--- a/common/src/debug_unlock.rs
+++ b/common/src/debug_unlock.rs
@@ -18,10 +18,10 @@ use caliptra_api::mailbox::{
     MailboxReqHeader, MailboxRespHeader, ProductionAuthDebugUnlockChallenge,
     ProductionAuthDebugUnlockReq, ProductionAuthDebugUnlockToken,
 };
-use caliptra_cfi_lib::{cfi_assert_eq_12_words, cfi_launder};
+use caliptra_cfi_lib::{cfi_assert_eq_12_words, cfi_assert_eq_8_words, cfi_launder};
 use caliptra_drivers::{
-    sha2_512_384::Sha2DigestOpTrait, Array4x12, Array4x16, AxiAddr, Dma, Ecc384, Ecc384PubKey,
-    Ecc384Result, Ecc384Scalar, Ecc384Signature, LEArray4x16, Mldsa87, Mldsa87PubKey,
+    sha2_512_384::Sha2DigestOpTrait, Array4x12, Array4x16, Array4x8, AxiAddr, Dma, Ecc384,
+    Ecc384PubKey, Ecc384Result, Ecc384Scalar, Ecc384Signature, LEArray4x16, Mldsa87, Mldsa87PubKey,
     Mldsa87Result, Mldsa87Signature, Sha2_512_384, Sha2_512_384Acc, ShaAccLockState, SocIfc,
     StreamEndianness, Trng,
 };
@@ -139,6 +139,17 @@ pub fn validate_debug_unlock_token(
         cfi_assert_eq_12_words(
             &Array4x12::from(token.challenge).0,
             &Array4x12::from(challenge.challenge).0,
+        );
+    }
+
+    // Check if the token is bound to this device.
+    if cfi_launder(token.unique_device_identifier) != challenge.unique_device_identifier {
+        crate::cprintln!("Unique device identifier mismatch");
+        Err(CaliptraError::SS_DBG_UNLOCK_PROD_INVALID_TOKEN_CHALLENGE)?;
+    } else {
+        cfi_assert_eq_8_words(
+            &Array4x8::from(token.unique_device_identifier).0,
+            &Array4x8::from(challenge.unique_device_identifier).0,
         );
     }
 

--- a/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
+++ b/runtime/tests/runtime_integration_tests/test_debug_unlock.rs
@@ -544,6 +544,200 @@ fn test_dbg_unlock_prod_invalid_token_challenge() {
 }
 
 #[test]
+#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+fn test_dbg_unlock_prod_invalid_token_udi() {
+    let signing_ecc_key = p384::ecdsa::SigningKey::random(&mut StdRng::from_entropy());
+    let verifying_ecc_key = VerifyingKey::from(&signing_ecc_key);
+    let ecc_pub_key_bytes = {
+        let mut pk = [0; 96];
+        let ecc_key = verifying_ecc_key.to_encoded_point(false);
+        pk[..48].copy_from_slice(ecc_key.x().unwrap());
+        pk[48..].copy_from_slice(ecc_key.y().unwrap());
+        pk
+    };
+
+    let ecc_pub_key = u8_to_u32_be(&ecc_pub_key_bytes);
+    let ecc_pub_key_bytes = ecc_pub_key.as_bytes();
+
+    let (verifying_mldsa_key, signing_mldsa_key) = fips204::ml_dsa_87::try_keygen().unwrap();
+    let mldsa_pub_key_bytes = verifying_mldsa_key.into_bytes();
+
+    let mldsa_pub_key = u8_to_u32_le(&mldsa_pub_key_bytes);
+    let mldsa_pub_key_bytes = mldsa_pub_key.as_bytes();
+
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    let image_info = vec![
+        ImageInfo::new(
+            StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
+            CodeRange::new(ROM_ORG, ROM_ORG + ROM_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(FMC_ORG, FMC_ORG + FMC_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(RUNTIME_ORG, RUNTIME_ORG + RUNTIME_SIZE),
+        ),
+    ];
+
+    let unlock_level = 5u8;
+    let mut prod_dbg_unlock_keypairs: Vec<(&[u8; 96], &[u8; 2592])> =
+        vec![(&[0; 96], &[0; 2592]); 8];
+    prod_dbg_unlock_keypairs[(unlock_level - 1) as usize] = (
+        ecc_pub_key_bytes.try_into().unwrap(),
+        mldsa_pub_key_bytes.try_into().unwrap(),
+    );
+
+    let init_params = InitParams {
+        rom: &rom,
+        security_state,
+        prod_dbg_unlock_keypairs,
+        debug_intent: true,
+        subsystem_mode: true,
+        stack_info: Some(StackInfo::new(image_info)),
+        ..Default::default()
+    };
+
+    let mcu_fw = vec![1, 2, 3, 4];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata(metadata);
+    let soc_manifest = soc_manifest.as_bytes();
+
+    let runtime_args = RuntimeTestArgs {
+        init_params: Some(init_params),
+        soc_manifest: Some(soc_manifest),
+        mcu_fw_image: Some(&mcu_fw),
+        ..Default::default()
+    };
+
+    let mut model = run_rt_test(runtime_args);
+
+    model
+        .soc_ifc()
+        .ss_dbg_service_reg_req()
+        .write(|w| w.prod_dbg_unlock_req(true));
+
+    let request = ProductionAuthDebugUnlockReq {
+        length: {
+            let req_len = size_of::<ProductionAuthDebugUnlockReq>() - size_of::<MailboxReqHeader>();
+            (req_len / size_of::<u32>()) as u32
+        },
+        unlock_level,
+        ..Default::default()
+    };
+    let checksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ),
+        &request.as_bytes()[4..],
+    );
+    let request = ProductionAuthDebugUnlockReq {
+        hdr: MailboxReqHeader { chksum: checksum },
+        ..request
+    };
+    let resp = model
+        .mailbox_execute(
+            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_REQ.into(),
+            request.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+
+    let challenge = ProductionAuthDebugUnlockChallenge::read_from_bytes(resp.as_slice()).unwrap();
+    let token_udi = [0xA5u8; 32];
+    assert_ne!(token_udi, challenge.unique_device_identifier);
+
+    let reserved = [0u8; 3];
+
+    let mut sha384 = sha2::Sha384::new();
+    sha384.update(token_udi);
+    sha384.update([unlock_level]);
+    sha384.update(reserved);
+    sha384.update(challenge.challenge);
+    let sha384_digest = sha384.finalize();
+    let (ecc_signature, _id) = signing_ecc_key
+        .sign_prehash_recoverable(sha384_digest.as_slice())
+        .unwrap();
+    let ecc_signature = ecc_signature.to_bytes();
+    let ecc_signature = ecc_signature.as_slice();
+    let ecc_signature = u8_to_u32_be(ecc_signature);
+
+    let mut sha512 = sha2::Sha512::new();
+    sha512.update(token_udi);
+    sha512.update([unlock_level]);
+    sha512.update(reserved);
+    sha512.update(challenge.challenge);
+    let sha512_digest = sha512.finalize();
+
+    let mldsa_signature = signing_mldsa_key
+        .try_sign_with_seed(&[0; 32], &sha512_digest, &[])
+        .unwrap();
+    let mldsa_signature = {
+        let mut sig = [0; 4628];
+        sig[..4627].copy_from_slice(&mldsa_signature);
+        u8_to_u32_le(&sig)
+    };
+
+    let token = ProductionAuthDebugUnlockToken {
+        length: {
+            let req_len =
+                size_of::<ProductionAuthDebugUnlockToken>() - size_of::<MailboxReqHeader>();
+            (req_len / size_of::<u32>()) as u32
+        },
+        unique_device_identifier: token_udi,
+        unlock_level,
+        challenge: challenge.challenge,
+        ecc_public_key: ecc_pub_key.try_into().unwrap(),
+        mldsa_public_key: mldsa_pub_key.try_into().unwrap(),
+        ecc_signature: ecc_signature.try_into().unwrap(),
+        mldsa_signature: mldsa_signature.try_into().unwrap(),
+        ..Default::default()
+    };
+    let checksum = caliptra_common::checksum::calc_checksum(
+        u32::from(CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN),
+        &token.as_bytes()[4..],
+    );
+    let token = ProductionAuthDebugUnlockToken {
+        hdr: MailboxReqHeader { chksum: checksum },
+        ..token
+    };
+
+    assert_eq!(
+        model.mailbox_execute(
+            CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN.into(),
+            token.as_bytes(),
+        ),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::SS_DBG_UNLOCK_PROD_INVALID_TOKEN_CHALLENGE.into()
+        ))
+    );
+
+    model.step_until(|m| {
+        let resp = m.soc_ifc().ss_dbg_service_reg_rsp().read();
+        !resp.prod_dbg_unlock_in_progress()
+    });
+
+    assert!(model
+        .soc_ifc()
+        .ss_dbg_service_reg_rsp()
+        .read()
+        .prod_dbg_unlock_fail());
+}
+
+#[test]
 fn test_dbg_unlock_prod_wrong_public_keys() {
     let signing_ecc_key = p384::ecdsa::SigningKey::random(&mut StdRng::from_entropy());
     let verifying_ecc_key = VerifyingKey::from(&signing_ecc_key);


### PR DESCRIPTION
Reject production debug unlock tokens whose unique device identifier does not match the UDI returned in the challenge. This ensures a token signed for one device cannot be replayed against another device with a matching nonce.