### PR TITLE
[OCP-LOCK]: Update OCP LOCK key ladder to use DOE

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-370340183716a684540b1e7e9136d59af3ae4354a84f8ae7171c5854a17e76ab6f856894b2ce102bab4e88a0dd41f635  caliptra-rom-no-log.bin
-a6d0ad9e6dfe82fc8f3683c2a105c683ee7950434137e17c4d6526cf502601f4610b5177b2637cc7675013d9a75ca146  caliptra-rom-with-log.bin
+7976b87943b9e31d0026a3c8998e530cdcf3925e57da99d61d7ad50e7e89fe7c826c6607962d2050618b02ed9fec808d  caliptra-rom-no-log.bin
+dbd9b6898873223047a3578bab1afbb037f39aed8e12a65d60520fa922730d4e0e61df206a6d8c68a59793fa5aaf0414  caliptra-rom-with-log.bin

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -153,6 +153,10 @@ const DOE_TEST_VECTORS_DEBUG_MODE: DoeTestVectors = DoeTestVectors {
             0xaaaa_aaaa,
             0xaaaa_aaaa,
         ],
+        hek_seed: [
+            2860620551, 2304452848, 871097381, 3924343081, 1815452837, 1480756109, 2219727310,
+            3486118852,
+        ],
     },
 
     // The expected results of the HMAC operations performed by the test.
@@ -214,6 +218,7 @@ fn test_generate_doe_vectors_when_debug_not_locked() {
 
         // In debug mode, this defaults to 0xaaaa_aaaa
         keyvault_initial_word_value: 0xaaaa_aaaa,
+        hek_seed: [0u32; 8],
     });
     assert_eq!(vectors, DOE_TEST_VECTORS_DEBUG_MODE);
 }
@@ -251,6 +256,10 @@ const DOE_TEST_VECTORS: DoeTestVectors = DoeTestVectors {
         field_entropy: [
             0x3d75d35e, 0xbc44a31e, 0xad27aee5, 0x75cdd170, 0xe51dcaf4, 0x09c096ae, 0xa70ff448,
             0x64834722, 0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        ],
+        hek_seed: [
+            3923443814, 3838548747, 818996002, 3631880110, 795805636, 902969462, 2272616137,
+            4267400515,
         ],
     },
     expected_test_results: DoeTestResults {
@@ -309,6 +318,7 @@ fn test_generate_doe_vectors_when_debug_locked() {
 
         // in debug-locked mode, this defaults to 0
         keyvault_initial_word_value: 0x0000_0000,
+        hek_seed: [0u32; 8],
     });
     assert_eq!(vectors, DOE_TEST_VECTORS);
 }

--- a/hw-model/types/src/lib.rs
+++ b/hw-model/types/src/lib.rs
@@ -23,6 +23,8 @@ pub const DEFAULT_FIELD_ENTROPY: [u32; 8] = [
     0x80818283, 0x84858687, 0x88898a8b, 0x8c8d8e8f, 0x90919293, 0x94959697, 0x98999a9b, 0x9c9d9e9f,
 ];
 
+pub const DEFAULT_HEK_SEED: [u32; 8] = [0xABDEu32; 8];
+
 pub const DEFAULT_CPTRA_OBF_KEY: [u32; 8] = [
     0xa0a1a2a3, 0xb0b1b2b3, 0xc0c1c2c3, 0xd0d1d2d3, 0xe0e1e2e3, 0xf0f1f2f3, 0xa4a5a6a7, 0xb4b5b6b7,
 ];

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -38,7 +38,7 @@ use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 /// Initialization Vector used by Deobfuscation Engine during UDS / field entropy decryption.
-const DOE_IV: Array4x4 = Array4xN::<4, 16>([0xfb10365b, 0xa1179741, 0xfba193a1, 0x0f406d7e]);
+pub const DOE_IV: Array4x4 = Array4xN::<4, 16>([0xfb10365b, 0xa1179741, 0xfba193a1, 0x0f406d7e]);
 
 /// Label used for HKDF-Extract (salt) and HKDF-Expand (info) when deriving the Stable Owner Root Key.
 const STABLE_OWNER_ROOT_KEY_LABEL: &[u8] = b"stable_owner_root_key";
