### PR TITLE
[fix] Run ML-KEM KATs before driver use

### DIFF
--- a/drivers/src/abr.rs
+++ b/drivers/src/abr.rs
@@ -104,11 +104,11 @@ impl Abr {
     ///     ml_kem.key_pair(seeds)
     /// })?;
     /// ```
-    pub fn with_ml_kem<'s, F, R>(&'s mut self, f: F) -> R
+    pub fn with_ml_kem<'s, F, R>(&'s mut self, f: F) -> CaliptraResult<R>
     where
-        F: FnOnce(MlKem1024<'s>) -> R,
+        F: FnOnce(MlKem1024<'s>) -> CaliptraResult<R>,
     {
-        let ml_kem = MlKem1024::new(&mut self.abr);
+        let ml_kem = MlKem1024::new(&mut self.abr)?;
         f(ml_kem)
     }
 }

--- a/drivers/src/hpke/kem/hybrid.rs
+++ b/drivers/src/hpke/kem/hybrid.rs
@@ -215,7 +215,7 @@ impl
 
         let (pq_enc, pq_shared_secret) = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg)?;
             let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.encap(&mut ctx, pq_ek)?
@@ -251,7 +251,7 @@ impl
 
         let pq_shared_secret = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg)?;
             let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.decap(&mut ctx, pq_enc)?
@@ -279,7 +279,7 @@ impl
     ) -> CaliptraResult<HybridEncapsulationKey> {
         let pq_ek = {
             let (pq_seed, _) = Self::expand_seed(ctx.sha, &self.seed)?;
-            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg);
+            let mut ml_kem_driver = MlKem1024::new(ctx.abr_reg)?;
             let mut ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem_driver);
             let mut mlkem = MlKem::derive_key_pair_raw(pq_seed);
             mlkem.serialize_public_key(&mut ctx)?

--- a/drivers/src/hpke/mod.rs
+++ b/drivers/src/hpke/mod.rs
@@ -221,7 +221,7 @@ impl HpkeContext {
             match key {
                 HpkePrivateKey::MlKem { handle, context } if handle == hpke_handle => {
                     let mut kem = {
-                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg());
+                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg())?;
                         let mut ctx = MlKemContext::new(trng, sha, &mut ml_kem_driver);
                         MlKem::derive_key_pair(&mut ctx, context.as_ref())?
                     };
@@ -306,7 +306,7 @@ impl HpkeContext {
                         .ok_or(CaliptraError::RUNTIME_OCP_LOCK_DESERIALIZE_ENC_FAILURE)?;
 
                     let mut kem = {
-                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg());
+                        let mut ml_kem_driver = MlKem1024::new(abr.abr_reg())?;
                         let mut ctx = MlKemContext::new(trng, sha, &mut ml_kem_driver);
                         MlKem::derive_key_pair(&mut ctx, context.as_ref())?
                     };
@@ -442,7 +442,7 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
             .map_err(|_| CaliptraError::RUNTIME_DRIVER_HPKE_ML_KEM_PKR_DESERIALIZATION_FAIL)?;
 
         let (enc, shared_secret) = {
-            let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+            let mut ml_kem = MlKem1024::new(ctx.abr_reg)?;
             let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
             kem.encap(&mut kem_ctx, pkr)?
         };
@@ -466,7 +466,7 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
         info: &[u8],
     ) -> CaliptraResult<EncryptionContext<Receiver>> {
         let shared_secret = {
-            let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+            let mut ml_kem = MlKem1024::new(ctx.abr_reg)?;
             let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
             kem.decap(&mut kem_ctx, enc)?
         };
@@ -488,7 +488,7 @@ impl Hpke<{ MlKem::NSK }, { MlKem::NENC }, { MlKem::NPK }, { MlKem::NSECRET }>
         ctx: &mut Self::DriverContext<'_>,
         out_key: &mut [u8; MlKem::NPK],
     ) -> CaliptraResult<usize> {
-        let mut ml_kem = MlKem1024::new(ctx.abr_reg);
+        let mut ml_kem = MlKem1024::new(ctx.abr_reg)?;
         let mut kem_ctx = MlKemContext::new(ctx.trng, ctx.sha, &mut ml_kem);
         let ek = kem.serialize_public_key(&mut kem_ctx)?;
         out_key.clone_from_slice(ek.as_ref());

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -149,11 +149,13 @@ pub struct MlKem1024<'a> {
 }
 
 impl<'a> MlKem1024<'a> {
-    pub fn new(mlkem: &'a mut AbrReg) -> Self {
-        Self { mlkem }
+    pub fn new(mlkem: &'a mut AbrReg) -> CaliptraResult<Self> {
+        let mut driver = Self { mlkem };
+        driver.run_kats()?;
+        Ok(driver)
     }
 
-    /// Re-run KATs (for FIPS self-test).
+    /// Run KATs.
     pub fn run_kats(&mut self) -> CaliptraResult<()> {
         crate::kats::execute_mlkem1024_kat(self)
     }

--- a/drivers/test-fw/src/bin/hpke_tests.rs
+++ b/drivers/test-fw/src/bin/hpke_tests.rs
@@ -71,7 +71,7 @@ fn test_ml_kem_1024_test_vector() {
     let hpke = unsafe { HpkeMlKemContext::from_seed(MLKEM_TEST_VECTOR.ikm_r.try_into().unwrap()) };
 
     let mut kem = {
-        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg());
+        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg()).unwrap();
         let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut ml_kem_driver);
         MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap()
     };
