### PR TITLE
[fix] Runtime: Bound auth manifest metadata lookup by entry_count

### DIFF
--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -14,9 +14,9 @@ Abstract:
 
 use caliptra_auth_man_types::{AuthManifestImageMetadata, AuthManifestImageMetadataCollection};
 
-/// Search for a metadata entry in the sorted `AuthManifestImageMetadataCollection` that matches the firmware ID.
+/// Search for an active metadata entry in the sorted `AuthManifestImageMetadataCollection` that matches the firmware ID.
 ///
-/// This function performs a binary search on the `image_metadata_list` of the provided `AuthManifestImageMetadataCollection`.
+/// This function performs a binary search on the active entries in the `image_metadata_list` of the provided `AuthManifestImageMetadataCollection`.
 /// It compares the firmware ID (`fw_id`) of each metadata entry with the provided `cmd_fw_id`.
 ///
 /// # Arguments
@@ -34,13 +34,12 @@ pub fn find_metadata_entry(
     auth_manifest_image_metadata_col: &AuthManifestImageMetadataCollection,
     cmd_fw_id: u32,
 ) -> Option<&AuthManifestImageMetadata> {
-    auth_manifest_image_metadata_col
+    let image_metadata_list = auth_manifest_image_metadata_col
         .image_metadata_list
+        .get(..auth_manifest_image_metadata_col.entry_count as usize)?;
+
+    image_metadata_list
         .binary_search_by(|metadata| metadata.fw_id.cmp(&cmd_fw_id))
         .ok()
-        .map(|index| {
-            auth_manifest_image_metadata_col
-                .image_metadata_list
-                .get(index)
-        })?
+        .and_then(|index| image_metadata_list.get(index))
 }

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -36,6 +36,7 @@ pub const IMAGE_DIGEST_BAD: [u8; 48] = [
 pub const FW_ID_1: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
 pub const FW_ID_2: [u8; 4] = [0x02, 0x00, 0x00, 0x00];
 pub const FW_ID_BAD: [u8; 4] = [0xDE, 0xED, 0xBE, 0xEF];
+pub const FW_ID_DEFAULT_PADDING: [u8; 4] = u32::MAX.to_le_bytes();
 const AUTH_AND_STASH_TCI_TAG: u32 = 0x4154_5348;
 
 #[cfg(feature = "fpga_subsystem")]
@@ -329,6 +330,46 @@ fn test_authorize_and_stash_cmd_deny_authorization_wrong_id_no_hash() {
     let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
         hdr: MailboxReqHeader { chksum: 0 },
         fw_id: FW_ID_BAD,
+        source: ImageHashSource::InRequest as u32,
+        flags: 0, // Don't skip stash
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            authorize_and_stash_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        authorize_and_stash_resp.auth_req_result,
+        IMAGE_NOT_AUTHORIZED
+    );
+}
+
+#[test]
+fn test_authorize_and_stash_ignores_padding_metadata_entries() {
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_ignore_auth_check(false);
+    flags.set_image_source(ImageHashSource::InRequest as u32);
+
+    let image_metadata = vec![AuthManifestImageMetadata {
+        fw_id: 1,
+        flags: flags.0,
+        digest: IMAGE_DIGEST1,
+        ..Default::default()
+    }];
+    let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
+    let mut model = set_auth_manifest(Some(auth_manifest));
+
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: FW_ID_DEFAULT_PADDING,
+        measurement: [0u8; 48],
         source: ImageHashSource::InRequest as u32,
         flags: 0, // Don't skip stash
         ..Default::default()


### PR DESCRIPTION
Update find_metadata_entry to search only the active auth manifest metadata entries rather than the full fixed-size backing array.

Fixes #3731.