@@ -81,6 +81,12 @@ impl InitDevIdLayer {
 
         // Derive Stable Owner Root Key from HEK seed (if enabled).
         Self::derive_stable_owner_root_key(env)?;
+
+        // The OCP LOCK flow requires the HEK seed to be extracted using the DOE.
+        // This must be done BEFORE we clear the DOE secrets below.
+        if env.soc_ifc.ocp_lock_enabled() {
+            env.doe.decrypt_hek_seed(&DOE_IV, KEY_ID_HEK_SEED)?;
+        }
 
         // Clear Deobfuscation Engine Secrets
         Self::clear_doe_secrets(env)?;

--- a/rom/dev/src/flow/cold_reset/ocp_lock.rs
+++ b/rom/dev/src/flow/cold_reset/ocp_lock.rs
@@ -11,17 +11,15 @@ use caliptra_common::{
     crypto::Crypto,
     keyids::{
         ocp_lock::{KEY_ID_HEK, KEY_ID_MDK},
-        KEY_ID_ROM_FMC_CDI,
+        KEY_ID_HEK_SEED, KEY_ID_ROM_FMC_CDI, KEY_ID_TMP,
     },
 };
 use caliptra_drivers::{
-    Array4x8, CaliptraResult, HekSeedState, HmacMode, KeyUsage, KeyVault, Lifecycle,
-    PersistentData, SocIfc,
+    Array4x8, CaliptraResult, HekSeedState, HmacData, HmacKey, HmacMode, KeyReadArgs, KeyUsage,
+    KeyVault, Lifecycle, PersistentData, SocIfc,
 };
 
 use crate::rom_env::RomEnv;
-
-use zerocopy::IntoBytes;
 
 /// Run the OCP LOCK Cold Reset flow
 ///
@@ -48,17 +46,41 @@ pub fn ocp_lock_cold_reset_flow(env: &mut RomEnv) -> CaliptraResult<()> {
 /// * `env` - ROM Environment
 #[cfg_attr(feature = "cfi", cfi_mod_fn)]
 fn derive_hek(env: &mut RomEnv) -> CaliptraResult<()> {
-    let hek_seed = env.soc_ifc.fuse_bank().ocp_hek_seed();
-    Crypto::hmac_kdf(
-        &mut env.hmac,
-        &mut env.trng,
-        KEY_ID_ROM_FMC_CDI,
-        b"ocp_lock_hek",
-        Some(hek_seed.as_bytes()),
-        KEY_ID_HEK,
-        HmacMode::Hmac512,
-        KeyUsage::default().set_hmac_key_en(),
-    )?;
+    // HKDF-Extract — HMAC(key=CDI, data=HEK_seed_in_KV)
+    let result = (|| -> CaliptraResult<()> {
+        env.hmac.hmac(
+            HmacKey::Key(KeyReadArgs::new(KEY_ID_ROM_FMC_CDI)),
+            HmacData::Key(KeyReadArgs::new(KEY_ID_HEK_SEED)),
+            &mut env.trng,
+            caliptra_drivers::HmacTag::Key(caliptra_drivers::KeyWriteArgs::new(
+                KEY_ID_TMP,
+                KeyUsage::default().set_hmac_key_en(),
+            )),
+            HmacMode::Hmac512,
+        )?;
+
+        // HKDF-Expand — HMAC-KDF(key=PRK, label) -> HEK
+        Crypto::hmac_kdf(
+            &mut env.hmac,
+            &mut env.trng,
+            KEY_ID_TMP,
+            b"ocp_lock_hek",
+            None,
+            KEY_ID_HEK,
+            HmacMode::Hmac512,
+            KeyUsage::default().set_hmac_key_en(),
+        )?;
+        Ok(())
+    })();
+
+    // Always erase the temporary keys
+    let erase_result1 = env.key_vault.erase_key(KEY_ID_HEK_SEED);
+    let erase_result2 = env.key_vault.erase_key(KEY_ID_TMP);
+
+    result?;
+    erase_result1?;
+    erase_result2?;
+
     Ok(())
 }
 

--- a/rom/dev/tests/rom_integration_tests/test_ocp_lock.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ocp_lock.rs
@@ -26,27 +26,27 @@ fn test_hek_seed_states() {
         DeviceLifecycle::Production,
         &[HekSeedState::Programmed, HekSeedState::ProgrammedEmpty],
         true,
-        [0xABDEu32; 8],
+        caliptra_hw_model_types::DEFAULT_HEK_SEED,
     );
     // Test PROD HEK seed states that disallow HEK usage
     hek_seed_state_helper(
         DeviceLifecycle::Production,
         &[HekSeedState::Unavailable],
         false,
-        [0xABDEu32; 8],
+        caliptra_hw_model_types::DEFAULT_HEK_SEED,
     );
     // Manufacturing and Unprovisioned LC should allow HEK usage in all HEK seed states.
     hek_seed_state_helper(
         DeviceLifecycle::Manufacturing,
         ALL_HEK_SEED_STATES,
         true,
-        [0xABDEu32; 8],
+        caliptra_hw_model_types::DEFAULT_HEK_SEED,
     );
     hek_seed_state_helper(
         DeviceLifecycle::Unprovisioned,
         ALL_HEK_SEED_STATES,
         true,
-        [0xABDEu32; 8],
+        caliptra_hw_model_types::DEFAULT_HEK_SEED,
     );
     // A programmed HEK seed cannot be all zeros
     hek_seed_state_helper(

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_derive_mek.rs
@@ -38,7 +38,7 @@ static EXPECTED_MEK: LazyLock<Mek> = LazyLock::new(|| {
     let doe_out = DoeOutput::generate(&DoeInput::default());
     OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32])
         .derive_mek()
 });
@@ -79,7 +79,7 @@ fn test_derive_mek_mix_mpk_hitless_update() {
     let doe_out = DoeOutput::generate(&DoeInput::default());
     let mut builder = OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32]);
 
     let mpks = mix_mpk_flow(&mut model, &mut builder, None);
