### PR TITLE
ROM: verify firmware after loading to ICCM

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-74e8f78d5a151a7c937cb83565aa0af808fe8c558a0b1287ed3780bc0e2656287ed1ea5fdbfe1b2ed9e5c42e58eba7d2  caliptra-rom-no-log.bin
-5e098276e2f07506a9dd51077c2c77e0b31a37ec6cf5dce4bd268f47e44745fd8bd30a827bf5c38a0f3321b3e71fb7d4  caliptra-rom-with-log.bin
+2c7e08db9ea8cd7612369b44645f1f5f68e153278fe8651720d3c730f857d5add642f2cee9f8955a28067e2d9ee4d7c3  caliptra-rom-no-log.bin
+d5ce1c369e9a7a2016f4fb3ef9d69eeb2d614463b26021d1a4515fa168b7c395ef68ba347af3ffa39ec3175639359d19  caliptra-rom-with-log.bin

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -218,8 +218,9 @@ impl FirmwareProcessor {
         )?;
         report_boot_status(FwProcessorExtendPcrComplete.into());
 
-        // Load the image
+        // Load the image, then verify the loaded ICCM contents against the manifest in DCCM.
         Self::load_image(manifest, txn.as_deref_mut(), &mut env.soc_ifc, &mut env.dma)?;
+        crate::flow::loaded_image::verify_fmc_and_runtime(manifest, &mut env.sha2_512_384)?;
 
         // Complete the mailbox transaction indicating success.
         if let Some(ref mut txn) = txn {

--- a/rom/dev/src/flow/loaded_image.rs
+++ b/rom/dev/src/flow/loaded_image.rs
@@ -1,0 +1,74 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    loaded_image.rs
+
+Abstract:
+
+    File contains helpers for verifying firmware after it has been loaded.
+
+--*/
+
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_mod_fn;
+use caliptra_drivers::{CaliptraResult, Sha2_512_384};
+use caliptra_error::CaliptraError;
+use caliptra_image_types::{ImageManifest, ImageTocEntry};
+
+/// Verify the FMC and runtime images after they have been loaded into ICCM.
+#[cfg_attr(feature = "cfi", cfi_mod_fn)]
+pub(super) fn verify_fmc_and_runtime(
+    manifest: &ImageManifest,
+    sha2_512_384: &mut Sha2_512_384,
+) -> CaliptraResult<()> {
+    verify_entry(
+        &manifest.fmc,
+        sha2_512_384,
+        CaliptraError::IMAGE_VERIFIER_ERR_FMC_DIGEST_FAILURE,
+        CaliptraError::IMAGE_VERIFIER_ERR_FMC_DIGEST_MISMATCH,
+    )?;
+    verify_runtime(manifest, sha2_512_384)
+}
+
+/// Verify the runtime image after it has been loaded into ICCM.
+#[cfg_attr(feature = "cfi", cfi_mod_fn)]
+pub(super) fn verify_runtime(
+    manifest: &ImageManifest,
+    sha2_512_384: &mut Sha2_512_384,
+) -> CaliptraResult<()> {
+    verify_entry(
+        &manifest.runtime,
+        sha2_512_384,
+        CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_FAILURE,
+        CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH,
+    )
+}
+
+/// Verify one loaded image entry against its manifest digest.
+#[cfg_attr(feature = "cfi", cfi_mod_fn)]
+fn verify_entry(
+    entry: &ImageTocEntry,
+    sha2_512_384: &mut Sha2_512_384,
+    digest_failure: CaliptraError,
+    digest_mismatch: CaliptraError,
+) -> CaliptraResult<()> {
+    // SAFETY: Image verification has already validated that this entry's load range is
+    // entirely within ICCM and that the entry size is non-zero. ROM has just copied this
+    // range into ICCM, so it is valid to read it as bytes for the post-copy digest check.
+    let image =
+        unsafe { core::slice::from_raw_parts(entry.load_addr as *const u8, entry.size as usize) };
+    let actual = sha2_512_384
+        .sha384_digest(image)
+        .map_err(|_| digest_failure)?
+        .0;
+
+    if entry.digest != actual {
+        Err(digest_mismatch)?;
+    }
+    caliptra_cfi_lib::cfi_assert_eq_12_words(&entry.digest, &actual);
+
+    Ok(())
+}

--- a/rom/dev/src/flow/mod.rs
+++ b/rom/dev/src/flow/mod.rs
@@ -16,6 +16,7 @@ mod cold_reset;
 pub mod debug_unlock;
 #[cfg(feature = "fake-rom")]
 mod fake;
+mod loaded_image;
 pub(crate) mod uds_programming;
 mod update_reset;
 mod warm_reset;

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -172,6 +172,9 @@ impl UpdateResetFlow {
                 &mut env.dma,
                 staging_addr,
             )?;
+            crate::flow::loaded_image::verify_runtime(&manifest, &mut env.sha2_512_384)?;
+            // Complete only after the loaded ICCM contents have been verified.
+            recv_txn.complete(true)?;
             Ok(())
         };
         if let Err(e) = process_txn() {
@@ -267,8 +270,6 @@ impl UpdateResetFlow {
         } else {
             Self::load_image_from_mbox(manifest, txn)?;
         }
-        // Call the complete here to reset the execute bit
-        txn.complete(true)?;
         Ok(())
     }
 


### PR DESCRIPTION
Add a post-copy digest check for firmware loaded into ICCM. Cold boot now
verifies the loaded FMC and runtime images against the firmware manifest
stored in DCCM before completing firmware processing. Update reset verifies
the loaded runtime image before reporting success.

This is a bug fix and defense-in-depth improvement: the image was already
verified before copying, but this also detects corruption during transfer
into ICCM.

Related: chipsalliance/caliptra-sw#817