### PR TITLE
[ci] bump MCU to e510070 and re-enable encrypted FW FPGA test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,15 +12,6 @@
 # and our CI build pulls it in.
 # See https://github.com/chipsalliance/caliptra-mcu-sw/pull/1135 (a04a9c28)
 # which introduced the cfg(feature = "ocp-lock") gate.
-#
-# TEMPORARILY skipped: test_encrypted_firmware::test_encrypted_firmware_decrypt_dma
-# Hits the 180s nextest slow-timeout on FPGA subsystem under MCU 6f3bea29. The
-# MCU runs through the encrypted boot flow successfully (CM_IMPORT,
-# CM_AES_GCM_DECRYPT_DMA, MCU ROM digest verification), then triggers a warm
-# reset to enter FwBoot. Test framework appears to be waiting on something
-# afterwards that never settles. Investigating separately — likely related to
-# the FwBoot path after warm reset in the new MCU ROM. Re-enable once the
-# underlying issue is understood.
 [profile.fpga-subsystem]
 default-filter = """
 (package(caliptra-hw-model) and test(tests::test_execution)) |
@@ -38,7 +29,6 @@ default-filter = """
     - test(test_invoke_dpe::test_export_cdi_destroyed_root_context)
     - test(test_fe_programming::test_fe_programming_cmd)
     - test(/^test_ocp_lock::/)
-    - test(test_encrypted_firmware::test_encrypted_firmware_decrypt_dma)
     - test(test_set_auth_manifest::test_set_auth_manifest_cmd_external)) |
 (package(caliptra-rom)
     - test(test_debug_unlock::)

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -61,7 +61,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: 6f3bea29ec2fd0d8613d78228cfd8e67726ef4ad 
+  CALIPTRA_MCU_COMMIT: e510070082ba74c2fd6d72c6b39c784bafec1246
 
 jobs:
   check_cache:
@@ -113,7 +113,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db888988
-      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '6f3bea29ec2fd0d8613d78228cfd8e67726ef4ad' }}
+      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || 'e510070082ba74c2fd6d72c6b39c784bafec1246' }}
 
     steps:
       - name: Checkout repo

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -408,6 +408,36 @@ pub enum DpeResult {
     MboxCmdFailure(CaliptraError),
 }
 
+/// Issue a mailbox command, retrying while the mailbox lock is held by another
+/// agent (e.g. the MCU ROM finishing post-runtime fuse work on the FPGA
+/// subsystem profile). On `UnableToLockMailbox`, step the model to let the MCU
+/// make progress and try again. All other errors and successful responses are
+/// returned immediately.
+pub fn mailbox_execute_with_lock_retry(
+    model: &mut DefaultHwModel,
+    cmd: u32,
+    buf: &[u8],
+) -> std::result::Result<Option<Vec<u8>>, ModelError> {
+    // Generous bounds: the MCU ROM's post-RT fuse work observed on FPGA
+    // subsystem completes well within a few hundred thousand cycles, so up to
+    // ~100 attempts of ~1000 steps each (~100k steps total) gives substantial
+    // headroom without making a wedged test hang for long.
+    const MAX_ATTEMPTS: u32 = 100;
+    const STEPS_PER_ATTEMPT: u32 = 1000;
+
+    for _ in 0..MAX_ATTEMPTS {
+        match model.mailbox_execute(cmd, buf) {
+            Err(ModelError::UnableToLockMailbox) => {
+                for _ in 0..STEPS_PER_ATTEMPT {
+                    model.step();
+                }
+            }
+            other => return other,
+        }
+    }
+    Err(ModelError::UnableToLockMailbox)
+}
+
 pub fn check_header_checksum(resp: &[u8]) -> anyhow::Result<()> {
     let resp_hdr =
         MailboxReqHeader::try_read_from_bytes(&resp[..core::mem::size_of::<MailboxReqHeader>()])

--- a/runtime/tests/runtime_integration_tests/test_firmware_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_firmware_verify.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{start_rt_test_pqc_model, RuntimeTestArgs};
+use crate::common::{mailbox_execute_with_lock_retry, start_rt_test_pqc_model, RuntimeTestArgs};
 use caliptra_api::mailbox::{FirmwareVerifyResp, FirmwareVerifyResult};
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::CommandId;
@@ -18,10 +18,13 @@ fn test_firmware_verify_success() {
     let image = image_bundle.to_bytes().unwrap();
     model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
 
-    let resp = model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_VERIFY), image.as_slice())
-        .unwrap()
-        .expect("Failed to verify valid caliptra image");
+    let resp = mailbox_execute_with_lock_retry(
+        &mut model,
+        u32::from(CommandId::FIRMWARE_VERIFY),
+        image.as_slice(),
+    )
+    .unwrap()
+    .expect("Failed to verify valid caliptra image");
 
     let firmware_verify_resp = FirmwareVerifyResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
@@ -40,7 +43,8 @@ fn test_firmware_verify_invalid_image() {
 
     let invalid_image = vec![0u8; 1024]; // An obviously invalid image
 
-    let resp = model.mailbox_execute(
+    let resp = mailbox_execute_with_lock_retry(
+        &mut model,
         u32::from(CommandId::FIRMWARE_VERIFY),
         invalid_image.as_slice(),
     );
@@ -65,13 +69,13 @@ fn test_firmware_verify_invalid_image() {
     }
 
     let invalid_image = vec![0u8; 32 * 1024]; // An obviously invalid image
-    let resp = model
-        .mailbox_execute(
-            u32::from(CommandId::FIRMWARE_VERIFY),
-            invalid_image.as_slice(),
-        )
-        .unwrap()
-        .expect("Expected a response for invalid image");
+    let resp = mailbox_execute_with_lock_retry(
+        &mut model,
+        u32::from(CommandId::FIRMWARE_VERIFY),
+        invalid_image.as_slice(),
+    )
+    .unwrap()
+    .expect("Expected a response for invalid image");
     let firmware_verify_resp = FirmwareVerifyResp::read_from_bytes(resp.as_slice()).unwrap();
     assert_eq!(
         firmware_verify_resp.verify_result,


### PR DESCRIPTION
The MCU main-2.1 tip now sends ACTIVATE_FIRMWARE INITIAL_ACTIVATE after encrypted decrypt (caliptra-mcu-sw#1450), unblocking test_encrypted_firmware::test_encrypted_firmware_decrypt_dma on the fpga-subsystem profile.

Also adds retries to mailbox lock grabbing in integration tests to avoid problems when racing MCU ROM to getting the mailbox lock.