@@ -95,7 +95,7 @@ fn test_derive_mek_mix_mpk_hitless_update() {
 
     let mut new_builder = OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32]);
 
     mix_mpk_flow(&mut model, &mut new_builder, Some(&mpks));
@@ -327,7 +327,7 @@ fn test_derive_mek_mix_mpk() {
     let doe_out = DoeOutput::generate(&DoeInput::default());
     let mut builder = OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32]);
 
     for _ in 0..3 {
@@ -498,7 +498,7 @@ fn test_derive_mek_debug_unlocked() {
     let debug_unlocked_doe_out = DoeOutput::generate(&DoeInput::debug_unlocked());
     let expected_debug_unlocked_mek = OcpLockKeyLadderBuilder::new(debug_unlocked_doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32])
         .derive_mek();
 

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_generate_mpk.rs
@@ -25,7 +25,7 @@ static KEY_LADDER: LazyLock<OcpLockKeyLadderBuilder> = LazyLock::new(|| {
     // * Same HEK
     // * Same DPK / SEK
     let doe_out = DoeOutput::generate(&DoeInput::default());
-    OcpLockKeyLadderBuilder::new(doe_out).add_hek([0xABDEu32; 8])
+    OcpLockKeyLadderBuilder::new(doe_out).add_hek()
 });
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
@@ -27,7 +27,7 @@ fn generate_test_mek() -> (Mek, WrappedKey) {
     let doe_out = DoeOutput::generate(&DoeInput::default());
     OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32])
         .generate_and_wrap_mek()
 }

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rewrap_mpk.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_rewrap_mpk.rs
@@ -24,7 +24,7 @@ static KEY_LADDER: LazyLock<OcpLockKeyLadderBuilder> = LazyLock::new(|| {
     // * Same HEK
     // * Same DPK / SEK
     let doe_out = DoeOutput::generate(&DoeInput::default());
-    OcpLockKeyLadderBuilder::new(doe_out).add_hek([0xABDEu32; 8])
+    OcpLockKeyLadderBuilder::new(doe_out).add_hek()
 });
 
 #[test]

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -45,6 +45,9 @@ pub struct DoeInput {
     // The field entropy, as stored in the fuses
     pub field_entropy_seed: [u32; 8],
 
+    // The HEK seed, as stored in the fuses
+    pub hek_seed: [u32; 8],
+
     // The initial value of key-vault entry words at startup
     pub keyvault_initial_word_value: u32,
 }
