### PR TITLE
runtime: Enable `unused` lint

### DIFF
--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -12,38 +12,19 @@ Abstract:
 
 --*/
 
-use core::cmp::{self, min};
-use core::mem::size_of;
-
-use crate::{dpe_crypto::DpeCrypto, CptraDpeTypes, DpePlatform, Drivers, StashMeasurementCmd};
+use crate::{Drivers, StashMeasurementCmd};
 use caliptra_auth_man_types::{
-    AuthManifestImageMetadata, AuthManifestImageMetadataCollection, AuthManifestPreamble,
-    ImageMetadataFlags, AUTH_MANIFEST_MARKER,
+    AuthManifestImageMetadata, AuthManifestImageMetadataCollection, ImageMetadataFlags,
 };
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
 use caliptra_common::mailbox_api::{
     AuthAndStashFlags, AuthorizeAndStashReq, AuthorizeAndStashResp, ImageHashSource, MailboxResp,
-    MailboxRespHeader, SetAuthManifestReq,
+    MailboxRespHeader,
 };
-use caliptra_drivers::{
-    pcr_log::PCR_ID_STASH_MEASUREMENT, Array4x12, Array4xN, AuthManifestImageMetadataList,
-    CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Signature, HashValue, Lms,
-    PersistentData, RomVerifyConfig, Sha256, Sha384, SocIfc,
-};
-use caliptra_image_types::{
-    ImageDigest, ImageEccPubKey, ImageEccSignature, ImageLmsPublicKey, ImageLmsSignature,
-    ImagePreamble, SHA192_DIGEST_WORD_SIZE, SHA384_DIGEST_BYTE_SIZE,
-};
-use crypto::{AlgLen, Crypto};
-use dpe::{
-    commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
-    dpe_instance::DpeEnv,
-    response::DpeErrorCode,
-};
-use memoffset::offset_of;
-use zerocopy::{FromBytes, IntoBytes};
+use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult};
+use dpe::response::DpeErrorCode;
+use zerocopy::FromBytes;
 
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
 pub const IMAGE_NOT_AUTHORIZED: u32 = 0x21523F21; // FW ID not found in the image metadata entry collection.

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,22 +12,18 @@ Abstract:
 
 --*/
 
-use bitflags::bitflags;
 use caliptra_common::mailbox_api::{
     CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxResp,
     MailboxRespHeader,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::{
-    commands::{CertifyKeyCmd, Command, CommandExecution},
+    commands::{CertifyKeyCmd, CommandExecution},
     response::Response,
 };
 use zerocopy::{FromBytes, IntoBytes};
 
-use crate::{
-    CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges, MAX_CERT_CHAIN_SIZE,
-    PL0_PAUSER_FLAG,
-};
+use crate::{CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges};
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
@@ -83,7 +79,7 @@ impl CertifyKeyExtendedCmd {
             ),
         };
 
-        let mut dpe = &mut pdata.dpe;
+        let dpe = &mut pdata.dpe;
         let certify_key_cmd = CertifyKeyCmd::ref_from_bytes(&cmd.certify_key_req[..])
             .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let locality = drivers.mbox.user();

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -16,8 +16,8 @@ use crate::Drivers;
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::{keyids::KEY_ID_EXPORTED_DPE_CDI, mailbox_api::MailboxResp};
 use caliptra_drivers::{
-    hmac384_kdf, Array4x12, CaliptraError, CaliptraResult, Ecc384Seed, Hmac384Key, KeyId,
-    KeyReadArgs, KeyUsage, KeyWriteArgs,
+    hmac384_kdf, Array4x12, CaliptraResult, Ecc384Seed, Hmac384Key, KeyId, KeyReadArgs, KeyUsage,
+    KeyWriteArgs,
 };
 use dpe::U8Bool;
 

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -12,25 +12,18 @@ Abstract:
 
 --*/
 
