### PR TITLE
[fix] Use configurable OTP status offset for UDS/FE

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-74e8f78d5a151a7c937cb83565aa0af808fe8c558a0b1287ed3780bc0e2656287ed1ea5fdbfe1b2ed9e5c42e58eba7d2  caliptra-rom-no-log.bin
-5e098276e2f07506a9dd51077c2c77e0b31a37ec6cf5dce4bd268f47e44745fd8bd30a827bf5c38a0f3321b3e71fb7d4  caliptra-rom-with-log.bin
+fc24678b4f3e676fc1b834c4de2eaeee54bd941427ace7eb21dcbb29a5347e572c80326866dd12cb2a76ac89ab997670  caliptra-rom-no-log.bin
+8c659cdf31f8f4cfe0e1736b66454e05226c700c671464a4bea56bcf44f23bdd0944ca8ee2a20b8b3a5ece103dd38451  caliptra-rom-with-log.bin

--- a/common/src/uds_fe_programming.rs
+++ b/common/src/uds_fe_programming.rs
@@ -52,6 +52,7 @@ struct OtpCtrlConfig {
     fuse_controller_base_addr: u64,
     seed_config: SeedConfig,
     dai_idle_bit_num: u32,
+    status_reg_addr: Option<u64>,
     direct_access_cmd_reg_addr: u64,
     direct_access_address_reg_addr: u64,
     direct_access_wdata_0_reg_addr: u64,
@@ -67,6 +68,13 @@ impl UdsFeProgrammingFlow {
         let fuse_controller_base_addr = soc_ifc.fuse_controller_base_addr();
         let seed_config = self.get_seed_config(soc_ifc);
         let dai_idle_bit_num = soc_ifc.otp_dai_idle_bit_num();
+        let status_reg_offset = soc_ifc.otp_status_reg_offset();
+        let status_reg_addr = if status_reg_offset != 0 {
+            Some(fuse_controller_base_addr + status_reg_offset as u64)
+        } else {
+            // TODO: Remove this fallback once MCU programs the OTP status register offset.
+            None
+        };
         let direct_access_cmd_reg_addr =
             fuse_controller_base_addr + soc_ifc.otp_direct_access_cmd_reg_offset() as u64;
         let direct_access_address_reg_addr =
@@ -85,6 +93,7 @@ impl UdsFeProgrammingFlow {
             fuse_controller_base_addr,
             seed_config,
             dai_idle_bit_num,
+            status_reg_addr,
             direct_access_cmd_reg_addr,
             direct_access_address_reg_addr,
             direct_access_wdata_0_reg_addr,
@@ -215,7 +224,11 @@ impl UdsFeProgrammingFlow {
             let _ = otp_ctrl.with_regs_mut(|regs| {
                 // Helper function to check if DAI is idle using the configurable bit number
                 let is_dai_idle = || -> bool {
-                    let status: u32 = regs.status().read().into();
+                    let status = if let Some(status_reg_addr) = config.status_reg_addr {
+                        dma.read_dword(AxiAddr::from(status_reg_addr))
+                    } else {
+                        regs.status().read().into()
+                    };
                     (status & (1 << config.dai_idle_bit_num)) != 0
                 };
 
@@ -328,7 +341,11 @@ impl UdsFeProgrammingFlow {
         let _ = otp_ctrl.with_regs_mut(|regs| {
             // Helper to wait for DAI idle state
             let wait_dai_idle = || loop {
-                let status: u32 = regs.status().read().into();
+                let status = if let Some(status_reg_addr) = config.status_reg_addr {
+                    dma.read_dword(AxiAddr::from(status_reg_addr))
+                } else {
+                    regs.status().read().into()
+                };
                 if (status & (1 << config.dai_idle_bit_num)) != 0 {
                     break;
                 }

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -666,6 +666,10 @@ impl SocIfc {
         (self.soc_ifc.regs().ss_strap_generic().at(0).read() >> 16) & 0xFFFF
     }
 
+    pub fn otp_status_reg_offset(&self) -> u32 {
+        self.soc_ifc.regs().ss_strap_generic().at(0).read() & 0xFFFF
+    }
+
     pub fn otp_direct_access_cmd_reg_offset(&self) -> u32 {
         self.soc_ifc.regs().ss_strap_generic().at(1).read() & 0xFFFF
     }

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -297,11 +297,12 @@ The following flows are conducted when the ROM is operating in the manufacturing
 3. ROM then retrieves the UDS granularity from the `CPTRA_GENERIC_INPUT_WIRES` register0 Bit31 to learn if the fuse row is accessible with 32-bit or 64-bit granularity.  If the bit is reset, it indicates 64-bit granularity; otherwise, it indicates 32-bit granularity.
 
 4. ROM computes the following values:
-    - DAI_IDLE bit offset: (`SS_STRAP_GENERIC` register0 >> 16) & 0xFFFF
-    - `DIRECT_ACCESS_CMD` offset: (`SS_STRAP_GENERIC` register1) & 0xFFFF + Fuse Controller's base address.
+    - `STATUS` register address: Fuse Controller's base address + ((`SS_STRAP_GENERIC` register0) & 0xFFFF).
+    - DAI_IDLE bit index within the `STATUS` register: (`SS_STRAP_GENERIC` register0 >> 16) & 0xFFFF.
+    - `DIRECT_ACCESS_CMD` register address: Fuse Controller's base address + ((`SS_STRAP_GENERIC` register1) & 0xFFFF).
 
 4. ROM then performs the following steps until all the 512 bits of the UDS seed are programmed:
-    1. The ROM verifies the idle state of the DAI by reading the `STATUS` register `DAI_IDLE` bit (offset retrieved above) of the Fuse Controller, located at offset 0x10 from the Fuse Controller's base address.
+    1. The ROM verifies the idle state of the DAI by reading the `STATUS` register `DAI_IDLE` bit using the offset retrieved above.
     2. If the granularity is 32-bit, the ROM writes the next word from the UDS seed to the `DIRECT_ACCESS_WDATA_0` register. If the granularity is 64-bit, the ROM writes the next two words to `the DIRECT_ACCESS_WDATA_0` and `DIRECT_ACCESS_WDATA_1` registers, located at offsets 0x8 and 0xC respectively from the `DIRECT_ACCESS_CMD` register.
     3. The ROM writes the lower 32 bits of the UDS Seed programming base address to the `DIRECT_ACCESS_ADDRESS` register, located at offset 0x4 from the `DIRECT_ACCESS_CMD` register.
     4. The ROM triggers the UDS seed write command by writing 0x2 to the `DIRECT_ACCESS_CMD` register..

--- a/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
+++ b/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
@@ -17,10 +17,13 @@ use caliptra_api::{
 };
 use caliptra_builder::firmware::{self};
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{DbgManufServiceRegReq, DeviceLifecycle, HwModel, SecurityState};
+use caliptra_hw_model::{
+    BootParams, DbgManufServiceRegReq, DeviceLifecycle, HwModel, SecurityState,
+};
 use zerocopy::IntoBytes;
 
 const UDS_FE_PROGRAMMING_SHUTDOWN_SUCCESS: u32 = 0xa006_0004;
+const OTP_STATUS_REG_OFFSET: u32 = 0x10;
 
 #[cfg_attr(any(feature = "fpga_subsystem", feature = "fpga_realtime"), ignore)] // No fuse controller in FPGA without MCI
 #[test]
@@ -86,6 +89,39 @@ fn test_uds_programming_granularity_64bit() {
     let config_val = hw.soc_ifc().cptra_hw_config().read();
     // 0: 64-bits, 1: 32-bits
     assert!(!config_val.fuse_granularity());
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI
+#[test]
+fn test_uds_programming_configurable_status_reg_offset() {
+    let security_state =
+        *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing);
+    let dbg_manuf_service = *DbgManufServiceRegReq::default().set_uds_program_req(true);
+    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env_fpga(cfg!(
+        feature = "fpga_subsystem"
+    )))
+    .unwrap();
+    let mut hw = caliptra_hw_model::new_unbooted(caliptra_hw_model::InitParams {
+        rom: &rom,
+        security_state,
+        dbg_manuf_service,
+        subsystem_mode: true,
+        uds_fuse_row_granularity_64: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let otp_dai_idle_bit_num = hw.soc_ifc().ss_strap_generic().at(0).read() & 0xFFFF_0000;
+    hw.soc_ifc()
+        .ss_strap_generic()
+        .at(0)
+        .write(|_| otp_dai_idle_bit_num | OTP_STATUS_REG_OFFSET);
+    hw.boot(BootParams::default()).unwrap();
+
+    hw.step_until(|m| {
+        let resp = m.soc_ifc().ss_dbg_service_reg_rsp().read();
+        resp.uds_program_success()
+    });
 }
 
 #[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI


### PR DESCRIPTION
Read the OTP status register offset from SS_STRAP_GENERIC[0][15:0] and use it when polling DAI idle state during UDS/FE programming. Keep the existing generated status register path as a temporary fallback until MCU programs the offset.

Add ROM integration coverage for the configured status offset path.

Fixes #3710