@@ -57,6 +60,8 @@ impl Default for DoeInput {
 
             uds_seed: caliptra_hw_model_types::DEFAULT_UDS_SEED,
             field_entropy_seed: caliptra_hw_model_types::DEFAULT_FIELD_ENTROPY,
+
+            hek_seed: caliptra_hw_model_types::DEFAULT_HEK_SEED,
 
             // in debug-locked mode, this defaults to 0
             keyvault_initial_word_value: 0x0000_0000,
@@ -74,6 +79,8 @@ impl DoeInput {
             uds_seed: [0xffff_ffff_u32; 16],
             field_entropy_seed: [0xffff_ffff_u32; 8],
 
+            hek_seed: [0xffff_ffff_u32; 8],
+
             // In debug mode, this defaults to 0xaaaa_aaaa
             keyvault_initial_word_value: 0xaaaa_aaaa,
         }
@@ -87,6 +94,9 @@ pub struct DoeOutput {
 
     // The decrypted field entropy as stored in the key vault (with padding)
     pub field_entropy: [u32; 12],
+
+    // The decrypted HEK seed as stored in the key vault
+    pub hek_seed: [u32; 8],
 }
 impl DoeOutput {
     /// A standalone implementation of the cryptographic operations necessary to
@@ -115,6 +125,8 @@ impl DoeOutput {
             // used as a HMAC key, but not when used as HMAC
             // data).
             field_entropy: [input.keyvault_initial_word_value; 12],
+
+            hek_seed: [0_u32; 8],
         };
 
         result
@@ -135,6 +147,16 @@ impl DoeOutput {
                 swap_word_bytes(&input.field_entropy_seed).as_bytes(),
             ));
         swap_word_bytes_inplace(&mut result.field_entropy);
+
+        result
+            .hek_seed
+            .as_mut_bytes()
+            .copy_from_slice(&aes256_decrypt_blocks(
+                swap_word_bytes(&input.doe_obf_key).as_bytes(),
+                swap_word_bytes(&input.doe_iv).as_bytes(),
+                swap_word_bytes(&input.hek_seed).as_bytes(),
+            ));
+        swap_word_bytes_inplace(&mut result.hek_seed);
 
         result
     }
@@ -158,6 +180,7 @@ fn test_doe_output() {
             0x690aaee2,
         ],
         keyvault_initial_word_value: 0x5555_5555,
+        ..Default::default()
     });
     assert_eq!(
         output,
@@ -170,7 +193,8 @@ fn test_doe_output() {
             field_entropy: [
                 437386532, 405572964, 972652519, 2702758929, 92052297, 1822317414, 295423989,
                 3895283936, 1431655765, 1431655765, 1431655765, 1431655765
-            ]
+            ],
+            hek_seed: output.hek_seed,
         }
     );
 }
@@ -282,17 +306,7 @@ pub struct OcpLockKeyLadderBuilder {
     hek: Option<[u32; 16]>,
     mdk: Option<[u32; 16]>,
     intermediate_mek_secret: Option<[u32; 16]>,
-}
-
-impl From<IDevId> for OcpLockKeyLadderBuilder {
-    fn from(value: IDevId) -> Self {
-        Self {
-            cdi: value.cdi,
-            hek: None,
-            mdk: None,
-            intermediate_mek_secret: None,
-        }
-    }
+    hek_seed: [u32; 8],
 }
 
 impl OcpLockKeyLadderBuilder {
@@ -303,15 +317,19 @@ impl OcpLockKeyLadderBuilder {
             hek: None,
             mdk: None,
             intermediate_mek_secret: None,
+            hek_seed: output.hek_seed,
         }
     }
 
