### PR TITLE
runtime: add ACTIVATE_FIRMWARE INITIAL_ACTIVATE flag

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1185,6 +1185,8 @@ pub struct ActivateFirmwareReq {
     pub fw_id_count: u32,
     pub fw_ids: [u32; ActivateFirmwareReq::MAX_FW_ID_COUNT],
     pub mcu_fw_image_size: u32,
+    /// Optional flags. See [`ActivateFirmwareFlags`].
+    pub flags: u32,
 }
 impl Request for ActivateFirmwareReq {
     const ID: CommandId = CommandId::ACTIVATE_FIRMWARE;
@@ -1204,7 +1206,36 @@ impl Default for ActivateFirmwareReq {
             fw_id_count: 0,
             mcu_fw_image_size: 0,
             fw_ids: [0; ActivateFirmwareReq::MAX_FW_ID_COUNT],
+            flags: 0,
         }
+    }
+}
+
+bitflags::bitflags! {
+    /// Flags for [`ActivateFirmwareReq`].
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct ActivateFirmwareFlags: u32 {
+        /// First-time MCU activation after the encrypted-boot flow:
+        /// MCU ROM has already loaded firmware into MCU SRAM via
+        /// `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` (and possibly decrypted
+        /// it in place via `CM_AES_GCM_DECRYPT_DMA`. Caliptra runtime
+        /// should publish `FW_EXEC_CTRL[MCU]` so MCI releases MCU
+        /// from reset after MCU ROM triggers its own warm reset, and
+        /// skip the hitless-update reset/reload/verify sequence.
+        ///
+        /// Caliptra runtime only honors this flag when:
+        ///   * `BootMode::EncryptedFirmware` was set by ROM
+        ///     (i.e., `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` was the recovery
+        ///     cmd), and
+        ///   * `FW_EXEC_CTRL[MCU]` is currently `0` (MCU has not been
+        ///     activated yet)
+        const INITIAL_ACTIVATE = 1 << 0;
+    }
+}
+
+impl From<u32> for ActivateFirmwareFlags {
+    fn from(value: u32) -> Self {
+        ActivateFirmwareFlags::from_bits_truncate(value)
     }
 }
 

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -1468,8 +1468,9 @@ pub trait HwModel: SocManager {
         encrypted_mcu_fw: &[u8],
     ) -> Result<(), ModelError> {
         use api::mailbox::{
-            CmAesGcmDecryptDmaReq, CmAesGcmDecryptDmaResp, CmImportReq, CmImportResp, CmKeyUsage,
-            CommandId, GetMcuFwSizeResp, MailboxReqHeader, MailboxRespHeader,
+            ActivateFirmwareFlags, ActivateFirmwareReq, CmAesGcmDecryptDmaReq,
+            CmAesGcmDecryptDmaResp, CmImportReq, CmImportResp, CmKeyUsage, CommandId,
+            GetMcuFwSizeResp, MailboxReqHeader, MailboxRespHeader,
             CM_AES_GCM_DECRYPT_DMA_MAX_AAD_SIZE,
         };
         use zerocopy::transmute;
@@ -1569,6 +1570,28 @@ pub trait HwModel: SocManager {
         if decrypt_resp.tag_verified != 1 {
             return Err(ModelError::MailboxCmdFailed(0));
         }
+
+        // Step 5: Publish FW_EXEC_CTRL[MCU] via ACTIVATE_FIRMWARE +
+        // INITIAL_ACTIVATE so MCI will release MCU from BOOT_RST_MCU on the
+        // next warm reset. This mirrors what the real MCU ROM does at the
+        // tail of the encrypted-boot flow before it triggers warm reset.
+        let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            fw_id_count: 1,
+            mcu_fw_image_size: ciphertext.len() as u32,
+            fw_ids: {
+                let mut arr = [0u32; ActivateFirmwareReq::MAX_FW_ID_COUNT];
+                arr[0] = ActivateFirmwareReq::MCU_IMAGE_ID;
+                arr
+            },
+            flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
+        });
+        activate_cmd.populate_chksum().unwrap();
+        self.mailbox_execute(
+            u32::from(CommandId::ACTIVATE_FIRMWARE),
+            activate_cmd.as_bytes().unwrap(),
+        )?
+        .ok_or(ModelError::MailboxNoResponseData)?;
 
         Ok(())
     }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -51,7 +51,8 @@ When ROM receives the `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` command instead of `RI_DO
 3. The MCU ROM can then:
    - Import an AES key using `CM_IMPORT`
    - Decrypt the firmware in-place using `CM_AES_GCM_DECRYPT_DMA`
-   - Send `CM_ACTIVATE_FIRMWARE` to activate the decrypted MCU firmware
+   - Send `ACTIVATE_FIRMWARE` with the `INITIAL_ACTIVATE` flag set, so Runtime publishes `FW_EXEC_CTRL[MCU]` without performing the hitless-update reload/verify dance (the firmware was already integrity-checked end-to-end by `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` and `CM_AES_GCM_DECRYPT_DMA`). See [`ACTIVATE_FIRMWARE`](#activate_firmware) for the gating rules.
+   - Trigger a warm reset; MCI releases MCU once `FW_EXEC_CTRL[MCU]` is asserted, and MCU FwBoot jumps into the decrypted firmware.
 
 The `CM_AES_GCM_DECRYPT_DMA` command is intended to be used for the `EncryptedFirmware` boot mode and performs a SHA384 integrity check of the ciphertext before decryption, but can be used to decrypt other images as well in any boot mode.
 
@@ -1511,6 +1512,41 @@ Command Code: `0x4143_5446` ("ACTF")
 | count          | u32            | Number of image_ids to activate. Item count of image_ids array parameter |
 | mcu_image_size | u32            | Size of MCU image, if included in the activation |
 | image_ids      | Array of u8[4] | Array of Image ids in little-endian format                           |
+| flags          | u32            | Optional flags (see below). Caliptra runtime 2.1.1+ only.                  |
+
+*Flags*
+
+| **Bit** | **Name**          | **Description**                                                                                                          |
+| ------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 0       | `INITIAL_ACTIVATE`| First-time MCU activation after the encrypted-boot flow. Caliptra runtime 2.1.1+ only. See below. |
+
+Unknown flag bits are rejected with `RUNTIME_MAILBOX_INVALID_PARAMS`.
+
+`INITIAL_ACTIVATE` is used exclusively by MCU ROM at the tail of the
+`EncryptedFirmware` boot flow. MCU ROM has already loaded firmware into MCU
+SRAM via `RI_DOWNLOAD_ENCRYPTED_FIRMWARE` and decrypted it in place via
+`CM_AES_GCM_DECRYPT_DMA`. When this flag is set, Caliptra Runtime:
+
+- Skips the hitless-update steps (set `RESET_REASON.FwHitlessUpd`, clear
+  `FW_EXEC_CTRL`, wait for MCU reset request and reset assertion, DMA-reload
+  from staging, re-`AuthorizeAndStash`).
+- Just publishes `FW_EXEC_CTRL[MCU]` (and any other requested bits) so that
+  MCI's `BOOT_RST_MCU` state releases MCU from reset on the next warm reset
+  that MCU ROM triggers.
+
+Caliptra Runtime only honors `INITIAL_ACTIVATE` when **all** of the following
+are true; otherwise the command fails with `IMAGE_VERIFIER_ACTIVATION_FAILED`:
+
+1. The MCU image bit is included in the activation request.
+2. The boot mode set by ROM is `EncryptedFirmware` (i.e., ROM received
+   `RI_DOWNLOAD_ENCRYPTED_FIRMWARE`).
+3. `FW_EXEC_CTRL[MCU]` is currently `0` — this is an initial activation,
+   not a hitless update masquerading as one.
+
+Together, these checks ensure that the MCU SRAM contents are
+integrity-protected end-to-end (ciphertext digest verified during recovery;
+GCM tag verified during `CM_AES_GCM_DECRYPT_DMA`) before Caliptra releases
+MCU to execute them.
 
 *Table: `ACTIVATE_FIRMWARE` output arguments*
 

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -18,11 +18,15 @@ use crate::authorize_and_stash::AuthorizeAndStashCmd;
 use crate::drivers::{McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
-use caliptra_api::mailbox::{AuthAndStashFlags, AuthorizeAndStashReq, ImageHashSource};
+use caliptra_api::mailbox::{
+    ActivateFirmwareFlags, AuthAndStashFlags, AuthorizeAndStashReq, ImageHashSource,
+};
 use caliptra_auth_man_types::ImageMetadataFlags;
 use caliptra_common::mailbox_api::{ActivateFirmwareReq, ActivateFirmwareResp, MailboxRespHeader};
 use caliptra_drivers::dma::MCU_SRAM_OFFSET;
-use caliptra_drivers::{AesDmaMode, AxiAddr, CaliptraError, CaliptraResult, DmaMmio, DmaRecovery};
+use caliptra_drivers::{
+    AesDmaMode, AxiAddr, BootMode, CaliptraError, CaliptraResult, DmaMmio, DmaRecovery,
+};
 use caliptra_ureg::Mmio;
 
 pub const MCI_TOP_REG_RESET_REASON_OFFSET: u32 = 0x38;
@@ -73,16 +77,38 @@ impl ActivateFirmwareCmd {
             .unwrap()
         };
 
+        let flags_raw: u32 = if cmd_args.len() >= core::mem::size_of::<ActivateFirmwareReq>() {
+            // `flags` is the last field; older callers that pre-date this
+            // field send a shorter buffer, in which case it defaults to zero.
+            let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
+            let offset = offset_of!(ActivateFirmwareReq, flags);
+            u32::from_le_bytes(
+                cmd_args
+                    .get(offset..offset + 4)
+                    .ok_or(err)?
+                    .try_into()
+                    .map_err(|_| err)?,
+            )
+        } else {
+            0
+        };
+        // Reject unknown flag bits explicitly — `from_bits_truncate` (used by
+        // our `From<u32>` impl below) would silently drop them.
+        if flags_raw & !ActivateFirmwareFlags::all().bits() != 0 {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        }
+        let flags: ActivateFirmwareFlags = flags_raw.into();
+
         let mut images_to_activate_bitmap: [u32; 4] = [0; 4];
         for i in 0..fw_id_count {
+            let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
             let offset = offset_of!(ActivateFirmwareReq, fw_ids) + (i * 4);
-            if cmd_args.len() < offset + 4 {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-            }
             let fw_id = u32::from_le_bytes(
-                cmd_args[offset..offset + 4]
+                cmd_args
+                    .get(offset..offset + 4)
+                    .ok_or(err)?
                     .try_into()
-                    .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?,
+                    .map_err(|_| err)?,
             );
             if fw_id == ActivateFirmwareReq::RESERVED0_IMAGE_ID
                 || fw_id == ActivateFirmwareReq::RESERVED1_IMAGE_ID
@@ -111,8 +137,13 @@ impl ActivateFirmwareCmd {
             Self::set_bit(&mut images_to_activate_bitmap, exec_bit as usize);
         }
 
-        Self::activate_fw(drivers, &images_to_activate_bitmap, mcu_image_size as u32)
-            .map_err(|_| CaliptraError::IMAGE_VERIFIER_ACTIVATION_FAILED)?;
+        Self::activate_fw(
+            drivers,
+            &images_to_activate_bitmap,
+            mcu_image_size as u32,
+            flags,
+        )
+        .map_err(|_| CaliptraError::IMAGE_VERIFIER_ACTIVATION_FAILED)?;
 
         let resp = mutrefbytes::<ActivateFirmwareResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
@@ -124,6 +155,7 @@ impl ActivateFirmwareCmd {
         drivers: &mut Drivers,
         activate_bitmap: &[u32; 4],
         mcu_image_size: u32,
+        flags: ActivateFirmwareFlags,
     ) -> Result<(), ()> {
         let mci_base_addr: AxiAddr = drivers.soc_ifc.mci_base_addr().into();
         let mut go_bitmap: [u32; 4] = [0; 4];
@@ -133,22 +165,64 @@ impl ActivateFirmwareCmd {
 
         let mut temp_bitmap: [u32; 4] = [0; 4];
 
-        if Self::is_bit_set(activate_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize) {
+        let mcu_activate_requested =
+            Self::is_bit_set(activate_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize);
+
+        // INITIAL_ACTIVATE is the first-boot path after encrypted firmware:
+        // MCU ROM has already loaded firmware into MCU SRAM via
+        // RI_DOWNLOAD_ENCRYPTED_FIRMWARE and decrypted it in place via
+        // CM_AES_GCM_DECRYPT_DMA. Skip the hitless-update dance and just
+        // publish FW_EXEC_CTRL so MCI releases MCU from reset after MCU ROM
+        // triggers its own warm reset.
+        //
+        // Gated on two conditions that together prove the SRAM contents are
+        // trusted and that no hitless update is in flight:
+        //   * BootMode::EncryptedFirmware was set by ROM (cannot be forged
+        //     from a mailbox client).
+        //   * FW_EXEC_CTRL[MCU] is currently 0 (MCU has not been activated
+        //     yet — otherwise the caller is masquerading a real hitless
+        //     update as an initial activation).
+        let initial_activate = flags.contains(ActivateFirmwareFlags::INITIAL_ACTIVATE);
+        if initial_activate {
+            if !mcu_activate_requested {
+                // The flag only makes sense paired with the MCU image.
+                return Err(());
+            }
+            if drivers.persistent_data.get().rom.boot_mode != BootMode::EncryptedFirmware {
+                return Err(());
+            }
+            if Self::is_bit_set(&go_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize) {
+                return Err(());
+            }
+        }
+
+        if mcu_activate_requested && !initial_activate {
             // If MCU image is being activated, set the RESET_REASON first before clearing the FW_EXEC_CTRL
             // to ensure the correct reset reason is captured after the reset.
             drivers.persistent_data.get_mut().fw.mcu_firmware_loaded =
                 McuFwStatus::HitlessUpdateStarted.into();
             Drivers::set_mcu_reset_reason(drivers, McuResetReason::FwHitlessUpd);
+        } else if mcu_activate_requested && initial_activate {
+            // Tell MCI to record this as a firmware-boot reset (bit
+            // `FwBootUpdReset`) so that after MCU ROM triggers its warm
+            // reset and MCI releases MCU from BOOT_RST_MCU, MCU ROM reads
+            // `RESET_REASON.FwBootUpdReset = 1` and dispatches to the
+            // FwBoot flow (which jumps to the decrypted firmware in SRAM)
+            // instead of re-running cold boot in a loop.
+            Drivers::set_mcu_reset_reason(drivers, McuResetReason::FwBoot);
         }
 
-        // Caliptra clears FW_EXEC_CTRL for all affected images
+        // Caliptra clears FW_EXEC_CTRL for all affected images. On
+        // INITIAL_ACTIVATE the bits are already clear (we verified
+        // FW_EXEC_CTRL[MCU] == 0 above), so this is a no-op and no
+        // notif_cptra_mcu_reset_req_sts interrupt is raised toward MCU.
         for i in 0..4 {
             temp_bitmap[i] = go_bitmap[i] & !activate_bitmap[i];
         }
 
         drivers.soc_ifc.set_ss_generic_fw_exec_ctrl(&temp_bitmap);
 
-        if Self::is_bit_set(activate_bitmap, ActivateFirmwareReq::MCU_IMAGE_ID as usize) {
+        if mcu_activate_requested && !initial_activate {
             // MCU sees request from Caliptra and shall clear the interrupt status.
             // MCU sets RESET_REQUEST.mcu_req in MCI to request a reset.
             // MCI does an MCU halt req/ack handshake to ensure the MCU is idle
@@ -231,13 +305,25 @@ impl ActivateFirmwareCmd {
             .map_err(|_| ())?;
 
             drivers.persistent_data.get_mut().fw.mcu_firmware_loaded = McuFwStatus::Loaded.into();
+        } else if mcu_activate_requested && initial_activate {
+            // INITIAL_ACTIVATE: firmware is already in MCU SRAM and was
+            // integrity-checked end-to-end during the encrypted-boot flow:
+            //   * recovery_flow::sha384_mcu_sram verified the ciphertext
+            //     against the auth-manifest digest before MCU ROM saw it.
+            //   * CM_AES_GCM_DECRYPT_DMA verified the GCM tag before MCU
+            //     ROM returned successfully from the decrypt mailbox call.
+            // Skip reload + AuthorizeAndStash; just mark as loaded.
+            drivers.persistent_data.get_mut().fw.mcu_firmware_loaded = McuFwStatus::Loaded.into();
         }
 
         for i in 0..4 {
             temp_bitmap[i] = go_bitmap[i] | activate_bitmap[i];
         }
 
-        // Caliptra sets FW_EXEC_CTRL
+        // Caliptra sets FW_EXEC_CTRL. On INITIAL_ACTIVATE this is the only
+        // hardware effect of the entire command: it asserts
+        // mcu_sram_fw_exec_region_lock so MCI's BOOT_RST_MCU state will
+        // release MCU when MCU ROM next triggers its warm reset.
         drivers.soc_ifc.set_ss_generic_fw_exec_ctrl(&temp_bitmap);
         Ok(())
     }

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -148,7 +148,9 @@ impl RecoveryFlow {
             }
 
             // Check if firmware was loaded encrypted - if so, skip MCU activation
-            // MCU ROM will decrypt the firmware and send CM_ACTIVATE_FIRMWARE command
+            // MCU ROM will decrypt the firmware and send the ACTIVATE_FIRMWARE
+            // mailbox command with the INITIAL_ACTIVATE flag once it is ready
+            // for Caliptra to publish FW_EXEC_CTRL[MCU].
             let boot_mode = drivers.persistent_data.get().rom.boot_mode;
             if boot_mode == BootMode::EncryptedFirmware {
                 cprintln!("[rt] Encrypted firmware boot mode - skipping MCU activation");

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -1,9 +1,10 @@
 // Licensed under the Apache-2.0 license
 use crate::test_authorize_and_stash::set_auth_manifest_with_test_sram;
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_api::mailbox::ActivateFirmwareReq;
+use caliptra_api::mailbox::{ActivateFirmwareFlags, ActivateFirmwareReq};
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
+use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
     MailboxReqHeader,
@@ -11,7 +12,7 @@ use caliptra_common::mailbox_api::{
 use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
 use caliptra_runtime::IMAGE_AUTHORIZED;
 use sha2::{Digest, Sha384};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
 pub const TEST_SRAM_SIZE: usize = 64 * 1024; // 64 KB
 
@@ -228,6 +229,7 @@ fn test_activate_mcu_fw_success() {
             arr[0] = MCU_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
     send_activate_firmware_cmd(&mut model, activate_cmd, true)
@@ -267,6 +269,7 @@ fn test_activate_mcu_soc_fw_success() {
             arr[1] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -306,6 +309,7 @@ fn test_activate_soc_fw_success() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -345,6 +349,7 @@ fn test_activate_invalid_fw_id() {
             arr[0] = INVALID_FW_ID;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -382,6 +387,7 @@ fn test_activate_fw_id_not_in_manifest() {
             arr[0] = INVALID_FW_ID;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -419,6 +425,208 @@ fn test_invalid_exec_bit_in_manifest() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// Backward-compat: clients that pre-date the `flags` field send a request
+/// truncated to `size_of::<ActivateFirmwareReq>() - 4` bytes (no `flags`
+/// trailer). The runtime must treat the missing field as zero and proceed
+/// with the hitless-update path that those clients expect.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_old_format_no_flags() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    // Build the request via the current `ActivateFirmwareReq` struct (which
+    // includes `flags`), then truncate the trailing `flags` u32 off the wire
+    // bytes so the runtime parser sees exactly what an old client would have
+    // sent. Compute the checksum over the truncated bytes (excluding the
+    // 4-byte `chksum` field).
+    let req = ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: 0,
+    };
+    let full_bytes = req.as_bytes();
+    let old_len = full_bytes.len() - core::mem::size_of::<u32>();
+    let mut truncated = full_bytes[..old_len].to_vec();
+
+    // Patch the checksum so it covers exactly the truncated payload.
+    let chksum = calc_checksum(
+        u32::from(CommandId::ACTIVATE_FIRMWARE),
+        &truncated[core::mem::size_of::<u32>()..],
+    );
+    truncated[..core::mem::size_of::<u32>()].copy_from_slice(&chksum.to_le_bytes());
+
+    // Send the truncated buffer directly. Mirrors the
+    // `send_activate_firmware_cmd` helper but bypasses MailboxReq so we
+    // control the exact wire length.
+    model
+        .start_mailbox_execute(u32::from(CommandId::ACTIVATE_FIRMWARE), &truncated)
+        .unwrap();
+    #[cfg(feature = "fpga_subsystem")]
+    {
+        // The MCU image is included, so simulate the MCU-reset ack handshake
+        // (same as send_activate_firmware_cmd with reset_expected=true).
+        let mut retry_count = 10;
+        loop {
+            let intr_status = model
+                .mmio
+                .mci()
+                .unwrap()
+                .regs()
+                .intr_block_rf()
+                .notif0_internal_intr_r()
+                .read();
+            if intr_status.notif_cptra_mcu_reset_req_sts() {
+                break;
+            }
+            retry_count -= 1;
+            if retry_count == 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        model
+            .mmio
+            .mci()
+            .unwrap()
+            .regs()
+            .intr_block_rf()
+            .notif0_internal_intr_r()
+            .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
+        model
+            .mmio
+            .mci()
+            .unwrap()
+            .regs()
+            .reset_request()
+            .modify(|r| r.mcu_req(true));
+    }
+    model
+        .finish_mailbox_execute()
+        .unwrap()
+        .expect("ACTIVATE_FIRMWARE without flags trailer should succeed");
+}
+
+/// Reject unknown flag bits with `RUNTIME_MAILBOX_INVALID_PARAMS`. The
+/// reserved high bit acts as a stand-in for any future undefined flag.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_unknown_flag_bit_rejected() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        // A bit that is not part of `ActivateFirmwareFlags`.
+        flags: 1 << 31,
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// `INITIAL_ACTIVATE` is only honored when ROM set
+/// `BootMode::EncryptedFirmware`. In the normal boot flow used by this test
+/// the boot mode is `Normal`, so Caliptra must reject the request rather
+/// than skip the hitless-update steps.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_initial_activate_wrong_boot_mode() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    // `load_and_authorize_fw` does a normal boot, so boot_mode is Normal.
+    // The flag must be rejected.
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// `INITIAL_ACTIVATE` requires the MCU image bit to be in the activation
+/// bitmap. Sending it with only SoC ids must be rejected.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let soc_image = Image {
+        fw_id: SOC_FW_ID_1,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
+        contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
+        exec_bit: 3,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image, soc_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = SOC_FW_ID_1;
+            arr
+        },
+        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
     });
     activate_cmd.populate_chksum().unwrap();
 

--- a/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_encrypted_firmware.rs
@@ -49,6 +49,10 @@ fn test_encrypted_firmware_decrypt_dma() {
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    // exec_bit 2 = MCU image. Caliptra runtime requires this to be set in
+    // the manifest so ACTIVATE_FIRMWARE knows which FW_EXEC_CTRL bit to
+    // publish for the MCU image during the post-decrypt activation step.
+    flags.set_exec_bit(2);
     let crypto = Crypto::default();
     let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw_image).unwrap());
     let metadata = vec![AuthManifestImageMetadata {


### PR DESCRIPTION
Lets MCU ROM finalize the encrypted-boot flow: after MCU ROM decrypts firmware in MCU SRAM via CM_AES_GCM_DECRYPT_DMA, it sends ACTIVATE_FIRMWARE with this flag so Caliptra publishes FW_EXEC_CTRL[MCU] and sets RESET_REASON.FwBootUpdReset, without performing the hitless-update reset/reload/verify dance. Without this MCI's BOOT_RST_MCU state holds MCU in reset forever after the post-decrypt warm reset.

Gated on BootMode::EncryptedFirmware (set by ROM only on RI_DOWNLOAD_ENCRYPTED_FIRMWARE) and FW_EXEC_CTRL[MCU] == 0 to prevent a real hitless update from masquerading as initial activation.

The new field is appended; older callers that omit it are treated as flags=0 (existing hitless-update behavior).

Tested locally with an appropriate MCU ROM change on FPGA to ensure that this new flow works. (Will send a separate PR to update the MCU commit and re-enable he encrypted firmware test when MCU ROM adds this new flag.)