### PR TITLE
[fix] `ActivateFirmware` to call `AuthorizeAndStash` correctly

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -1289,7 +1289,7 @@ pub trait HwModel: SocManager {
 
         if self.subsystem_mode() && buf.len() > api::mailbox::SUBSYSTEM_MAILBOX_SIZE_LIMIT {
             // Write payload to staging area
-            let staging_addr = self.write_payload_to_ss_staging_area(buf)?;
+            let staging_addr = self.write_payload_to_ss_staging_area(buf, 0)?;
 
             // Create external mailbox command
             let external_cmd = api::mailbox::ExternalMailboxCmdReq {
@@ -1388,12 +1388,20 @@ pub trait HwModel: SocManager {
     }
 
     /// Upload payload to external MCU SRAM
-    fn write_payload_to_ss_staging_area(&mut self, _payload: &[u8]) -> Result<u64, ModelError> {
+    fn write_payload_to_ss_staging_area(
+        &mut self,
+        _payload: &[u8],
+        _offset: usize,
+    ) -> Result<u64, ModelError> {
         Err(ModelError::SubsystemSramError)
     }
 
     /// Read payload from external MCU SRAM staging area
-    fn read_payload_from_ss_staging_area(&mut self, _length: usize) -> Result<Vec<u8>, ModelError> {
+    fn read_payload_from_ss_staging_area(
+        &mut self,
+        _length: usize,
+        _offset: usize,
+    ) -> Result<Vec<u8>, ModelError> {
         Err(ModelError::SubsystemSramError)
     }
 
@@ -1539,7 +1547,7 @@ pub trait HwModel: SocManager {
         let cmk = cm_import_resp.cmk.clone();
 
         // Step 3: Write ciphertext to staging area and get the AXI address
-        let mcu_sram_addr = self.write_payload_to_ss_staging_area(ciphertext)?;
+        let mcu_sram_addr = self.write_payload_to_ss_staging_area(ciphertext, 0)?;
 
         // Step 4: Build and send CM_AES_GCM_DECRYPT_DMA request
         let decrypt_req = CmAesGcmDecryptDmaReq {
@@ -1669,6 +1677,11 @@ pub trait HwModel: SocManager {
     /// Get OCP LOCK Info
     fn ocp_lock_state(&mut self) -> Option<OcpLockState> {
         None
+    }
+
+    /// Get MCI BusMmio
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        panic!("mci unimplemented");
     }
 }
 

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -45,18 +45,27 @@ use crate::OcpLockState;
 use crate::Output;
 use crate::TrngMode;
 
+const EMULATOR_MCI_ADDR: u32 = 0x2100_0000;
+const EMULATOR_MCI_ADDR_RANGE_SIZE: u32 = 0xe0_0000;
+const EMULATOR_MCI_END_ADDR: u32 = EMULATOR_MCI_ADDR + EMULATOR_MCI_ADDR_RANGE_SIZE - 1;
+
 pub struct EmulatedApbBus<'a> {
     model: &'a mut ModelEmulated,
 }
 
 impl Bus for EmulatedApbBus<'_> {
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
-        let result = self.model.soc_to_caliptra_bus.read(size, addr);
+        let (result, name) = match addr {
+            EMULATOR_MCI_ADDR..=EMULATOR_MCI_END_ADDR => {
+                (self.model.mci.read(size, addr - EMULATOR_MCI_ADDR), "MCI")
+            }
+            _ => (self.model.soc_to_caliptra_bus.read(size, addr), "SoC"),
+        };
         self.model
             .cpu
             .bus
             .inner_mut()
-            .log_read("SoC", size, addr, result);
+            .log_read(name, size, addr, result);
         result
     }
     fn write(
@@ -65,12 +74,18 @@ impl Bus for EmulatedApbBus<'_> {
         addr: RvAddr,
         val: RvData,
     ) -> Result<(), caliptra_emu_bus::BusError> {
-        let result = self.model.soc_to_caliptra_bus.write(size, addr, val);
+        let (result, name) = match addr {
+            EMULATOR_MCI_ADDR..=EMULATOR_MCI_END_ADDR => (
+                self.model.mci.write(size, addr - EMULATOR_MCI_ADDR, val),
+                "MCI",
+            ),
+            _ => (self.model.soc_to_caliptra_bus.write(size, addr, val), "SoC"),
+        };
         self.model
             .cpu
             .bus
             .inner_mut()
-            .log_write("SoC", size, addr, val, result);
+            .log_write(name, size, addr, val, result);
         result
     }
 }
@@ -335,6 +350,18 @@ impl HwModel for ModelEmulated {
         EmulatedApbBus { model: self }
     }
 
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        if !self.subsystem_mode() {
+            panic!("Tried to use the MCI interface in Core only mode")
+        }
+        unsafe {
+            caliptra_registers::mci::RegisterBlock::new_with_mmio(
+                EMULATOR_MCI_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
+    }
+
     fn step(&mut self) {
         if self.cpu_enabled.get() {
             self.cpu.step(self.trace_fn.as_deref_mut());
@@ -536,10 +563,22 @@ impl HwModel for ModelEmulated {
         Ok(AxiRootBus::mcu_sram_offset())
     }
 
-    fn write_payload_to_ss_staging_area(&mut self, payload: &[u8]) -> Result<u64, ModelError> {
+    fn write_payload_to_ss_staging_area(
+        &mut self,
+        payload: &[u8],
+        offset: usize,
+    ) -> Result<u64, ModelError> {
         if !self.subsystem_mode() {
             return Err(ModelError::SubsystemSramError);
         }
+        assert!(
+            offset % 4 == 0,
+            "Staging area offset must be 4-byte aligned"
+        );
+        assert!(
+            payload.len() % 4 == 0,
+            "Payload length must be a multiple of 4"
+        );
 
         let payload_len = payload.len();
         self.cpu
@@ -550,20 +589,24 @@ impl HwModel for ModelEmulated {
             .axi
             .mcu_sram
             .data_mut()
-            .get_mut(..payload_len)
+            .get_mut(offset..offset + payload_len)
             .ok_or(ModelError::SubsystemSramError)?
             .copy_from_slice(payload);
-        self.staging_physical_address()
+        Ok(self.staging_physical_address()? + offset as u64)
     }
 
-    fn read_payload_from_ss_staging_area(&mut self, length: usize) -> Result<Vec<u8>, ModelError> {
+    fn read_payload_from_ss_staging_area(
+        &mut self,
+        length: usize,
+        offset: usize,
+    ) -> Result<Vec<u8>, ModelError> {
         if !self.subsystem_mode() {
             return Err(ModelError::SubsystemSramError);
         }
 
         let mcu_sram_data = self.cpu.bus.inner_mut().bus.dma.axi.mcu_sram.data();
         let payload = mcu_sram_data
-            .get(..length)
+            .get(offset..offset + length)
             .ok_or(ModelError::SubsystemSramError)?
             .to_vec();
         Ok(payload)

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -225,7 +225,7 @@ pub struct Mci {
 }
 
 impl Mci {
-    pub fn regs(&self) -> caliptra_registers::mci::RegisterBlock<BusMmio<FpgaRealtimeBus<'_>>> {
+    pub fn regs<'a>(&self) -> caliptra_registers::mci::RegisterBlock<BusMmio<FpgaRealtimeBus<'a>>> {
         unsafe {
             caliptra_registers::mci::RegisterBlock::new_with_mmio(
                 EMULATOR_MCI_ADDR as *mut u32,
@@ -1804,6 +1804,10 @@ impl HwModel for ModelFpgaSubsystem {
         }
     }
 
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        self.mmio.mci().unwrap().regs()
+    }
+
     fn step(&mut self) {
         self.handle_log();
         self.handle_flash();
@@ -2414,8 +2418,20 @@ impl HwModel for ModelFpgaSubsystem {
         Ok(mci_base_addr + 0xc00000)
     }
 
-    fn write_payload_to_ss_staging_area(&mut self, payload: &[u8]) -> Result<u64, ModelError> {
-        let staging_offset = 0xc00000_usize / 4; // Convert to u32 offset since mci.ptr is *mut u32
+    fn write_payload_to_ss_staging_area(
+        &mut self,
+        payload: &[u8],
+        offset: usize,
+    ) -> Result<u64, ModelError> {
+        assert!(
+            offset % 4 == 0,
+            "Staging area offset must be 4-byte aligned"
+        );
+        assert!(
+            payload.len() % 4 == 0,
+            "Payload length must be a multiple of 4"
+        );
+        let staging_offset = (0xc00000_usize + offset) / 4; // Convert to u32 offset since mci.ptr is *mut u32
         let staging_ptr = unsafe { self.mmio.mci().unwrap().ptr.add(staging_offset) };
 
         // Write complete u32 chunks
@@ -2432,12 +2448,20 @@ impl HwModel for ModelFpgaSubsystem {
             }
         }
 
-        // Return the physical address of the staging area
-        self.staging_physical_address()
+        // Return the physical address of the staging area + offset
+        Ok(self.staging_physical_address()? + offset as u64)
     }
 
-    fn read_payload_from_ss_staging_area(&mut self, len: usize) -> Result<Vec<u8>, ModelError> {
-        let staging_offset = 0xc00000_usize / 4; // Convert to u32 offset since mci.ptr is *mut u32
+    fn read_payload_from_ss_staging_area(
+        &mut self,
+        len: usize,
+        offset: usize,
+    ) -> Result<Vec<u8>, ModelError> {
+        assert!(
+            offset % 4 == 0,
+            "Staging area offset must be 4-byte aligned"
+        );
+        let staging_offset = (0xc00000_usize + offset) / 4; // Convert to u32 offset since mci.ptr is *mut u32
         let staging_ptr = unsafe { self.mmio.mci().unwrap().ptr.add(staging_offset) };
 
         let mut result = Vec::with_capacity(len);

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -348,10 +348,6 @@ impl HwModel for ModelVerilated {
         tx
     }
 
-    fn write_payload_to_ss_staging_area(&mut self, _payload: &[u8]) -> Result<u64, ModelError> {
-        Err(ModelError::SubsystemSramError)
-    }
-
     fn fuses(&self) -> &Fuses {
         &self.fuses
     }
@@ -448,14 +444,6 @@ impl ModelVerilated {
     fn events_to_caliptra(&mut self) -> mpsc::Sender<Event> {
         let (tx, _rx) = mpsc::channel();
         tx
-    }
-
-    fn write_payload_to_ss_staging_area(&mut self, _payload: &[u8]) -> Result<u64, ModelError> {
-        Err(ModelError::SubsystemSramError)
-    }
-
-    fn read_payload_from_ss_staging_area(&mut self, _len: usize) -> Result<Vec<u8>, ModelError> {
-        Err(ModelError::SubsystemSramError)
     }
 
     fn fuses(&self) -> &Fuses {

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use core::mem::offset_of;
 
-use crate::authorize_and_stash::AuthorizeAndStashCmd;
+use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
 use crate::drivers::{McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
@@ -286,6 +286,7 @@ impl ActivateFirmwareCmd {
                 measurement: [0; 48],
                 source: ImageHashSource::LoadAddress.into(),
                 flags: AuthAndStashFlags::SKIP_STASH.bits(),
+                image_size: mcu_image_size,
                 ..Default::default()
             };
 
@@ -296,13 +297,17 @@ impl ActivateFirmwareCmd {
                 .manifest1
                 .header
                 .pl0_pauser;
-            AuthorizeAndStashCmd::authorize_and_stash(
+            let authorization_result = AuthorizeAndStashCmd::authorize_and_stash(
                 drivers,
                 &auth_and_stash_req,
                 pl0_pauser_locality,
             )
-            .map(|_| ())
             .map_err(|_| ())?;
+
+            // Make sure the image was properly authorized.
+            if authorization_result != authorize_and_stash::IMAGE_AUTHORIZED {
+                return Err(());
+            }
 
             drivers.persistent_data.get_mut().fw.mcu_firmware_loaded = McuFwStatus::Loaded.into();
         } else if mcu_activate_requested && initial_activate {

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -532,7 +532,7 @@ pub fn execute_dpe_cmd_raw(
         resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
     } else {
         let resp = model
-            .read_payload_from_ss_staging_area(size_of::<InvokeDpeResp>())
+            .read_payload_from_ss_staging_area(size_of::<InvokeDpeResp>(), 0)
             .unwrap();
         resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
         check_header_checksum(resp_hdr.as_bytes_partial().unwrap()).unwrap();

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -1,7 +1,8 @@
 // Licensed under the Apache-2.0 license
-use crate::test_authorize_and_stash::set_auth_manifest_with_test_sram;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 use caliptra_api::mailbox::{ActivateFirmwareFlags, ActivateFirmwareReq};
+use caliptra_api::SocManager;
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
 use caliptra_common::checksum::calc_checksum;
@@ -9,7 +10,8 @@ use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
     MailboxReqHeader,
 };
-use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, ModelError};
+use caliptra_kat::CaliptraError;
 use caliptra_runtime::IMAGE_AUTHORIZED;
 use sha2::{Digest, Sha384};
 use zerocopy::{FromBytes, IntoBytes};
@@ -36,25 +38,13 @@ pub const MCU_FW_ID_1: u32 = 0x2;
 pub const SOC_FW_ID_1: u32 = 0x3;
 pub const INVALID_FW_ID: u32 = 128;
 
-pub const MCU_LOAD_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo,
-    hi: 0x0000_0000,
-};
+pub const MCU_LOAD_OFFSET: usize = 0x000;
 
-pub const MCU_STAGING_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x200,
-    hi: 0x0000_0000,
-};
+pub const MCU_STAGING_OFFSET: usize = 0x200;
 
-pub const SOC_LOAD_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x100,
-    hi: 0x0000_0000,
-};
+pub const SOC_LOAD_OFFSET: usize = 0x100;
 
-pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x300,
-    hi: 0x0000_0000,
-};
+pub const SOC_STAGING_OFFSET: usize = 0x300;
 
 pub const MCU_FW_SIZE: usize = 256;
 pub const SOC_FW_SIZE: usize = 256;
@@ -62,57 +52,95 @@ pub const SOC_FW_SIZE: usize = 256;
 #[derive(Debug, Clone)]
 struct Image {
     pub fw_id: u32,
-    pub staging_address: Addr64,
-    pub load_address: Addr64,
+    pub staging_offset: usize,
+    pub load_offset: usize,
     pub exec_bit: u8,
     pub contents: Vec<u8>,
 }
 
 fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
+    let staging_addr = caliptra_hw_model::new_unbooted(InitParams {
+        subsystem_mode: true,
+        ..Default::default()
+    })
+    .unwrap()
+    .staging_physical_address()
+    .unwrap();
+
     let mut image_metadata = Vec::new();
-    let mut test_sram_contents = vec![0u8; TEST_SRAM_SIZE];
     for image in images {
         let mut flags = ImageMetadataFlags(0);
         flags.set_ignore_auth_check(false);
         flags.set_image_source(ImageHashSource::StagingAddress as u32);
         flags.set_exec_bit(image.exec_bit as u32);
 
-        let load_memory_contents = image.contents.clone();
-
         let mut hasher = Sha384::new();
-        hasher.update(load_memory_contents);
+        hasher.update(&image.contents);
         let fw_digest = hasher.finalize();
+
+        let image_staging_address = Addr64 {
+            lo: staging_addr as u32 + image.staging_offset as u32,
+            hi: (staging_addr >> 32) as u32,
+        };
+
+        let image_load_address = Addr64 {
+            lo: staging_addr as u32 + image.load_offset as u32,
+            hi: (staging_addr >> 32) as u32,
+        };
 
         image_metadata.push(AuthManifestImageMetadata {
             fw_id: image.fw_id,
             flags: flags.0,
             digest: fw_digest.into(),
-            image_staging_address: image.staging_address,
-            image_load_address: image.load_address,
+            image_staging_address,
+            image_load_address,
             ..Default::default()
         });
-
-        // Load the firmware contents into the staging area in test SRAM
-        let staging_address = image.staging_address.lo as usize - TEST_SRAM_BASE.lo as usize;
-        let image_size = image.contents.len();
-        assert!(staging_address + image_size <= TEST_SRAM_SIZE);
-        test_sram_contents[staging_address..staging_address + image_size]
-            .copy_from_slice(&image.contents);
     }
 
     let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
-    let mut model = set_auth_manifest_with_test_sram(
-        Some(auth_manifest),
-        &test_sram_contents,
-        &images[0].contents,
-    );
+    let runtime_args = RuntimeTestArgs {
+        subsystem_mode: true,
+        test_image_options: Some(caliptra_builder::ImageOptions {
+            pqc_key_type: caliptra_image_types::FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        }),
+        soc_manifest: Some(auth_manifest.as_bytes()),
+        mcu_fw_image: Some(&images[0].contents),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(runtime_args);
 
-    #[cfg(feature = "fpga_subsystem")]
-    {
-        crate::test_authorize_and_stash::write_mcu_mbox_sram(&mut model, &test_sram_contents);
-    }
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read()
+            == u32::from(caliptra_runtime::RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut set_auth_manifest_cmd =
+        MailboxReq::SetAuthManifest(caliptra_common::mailbox_api::SetAuthManifestReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            manifest_size: auth_manifest.as_bytes().len() as u32,
+            manifest: {
+                let mut slice =
+                    [0u8; caliptra_common::mailbox_api::SetAuthManifestReq::MAX_MAN_SIZE];
+                slice[..auth_manifest.as_bytes().len()].copy_from_slice(auth_manifest.as_bytes());
+                slice
+            },
+        });
+    set_auth_manifest_cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            u32::from(CommandId::SET_AUTH_MANIFEST),
+            set_auth_manifest_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
 
     for image in images {
+        model
+            .write_payload_to_ss_staging_area(&image.contents, image.staging_offset)
+            .unwrap();
         let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
             hdr: MailboxReqHeader { chksum: 0 },
             fw_id: image.fw_id.to_le_bytes(),
@@ -151,20 +179,13 @@ fn send_activate_firmware_cmd(
             activate_cmd.as_bytes().unwrap(),
         )
         .unwrap();
-    #[cfg(feature = "fpga_subsystem")]
-    {
-        if reset_expected {
+    if reset_expected {
+        #[cfg(feature = "fpga_subsystem")]
+        {
             let clear_interrupt = |model: &mut DefaultHwModel| {
                 let mut retry_count = 10;
                 loop {
-                    let intr_status = model
-                        .mmio
-                        .mci()
-                        .unwrap()
-                        .regs()
-                        .intr_block_rf()
-                        .notif0_internal_intr_r()
-                        .read();
+                    let intr_status = model.mci().intr_block_rf().notif0_internal_intr_r().read();
                     if intr_status.notif_cptra_mcu_reset_req_sts() {
                         break;
                     }
@@ -175,33 +196,31 @@ fn send_activate_firmware_cmd(
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
                 model
-                    .mmio
                     .mci()
-                    .unwrap()
-                    .regs()
                     .intr_block_rf()
                     .notif0_internal_intr_r()
                     .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
-                model
-                    .mmio
-                    .mci()
-                    .unwrap()
-                    .regs()
-                    .reset_request()
-                    .modify(|r| r.mcu_req(true));
+                model.mci().reset_request().modify(|r| r.mcu_req(true));
             };
             clear_interrupt(model);
         }
-    }
-    #[cfg(all(
-        not(feature = "verilator"),
-        not(feature = "fpga_realtime"),
-        not(feature = "fpga_subsystem")
-    ))]
-    {
-        let _ = reset_expected;
-        // In emulator mode, since FW_EXEC_CTRL bit is already cleared,
-        // the MCU will be already in reset state
+        #[cfg(all(
+            not(feature = "verilator"),
+            not(feature = "fpga_realtime"),
+            not(feature = "fpga_subsystem")
+        ))]
+        {
+            model.step_until(|m| {
+                let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
+                intr_status.notif_cptra_mcu_reset_req_sts()
+            });
+            model
+                .mci()
+                .intr_block_rf()
+                .notif0_internal_intr_r()
+                .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
+            model.mci().reset_request().modify(|r| r.mcu_req(true));
+        }
     }
     model.finish_mailbox_execute()
 }
@@ -211,8 +230,8 @@ fn send_activate_firmware_cmd(
 fn test_activate_mcu_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -242,16 +261,16 @@ fn test_activate_mcu_fw_success() {
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -283,16 +302,16 @@ fn test_activate_mcu_soc_fw_success() {
 fn test_activate_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -323,16 +342,16 @@ fn test_activate_soc_fw_success() {
 fn test_activate_invalid_fw_id() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -361,16 +380,16 @@ fn test_activate_invalid_fw_id() {
 fn test_activate_fw_id_not_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -399,16 +418,16 @@ fn test_activate_fw_id_not_in_manifest() {
 fn test_invalid_exec_bit_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 0,
     };
@@ -441,8 +460,8 @@ fn test_invalid_exec_bit_in_manifest() {
 fn test_activate_firmware_old_format_no_flags() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -521,6 +540,23 @@ fn test_activate_firmware_old_format_no_flags() {
             .reset_request()
             .modify(|r| r.mcu_req(true));
     }
+    #[cfg(all(
+        not(feature = "verilator"),
+        not(feature = "fpga_realtime"),
+        not(feature = "fpga_subsystem")
+    ))]
+    {
+        model.step_until(|m| {
+            let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
+            intr_status.notif_cptra_mcu_reset_req_sts()
+        });
+        model
+            .mci()
+            .intr_block_rf()
+            .notif0_internal_intr_r()
+            .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
+        model.mci().reset_request().modify(|r| r.mcu_req(true));
+    }
     model
         .finish_mailbox_execute()
         .unwrap()
@@ -534,8 +570,8 @@ fn test_activate_firmware_old_format_no_flags() {
 fn test_activate_firmware_unknown_flag_bit_rejected() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -568,8 +604,8 @@ fn test_activate_firmware_unknown_flag_bit_rejected() {
 fn test_activate_firmware_initial_activate_wrong_boot_mode() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -601,16 +637,16 @@ fn test_activate_firmware_initial_activate_wrong_boot_mode() {
 fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -631,4 +667,44 @@ fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
     activate_cmd.populate_chksum().unwrap();
 
     assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_mcu_fw_digest_mismatch() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    // Tamper with the image in the staging area so the digest won't match the manifest
+    model
+        .write_payload_to_ss_staging_area(&[0x75u8, 0x55u8, 0x55u8, 0x55u8], MCU_STAGING_OFFSET)
+        .unwrap();
+
+    // Send ActivateFirmware command
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: 0,
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert_eq!(
+        send_activate_firmware_cmd(&mut model, activate_cmd, true),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::IMAGE_VERIFIER_ACTIVATION_FAILED.into()
+        ))
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -103,7 +103,7 @@ fn execute_certify_key_extended_cmd_helper(
     let mut certify_key_extended_resp = CertifyKeyExtendedResp::default();
     if external_response {
         let resp = model
-            .read_payload_from_ss_staging_area(size_of::<CertifyKeyExtendedResp>())
+            .read_payload_from_ss_staging_area(size_of::<CertifyKeyExtendedResp>(), 0)
             .unwrap();
         certify_key_extended_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
         check_header_checksum(certify_key_extended_resp.as_bytes_partial().unwrap())?;

--- a/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
@@ -90,7 +90,7 @@ fn test_encrypted_firmware_decrypt_dma() {
 
     // Read back the decrypted firmware from MCU SRAM and verify.
     let decrypted_fw = model
-        .read_payload_from_ss_staging_area(mcu_fw_plaintext.len())
+        .read_payload_from_ss_staging_area(mcu_fw_plaintext.len(), 0)
         .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
This adds the `image_size` to the `AuthorizeAndStashReq` used in `ActivateFirmware`

This also rearchitects the tests to allow modifying the staging content more easily.