### PR TITLE
Fix OTP FuseController DMA emulator for field entropy programming

### DIFF
--- a/sw-emulator/lib/periph/src/dma/otp_fc.rs
+++ b/sw-emulator/lib/periph/src/dma/otp_fc.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use bitfield::size_of;
-use caliptra_emu_bus::{BusError, ReadOnlyRegister, WriteOnlyRegister};
+use caliptra_emu_bus::{Bus, BusError, ReadOnlyRegister, WriteOnlyRegister};
 use caliptra_emu_derive::Bus;
 use caliptra_emu_types::RvSize;
 use smlang::statemachine;
@@ -69,8 +69,13 @@ pub enum Granularity {
     Bits64,
 }
 
-// [TODO][CAP2] Used for both UDS (flow correct) and field entropy (needs implementation).
-const FUSE_BANK_SIZE_BYTES: usize = 64;
+// Fuse bank layout (from UDS seed base address):
+//   UDS:           64 bytes (16 x u32)
+//   UDS digest:     8 bytes ( 2 x u32)
+//   FE partitions:  4 x (8 bytes data + 8 bytes digest) = 64 bytes
+//   Total:         136 bytes (34 x u32)
+const FUSE_BANK_SIZE_BYTES: usize = 136;
+const UDS_SIZE_BYTES: usize = 64;
 
 pub struct Context {
     pub address: Option<u32>,
@@ -145,9 +150,10 @@ impl StateMachineContext for Context {
     fn start_digest(&mut self) -> Result<(), ()> {
         use sha2::{Digest, Sha512};
 
-        // Compute SHA-512 hash of fuse bank contents
+        // Compute SHA-512 hash of UDS portion of fuse bank (first 64 bytes)
         let mut hasher = Sha512::new();
-        for word in self.fuse_bank.iter() {
+        let uds_words = UDS_SIZE_BYTES / size_of::<u32>();
+        for word in self.fuse_bank[..uds_words].iter() {
             hasher.update(word.to_be_bytes());
         }
         let hash = hasher.finalize();
@@ -197,8 +203,8 @@ pub struct FuseController {
 }
 
 impl FuseController {
-    // The fuse banks is emulated as part of this peripheral
-    pub const FUSE_BANK_OFFSET: u64 = 0x800;
+    /// Register offset for ss_uds_seed_base_addr_l in the SoC register block
+    const SS_UDS_SEED_BASE_ADDR_L_OFFSET: u32 = 0x520;
 
     pub fn new(soc_reg: SocRegistersInternal) -> Self {
         // [TODO][CAP2] get actual granularity from soc_reg HWCFG
@@ -246,12 +252,21 @@ impl FuseController {
     }
 
     pub fn write_address(&mut self, _size: RvSize, val: u32) -> Result<(), BusError> {
-        // Only use lowest 12 bits and make relative to FUSE_BANK_OFFSET
-        let masked_addr = (val & 0xFFF) as u64;
-        if masked_addr < Self::FUSE_BANK_OFFSET {
+        // Read the UDS seed base address from SoC registers to determine the
+        // fuse bank base. The firmware writes (dest & 0xFFF) where dest is
+        // computed relative to this base.
+        let uds_base = self
+            .state_machine
+            .context
+            .soc_reg
+            .read(RvSize::Word, Self::SS_UDS_SEED_BASE_ADDR_L_OFFSET)
+            .map_err(|_| BusError::StoreAccessFault)?;
+        let base_offset = uds_base & 0xFFF;
+        let masked_addr = val & 0xFFF;
+        if masked_addr < base_offset {
             return Err(BusError::StoreAccessFault);
         }
-        let relative_addr = (masked_addr - Self::FUSE_BANK_OFFSET) as u32;
+        let relative_addr = masked_addr - base_offset;
         self.state_machine.context.address = Some(relative_addr);
         Ok(())
     }

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -932,8 +932,8 @@ impl SocRegistersImpl {
         let cptra_offset = 0x3000_0000u64;
         let rri_offset = crate::dma::axi_root_bus::AxiRootBus::RECOVERY_REGISTER_INTERFACE_OFFSET;
         let otc_fc_offset = crate::dma::axi_root_bus::AxiRootBus::OTC_FC_OFFSET;
-        // To make things easy the fuse bank is part of the fuse bank controller emulation
-        let uds_seed_offset = otc_fc_offset + crate::dma::otp_fc::FuseController::FUSE_BANK_OFFSET;
+        // The fuse bank starts at offset 0x800 within the OTP fuse controller address space
+        let uds_seed_offset = otc_fc_offset + 0x800;
         let mci_base = crate::dma::axi_root_bus::AxiRootBus::ss_mci_offset();
         let ss_prod_dbg_unlock_fuse_offset = crate::mci::MciRegs::SS_MANUF_DBG_UNLOCK_FUSE_OFFSET;
         let ss_prod_dbg_unlock_number_of_fuses =


### PR DESCRIPTION
## Summary

Fix the OTP FuseController DMA emulator to correctly handle field entropy (FE) programming flows.

## Changes

### `sw-emulator/lib/periph/src/dma/otp_fc.rs`
- **Expand fuse bank size**: Increase `FUSE_BANK_SIZE_BYTES` from 64 to 136 bytes to accommodate the full fuse layout: UDS (64 bytes) + UDS digest (8 bytes) + 4 FE partitions (4 × 16 bytes = 64 bytes)
- **Dynamic base address**: Read `ss_uds_seed_base_addr_l` from SoC registers at runtime instead of hardcoding `FUSE_BANK_OFFSET = 0x800`. The MCU ROM sets this register to the actual fuse bank base address, and the emulator now uses it to correctly compute relative offsets for DMA writes.
- **Scope digest to UDS only**: Restrict `start_digest()` to hash only the UDS portion (first 64 bytes) of the fuse bank, matching hardware behavior.

### `sw-emulator/lib/periph/src/soc_reg.rs`
- Inline the `0x800` constant directly since `FuseController::FUSE_BANK_OFFSET` is no longer a public constant.

## Problem

When MCU firmware attempted FE programming via the Caliptra mailbox, the DMA emulator would fail because:
1. The fuse bank was only 64 bytes (enough for UDS, but not FE partitions)
2. The base offset was hardcoded to `0x800`, but firmware writes addresses relative to the value in `ss_uds_seed_base_addr_l` (which is `0x48` after MCU ROM initialization), causing address validation to reject valid FE writes

## Testing

- Tested with `test_fe_programming_cmd` and `test_fe_programming_invalid_partition` in caliptra-sw (both pass)
- Tested with `test_fe_prog_debug_bytes` MCU integration test (passes with SUCCESS status)