### PR TITLE
runtime: Add MCU RT to DPE with SVN for attestation

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -57,6 +57,8 @@ pub const CMB_AES_KEY_SHARE_SIZE: u32 = 32;
 pub const DOT_OWNER_PK_HASH_SIZE: u32 = 13 * 4;
 pub const CLEARED_NON_FATAL_FW_ERROR_SIZE: u32 = 4;
 pub const MCU_FIRMWARE_LOADED_SIZE: u32 = 4;
+#[cfg(feature = "runtime")]
+pub const SOC_MANIFEST_SVN_SIZE: u32 = 4;
 pub const _DPE_PL_CONTEXT_LIMITS_WITH_PAD_SIZE: u32 = 4; // u8 + u8 + 2 bytes padding
 
 #[cfg(feature = "runtime")]
@@ -94,6 +96,15 @@ pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
 #[cfg(feature = "runtime")]
 pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
+
+#[cfg(feature = "runtime")]
+#[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize, Default)]
+#[repr(C)]
+pub struct CaliptraManagedDpeContextIndices {
+    pub cciv: u8,
+    pub mcu_rt: u8,
+    pub reserved: [u8; 2],
+}
 
 #[derive(Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes, Zeroize)]
 #[repr(C)]
@@ -381,6 +392,14 @@ pub struct PersistentData {
     /// changing the frozen ROM binary. FMC writes this during handoff,
     /// runtime reads it for MLDSA signing operations.
     pub rt_mldsa_keypair_seed_kv_hdl: HandOffDataHandle,
+
+    /// SoC manifest SVN, stored after auth manifest validation.
+    /// Used as the MCU RT current_svn when creating the MCU RT DPE context.
+    #[cfg(feature = "runtime")]
+    pub soc_manifest_svn: u32,
+
+    #[cfg(feature = "runtime")]
+    pub caliptra_managed_dpe_context_indices: CaliptraManagedDpeContextIndices,
 }
 
 impl PersistentData {
@@ -548,7 +567,30 @@ impl PersistentData {
                 addr_of!((*P).dpe_pl0_context_limit) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
+            persistent_data_offset += _DPE_PL_CONTEXT_LIMITS_WITH_PAD_SIZE;
+            assert_eq!(
+                addr_of!((*P).rt_mldsa_keypair_seed_kv_hdl) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+            persistent_data_offset += size_of::<HandOffDataHandle>() as u32;
+            #[cfg(feature = "runtime")]
+            {
+                assert_eq!(
+                    addr_of!((*P).soc_manifest_svn) as u32,
+                    memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+                );
+                persistent_data_offset += SOC_MANIFEST_SVN_SIZE;
+                assert_eq!(
+                    addr_of!((*P).caliptra_managed_dpe_context_indices) as u32,
+                    memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+                );
+                persistent_data_offset += size_of::<CaliptraManagedDpeContextIndices>() as u32;
+            }
 
+            assert_eq!(
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset,
+                memory_layout::DATA_ORG
+            );
             assert_eq!(P.add(1) as u32, memory_layout::DATA_ORG);
         }
     }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1589,14 +1589,14 @@ impl CaliptraError {
             "Runtime Error: Attested CSR COSE Sign1 encoding error"
         ),
         (
-            RUNTIME_CCIV_CONTEXT_NOT_FOUND,
+            RUNTIME_DPE_CONTEXT_NOT_FOUND,
             0x000E0093,
-            "Runtime Error: CCIV context not found"
+            "Runtime Error: DPE context not found"
         ),
         (
-            RUNTIME_MULTIPLE_CCIV_CONTEXTS_FOUND,
+            RUNTIME_MULTIPLE_DPE_CONTEXTS_FOUND,
             0x000E0094,
-            "Runtime Error: Multiple CCIV contexts found"
+            "Runtime Error: Multiple DPE contexts found"
         ),
         (
             RUNTIME_INVOKE_DPE_RESPONSE_TOO_LARGE,

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -18,7 +18,7 @@ use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
 use crate::drivers::{McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
-use caliptra_api::mailbox::{AuthAndStashFlags, AuthorizeAndStashReq, ImageHashSource};
+use caliptra_api::mailbox::{AuthorizeAndStashReq, ImageHashSource};
 use caliptra_auth_man_types::ImageMetadataFlags;
 use caliptra_common::mailbox_api::{ActivateFirmwareReq, ActivateFirmwareResp, MailboxRespHeader};
 use caliptra_drivers::dma::MCU_SRAM_OFFSET;
@@ -202,28 +202,32 @@ impl ActivateFirmwareCmd {
                 )
                 .map_err(|_| ())?;
 
-            // Verify MCU after loading
+            // Update MCU RT DPE context with new measurement.
+            // SVN stays the same as the recovery boot value.
             let auth_and_stash_req = AuthorizeAndStashReq {
                 fw_id: ActivateFirmwareReq::MCU_IMAGE_ID.to_le_bytes(),
                 measurement: [0; 48],
                 source: ImageHashSource::LoadAddress.into(),
-                flags: AuthAndStashFlags::SKIP_STASH.bits(),
                 image_size: mcu_image_size,
                 ..Default::default()
             };
 
             let pl0_pauser_locality = drivers.persistent_data.get().manifest1.header.pl0_pauser;
-            let authorization_result = AuthorizeAndStashCmd::authorize_and_stash(
-                drivers,
-                &auth_and_stash_req,
-                pl0_pauser_locality,
-            )
-            .map_err(|_| ())?;
+            let (authorization_result, measurement) =
+                AuthorizeAndStashCmd::authorize_image(drivers, &auth_and_stash_req)
+                    .map_err(|_| ())?;
 
             // Make sure the image was properly authorized.
             if authorization_result != authorize_and_stash::IMAGE_AUTHORIZED {
                 return Err(());
             }
+            drivers
+                .update_caliptra_managed_measurement(
+                    Drivers::MCU_RT_TCI_TYPE,
+                    &measurement,
+                    Some(pl0_pauser_locality),
+                )
+                .map_err(|_| ())?;
 
             drivers.persistent_data.get_mut().mcu_firmware_loaded = McuFwStatus::Loaded.into();
         }

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -67,6 +67,39 @@ impl AuthorizeAndStashCmd {
         cmd: &AuthorizeAndStashReq,
         locality: u32,
     ) -> CaliptraResult<u32> {
+        let (auth_result, stash_measurement) = Self::authorize_image(drivers, cmd)?;
+
+        // Stash the measurement if the image is authorized.
+        if auth_result == IMAGE_AUTHORIZED {
+            let flags: AuthAndStashFlags = cmd.flags.into();
+            if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
+                let dpe_result = StashMeasurementCmd::stash_measurement(
+                    drivers,
+                    &cmd.fw_id,
+                    &stash_measurement,
+                    cmd.svn,
+                    drivers.caller_privilege_level(),
+                    locality,
+                )?;
+                if dpe_result != DpeErrorCode::NoError {
+                    drivers
+                        .soc_ifc
+                        .set_fw_extended_error(dpe_result.get_error_code());
+
+                    Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
+                }
+            }
+        }
+
+        Ok(auth_result)
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn authorize_image(
+        drivers: &mut Drivers,
+        cmd: &AuthorizeAndStashReq,
+    ) -> CaliptraResult<(u32, [u8; 48])> {
         let source = ImageHashSource::from(cmd.source);
         if source == ImageHashSource::Invalid {
             Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
@@ -82,7 +115,11 @@ impl AuthorizeAndStashCmd {
         let auth_manifest_image_metadata_col = &persistent_data.auth_manifest_image_metadata_col;
 
         let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
+        // The measurement used for both authorization and stashing/updating DPE.
+        // For InRequest source, this is cmd.measurement.
+        // For LoadAddress/StagingAddress, this is computed from the image in memory.
         let mut stash_measurement = cmd.measurement;
+
         let auth_result = if let Some(metadata_entry) =
             find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id)
         {
@@ -137,28 +174,7 @@ impl AuthorizeAndStashCmd {
         } else {
             IMAGE_NOT_AUTHORIZED
         };
-        // Stash the measurement if the image is authorized.
-        if auth_result == IMAGE_AUTHORIZED {
-            let flags: AuthAndStashFlags = cmd.flags.into();
-            if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
-                let dpe_result = StashMeasurementCmd::stash_measurement(
-                    drivers,
-                    &cmd.fw_id,
-                    &stash_measurement,
-                    cmd.svn,
-                    drivers.caller_privilege_level(),
-                    locality,
-                )?;
-                if dpe_result != DpeErrorCode::NoError {
-                    drivers
-                        .soc_ifc
-                        .set_fw_extended_error(dpe_result.get_error_code());
 
-                    Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
-                }
-            }
-        }
-
-        Ok(auth_result)
+        Ok((auth_result, stash_measurement))
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -55,7 +55,7 @@ use caliptra_dpe_response_buffer::SliceResponseBuffer;
 use caliptra_drivers::{
     cprintln,
     hand_off::DataStore,
-    pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
+    pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
     Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms, Mldsa87,
     Mldsa87PubKey, PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha1, Sha256, Sha256Alg,
@@ -167,6 +167,9 @@ pub struct Drivers {
 }
 
 impl Drivers {
+    pub const CCIV_TCI_TYPE: u32 = u32::from_be_bytes(*b"CCIV");
+    pub const MCU_RT_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
+
     /// # Safety
     ///
     /// Callers must ensure that this function is called only once, and that
@@ -230,6 +233,7 @@ impl Drivers {
                 if self.soc_ifc.subsystem_mode() {
                     RecoveryFlow::recovery_flow(self)?;
                 }
+                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::UpdateReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::UpdateReset);
@@ -237,6 +241,9 @@ impl Drivers {
                 Self::validate_context_tags(self)?;
                 Self::update_dpe_rt_tci(self)?;
                 Self::update_dpe_cciv(self)?;
+                // Repopulate appended context-index cache for hitless updates
+                // from older runtimes that did not have these persistent fields.
+                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::WarmReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::WarmReset);
@@ -287,49 +294,139 @@ impl Drivers {
         Ok(root_idx)
     }
 
-    /// Returns the index of the single CCIV context that is an immediate child of the DPE root.
-    /// Errors if none or if multiple are found.
-    ///
-    /// # Arguments
-    ///
-    /// * `dpe` - DpeInstance
-    ///
-    /// # Returns
-    ///
-    /// * `usize` - Index containing the CCIV DPE context
     #[inline(always)]
-    pub fn get_dpe_cciv_context_idx(dpe: &caliptra_dpe::State) -> CaliptraResult<usize> {
-        // Find the root context index using your existing helper
-        let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
-
-        let cciv_type = u32::from_be_bytes(*b"CCIV");
+    pub fn get_dpe_context_idx_by_tci_type(
+        dpe: &caliptra_dpe::State,
+        tci_type: u32,
+        locality: Option<u32>,
+        parent_idx: Option<u8>,
+    ) -> CaliptraResult<usize> {
         let mut found_idx: Option<usize> = None;
 
-        // Search only immediate children of root for an active, Normal CCIV context
         for (idx, ctx) in dpe.contexts.iter().enumerate() {
             if ctx.state != ContextState::Inactive
                 && ctx.context_type == ContextType::Normal
-                && ctx.parent_idx == root_idx
-                && ctx.tci.tci_type == cciv_type
+                && ctx.tci.tci_type == tci_type
+                && locality.is_none_or(|locality| ctx.locality == locality)
+                && parent_idx.is_none_or(|parent_idx| ctx.parent_idx == parent_idx)
             {
                 if found_idx.is_some() {
-                    // Multiple CCIV children found under root
-                    return Err(CaliptraError::RUNTIME_MULTIPLE_CCIV_CONTEXTS_FOUND);
+                    return Err(CaliptraError::RUNTIME_MULTIPLE_DPE_CONTEXTS_FOUND);
                 }
                 found_idx = Some(idx);
             }
         }
 
-        match found_idx {
-            Some(idx) => {
-                // prevent panic
-                if idx >= dpe.contexts.len() {
-                    return Err(CaliptraError::RUNTIME_CCIV_CONTEXT_NOT_FOUND);
-                }
-                Ok(idx)
-            }
-            None => Err(CaliptraError::RUNTIME_CCIV_CONTEXT_NOT_FOUND),
+        found_idx.ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)
+    }
+
+    #[inline(always)]
+    fn get_caliptra_managed_dpe_context_index(&self, tci_type: u32) -> CaliptraResult<usize> {
+        let indices = self
+            .persistent_data
+            .get()
+            .caliptra_managed_dpe_context_indices;
+        let idx = match tci_type {
+            Self::CCIV_TCI_TYPE => indices.cciv,
+            Self::MCU_RT_TCI_TYPE => indices.mcu_rt,
+            _ => return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND),
+        };
+
+        Ok(idx as usize)
+    }
+
+    fn cache_caliptra_managed_dpe_context_indices(&mut self) -> CaliptraResult<()> {
+        if self.persistent_data.get().attestation_disabled.get() {
+            return Ok(());
         }
+
+        let (cciv_idx, mcu_rt_idx) = {
+            let persistent_data = self.persistent_data.get();
+            let dpe = &persistent_data.state;
+            let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
+            let cciv_idx = Self::get_dpe_context_idx_by_tci_type(
+                dpe,
+                Self::CCIV_TCI_TYPE,
+                None,
+                Some(root_idx),
+            )?;
+            let mcu_rt_idx = Self::get_dpe_context_idx_by_tci_type(
+                dpe,
+                Self::MCU_RT_TCI_TYPE,
+                Some(persistent_data.manifest1.header.pl0_pauser),
+                None,
+            )
+            .ok();
+            (cciv_idx, mcu_rt_idx)
+        };
+
+        let indices = &mut self
+            .persistent_data
+            .get_mut()
+            .caliptra_managed_dpe_context_indices;
+        indices.cciv =
+            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        if let Some(mcu_rt_idx) = mcu_rt_idx {
+            indices.mcu_rt = u8::try_from(mcu_rt_idx)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn update_caliptra_managed_measurement(
+        &mut self,
+        tci_type: u32,
+        measurement: &[u8; 48],
+        locality: Option<u32>,
+    ) -> CaliptraResult<()> {
+        let persistent_data = self.persistent_data.get();
+        let idx = self.get_caliptra_managed_dpe_context_index(tci_type)?;
+        let ctx = persistent_data
+            .state
+            .contexts
+            .get(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        if ctx.state == ContextState::Inactive
+            || ctx.context_type != ContextType::Normal
+            || ctx.tci.tci_type != tci_type
+            || locality.is_some_and(|locality| ctx.locality != locality)
+        {
+            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
+        }
+        let prev_journey = persistent_data
+            .state
+            .contexts
+            .get(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?
+            .tci
+            .tci_cumulative
+            .0;
+
+        let mut digest_op = self.sha2_512_384.sha384_digest_init()?;
+        digest_op.update(&prev_journey)?;
+        digest_op.update(measurement)?;
+        let mut journey_hash = Array4x12::default();
+        digest_op.finalize(&mut journey_hash)?;
+        let new_journey: [u8; 48] = journey_hash.into();
+
+        let context = self
+            .persistent_data
+            .get_mut()
+            .state
+            .contexts
+            .get_mut(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        context.tci.tci_current = TciMeasurement(*measurement);
+        context.tci.tci_cumulative = TciMeasurement(new_journey);
+        self.pcr_bank.extend_pcr(
+            PCR_ID_STASH_MEASUREMENT,
+            &mut self.sha2_512_384,
+            measurement,
+        )?;
+        Ok(())
     }
 
     pub fn set_mcu_reset_reason(drivers: &mut Drivers, reason: McuResetReason) {
@@ -412,29 +509,34 @@ impl Drivers {
         }
         let initialization_values_hash: [u8; 48] =
             <[u8; 48]>::from(Self::compute_initialization_values_hash(drivers)?);
-        let dpe = &mut drivers.persistent_data.get_mut().state;
-        let cciv_idx = Self::get_dpe_cciv_context_idx(dpe)?;
-
         // Only update if changed
-        let prev_current: [u8; 48] = dpe.contexts[cciv_idx].tci.tci_current.0;
+        let dpe = &drivers.persistent_data.get().state;
+        let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
+        let cciv_idx =
+            Self::get_dpe_context_idx_by_tci_type(dpe, Self::CCIV_TCI_TYPE, None, Some(root_idx))?;
+        let cciv_ctx = drivers
+            .persistent_data
+            .get()
+            .state
+            .contexts
+            .get(cciv_idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        if cciv_ctx.state == ContextState::Inactive
+            || cciv_ctx.context_type != ContextType::Normal
+            || cciv_ctx.tci.tci_type != Self::CCIV_TCI_TYPE
+        {
+            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
+        }
+        let prev_current: [u8; 48] = cciv_ctx.tci.tci_current.0;
         if prev_current == initialization_values_hash {
             return Ok(());
         }
 
-        // Compute new journey: SHA-384(prev_journey || initialization_values_hash)
-        let prev_journey: [u8; 48] = dpe.contexts[cciv_idx].tci.tci_cumulative.0;
-        let mut digest_op = drivers.sha2_512_384.sha384_digest_init()?;
-        digest_op.update(&prev_journey)?;
-        digest_op.update(&initialization_values_hash)?;
-        let mut journey_hash = Array4x12::default();
-        digest_op.finalize(&mut journey_hash)?;
-        let new_journey: [u8; 48] = journey_hash.into();
-
-        // Update CCIV current and cumulative
-        dpe.contexts[cciv_idx].tci.tci_current = TciMeasurement(initialization_values_hash);
-        dpe.contexts[cciv_idx].tci.tci_cumulative = TciMeasurement(new_journey);
-
-        Ok(())
+        drivers.update_caliptra_managed_measurement(
+            Self::CCIV_TCI_TYPE,
+            &initialization_values_hash,
+            None,
+        )
     }
 
     fn update_fw_version(drivers: &mut Drivers, update_fmc_ver: bool, update_rt_ver: bool) {
@@ -657,6 +759,12 @@ impl Drivers {
             }
             Err(CaliptraError::RUNTIME_ADD_CCIV_MEASUREMENT_TO_DPE_FAILED)?
         }
+        pdata.caliptra_managed_dpe_context_indices.cciv = u8::try_from(
+            env.state
+                .get_active_context_pos(&ContextHandle::default(), pl0_pauser_locality)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
 
         // Call DeriveContext to create TCIs for each measurement added in ROM
         let num_measurements = pdata.fht.meas_log_index as usize;

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -118,12 +118,14 @@ impl RecoveryFlow {
         let digest: [u8; 48] = digest.into();
         cprintln!("[rt] Verifying MCU digest: {}", HexBytes(&digest));
         // verify the digest
+        let soc_manifest_svn = drivers.persistent_data.get().soc_manifest_svn;
         let auth_and_stash_req = AuthorizeAndStashReq {
             fw_id: [2, 0, 0, 0],
             measurement: digest,
             source: ImageHashSource::InRequest.into(),
             // We want to make sure this measurement is not skipped.
             flags: 0,
+            svn: soc_manifest_svn,
             ..Default::default()
         };
 

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -784,6 +784,10 @@ impl SetAuthManifestCmd {
         if !verify_only {
             persistent_data.auth_manifest_digest =
                 drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            // Store the SoC manifest SVN for use as the MCU RT current_svn
+            // when creating the MCU RT DPE context during recovery boot or
+            // hitless update.
+            persistent_data.soc_manifest_svn = auth_manifest_preamble.svn;
         }
         Ok(())
     }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -98,6 +98,21 @@ impl StashMeasurementCmd {
         };
 
         if let DpeErrorCode::NoError = dpe_result {
+            if metadata == &[2, 0, 0, 0] {
+                let mcu_rt_dpe_context_idx = drivers
+                    .persistent_data
+                    .get()
+                    .state
+                    .get_active_context_pos(&ContextHandle::default(), locality)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                drivers
+                    .persistent_data
+                    .get_mut()
+                    .caliptra_managed_dpe_context_indices
+                    .mcu_rt = u8::try_from(mcu_rt_dpe_context_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            }
+
             // Extend the measurement into PCR31
             drivers.pcr_bank.extend_pcr(
                 PCR_ID_STASH_MEASUREMENT,

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -192,9 +192,15 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 write_response(&mut drivers.mbox, root_measurement);
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_MEASUREMENT) => {
-                let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().state)
-                        .unwrap();
+                let dpe = &drivers.persistent_data.get().state;
+                let root_idx = Drivers::get_dpe_root_context_idx(dpe).unwrap() as u8;
+                let cciv_idx = Drivers::get_dpe_context_idx_by_tci_type(
+                    dpe,
+                    Drivers::CCIV_TCI_TYPE,
+                    None,
+                    Some(root_idx),
+                )
+                .unwrap();
                 let cciv_measurement = drivers.persistent_data.get().state.contexts[cciv_idx]
                     .tci
                     .tci_current
@@ -202,9 +208,15 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 write_response(&mut drivers.mbox, cciv_measurement);
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE) => {
-                let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().state)
-                        .unwrap();
+                let dpe = &drivers.persistent_data.get().state;
+                let root_idx = Drivers::get_dpe_root_context_idx(dpe).unwrap() as u8;
+                let cciv_idx = Drivers::get_dpe_context_idx_by_tci_type(
+                    dpe,
+                    Drivers::CCIV_TCI_TYPE,
+                    None,
+                    Some(root_idx),
+                )
+                .unwrap();
                 let cciv_measurement = drivers.persistent_data.get().state.contexts[cciv_idx]
                     .tci
                     .tci_cumulative

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -5,8 +5,8 @@ use caliptra_api::mailbox::ActivateFirmwareReq;
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
 use caliptra_common::mailbox_api::{
-    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
-    MailboxReqHeader,
+    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetTaggedTciReq, GetTaggedTciResp,
+    ImageHashSource, MailboxReq, MailboxReqHeader, TagTciReq,
 };
 use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
 use caliptra_runtime::IMAGE_AUTHORIZED;
@@ -66,6 +66,7 @@ pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
 // hitless-update reset.
 pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
+const MCU_TCI_TAG: u32 = u32::from_be_bytes(*b"MCFW");
 
 /// Create a valid RISC-V firmware image that won't crash with an illegal
 /// instruction exception on real FPGA hardware. Uses `0x37` repeated, which
@@ -258,18 +259,60 @@ fn send_activate_firmware_cmd(
     model.finish_mailbox_execute()
 }
 
+fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
+    let mut tag_cmd = MailboxReq::TagTci(TagTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        handle: [0u8; 16],
+        tag: MCU_TCI_TAG,
+    });
+    tag_cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_TAG_TCI),
+            tag_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    get_mcu_tci(model)
+}
+
+fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
+    let mut get_cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        tag: MCU_TCI_TAG,
+    });
+    get_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_GET_TAGGED_TCI),
+            get_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap()
+}
+
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_activate_mcu_fw_success() {
+    let mcu_contents = mcu_test_firmware();
+    let mut hasher = Sha384::new();
+    hasher.update(&mcu_contents);
+    let mcu_digest: [u8; 48] = hasher.finalize().into();
+
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: mcu_test_firmware(),
+        contents: mcu_contents,
         exec_bit: 2,
     };
 
     let mut model = load_and_authorize_fw(&[mcu_image]);
+    let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
+    assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
 
     // Send ActivateFirmware command
     let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
@@ -286,6 +329,18 @@ fn test_activate_mcu_fw_success() {
     send_activate_firmware_cmd(&mut model, activate_cmd, true)
         .unwrap()
         .expect("We should have received a response");
+
+    #[cfg(not(feature = "fpga_subsystem"))]
+    {
+        let updated_mcu_tci = get_mcu_tci(&mut model);
+        assert_eq!(updated_mcu_tci.tci_current, mcu_digest);
+
+        let mut hasher = Sha384::new();
+        hasher.update(initial_mcu_tci.tci_cumulative);
+        hasher.update(mcu_digest);
+        let expected_updated_cumulative: [u8; 48] = hasher.finalize().into();
+        assert_eq!(updated_mcu_tci.tci_cumulative, expected_updated_cumulative);
+    }
 }
 
 #[cfg_attr(feature = "fpga_realtime", ignore)]

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -3,6 +3,7 @@
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+#[cfg(not(feature = "fpga_subsystem"))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, InitParams};
@@ -13,19 +14,56 @@ use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
-#[cfg_attr(
-    any(
-        feature = "verilator",
-        feature = "fpga_realtime",
-        feature = "fpga_subsystem"
-    ),
-    ignore
-)]
+#[derive(asn1::Asn1Read)]
+struct Fwid<'a> {
+    _hash_alg: asn1::ObjectIdentifier,
+    _digest: &'a [u8],
+}
+
+#[derive(asn1::Asn1Read)]
+struct IntegrityRegister<'a> {
+    #[implicit(0)]
+    _register_name: Option<asn1::IA5String<'a>>,
+    #[implicit(1)]
+    _register_num: Option<u64>,
+    #[implicit(2)]
+    _register_digests: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+}
+
+#[derive(asn1::Asn1Read)]
+struct TcbInfo<'a> {
+    #[implicit(0)]
+    _vendor: Option<asn1::Utf8String<'a>>,
+    #[implicit(1)]
+    _model: Option<asn1::Utf8String<'a>>,
+    #[implicit(2)]
+    _version: Option<asn1::Utf8String<'a>>,
+    #[implicit(3)]
+    svn: Option<u64>,
+    #[implicit(4)]
+    _layer: Option<u64>,
+    #[implicit(5)]
+    _index: Option<u64>,
+    #[implicit(6)]
+    _fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+    #[implicit(7)]
+    _flags: Option<asn1::BitString<'a>>,
+    #[implicit(8)]
+    _vendor_info: Option<&'a [u8]>,
+    #[implicit(9)]
+    tci_type: Option<&'a [u8]>,
+    #[implicit(10)]
+    _operational_flags_mask: Option<asn1::BitString<'a>>,
+    #[implicit(11)]
+    _integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
+}
+
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
 #[test]
 fn test_loads_mcu_fw() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
+    let mcu_fw = vec![0x37u8; 256];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
@@ -50,16 +88,20 @@ fn test_loads_mcu_fw() {
     args.mcu_fw_image = Some(&mcu_fw);
     let mut model = run_rt_test(args);
     model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
-    // check that we got an MCU write
-    let events = model.events_from_caliptra();
-    let mut found = false;
-    for event in events {
-        if event.dest == Device::MCU && matches!(event.event, EventData::MemoryWrite { .. }) {
-            found = true;
-            break;
+
+    #[cfg(not(feature = "fpga_subsystem"))]
+    {
+        // check that we got an MCU write
+        let events = model.events_from_caliptra();
+        let mut found = false;
+        for event in events {
+            if event.dest == Device::MCU && matches!(event.event, EventData::MemoryWrite { .. }) {
+                found = true;
+                break;
+            }
         }
+        assert!(found);
     }
-    assert!(found);
 }
 
 #[cfg_attr(
@@ -74,7 +116,7 @@ fn test_loads_mcu_fw() {
 fn test_mcu_fw_bad_signature() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
+    let mcu_fw = vec![0x37u8; 256];
     let bad_mcu_fw = vec![5, 6, 7, 8];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
@@ -105,4 +147,74 @@ fn test_mcu_fw_bad_signature() {
         CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH.into(),
         30_000_000,
     );
+}
+
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
+#[test]
+fn test_recovery_flow_with_svn() {
+    // Test that recovery boot passes the SoC manifest SVN to the MCU RT DPE context.
+    // The manifest is created with SVN=5, and fuses are configured to allow it.
+    use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+    use caliptra_image_types::FwVerificationPqcKeyType;
+
+    let mcu_fw = vec![0x37u8; 256];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata_with_svn(
+        metadata,
+        FwVerificationPqcKeyType::LMS,
+        5, // SVN = 5
+    );
+    let soc_manifest = soc_manifest.as_bytes();
+    let mut args = RuntimeTestArgs::default();
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    args.init_params = Some(InitParams {
+        rom: &rom,
+        subsystem_mode: true,
+        ..Default::default()
+    });
+    args.soc_manifest = Some(soc_manifest);
+    args.mcu_fw_image = Some(&mcu_fw);
+    args.soc_manifest_svn = Some(5);
+    args.soc_manifest_max_svn = Some(127);
+    let mut model = run_rt_test(args);
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
+    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
+    use x509_parser::{nom::Parser, prelude::*};
+
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+    let CertifyKeyResp::P384(certify_key_resp) = certify_key(&mut model, certify_key_cmd).unwrap()
+    else {
+        panic!("Wrong response type!");
+    };
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
+    let (_, cert) = X509CertificateParser::new()
+        .with_deep_parse_extensions(true)
+        .parse(cert_bytes)
+        .unwrap();
+    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
+    let ext = cert
+        .get_extension_unique(&multi_tcb_info_oid)
+        .unwrap()
+        .expect("MultiTcbInfo extension missing");
+    let mut parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
+    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
+    let mcfw_tcb_info = parsed_tcb_infos
+        .find(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
+        .expect("MCFW TCB info missing");
+    assert_eq!(mcfw_tcb_info.svn, Some(5));
 }

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -97,88 +97,78 @@ fn test_stash_measurement() {
 
 #[test]
 fn test_pcr31_extended_upon_stash_measurement() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
-    let runtime_test_args = RuntimeTestArgs {
-        test_fwid: Some(crate::test_update_reset::mbox_test_image()),
-        test_image_options: Some(image_options.clone()),
-        ..Default::default()
-    };
-    let mut model = run_rt_test(runtime_test_args);
+    fn run_sequence(stash_measurement: bool) -> [u8; 48] {
+        let image_options = ImageOptions {
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        };
+        let runtime_test_args = RuntimeTestArgs {
+            test_fwid: Some(crate::test_update_reset::mbox_test_image()),
+            test_image_options: Some(image_options.clone()),
+            ..Default::default()
+        };
+        let mut model = run_rt_test(runtime_test_args);
 
-    // Read PCR_ID_STASH_MEASUREMENT
-    let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
-    let pcr_31: [u8; 48] = pcr_31_resp.as_bytes().try_into().unwrap();
-
-    // update reset to the real runtime image
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        &APP_WITH_UART,
-        image_options.clone(),
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
-        .unwrap();
-
-    // stash a measurement
-    let measurement = [2u8; 48];
-    let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        metadata: [0u8; 4],
-        measurement,
-        context: [0u8; 48],
-        svn: 0,
-    });
-    cmd.populate_chksum().unwrap();
-
-    let _ = model
-        .mailbox_execute(
-            u32::from(CommandId::STASH_MEASUREMENT),
-            cmd.as_bytes().unwrap(),
+        // update reset to the real runtime image
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            &APP_WITH_UART,
+            image_options.clone(),
         )
         .unwrap()
-        .expect("We should have received a response");
-
-    // update reset back to mbox responder
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        crate::test_update_reset::mbox_test_image(),
-        image_options.clone(),
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .to_bytes()
         .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        crate::test_update_reset::mbox_test_image(),
-        image_options,
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        if stash_measurement {
+            let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                metadata: [0u8; 4],
+                measurement: [2u8; 48],
+                context: [0u8; 48],
+                svn: 0,
+            });
+            cmd.populate_chksum().unwrap();
+
+            let _ = model
+                .mailbox_execute(
+                    u32::from(CommandId::STASH_MEASUREMENT),
+                    cmd.as_bytes().unwrap(),
+                )
+                .unwrap()
+                .expect("We should have received a response");
+        }
+
+        // update reset back to mbox responder so we can read PCR31
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            crate::test_update_reset::mbox_test_image(),
+            image_options.clone(),
+        )
+        .unwrap()
+        .to_bytes()
         .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    // Read extended PCR_ID_STASH_MEASUREMENT
-    let extended_pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
-    let extended_pcr_31: [u8; 48] = extended_pcr_31_resp.as_bytes().try_into().unwrap();
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            crate::test_update_reset::mbox_test_image(),
+            image_options,
+        )
+        .unwrap()
+        .to_bytes()
+        .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    // no need to flip endianness here since PCRs are already in same endianness
-    // as sha2 hashes
-    let mut hasher = Sha384::new();
-    hasher.update(pcr_31);
-    hasher.update(measurement);
-    let expected_pcr_31 = hasher.finalize();
+        let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
+        pcr_31_resp.as_bytes().try_into().unwrap()
+    }
 
-    assert_eq!(expected_pcr_31.as_bytes(), extended_pcr_31);
+    assert_ne!(run_sequence(false), run_sequence(true));
 }


### PR DESCRIPTION
- Store SoC manifest SVN in PersistentData during set_auth_manifest
- Pass authenticated SVN in AuthorizeAndStashReq during recovery boot
- Add UPDATE_EXISTING flag to AUTHORIZE_AND_STASH for hitless update
- Add update_measurement() using RECURSIVE DeriveContext to extend MCU RT DPE context TCI in place without allocating new context slots
- MCU RT hitless update (activate_firmware) now uses UPDATE_EXISTING instead of SKIP_STASH to keep DPE attestation current
- Add integration tests verifying DPE state is correctly updated