@@ -113,7 +113,7 @@ fn test_ml_kem_1024_self_talk() {
 
     let hpke = HpkeMlKemContext::generate(&mut regs.trng).unwrap();
     let mut kem = {
-        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg());
+        let mut ml_kem_driver = MlKem1024::new(regs.abr.abr_reg()).unwrap();
         let mut ctx = MlKemContext::new(&mut regs.trng, &mut regs.sha3, &mut ml_kem_driver);
         MlKem::derive_key_pair(&mut ctx, hpke.as_ref()).unwrap()
     };

--- a/drivers/test-fw/src/bin/mlkem_tests.rs
+++ b/drivers/test-fw/src/bin/mlkem_tests.rs
@@ -97,7 +97,7 @@ fn test_mlkem_name() {
 fn test_key_pair_generation() {
     seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
 
     // Test key pair generation with arrays
     let seed_d = LEArray4x8::from(SEED_D);
@@ -305,7 +305,7 @@ fn test_key_pair_generation_from_kv() {
     };
 
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
     let mut hmac = unsafe { Hmac::new(HmacReg::new()) };
     let mut aes = Aes::new(unsafe { AesReg::new() }, unsafe { AesClpReg::new() }).unwrap();
 
@@ -407,7 +407,7 @@ fn test_key_pair_generation_from_kv() {
 fn test_encapsulate_and_decapsulate() {
     seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
 
     // Generate key pair
     let seed_d = LEArray4x8::from(SEED_D);
@@ -459,7 +459,7 @@ fn test_encapsulate_with_kv_message() {
     };
 
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
     let mut hmac = unsafe { Hmac::new(HmacReg::new()) };
 
     // Generate key pair
@@ -639,7 +639,7 @@ fn test_encapsulate_with_kv_message() {
 fn test_encapsulate_with_kv_output() {
     seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
 
     // Generate key pair
     let seed_d = LEArray4x8::from(SEED_D);
@@ -672,7 +672,7 @@ fn test_encapsulate_with_kv_output() {
 fn test_keygen_decapsulate() {
     seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
 
     // Generate key pair for encapsulation
     let seed_d = LEArray4x8::from(SEED_D);
@@ -711,7 +711,7 @@ fn test_keygen_decapsulate() {
 fn test_keygen_decapsulate_with_kv() {
     seed_abr_entropy();
     let mut abr_reg = unsafe { AbrReg::new() };
-    let mut mlkem = MlKem1024::new(&mut abr_reg);
+    let mut mlkem = MlKem1024::new(&mut abr_reg).unwrap();
     let mut aes = Aes::new(unsafe { AesReg::new() }, unsafe { AesClpReg::new() }).unwrap();
 
     // Generate key pair for encapsulation using KV

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -2472,7 +2472,7 @@ impl Commands {
 
         let (seed_d, seed_z) = Self::decrypt_mlkem_seeds(drivers, &cmd.cmk)?;
         let seeds = MlKem1024Seeds::Arrays(&seed_d, &seed_z);
-        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg())?;
         let (encaps_key, _decaps_key) = ml_kem.key_pair(seeds, None)?;
 
         let resp = mutrefbytes::<CmMlkemKeyGenResp>(resp)?;
@@ -2511,7 +2511,7 @@ impl Commands {
         };
 
         let mut shared_key = MlKem1024SharedKey::default();
-        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg())?;
         let ciphertext = ml_kem.encapsulate(
             &encaps_key,
             MlKem1024MessageSource::Array(&message),
@@ -2552,7 +2552,7 @@ impl Commands {
         let ciphertext: LEArray4x392 = (&cmd.ciphertext).into();
 
         let mut shared_key = MlKem1024SharedKey::default();
-        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg());
+        let mut ml_kem = MlKem1024::new(drivers.abr.abr_reg())?;
         ml_kem.keygen_decapsulate(
             seeds,
             &ciphertext,

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -186,9 +186,7 @@ pub mod fips_self_test_cmd {
         })?;
 
         // Run MLKEM1024 KAT separately since ABR can't be borrowed for both mldsa87 and mlkem1024
-        env.abr.with_ml_kem(|mut mlkem1024| {
-            caliptra_drivers::kats::execute_mlkem1024_kat(&mut mlkem1024)
-        })?;
+        let _mlkem1024 = caliptra_drivers::MlKem1024::new(env.abr.abr_reg())?;
 
         Ok(())
     }


### PR DESCRIPTION
Make MlKem1024 construction fallible so the ML-KEM KAT runs before any ML-KEM operation, and propagate the result through HPKE, runtime mailbox, and test firmware call sites.