-    pub fn add_hek(self, hek_seed: [u32; 8]) -> Self {
-        let mut hek: [u32; 16] = transmute!(hmac512_kdf(
+    pub fn add_hek(self) -> Self {
+        // PRK = HMAC(key=CDI, data=HEK_seed)
+        let prk: [u8; 64] = hmac512(
             swap_word_bytes(&self.cdi).as_bytes(),
-            b"ocp_lock_hek",
-            Some(hek_seed.as_bytes()),
-        ));
+            swap_word_bytes(&self.hek_seed).as_bytes(),
+        );
+
+        // HEK = KDF(key=PRK, label="ocp_lock_hek")
+        let mut hek: [u32; 16] = transmute!(hmac512_kdf(&prk, b"ocp_lock_hek", None,));
         swap_word_bytes_inplace(&mut hek);
         Self {
             hek: Some(hek),
@@ -504,28 +522,28 @@ fn test_golden_ocp_lock_keyladder() {
         ]
     );
 
-    let mek = OcpLockKeyLadderBuilder::from(generated_idevid)
+    let mek = OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .add_intermediate_mek_secret([0xAB; 32], [0xCD; 32])
         .derive_mek();
     assert_eq!(
         mek.checksum,
-        [208, 2, 161, 131, 8, 80, 187, 246, 107, 90, 21, 150, 58, 194, 61, 52]
+        [70, 6, 214, 126, 147, 72, 126, 46, 90, 212, 113, 85, 217, 193, 150, 182]
     );
     assert_eq!(
         mek.mek,
         [
-            94, 152, 39, 23, 80, 241, 238, 103, 219, 79, 3, 73, 159, 38, 155, 127, 106, 161, 12,
-            18, 56, 249, 187, 171, 151, 33, 80, 177, 43, 88, 170, 232, 206, 234, 175, 214, 95, 181,
-            46, 96, 36, 178, 8, 146, 11, 219, 238, 52, 72, 59, 214, 205, 102, 183, 43, 144, 0, 226,
-            80, 160, 212, 180, 219, 171
+            235, 114, 154, 59, 138, 17, 5, 205, 58, 53, 45, 24, 253, 200, 171, 74, 184, 17, 186,
+            43, 158, 48, 110, 1, 106, 105, 191, 44, 46, 195, 83, 105, 195, 151, 38, 91, 1, 134, 10,
+            187, 197, 219, 237, 98, 58, 38, 97, 163, 221, 220, 4, 83, 33, 23, 201, 172, 223, 16,
+            12, 7, 240, 156, 227, 208
         ]
     );
 
-    let mpk = OcpLockKeyLadderBuilder::from(generated_idevid)
+    let mpk = OcpLockKeyLadderBuilder::new(doe_out)
         .add_mdk()
-        .add_hek([0xABDEu32; 8])
+        .add_hek()
         .decrypt_locked_mpk(
             [0xAB; 32],
             &[0xAE; 32],
@@ -542,11 +560,11 @@ fn test_golden_ocp_lock_keyladder() {
                     254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
                 ],
                 ct: vec![
-                    218, 219, 239, 125, 175, 23, 17, 207, 15, 19, 221, 63, 30, 192, 234, 45, 254,
-                    19, 63, 27, 63, 108, 28, 203, 11, 102, 222, 203, 23, 224, 168, 152,
+                    220, 72, 67, 131, 218, 104, 31, 1, 0, 121, 122, 88, 196, 75, 47, 119, 64, 143,
+                    219, 79, 14, 166, 252, 194, 5, 93, 16, 186, 49, 62, 36, 62,
                 ],
                 tag: vec![
-                    226, 113, 183, 232, 106, 130, 197, 42, 62, 30, 165, 176, 39, 85, 213, 122,
+                    204, 1, 194, 66, 137, 31, 1, 218, 227, 93, 26, 217, 118, 178, 120, 93,
                 ],
             },
         );
@@ -573,6 +591,7 @@ fn test_idevid() {
             0xdbca1cfa, 0x149c0355, 0x7ee48ddb, 0xb022238b, 0x057c9b49, 0x6c9e5b66, 0x119bcff5,
             0xe82d50e0, 0x55555555, 0x55555555, 0x55555555, 0x55555555,
         ],
+        hek_seed: [0u32; 8],
     });
     assert_eq!(
         idevid,
@@ -653,6 +672,7 @@ fn test_ldevid() {
             0xdbca1cfa, 0x149c0355, 0x7ee48ddb, 0xb022238b, 0x057c9b49, 0x6c9e5b66, 0x119bcff5,
             0xe82d50e0, 0x55555555, 0x55555555, 0x55555555, 0x55555555,
         ],
+        hek_seed: [0u32; 8],
     });
     assert_eq!(
         ldevid,


### PR DESCRIPTION
- Updated ROM to use DOE for HEK seed deobfuscation to comply with HW spec.
- Implemented two-step HKDF for HEK derivation because DOE secrets can only be used as data.
- Updated tests in `derive.rs` to match new ladder.

Resolves chipsalliance/caliptra-sw#3584

NOTE:

- The OCP LOCK flow from earlier IS STILL SECURE.
- This ROM creates a different HEK to previous versions.