-use core::cmp::min;
-
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
 use caliptra_common::keyids::{
     KEY_ID_DPE_CDI, KEY_ID_DPE_PRIV_KEY, KEY_ID_EXPORTED_DPE_CDI, KEY_ID_TMP,
 };
 use caliptra_drivers::{
     hmac384_kdf, Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Scalar, Ecc384Seed,
-    ExportedCdiEntry, ExportedCdiHandles, Hmac384, Hmac384Data, Hmac384Key, Hmac384Tag, KeyId,
-    KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs, Sha384, Sha384DigestOp, Trng,
+    ExportedCdiEntry, ExportedCdiHandles, Hmac384, KeyId, KeyReadArgs, KeyUsage, KeyVault,
+    KeyWriteArgs, Sha384, Sha384DigestOp, Trng,
 };
 use constant_time_eq::constant_time_eq;
 use crypto::{AlgLen, Crypto, CryptoBuf, CryptoError, Digest, EcdsaPub, EcdsaSig, Hasher};
-use dpe::{
-    response::DpeErrorCode, x509::MeasurementData, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE,
-};
-use zerocopy::IntoBytes;
-use zeroize::Zeroize;
+use dpe::{ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 
 pub struct DpeCrypto<'a> {
     sha384: &'a mut Sha384,
@@ -252,14 +245,14 @@ impl<'a> Crypto for DpeCrypto<'a> {
                 // Matching existing slot
                 ExportedCdiEntry {
                     key,
-                    handle,
+                    handle: _,
                     active,
                 } if active.get() && *key == cdi_slot => {
                     Err(CryptoError::ExportedCdiHandleDuplicateCdi)?
                 }
                 ExportedCdiEntry {
-                    key,
-                    handle,
+                    key: _,
+                    handle: _,
                     active,
                 } if !active.get() => {
                     // Empty slot

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -16,19 +16,13 @@ use core::cmp::min;
 
 use arrayvec::ArrayVec;
 use caliptra_drivers::cprintln;
-use caliptra_image_types::{ImageHeader, ImageManifest};
 use caliptra_x509::{NotAfter, NotBefore};
 use crypto::Digest;
-use dpe::{
-    x509::{CertWriter, DirectoryString, Name},
-    DPE_PROFILE,
-};
+use dpe::x509::{CertWriter, DirectoryString, Name};
 use platform::{
     CertValidity, OtherName, Platform, PlatformError, SignerIdentifier, SubjectAltName, Ueid,
-    MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE,
-    MAX_SN_SIZE,
+    MAX_CHUNK_SIZE, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE,
 };
-use zerocopy::IntoBytes;
 
 use crate::{subject_alt_name::AddSubjectAltNameCmd, MAX_CERT_CHAIN_SIZE};
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -12,10 +12,10 @@ Abstract:
 
 --*/
 
-#![cfg_attr(not(feature = "fip-self-test"), allow(unused))]
+#![cfg_attr(not(feature = "fips_self_test"), allow(unused))]
 
 #[cfg(feature = "fips_self_test")]
-pub use crate::fips::{fips_self_test_cmd, fips_self_test_cmd::SelfTestStatus};
+pub use crate::fips::fips_self_test_cmd::SelfTestStatus;
 
 use crate::{
     dice, CptraDpeTypes, DisableAttestationCmd, DpeCrypto, DpePlatform, Mailbox, CALIPTRA_LOCALITY,
@@ -24,23 +24,21 @@ use crate::{
 };
 
 use arrayvec::ArrayVec;
-use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder};
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
 use caliptra_drivers::KeyId;
 use caliptra_drivers::{
-    cprint, cprintln,
+    cprintln,
     pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     Array4x12, CaliptraError, CaliptraResult, DataVault, Ecc384, KeyVault, Lms,
     PersistentDataAccessor, Pic, ResetReason, Sha1, SocIfc,
 };
 use caliptra_drivers::{
-    hand_off::DataStore, Ecc384PubKey, Hmac384, PcrBank, PcrId, Sha256, Sha256Alg, Sha2_512_384Acc,
-    Sha384, Trng,
+    hand_off::DataStore, Hmac384, PcrBank, Sha256, Sha256Alg, Sha2_512_384Acc, Sha384, Trng,
 };
 use caliptra_image_types::ImageManifest;
 use caliptra_registers::el2_pic_ctrl::El2PicCtrl;
-use caliptra_registers::mbox::enums::MboxStatusE;
 use caliptra_registers::{
     csrng::CsrngReg, dv::DvReg, ecc::EccReg, entropy_src::EntropySrcReg, hmac::HmacReg, kv::KvReg,
     mbox::MboxCsr, pv::PvReg, sha256::Sha256Reg, sha512::Sha512Reg, sha512_acc::Sha512AccCsr,
@@ -55,12 +53,11 @@ use dpe::MAX_HANDLES;
 use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    support::Support,
+    dpe_instance::{DpeEnv, DpeInstance},
 };
 
 use core::cmp::Ordering::{Equal, Greater};
-use crypto::{AlgLen, Crypto, CryptoBuf, Hasher, MAX_EXPORTED_CDI_SIZE};
+use crypto::CryptoBuf;
 use zerocopy::IntoBytes;
 
 #[derive(PartialEq, Clone, Copy)]
@@ -205,7 +202,7 @@ impl Drivers {
             .contexts
             .iter()
             .enumerate()
-            .find(|&(idx, context)| {
+            .find(|&(_idx, context)| {
                 context.state != ContextState::Inactive
                     && context.parent_idx == Context::ROOT_INDEX
                     && context.context_type == ContextType::Normal
@@ -264,13 +261,13 @@ impl Drivers {
     }
 
     /// Validate DPE and disable attestation if validation fails
-    fn validate_dpe_structure(mut drivers: &mut Drivers) -> CaliptraResult<()> {
+    fn validate_dpe_structure(drivers: &mut Drivers) -> CaliptraResult<()> {
         let dpe = &mut drivers.persistent_data.get_mut().dpe;
         let dpe_validator = DpeValidator { dpe };
         let validation_result = dpe_validator.validate_dpe();
         if let Err(e) = validation_result {
             // If SRAM Dpe Instance validation fails, disable attestation
-            let mut result = DisableAttestationCmd::execute(drivers);
+            let result = DisableAttestationCmd::execute(drivers);
             if cfi_launder(result.is_ok()) {
                 cfi_assert!(result.is_ok());
             } else {
@@ -290,7 +287,6 @@ impl Drivers {
                 }
             }
         } else {
-            let pl0_pauser = drivers.persistent_data.get().manifest1.header.pl0_pauser;
             // check that DPE used context limits are not exceeded
             let dpe_context_threshold_exceeded =
                 drivers.is_dpe_context_threshold_exceeded(drivers.caller_privilege_level());
@@ -355,8 +351,8 @@ impl Drivers {
         // Compute new journey: SHA-384(prev_journey || initialization_values_hash)
         let prev_journey: [u8; 48] = dpe.contexts[cciv_idx].tci.tci_cumulative.0;
         let mut digest_op = drivers.sha384.digest_init()?;
-        digest_op.update(&prev_journey);
-        digest_op.update(&initialization_values_hash);
+        digest_op.update(&prev_journey)?;
+        digest_op.update(&initialization_values_hash)?;
         let mut journey_hash = Array4x12::default();
         digest_op.finalize(&mut journey_hash)?;
         let new_journey: [u8; 48] = journey_hash.into();
@@ -429,13 +425,13 @@ impl Drivers {
     }
 
     /// Check that inactive DPE contexts do not have context tags set
-    fn validate_context_tags(mut drivers: &mut Drivers) -> CaliptraResult<()> {
+    fn validate_context_tags(drivers: &mut Drivers) -> CaliptraResult<()> {
         let pdata = drivers.persistent_data.get();
         let context_has_tag = &pdata.context_has_tag;
         let context_tags = &pdata.context_tags;
         let dpe = &pdata.dpe;
 
-        for i in (0..MAX_HANDLES) {
+        for i in 0..MAX_HANDLES {
             if dpe.contexts[i].state == ContextState::Inactive {
                 if context_tags[i] != 0 {
                     return Err(CaliptraError::RUNTIME_CONTEXT_TAGS_VALIDATION_FAILED);
@@ -481,7 +477,7 @@ impl Drivers {
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
         let pdata = drivers.persistent_data.get_mut();
-        let mut crypto = DpeCrypto::new(
+        let crypto = DpeCrypto::new(
             &mut drivers.sha384,
             &mut drivers.trng,
             &mut drivers.ecc384,
@@ -729,7 +725,7 @@ impl Drivers {
         let pl0_pauser = manifest_header.pl0_pauser;
 
         // When the PL0_PAUSER_FLAG bit is not set there can be no PL0 PAUSER.
-        if (flags & PL0_PAUSER_FLAG == 0) {
+        if flags & PL0_PAUSER_FLAG == 0 {
             return PauserPrivileges::PL1;
         }
 

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_common::cprintln;
-use caliptra_common::mailbox_api::{MailboxResp, MailboxRespHeader};
+use caliptra_common::mailbox_api::MailboxResp;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Ecc384;
@@ -22,7 +22,6 @@ use caliptra_drivers::KeyVault;
 use caliptra_drivers::Sha256;
 use caliptra_drivers::Sha2_512_384Acc;
 use caliptra_drivers::Sha384;
-use caliptra_registers::mbox::enums::MboxStatusE;
 use zeroize::Zeroize;
 
 use crate::Drivers;
@@ -66,7 +65,7 @@ pub mod fips_self_test_cmd {
     use super::*;
     use crate::RtBootStatus::{RtFipSelfTestComplete, RtFipSelfTestStarted};
     use caliptra_cfi_lib_git::cfi_assert_eq_8_words;
-    use caliptra_common::HexBytes;
+
     use caliptra_common::{verifier::FirmwareImageVerificationEnv, FMC_SIZE, RUNTIME_SIZE};
     use caliptra_drivers::{ResetReason, ShaAccLockState};
     use caliptra_image_types::{ImageTocEntry, RomInfo};
@@ -91,7 +90,7 @@ pub mod fips_self_test_cmd {
             env.persistent_data.get().manifest1.size
                 + env.persistent_data.get().manifest1.fmc.size
                 + env.persistent_data.get().manifest1.runtime.size,
-        );
+        )?;
         env.mbox
             .copy_bytes_to_mbox(env.persistent_data.get().manifest1.as_bytes())?;
 
@@ -105,8 +104,8 @@ pub mod fips_self_test_cmd {
             return Err(CaliptraError::RUNTIME_INVALID_RUNTIME_SIZE);
         }
 
-        let fmc = unsafe { create_slice(&fmc_toc) };
-        let rt = unsafe { create_slice(&rt_toc) };
+        let fmc = unsafe { create_slice(fmc_toc) };
+        let rt = unsafe { create_slice(rt_toc) };
 
         env.mbox.copy_bytes_to_mbox(fmc.as_bytes())?;
         env.mbox.copy_bytes_to_mbox(rt.as_bytes())?;
@@ -162,16 +161,16 @@ pub mod fips_self_test_cmd {
             // Hmac384 Engine
             hmac384: &mut env.hmac384,
 
-            /// Cryptographically Secure Random Number Generator
+            // Cryptographically Secure Random Number Generator
             trng: &mut env.trng,
 
             // LMS Engine
             lms: &mut env.lms,
 
-            /// Ecc384 Engine
+            // Ecc384 Engine
             ecc384: &mut env.ecc384,
 
-            /// SHA Acc Lock State
+            // SHA Acc Lock State
             sha_acc_lock_state: ShaAccLockState::NotAcquired,
         };
 

--- a/runtime/src/get_fmc_alias_csr.rs
+++ b/runtime/src/get_fmc_alias_csr.rs
@@ -3,23 +3,17 @@
 use crate::Drivers;
 
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
 
-use caliptra_common::{
-    cprintln,
-    mailbox_api::{GetFmcAliasCsrReq, GetFmcAliasCsrResp, MailboxResp, MailboxRespHeader},
-};
+use caliptra_common::mailbox_api::{GetFmcAliasCsrResp, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
-use caliptra_drivers::{FmcAliasCsr, IdevIdCsr};
-
-use zerocopy::{FromBytes, IntoBytes};
+use caliptra_drivers::FmcAliasCsr;
 
 pub struct GetFmcAliasCsrCmd;
 impl GetFmcAliasCsrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers, _cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let csr_persistent_mem = &drivers.persistent_data.get().fmc_alias_csr;
 
         match csr_persistent_mem.get_csr_len() {

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -3,25 +3,17 @@
 use crate::Drivers;
 
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
 
-use caliptra_common::{
-    cprintln,
-    mailbox_api::{GetIdevCsrReq, GetIdevCsrResp, MailboxResp, MailboxRespHeader},
-};
+use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use caliptra_drivers::IdevIdCsr;
-
-use zerocopy::{FromBytes, IntoBytes};
 
 pub struct GetIdevCsrCmd;
 impl GetIdevCsrCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = GetIdevCsrReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+    pub(crate) fn execute(drivers: &mut Drivers, _cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
 
         match csr_persistent_mem.get_csr_len() {

--- a/runtime/src/hmac.rs
+++ b/runtime/src/hmac.rs
@@ -16,8 +16,8 @@ use caliptra_cfi_derive_git::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
 use caliptra_common::{crypto::Ecc384KeyPair, keyids::KEY_ID_TMP};
 use caliptra_drivers::{
-    hmac384_kdf, Array4x12, Ecc384PrivKeyOut, Ecc384PubKey, Hmac384Data, Hmac384Key, Hmac384Tag,
-    KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs,
+    hmac384_kdf, Array4x12, Hmac384Data, Hmac384Key, Hmac384Tag, KeyId, KeyReadArgs, KeyUsage,
+    KeyWriteArgs,
 };
 use caliptra_error::CaliptraResult;
 use zerocopy::IntoBytes;

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -15,7 +15,6 @@ Abstract:
 use crate::{handoff::RtHandoff, Drivers};
 use caliptra_common::mailbox_api::{FwInfoResp, GetIdevInfoResp, MailboxResp, MailboxRespHeader};
 use caliptra_drivers::CaliptraResult;
-use caliptra_image_types::RomInfo;
 
 pub struct FwInfoCmd;
 impl FwInfoCmd {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,22 +12,17 @@ Abstract:
 
 --*/
 
-use crate::{
-    CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges, PL0_PAUSER_FLAG,
-};
+use crate::{CptraDpeTypes, DpeCrypto, DpeEnv, DpePlatform, Drivers, PauserPrivileges};
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxResp, MailboxRespHeader};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
-use crypto::{AlgLen, Crypto};
 use dpe::{
-    commands::{
-        CertifyKeyCmd, Command, CommandExecution, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
-    },
-    context::{Context, ContextState},
+    commands::{CertifyKeyCmd, Command, CommandExecution, DeriveContextCmd, InitCtxCmd},
+    context::ContextState,
     response::{Response, ResponseHdr},
     DpeInstance, U8Bool, MAX_HANDLES,
 };
-use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
+use zerocopy::{IntoBytes, TryFromBytes};
 
 pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
@@ -90,9 +85,9 @@ impl InvokeDpeCmd {
             };
 
             let locality = drivers.mbox.user();
-            let mut dpe = &mut pdata.dpe;
-            let mut context_has_tag = &mut pdata.context_has_tag;
-            let mut context_tags = &mut pdata.context_tags;
+            let dpe = &mut pdata.dpe;
+            let context_has_tag = &mut pdata.context_has_tag;
+            let context_tags = &mut pdata.context_tags;
             let resp = match command {
                 Command::GetProfile => Ok(Response::GetProfile(
                     dpe.get_profile(&mut env.platform)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,7 +11,7 @@ Abstract:
     File contains exports for the Runtime library and mailbox command handling logic.
 
 --*/
-#![cfg_attr(not(feature = "fip-self-test"), allow(unused))]
+#![cfg_attr(not(feature = "fips_self_test"), allow(unused))]
 #![no_std]
 mod authorize_and_stash;
 mod capabilities;
@@ -43,8 +43,6 @@ mod verify;
 pub mod mailbox;
 use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter};
-use caliptra_registers::mbox::enums::MboxFsmE;
-use caliptra_registers::soc_ifc::SocIfcReg;
 pub use drivers::{Drivers, PauserPrivileges};
 use mailbox::Mailbox;
 
@@ -83,15 +81,12 @@ use tagging::{GetTaggedTciCmd, TagTciCmd};
 use caliptra_common::cprintln;
 
 use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult, ResetReason};
-use caliptra_registers::el2_pic_ctrl::El2PicCtrl;
-use caliptra_registers::{mbox::enums::MboxStatusE, soc_ifc};
+use caliptra_registers::mbox::enums::MboxStatusE;
+pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 use dpe::{
-    commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     dpe_instance::{DpeEnv, DpeTypes},
     support::Support,
-    DPE_PROFILE,
 };
-pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 
 use crate::{
     dice::GetRtAliasCertCmd,
@@ -141,7 +136,7 @@ fn enter_idle(drivers: &mut Drivers) {
     #[cfg(feature = "fips_self_test")]
     if let SelfTestStatus::InProgress(execute) = drivers.self_test_status {
         let lock = drivers.mbox.lock();
-        if lock == false {
+        if !lock {
             let result = execute(drivers);
             drivers.mbox.unlock();
             match result {
@@ -283,7 +278,7 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
         let reset_reason = drivers.soc_ifc.reset_reason();
         if reset_reason == ResetReason::WarmReset {
             cfi_assert_eq(drivers.soc_ifc.reset_reason(), ResetReason::WarmReset);
-            let mut result = DisableAttestationCmd::execute(drivers);
+            let result = DisableAttestationCmd::execute(drivers);
             if cfi_launder(result.is_ok()) {
                 cfi_assert!(result.is_ok());
             } else {
@@ -371,5 +366,4 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
             cfi_assert!(!cmd_ready);
         }
     }
-    Ok(())
 }

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -154,7 +154,7 @@ impl Mailbox {
     /// Write a word-aligned `buf` to the mailbox
     pub fn write_response(&mut self, buf: &[u8]) -> CaliptraResult<()> {
         self.set_dlen(buf.len() as u32)?;
-        self.copy_bytes_to_mbox(buf);
+        self.copy_bytes_to_mbox(buf)?;
         Ok(())
     }
 

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -18,7 +18,7 @@ use caliptra_common::mailbox_api::{
     ExtendPcrReq, GetPcrLogResp, IncrementPcrResetCounterReq, MailboxResp, MailboxRespHeader,
     QuotePcrsReq, QuotePcrsResp,
 };
-use caliptra_drivers::{hand_off::DataStore, CaliptraError, CaliptraResult, PcrBank, PcrId};
+use caliptra_drivers::{CaliptraError, CaliptraResult, PcrId};
 use zerocopy::{FromBytes, IntoBytes};
 
 pub struct IncrementPcrResetCounterCmd;
@@ -103,7 +103,7 @@ pub struct GetPcrLogCmd;
 impl GetPcrLogCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers, _cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
         let next_available = drivers.persistent_data.get().fht.pcr_log_index as usize;
         let Some(pcr_logs) = drivers.persistent_data.get().pcr_log.get(..next_available) else {
             return Err(CaliptraError::RUNTIME_PCR_INVALID_INDEX);

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -18,7 +18,7 @@ use caliptra_common::mailbox_api::{MailboxResp, PopulateIdevCertReq};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::IntoBytes;
 
-use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
+use crate::{Drivers, MAX_CERT_CHAIN_SIZE};
 
 pub struct PopulateIDevIdCertCmd;
 impl PopulateIDevIdCertCmd {
@@ -33,7 +33,6 @@ impl PopulateIDevIdCertCmd {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
             }
 
-            let flags = drivers.persistent_data.get().manifest1.header.flags;
             // PL1 cannot call this mailbox command
             if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
                 Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?

--- a/runtime/src/reallocate_dpe_context_limits.rs
+++ b/runtime/src/reallocate_dpe_context_limits.rs
@@ -17,13 +17,10 @@ use crate::{
     PauserPrivileges, PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
     PL0_DPE_ACTIVE_CONTEXT_THRESHOLD_MIN, PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
-use caliptra_common::cprint;
 use caliptra_common::mailbox_api::{
     MailboxResp, MailboxRespHeader, ReallocateDpeContextLimitsReq, ReallocateDpeContextLimitsResp,
 };
 use caliptra_drivers::{CaliptraError, CaliptraResult};
-use caliptra_image_types::RomInfo;
-use dpe::context::{Context, ContextState, ContextType};
 
 use zerocopy::FromBytes;
 

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -1,21 +1,21 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
+use crate::{Drivers, PauserPrivileges};
 
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 
 use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, RevokeExportedCdiHandleReq, RevokeExportedCdiHandleResp,
+    MailboxResp, RevokeExportedCdiHandleReq, RevokeExportedCdiHandleResp,
 };
 use caliptra_drivers::ExportedCdiEntry;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use constant_time_eq::constant_time_eq;
 use dpe::U8Bool;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 use zeroize::Zeroize;
 
 pub struct RevokeExportedCdiHandleCmd;
@@ -43,7 +43,7 @@ impl RevokeExportedCdiHandleCmd {
         {
             match slot {
                 ExportedCdiEntry {
-                    key,
+                    key: _,
                     handle,
                     active,
                 } if constant_time_eq(handle, &cmd.exported_cdi_handle) && active.get() => {

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,32 +15,21 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::verify;
-use crate::{dpe_crypto::DpeCrypto, CptraDpeTypes, DpePlatform, Drivers};
+use crate::Drivers;
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, AUTH_MANIFEST_MARKER,
 };
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::cfi_launder;
-use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, SetAuthManifestReq, StashMeasurementReq, StashMeasurementResp,
-};
+use caliptra_common::mailbox_api::{MailboxResp, SetAuthManifestReq};
 use caliptra_drivers::{
-    pcr_log::PCR_ID_STASH_MEASUREMENT, Array4x12, Array4xN, AuthManifestImageMetadataList,
-    CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Signature, HashValue, Lms,
-    PersistentData, RomVerifyConfig, Sha256, Sha384, SocIfc,
+    Array4x12, Array4xN, CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Signature,
+    HashValue, Lms, RomVerifyConfig, Sha256, Sha384, SocIfc,
 };
 use caliptra_image_types::{
     ImageDigest, ImageEccPubKey, ImageEccSignature, ImageLmsPublicKey, ImageLmsSignature,
     ImagePreamble, SHA192_DIGEST_WORD_SIZE, SHA384_DIGEST_BYTE_SIZE,
-};
-use crypto::{AlgLen, Crypto};
-use dpe::{
-    commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
-    dpe_instance::DpeEnv,
-    response::DpeErrorCode,
 };
 use memoffset::offset_of;
 use zerocopy::{FromBytes, IntoBytes};
@@ -233,7 +222,6 @@ impl SetAuthManifestCmd {
     fn verify_vendor_image_metadata_col(
         auth_manifest_preamble: &AuthManifestPreamble,
         image_metadata_col_digest: &ImageDigest,
-        sha384: &mut Sha384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
         soc_ifc: &SocIfc,
@@ -296,7 +284,6 @@ impl SetAuthManifestCmd {
     fn verify_owner_image_metadata_col(
         auth_manifest_preamble: &AuthManifestPreamble,
         image_metadata_col_digest: &ImageDigest,
-        sha384: &mut Sha384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
         soc_ifc: &SocIfc,
@@ -400,7 +387,6 @@ impl SetAuthManifestCmd {
         Self::verify_vendor_image_metadata_col(
             auth_manifest_preamble,
             &digest_metadata_col,
-            sha384,
             ecc384,
             sha256,
             soc_ifc,
@@ -409,7 +395,6 @@ impl SetAuthManifestCmd {
         Self::verify_owner_image_metadata_col(
             auth_manifest_preamble,
             &digest_metadata_col,
-            sha384,
             ecc384,
             sha256,
             soc_ifc,

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -6,13 +6,13 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
 
 use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
+    MailboxResp, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{Crypto, Digest, EcdsaPub, EcdsaSig};
 use dpe::{DPE_PROFILE, MAX_EXPORTED_CDI_SIZE};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
 pub struct SignWithExportedEcdsaCmd;
 impl SignWithExportedEcdsaCmd {
@@ -91,32 +91,27 @@ impl SignWithExportedEcdsaCmd {
             Self::ecdsa_sign(&mut crypto, &digest, &cmd.exported_cdi_handle)?;
 
         let mut resp = SignWithExportedEcdsaResp::default();
-        let mut bytes_written = 0;
 
         if r.len() <= resp.signature_r.len() {
             resp.signature_r[..r.len()].copy_from_slice(r.bytes());
-            bytes_written += r.len()
         } else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }
 
         if s.len() <= resp.signature_s.len() {
             resp.signature_s[..s.len()].copy_from_slice(s.bytes());
-            bytes_written += s.len()
         } else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }
 
         if x.len() <= resp.derived_pubkey_x.len() {
             resp.derived_pubkey_x[..x.len()].copy_from_slice(x.bytes());
-            bytes_written += x.len()
         } else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }
 
         if y.len() <= resp.derived_pubkey_y.len() {
             resp.derived_pubkey_y[..y.len()].copy_from_slice(y.bytes());
-            bytes_written += y.len()
         } else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -18,7 +18,6 @@ use caliptra_common::mailbox_api::{
     MailboxResp, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
-use crypto::{AlgLen, Crypto};
 use dpe::{
     commands::{CommandExecution, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
@@ -54,7 +53,7 @@ impl StashMeasurementCmd {
             let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
             let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
             let pdata = drivers.persistent_data.get_mut();
-            let mut crypto = DpeCrypto::new(
+            let crypto = DpeCrypto::new(
                 &mut drivers.sha384,
                 &mut drivers.trng,
                 &mut drivers.ecc384,

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -17,7 +17,7 @@ use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::IntoBytes;
 
-use crate::{Drivers, MAX_CERT_CHAIN_SIZE, PL0_PAUSER_FLAG};
+use crate::Drivers;
 
 pub struct AddSubjectAltNameCmd;
 impl AddSubjectAltNameCmd {

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -12,21 +12,15 @@ Abstract:
 
 --*/
 
-use crate::CfiCounter;
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
     GetTaggedTciReq, GetTaggedTciResp, MailboxResp, MailboxRespHeader, TagTciReq,
 };
-use caliptra_drivers::cprintln;
 use caliptra_error::{CaliptraError, CaliptraResult};
-use dpe::{
-    context::{ContextHandle, ContextState},
-    dpe_instance::DpeEnv,
-    U8Bool, MAX_HANDLES,
-};
+use dpe::{context::ContextHandle, U8Bool, MAX_HANDLES};
 use zerocopy::FromBytes;
 
-use crate::{dpe_crypto::DpeCrypto, CptraDpeTypes, DpePlatform, Drivers};
+use crate::Drivers;
 
 pub struct TagTciCmd;
 impl TagTciCmd {
@@ -36,9 +30,9 @@ impl TagTciCmd {
         let cmd = TagTciReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let pdata_mut = drivers.persistent_data.get_mut();
-        let mut dpe = &mut pdata_mut.dpe;
-        let mut context_has_tag = &mut pdata_mut.context_has_tag;
-        let mut context_tags = &mut pdata_mut.context_tags;
+        let dpe = &mut pdata_mut.dpe;
+        let context_has_tag = &mut pdata_mut.context_has_tag;
+        let context_tags = &mut pdata_mut.context_tags;
 
         // Make sure the tag isn't used by any other contexts.
         if (0..MAX_HANDLES).any(|i| {

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -22,7 +22,6 @@ use caliptra_drivers::{
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
 };
-use zerocopy::IntoBytes;
 use zerocopy::{BigEndian, FromBytes, LittleEndian, U32};
 
 pub struct EcdsaVerifyCmd;


### PR DESCRIPTION
Due to a misspelling in a configuration flag the `unused` lint was disabled for the runtime crate.  Correct this, so it is only enabled when expected (i.e. the fips self test configuration is false), and then patch all warnings which now propogate.