### PR TITLE
Fix stable owner tests with 2.1 ROM

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-3befdf9287ced84ee193c4f960841919cc37a21647143671f61dbebcc252355dc643340edb456a69d83a6ad01c314fef  caliptra-rom-no-log.bin
-bbbc22da3331d2c8af8961f5db5123cdcd4dd7c1ee9d152bb296ad1effb0ea4e4f9f531e2923e268a943dd4cac69cae8  caliptra-rom-with-log.bin
+602ffeec3a70a86b0df1510c72c03c58b19a20ceb01864a024aa326d0abe05dc58ef8c204b1456769327200796c933ca  caliptra-rom-no-log.bin
+baeaebcaeed31422491c274205d28b3987c6fbddf9963c9228c7863e70fbcbf169d94b4159dc1287d398fb86bcdd7928  caliptra-rom-with-log.bin

--- a/api/src/capabilities.rs
+++ b/api/src/capabilities.rs
@@ -20,6 +20,8 @@ bitflags::bitflags! {
         const ROM_BASE = 0b1;
         // ROM and hardware support for OCP LOCK
         const ROM_OCP_LOCK = 0b1 << 1;
+        // ROM and hardware support for Stable Owner Key
+        const ROM_STABLE_OWNER_KEY = 0b1 << 2;
         // Represents base capabilities present in Caliptra Runtime v1.0
         const RT_BASE = 0b1 << 64;
         // RT firmware and hardware supports OCP LOCK

--- a/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/capabilities.rs
@@ -44,6 +44,10 @@ impl CapabilitiesCmd {
             capabilities |= Capabilities::ROM_OCP_LOCK;
         }
 
+        if soc_ifc.stable_owner_key_available() {
+            capabilities |= Capabilities::ROM_STABLE_OWNER_KEY;
+        }
+
         capabilities_resp.hdr = MailboxRespHeader::default();
         capabilities_resp.capabilities = capabilities.to_bytes();
         let resp_bytes = capabilities_resp.as_bytes();

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -6,8 +6,8 @@ use crate::common::{assert_error, run_rt_test, start_rt_test_pqc_model, RuntimeT
 use aes::Aes256;
 use aes_gcm::{aead::AeadMutInPlace, Key};
 use caliptra_api::mailbox::{
-    populate_checksum, CmAesDecryptInitReq, CmAesDecryptUpdateReq, CmAesEncryptInitReq,
-    CmAesEncryptInitResp, CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq,
+    populate_checksum, CapabilitiesResp, CmAesDecryptInitReq, CmAesDecryptUpdateReq,
+    CmAesEncryptInitReq, CmAesEncryptInitResp, CmAesEncryptInitRespHeader, CmAesEncryptUpdateReq,
     CmAesGcmDecryptFinalReq, CmAesGcmDecryptFinalResp, CmAesGcmDecryptFinalRespHeader,
     CmAesGcmDecryptInitReq, CmAesGcmDecryptInitResp, CmAesGcmDecryptUpdateReq,
     CmAesGcmDecryptUpdateResp, CmAesGcmDecryptUpdateRespHeader, CmAesGcmEncryptFinalReq,
@@ -30,7 +30,7 @@ use caliptra_api::mailbox::{
     CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_SHAKE256_CONTEXT_SIZE, CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE,
     MLKEM1024_ENCAPS_KEY_SIZE, SHAKE256_MAX_DIGEST_BYTE_SIZE,
 };
-use caliptra_api::SocManager;
+use caliptra_api::{Capabilities, SocManager};
 use caliptra_drivers::AES_BLOCK_SIZE_BYTES;
 use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, SubsystemInitParams, TrngMode};
 use caliptra_image_types::FwVerificationPqcKeyType;
@@ -57,6 +57,19 @@ const HW_MODEL_MODES_SUBSYSTEM: [bool; 1] = [true];
 const HW_MODEL_MODES_SUBSYSTEM: [bool; 1] = [false];
 #[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
 const HW_MODEL_MODES_SUBSYSTEM: [bool; 2] = [false, true];
+
+fn rom_stable_owner_key_available(model: &mut DefaultHwModel) -> bool {
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::CAPABILITIES), &[]),
+    };
+    let response = model
+        .mailbox_execute(CommandId::CAPABILITIES.into(), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let capabilities_resp = CapabilitiesResp::ref_from_bytes(response.as_bytes()).unwrap();
+    let capabilities = Capabilities::try_from(capabilities_resp.capabilities.as_bytes()).unwrap();
+    capabilities.contains(Capabilities::ROM_STABLE_OWNER_KEY)
+}
 
 #[test]
 fn test_status() {
@@ -2958,6 +2971,11 @@ fn test_derive_stable_key_from_rom() {
             }
             model.step_until(|m| m.ready_for_fw());
 
+            if key_type == CmStableKeyType::OwnerKey && !rom_stable_owner_key_available(&mut model)
+            {
+                continue;
+            }
+
             let mut derive_request = MailboxReq::CmDeriveStableKey(CmDeriveStableKeyReq {
                 key_type: key_type.into(),
                 ..Default::default()
@@ -3127,6 +3145,10 @@ fn test_derive_stable_owner_key_different_info() {
         }
         model.step_until(|m| m.ready_for_fw());
 
+        if !rom_stable_owner_key_available(&mut model) {
+            continue;
+        }
+
         // Derive with info_a
         let info_a = [0x42u8; 32];
         let mut derive_request = MailboxReq::CmDeriveStableKey(CmDeriveStableKeyReq {
@@ -3291,8 +3313,9 @@ fn test_derive_keys_from_stable_owner_key() {
         if !subsystem_mode {
             continue;
         }
-        let (mut model, _image_bundle) = start_rt_test_pqc_model(
+        let (mut model, image_bundle) = start_rt_test_pqc_model(
             RuntimeTestArgs {
+                stop_at_rom: true,
                 subsystem_mode,
                 stable_owner_key_en: true,
                 ..Default::default()
@@ -3303,6 +3326,15 @@ fn test_derive_keys_from_stable_owner_key() {
         if subsystem_mode != model.subsystem_mode() {
             continue;
         }
+        model.step_until(|m| m.ready_for_fw());
+
+        if !rom_stable_owner_key_available(&mut model) {
+            continue;
+        }
+
+        let fw_image = image_bundle.to_bytes().unwrap();
+        crate::common::test_upload_firmware(&mut model, &fw_image, FwVerificationPqcKeyType::LMS);
+
         model.step_until(|m| {
             m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
         });


### PR DESCRIPTION
Gate Stable Owner Key runtime tests on the ROM capability bit so they skip OwnerKey paths when running against the frozen 2.1 ROM.