### PR TITLE
Add a new command to chunk DPE certificates

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -279,6 +279,7 @@ impl CommandId {
     pub const OCP_LOCK_LOAD_MEK: Self = Self(0x4C4D_454B); // "LMEK"
 
     pub const REALLOCATE_DPE_CONTEXT_LIMITS: Self = Self(0x5243_5458); // "RCTX"
+    pub const CERTIFY_KEY_CHUNKS: Self = Self(0x434B4348); // "CKCH"
 }
 
 impl From<u32> for CommandId {
@@ -443,6 +444,7 @@ pub enum MailboxResp {
     OcpLockClearKeyCache(OcpLockClearKeyCacheResp),
     OcpLockUnloadMek(OcpLockUnloadMekResp),
     OcpLockLoadMek(OcpLockLoadMekResp),
+    CertifyKeyChunks(CertifyKeyChunksResp),
 }
 
 pub const MAX_RESP_SIZE: usize = size_of::<MailboxResp>();
@@ -531,6 +533,7 @@ impl MailboxResp {
             MailboxResp::OcpLockClearKeyCache(resp) => Ok(resp.as_bytes()),
             MailboxResp::OcpLockUnloadMek(resp) => Ok(resp.as_bytes()),
             MailboxResp::OcpLockLoadMek(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_bytes()),
         }
     }
 
@@ -617,6 +620,7 @@ impl MailboxResp {
             MailboxResp::OcpLockClearKeyCache(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::OcpLockUnloadMek(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::OcpLockLoadMek(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -774,6 +778,7 @@ pub enum MailboxReq {
     OcpLockClearKeyCache(OcpLockClearKeyCacheReq),
     OcpLockUnloadMek(OcpLockUnloadMekReq),
     OcpLockLoadMek(OcpLockLoadMekReq),
+    CertifyKeyChunks(CertifyKeyChunksReq),
 }
 
 pub const MAX_REQ_SIZE: usize = size_of::<MailboxReq>();
@@ -881,6 +886,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockUnloadMek(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockLoadMek(req) => Ok(req.as_bytes()),
+            MailboxReq::CertifyKeyChunks(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -986,6 +992,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockUnloadMek(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockLoadMek(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CertifyKeyChunks(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -1097,6 +1104,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(_) => CommandId::OCP_LOCK_CLEAR_KEY_CACHE,
             MailboxReq::OcpLockUnloadMek(_) => CommandId::OCP_LOCK_UNLOAD_MEK,
             MailboxReq::OcpLockLoadMek(_) => CommandId::OCP_LOCK_LOAD_MEK,
+            MailboxReq::CertifyKeyChunks(_) => CommandId::CERTIFY_KEY_CHUNKS,
         }
     }
 
@@ -1675,6 +1683,76 @@ impl CertifyKeyExtendedResp {
     }
 }
 
+// CERTIFY_KEY_CHUNKS
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: CertifyKeyChunksFlags,
+    pub reserved: u32,
+    pub max_size: u32,
+    pub offset: u32,
+    pub certify_key_req: [u8; Self::CERTIFY_KEY_REQ_SIZE],
+}
+
+impl CertifyKeyChunksReq {
+    pub const CERTIFY_KEY_REQ_SIZE: usize = 72;
+}
+
+impl Request for CertifyKeyChunksReq {
+    const ID: CommandId = CommandId::CERTIFY_KEY_CHUNKS;
+    type Resp = CertifyKeyChunksResp;
+}
+
+#[repr(C)]
+#[derive(
+    Debug, PartialEq, Eq, FromBytes, Immutable, KnownLayout, IntoBytes, Default, Copy, Clone,
+)]
+pub struct CertifyKeyChunksFlags(pub u32);
+
+bitflags! {
+    impl CertifyKeyChunksFlags: u32 {
+        const USE_MLDSA = 1u32 << 31;
+    }
+}
+
+impl CertifyKeyChunksFlags {
+    pub fn use_mldsa(&self) -> bool {
+        self.contains(CertifyKeyChunksFlags::USE_MLDSA)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksRespInfo {
+    pub hdr: MailboxRespHeader,
+    pub context_handle: [u8; 16],
+    pub chunk_len: u32,
+    pub remaining: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksResp {
+    pub info: CertifyKeyChunksRespInfo,
+    pub certify_key_resp: [u8; Self::MAX_CHUNK_SIZE],
+}
+
+impl CertifyKeyChunksResp {
+    pub const MAX_CHUNK_SIZE: usize = 15 * 1024;
+}
+
+impl Response for CertifyKeyChunksResp {}
+
+impl Default for CertifyKeyChunksResp {
+    fn default() -> Self {
+        Self {
+            info: Default::default(),
+            certify_key_resp: [0u8; Self::MAX_CHUNK_SIZE],
+        }
+    }
+}
+
 // INVOKE_DPE_ECC384
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
@@ -1811,7 +1889,7 @@ pub struct InvokeDpeResp {
     pub data: [u8; InvokeDpeResp::DATA_MAX_SIZE], // variable length
 }
 impl InvokeDpeResp {
-    pub const DATA_MAX_SIZE: usize = 25152;
+    pub const DATA_MAX_SIZE: usize = 25168;
 }
 impl ResponseVarSize for InvokeDpeResp {}
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1352,6 +1352,34 @@ Command Code: `0x434B_584D` ("CKXM")
 | size               | u32       | The size of the response in the certify\_key\_resp field.                  |
 | certify\_key\_resp | u8[25152] | Certify Key Response.                                                      |
 
+### CERTIFY\_KEY\_CHUNKS
+
+Invokes a DPE `CertifyKey` command (ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+
+Command Code: `0x434B_4348` ("CKCH")
+
+*Table: `CERTIFY_KEY_CHUNKS` input arguments*
+
+| **Name**          | **Type** | **Description**                                                                       |
+| ----------------- | -------- | ------------------------------------------------------------------------------------- |
+| chksum            | u32      | Checksum over other input arguments, computed by the caller. Little endian.           |
+| flags             | u32      | Flags (reserved).                                                                     |
+| reserved          | u32      | Reserved.                                                                             |
+| max\_size         | u32      | The maximum length of the chunk the caller wants to receive. If 0, defaults to 15360. |
+| offset            | u32      | Offset into the full CertifyKey response to read from.                                |
+| certify\_key\_req | u8[72]   | The serialized DPE `CertifyKey` command.                                              |
+
+*Table: `CERTIFY_KEY_CHUNKS` output arguments*
+
+| **Name**           | **Type**  | **Description**                                                            |
+| ------------------ | --------- | -------------------------------------------------------------------------- |
+| chksum             | u32       | Checksum over other output arguments, computed by Caliptra. Little endian. |
+| fips\_status       | u32       | Indicates if the command is FIPS approved or an error.                     |
+| context\_handle    | u8[16]    | The new DPE context handle returned by the `CertifyKey` command.           |
+| chunk\_len         | u32       | The length of the chunk returned in `certify_key_resp`.                    |
+| remaining          | u32       | The number of bytes remaining in the full response after this chunk.       |
+| certify\_key\_resp | u8[15360] | The chunk of the DPE `CertifyKey` response.                                |
+
 ### SET_AUTH_MANIFEST
 
 The SoC uses this command and `SET_IMAGE_METADTA` to program an image manifest for Manifest-Based Image Authorization to Caliptra. In response to these commands, the Caliptra Runtime will verify the manifest by authenticating the public keys and in turn using them to authenticate the IMC. On successful verification, the Runtime will store the IMEs into DCCM for future use.

--- a/runtime/src/certify_key_chunks.rs
+++ b/runtime/src/certify_key_chunks.rs
@@ -1,0 +1,146 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    certify_key_chunks.rs
+
+Abstract:
+
+    File contains CertifyKeyChunks mailbox command.
+
+--*/
+
+use crate::{invoke_dpe::invoke_dpe_cmd, CaliptraDpeProfile, Drivers};
+use caliptra_api::mailbox::CertifyKeyChunksRespInfo;
+use caliptra_common::mailbox_api::{CertifyKeyChunksReq, CertifyKeyChunksResp};
+use caliptra_dpe::commands::{CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
+use caliptra_dpe::response::{CertifyKeyMldsa87Resp, CertifyKeyP384Resp};
+use caliptra_error::{CaliptraError, CaliptraResult};
+use memoffset::span_of;
+use zerocopy::FromBytes;
+
+pub struct CertifyKeyChunksCmd;
+impl CertifyKeyChunksCmd {
+    #[inline(never)]
+    pub(crate) fn execute(
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        mbox_resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let chunk_cmd = CertifyKeyChunksReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        let profile = if chunk_cmd.flags.use_mldsa() {
+            CaliptraDpeProfile::Mldsa87
+        } else {
+            CaliptraDpeProfile::Ecc384
+        };
+
+        let certify_key_cmd = match profile {
+            CaliptraDpeProfile::Ecc384 => Command::from(
+                CertifyKeyP384Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+            CaliptraDpeProfile::Mldsa87 => Command::from(
+                CertifyKeyMldsa87Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+        };
+
+        let (resp_info, certify_key_resp_bytes) =
+            CertifyKeyChunksRespInfo::mut_from_prefix(mbox_resp)
+                .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        let (min_resp_size, handle_range) = match profile {
+            CaliptraDpeProfile::Ecc384 => (
+                size_of::<CertifyKeyP384Resp>(),
+                span_of!(CertifyKeyP384Resp, new_context_handle..derived_pubkey_x),
+            ),
+            CaliptraDpeProfile::Mldsa87 => (
+                size_of::<CertifyKeyMldsa87Resp>(),
+                span_of!(CertifyKeyMldsa87Resp, new_context_handle..pubkey),
+            ),
+        };
+
+        if certify_key_resp_bytes.len() < min_resp_size {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+
+        // Get the full CertifyKey response
+        let cmd = &certify_key_cmd;
+        let dpe_resp_len = invoke_dpe_cmd(
+            profile,
+            drivers,
+            cmd,
+            None,
+            None,
+            None,
+            certify_key_resp_bytes,
+        )
+        .map_err(|e| {
+            // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+            if let Some(ext_err) = e.get_error_detail() {
+                drivers.soc_ifc.set_fw_extended_error(ext_err);
+            }
+            CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
+        })?;
+
+        // If the offset is past the end of the response this will make it have nothing in the
+        // chunk, but the caller will still get the handle back
+        let offset = usize::min(chunk_cmd.offset as usize, dpe_resp_len);
+
+        // Copy the new handle to the response header
+        resp_info.context_handle = certify_key_resp_bytes[handle_range].try_into().unwrap();
+
+        // Copy the chunk of the response to the beginning of the response buffer
+        let max_chunk_size = CertifyKeyChunksResp::MAX_CHUNK_SIZE;
+        let max_chunk_size = if chunk_cmd.max_size > 0 {
+            usize::min(max_chunk_size, chunk_cmd.max_size as usize)
+        } else {
+            max_chunk_size
+        };
+        let total_remaining = dpe_resp_len.saturating_sub(offset);
+        let chunk_len = core::cmp::min(total_remaining, max_chunk_size);
+        copy_to_start(certify_key_resp_bytes, offset, chunk_len)?;
+
+        // Fill in the rest of the response info
+        resp_info.chunk_len = chunk_len as u32;
+        resp_info.remaining = dpe_resp_len
+            .saturating_sub(offset)
+            .saturating_sub(chunk_len) as u32;
+
+        Ok(core::mem::size_of::<CertifyKeyChunksRespInfo>() + chunk_len)
+    }
+}
+
+fn copy_to_start(slice: &mut [u8], src_offset: usize, len: usize) -> CaliptraResult<()> {
+    let slice_len = slice.len();
+
+    if src_offset > slice_len || len > slice_len {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    }
+
+    let src_end = src_offset
+        .checked_add(len)
+        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    if src_end > slice_len {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    }
+
+    // Copy forwards (left to right) is always safe when copying to the start (dest = 0)
+    for i in 0..len {
+        let src_idx = src_offset + i;
+        let val = *slice
+            .get(src_idx)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        *slice
+            .get_mut(i)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)? = val;
+    }
+
+    Ok(())
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -17,6 +17,7 @@ mod activate_firmware;
 mod attested_csr;
 mod authorize_and_stash;
 mod capabilities;
+mod certify_key_chunks;
 mod certify_key_extended;
 mod cryptographic_mailbox;
 mod debug_unlock;
@@ -355,6 +356,9 @@ fn execute_command(
             GetRtAliasCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
         CommandId::ADD_SUBJECT_ALT_NAME => AddSubjectAltNameCmd::execute(drivers, cmd_bytes),
+        CommandId::CERTIFY_KEY_CHUNKS => {
+            certify_key_chunks::CertifyKeyChunksCmd::execute(drivers, cmd_bytes, resp)
+        }
         CommandId::CERTIFY_KEY_EXTENDED_ECC384 => {
             CertifyKeyExtendedCmd::execute_ecc384(drivers, cmd_bytes, resp)
         }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use anyhow::Context;
 use caliptra_api::{
     mailbox::{
         AxiResponseInfo, GetFmcAliasMlDsa87CertResp, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req,
@@ -16,7 +17,8 @@ use caliptra_builder::{
 };
 use caliptra_common::{
     mailbox_api::{
-        CommandId, GetFmcAliasEcc384CertResp, GetLdevCertResp, GetRtAliasCertResp, InvokeDpeReq,
+        CertifyKeyChunksFlags, CertifyKeyChunksReq, CertifyKeyChunksResp, CommandId,
+        GetFmcAliasEcc384CertResp, GetLdevCertResp, GetRtAliasCertResp, InvokeDpeReq,
         InvokeDpeResp, MailboxReq, MailboxReqHeader,
     },
     memory_layout::{ROM_ORG, ROM_SIZE, ROM_STACK_ORG, ROM_STACK_SIZE, STACK_ORG, STACK_SIZE},
@@ -30,7 +32,7 @@ use caliptra_dpe::{
         CommandHdr, DeriveContextCmd, SignFlags, SignMldsa87Cmd, SignP384Cmd,
     },
     context::ContextHandle,
-    response::{DpeErrorCode, Response, ResponseHdr},
+    response::{CertifyKeyResp, DpeErrorCode, Response, ResponseHdr, SignResp},
 };
 use caliptra_dpe_crypto::{Digest, Mu, PrecomputedSignData, Sha384};
 use caliptra_drivers::MfgFlags;
@@ -45,10 +47,14 @@ use caliptra_runtime::CaliptraDpeProfile;
 pub use caliptra_test::{
     default_soc_manifest_bytes, image_pk_desc_hash, test_upload_firmware, DEFAULT_MCU_FW,
 };
+use ml_dsa_01::{EncodedSignature, EncodedVerifyingKey, Signature, VerifyingKey};
 use openssl::{
     asn1::{Asn1Integer, Asn1Time, Asn1TimeRef},
     bn::BigNum,
+    ec::{EcGroup, EcKey},
+    ecdsa::EcdsaSig,
     hash::MessageDigest,
+    nid::Nid,
     pkey::{PKey, Private},
     x509::{X509Builder, X509},
     x509::{X509Name, X509NameBuilder},
@@ -570,6 +576,122 @@ pub fn execute_dpe_cmd_raw(
     Ok(resp_hdr)
 }
 
+pub fn certify_key(
+    model: &mut DefaultHwModel,
+    cmd: &mut CertifyKeyCommandNoRef,
+) -> anyhow::Result<CertifyKeyResp> {
+    if model.subsystem_mode() {
+        certify_key_chunks(model, cmd, None)
+    } else {
+        let resp = match cmd {
+            CertifyKeyCommandNoRef::P384(ref cmd) => {
+                let resp = execute_dpe_cmd_raw(
+                    model,
+                    CaliptraDpeProfile::Ecc384,
+                    &mut Command::from(cmd),
+                    None,
+                )?;
+                let resp = resp.data[..resp.data_size as usize].to_vec();
+                check_dpe_status(&resp, DpeErrorCode::NoError);
+                resp
+            }
+            CertifyKeyCommandNoRef::Mldsa(ref cmd) => {
+                let resp = execute_dpe_cmd_raw(
+                    model,
+                    CaliptraDpeProfile::Mldsa87,
+                    &mut Command::from(cmd),
+                    None,
+                )?;
+                let resp = resp.data[..resp.data_size as usize].to_vec();
+                check_dpe_status(&resp, DpeErrorCode::NoError);
+                resp
+            }
+        };
+        let resp = Response::try_read_from_bytes(&Command::from(&*cmd), &resp).map_err(|e| {
+            anyhow::anyhow!("Failed to convert response into DPE response. {:?}", e)
+        })?;
+        let Response::CertifyKey(resp) = resp else {
+            anyhow::bail!("Unexpected response type for CertifyKey command");
+        };
+        Ok(resp)
+    }
+}
+
+pub fn certify_key_chunks(
+    model: &mut DefaultHwModel,
+    cmd: &mut CertifyKeyCommandNoRef,
+    max_chunk_size: Option<usize>,
+) -> anyhow::Result<CertifyKeyResp> {
+    let mut full_resp = Vec::<u8>::new();
+    let mut offset = 0;
+
+    let use_mldsa = match cmd {
+        CertifyKeyCommandNoRef::P384(_) => false,
+        CertifyKeyCommandNoRef::Mldsa(_) => true,
+    };
+
+    let cmd_bytes = match cmd {
+        CertifyKeyCommandNoRef::P384(ref c) => c.as_bytes().to_vec(),
+        CertifyKeyCommandNoRef::Mldsa(ref c) => c.as_bytes().to_vec(),
+    };
+
+    let flags = if use_mldsa {
+        CertifyKeyChunksFlags::USE_MLDSA
+    } else {
+        CertifyKeyChunksFlags(0)
+    };
+
+    loop {
+        let mut certify_key_req = [0u8; 72];
+        certify_key_req[..cmd_bytes.len()].copy_from_slice(&cmd_bytes);
+        let req = CertifyKeyChunksReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            flags,
+            reserved: 0,
+            max_size: max_chunk_size.unwrap_or(0) as u32,
+            offset: offset as u32,
+            certify_key_req,
+        };
+        let mut mbox_cmd = MailboxReq::CertifyKeyChunks(req);
+        mbox_cmd.populate_chksum().unwrap();
+
+        let resp_data = model
+            .mailbox_execute(
+                u32::from(CommandId::CERTIFY_KEY_CHUNKS),
+                mbox_cmd.as_bytes().unwrap(),
+            )
+            .context("Failed to get chunked certify key response")?;
+        let resp_data = resp_data.expect("We should have received a response");
+        check_header_checksum(&resp_data).unwrap();
+
+        let mut resp = CertifyKeyChunksResp::default();
+        assert!(resp_data.len() <= size_of::<CertifyKeyChunksResp>());
+        resp.as_mut_bytes()[..resp_data.len()].copy_from_slice(&resp_data);
+
+        let chunk_len = resp.info.chunk_len as usize;
+        let remaining = resp.info.remaining as usize;
+
+        full_resp.extend_from_slice(&resp.certify_key_resp[..chunk_len]);
+
+        match cmd {
+            CertifyKeyCommandNoRef::P384(ref mut c) => c.handle.0 = resp.info.context_handle,
+            CertifyKeyCommandNoRef::Mldsa(ref mut c) => c.handle.0 = resp.info.context_handle,
+        }
+
+        if remaining == 0 {
+            break;
+        }
+        offset += chunk_len;
+    }
+
+    let resp = Response::try_read_from_bytes(&Command::from(&*cmd), &full_resp)
+        .map_err(|e| anyhow::anyhow!("Failed to convert response into DPE response. {:?}", e))?;
+    let Response::CertifyKey(resp) = resp else {
+        anyhow::bail!("Unexpected response type for CertifyKey command");
+    };
+    Ok(resp)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum CertifyKeyCommandNoRef {
     P384(CertifyKeyP384Cmd),
@@ -910,4 +1032,67 @@ pub fn calculate_cptra_config_init_vals_hash<T: HwModel>(
     hasher.update(manifest.runtime.entry_point.as_bytes());
 
     hasher.finalize().into()
+}
+
+pub fn verify_sign_and_certify_key(
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+    sign_resp: &Response,
+    certify_key_resp: &CertifyKeyResp,
+    data: &[u8],
+) {
+    match (profile, sign_resp, certify_key_resp) {
+        (
+            CaliptraDpeProfile::Ecc384,
+            Response::Sign(SignResp::P384(sign_resp)),
+            CertifyKeyResp::P384(certify_key_resp),
+        ) => {
+            let sig = EcdsaSig::from_private_components(
+                BigNum::from_slice(&sign_resp.sig_r).unwrap(),
+                BigNum::from_slice(&sign_resp.sig_s).unwrap(),
+            )
+            .unwrap();
+
+            let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
+                &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
+            )
+            .unwrap();
+            assert!(sig.verify(data, &ecc_pub_key).unwrap());
+
+            // Verify the certificate
+            let alias_cert_resp = get_rt_alias_ecc384_cert(model);
+            let alias_cert_bytes = alias_cert_resp.data().unwrap();
+            let alias_x509 = X509::from_der(alias_cert_bytes).unwrap();
+            let alias_pubkey = alias_x509.public_key().unwrap();
+
+            let leaf_cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+            let leaf_x509 = X509::from_der(leaf_cert_bytes).unwrap();
+            assert!(leaf_x509.verify(&alias_pubkey).unwrap());
+        }
+        (
+            CaliptraDpeProfile::Mldsa87,
+            Response::Sign(SignResp::Mldsa87(sign_resp)),
+            CertifyKeyResp::Mldsa87(certify_key_resp),
+        ) => {
+            let encoded_vk =
+                EncodedVerifyingKey::<ml_dsa_01::MlDsa87>::from(certify_key_resp.pubkey);
+            let vk = VerifyingKey::<ml_dsa_01::MlDsa87>::decode(&encoded_vk);
+            let encoded_sig = EncodedSignature::<ml_dsa_01::MlDsa87>::from(sign_resp.sig);
+            let sig = Signature::decode(&encoded_sig).unwrap();
+            assert!(vk.verify_mu(&TEST_MU.into(), &sig));
+
+            // Verify the certificate
+            let alias_cert_resp = get_rt_alias_mldsa87_cert(model);
+            let alias_cert_bytes = alias_cert_resp.data().unwrap();
+            let alias_x509 = X509::from_der(alias_cert_bytes).unwrap();
+            let alias_pubkey = alias_x509.public_key().unwrap();
+
+            let leaf_cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+            let leaf_x509 = X509::from_der(leaf_cert_bytes).unwrap();
+            assert!(leaf_x509.verify(&alias_pubkey).unwrap());
+        }
+        _ => panic!("Wrong response type!"),
+    }
 }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -7,6 +7,7 @@ mod test_authorize_and_stash;
 mod test_boot;
 mod test_cap_warmreset;
 mod test_capabilities;
+mod test_certify_key_chunks;
 mod test_certify_key_extended;
 mod test_certs;
 mod test_certs_384_warmreset;

--- a/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
+++ b/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_dpe::{
-    commands::{CertifyKeyCommand, CertifyKeyFlags, Command},
+    commands::{CertifyKeyCommand, CertifyKeyFlags},
     context::ContextHandle,
-    response::{CertifyKeyResp, Response},
+    response::CertifyKeyResp,
 };
 use caliptra_hw_model::DefaultHwModel;
 use caliptra_runtime::CaliptraDpeProfile;
@@ -11,23 +11,18 @@ use openssl::x509::X509;
 
 use super::*;
 use crate::common::{
-    execute_dpe_cmd, run_rt_test, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, DpeResult,
-    RuntimeTestArgs, TEST_LABEL,
+    certify_key, run_rt_test, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, RuntimeTestArgs,
+    TEST_LABEL,
 };
 
 /// Generate an ECC384 DPE leaf cert using CertifyKey and return it as X509.
 fn get_ecc_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
-    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
         profile: CaliptraDpeProfile::Ecc384,
         ..Default::default()
     });
-    let resp = execute_dpe_cmd(
-        model,
-        CaliptraDpeProfile::Ecc384,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
@@ -36,20 +31,15 @@ fn get_ecc_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
 
 /// Generate an MLDSA87 DPE leaf cert using CertifyKey and return it as X509.
 fn get_mldsa_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
-    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
         profile: CaliptraDpeProfile::Mldsa87,
         handle: ContextHandle::default(),
         label: TEST_LABEL,
         flags: CertifyKeyFlags::empty(),
         format: CertifyKeyCommand::FORMAT_X509,
     });
-    let resp = execute_dpe_cmd(
-        model,
-        CaliptraDpeProfile::Mldsa87,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::Mldsa87(certify_key_resp))) = resp else {
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::Mldsa87(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])

--- a/runtime/tests/runtime_integration_tests/test_certify_key_chunks.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_chunks.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache-2.0 license
+
+use crate::common::{
+    execute_dpe_cmd, run_rt_test, verify_sign_and_certify_key, CertifyKeyCommandNoRef,
+    CreateCertifyKeyCmdArgs, CreateSignCmdArgs, DpeResult, RuntimeTestArgs, SignCommandNoRef,
+    TEST_SD_MU, TEST_SD_SHA384,
+};
+use caliptra_api::SocManager;
+use caliptra_dpe::commands::{CertifyKeyCommand, Command};
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
+
+fn test_certify_chunks_helper(profile: CaliptraDpeProfile, max_chunk_size: Option<usize>) {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let data = match profile {
+        CaliptraDpeProfile::Ecc384 => TEST_SD_SHA384,
+        CaliptraDpeProfile::Mldsa87 => TEST_SD_MU,
+    };
+
+    let sign_cmd = SignCommandNoRef::new(CreateSignCmdArgs {
+        profile,
+        data: data.clone(),
+        ..Default::default()
+    });
+
+    let sign_resp = execute_dpe_cmd(
+        &mut model,
+        profile,
+        &mut Command::from(&sign_cmd),
+        DpeResult::Success,
+    )
+    .unwrap();
+
+    let mut certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile,
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+
+    let certify_key_resp =
+        crate::common::certify_key_chunks(&mut model, &mut certify_key_cmd, max_chunk_size)
+            .unwrap();
+
+    verify_sign_and_certify_key(
+        &mut model,
+        profile,
+        &sign_resp,
+        &certify_key_resp,
+        data.as_slice(),
+    );
+}
+
+#[test]
+fn test_certify_key_chunks_ecdsa_helper_subsystem() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Ecc384, None);
+}
+
+#[test]
+fn test_certify_key_chunks_ecdsa_helper_subsystem_max_chunk_size() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Ecc384, Some(512));
+}
+
+#[test]
+fn test_certify_key_chunks_mldsa_helper_subsystem_max_chunk_size() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Mldsa87, Some(512));
+}

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 #![allow(unexpected_cfgs)]
 
-use crate::common::PQC_KEY_TYPE;
+use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE};
 use crate::common::{
     execute_dpe_cmd, generate_test_x509_cert, get_ecc_fmc_alias_cert, get_mldsa_fmc_alias_cert,
     get_rt_alias_ecc384_cert, get_rt_alias_mldsa87_cert, run_rt_test, run_rt_test_pqc, DpeResult,
@@ -19,8 +19,9 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_common::x509::get_tbs;
 use caliptra_dpe::commands::{CertifyKeyCommand, DeriveContextCmd};
+use caliptra_dpe::response::CertifyKeyP384Resp;
 use caliptra_dpe::{
-    commands::{CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command, DeriveContextFlags},
+    commands::{CertifyKeyFlags, Command, DeriveContextFlags},
     context::ContextHandle,
     response::{CertifyKeyResp, Response},
 };
@@ -442,19 +443,9 @@ fn test_dpe_leaf_cert() {
     let rt_resp = get_rt_alias_ecc384_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        CaliptraDpeProfile::Ecc384,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     let dpe_leaf_cert: X509 =
@@ -541,20 +532,10 @@ fn test_full_cert_chain_mldsa87() {
         .unwrap();
 }
 
-fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyResp {
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        model,
-        CaliptraDpeProfile::Ecc384,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
+fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyP384Resp {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     certify_key_resp

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -6,10 +6,7 @@ use caliptra_builder::{
 };
 use caliptra_common::mailbox_api::{CommandId, FwInfoResp, MailboxReqHeader, MailboxRespHeader};
 use caliptra_dpe::{
-    commands::{
-        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command, SignFlags,
-        SignP384Cmd as SignCmd,
-    },
+    commands::{Command, SignFlags, SignP384Cmd as SignCmd},
     context::ContextHandle,
     response::{CertifyKeyResp, Response, SignResp},
 };
@@ -26,8 +23,8 @@ use openssl::{
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_ecc384_cert, run_rt_test, DpeResult, RuntimeTestArgs,
-    TEST_DIGEST, TEST_LABEL,
+    certify_key, execute_dpe_cmd, get_rt_alias_ecc384_cert, run_rt_test, CertifyKeyCommandNoRef,
+    CreateCertifyKeyCmdArgs, DpeResult, RuntimeTestArgs, TEST_DIGEST, TEST_LABEL,
 };
 
 #[test]
@@ -71,19 +68,9 @@ fn test_disable_attestation_cmd() {
     );
 
     // get pub key
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        CaliptraDpeProfile::Ecc384,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -156,22 +143,9 @@ fn test_attestation_disabled_flag_after_update_reset() {
     let rt_resp = get_rt_alias_ecc384_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        CaliptraDpeProfile::Ecc384,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(certify_key_resp)) = resp else {
-        panic!("Wrong response type!");
-    };
-    let dpe_leaf_cert: X509 = X509::from_der(certify_key_resp.cert().unwrap()).unwrap();
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let dpe_leaf_cert: X509 = X509::from_der(resp.cert().unwrap()).unwrap();
 
     assert!(!dpe_leaf_cert
         .verify(&rt_cert.public_key().unwrap())

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -1,13 +1,13 @@
 // Licensed under the Apache-2.0 license.
 
 use crate::common::{
-    check_dpe_status, execute_dpe_cmd, execute_dpe_cmd_raw, get_rt_alias_ecc384_cert,
-    get_rt_alias_mldsa87_cert, run_rt_test, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs,
-    CreateSignCmdArgs, DpeResult, RuntimeTestArgs, SignCommandNoRef, TEST_MU, TEST_SD_MU,
-    TEST_SD_SHA384,
+    certify_key, check_dpe_status, execute_dpe_cmd, execute_dpe_cmd_raw, get_rt_alias_ecc384_cert,
+    get_rt_alias_mldsa87_cert, run_rt_test, verify_sign_and_certify_key, CertifyKeyCommandNoRef,
+    CreateCertifyKeyCmdArgs, CreateSignCmdArgs, DpeResult, RuntimeTestArgs, SignCommandNoRef,
+    TEST_SD_MU, TEST_SD_SHA384,
 };
 use caliptra_api::{
-    mailbox::{AxiResponseInfo, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req},
+    mailbox::{AxiResponseInfo, InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req, InvokeDpeResp},
     SocManager,
 };
 use caliptra_common::mailbox_api::{
@@ -19,7 +19,7 @@ use caliptra_dpe::{
         GetProfileCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags,
     },
     context::ContextHandle,
-    response::{CertifyKeyResp, DpeErrorCode, Response, SignResp},
+    response::{DpeErrorCode, Response, SignResp},
 };
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel, SecurityState};
@@ -32,13 +32,7 @@ use cms::{
 use ml_dsa_01::{
     signature::Verifier, EncodedSignature, EncodedVerifyingKey, Signature, VerifyingKey,
 };
-use openssl::{
-    bn::BigNum,
-    ec::{EcGroup, EcKey},
-    ecdsa::EcdsaSig,
-    nid::Nid,
-    x509::X509,
-};
+use openssl::{ecdsa::EcdsaSig, x509::X509};
 use sha2::{Digest, Sha384};
 use x509_parser::{nom::Parser, prelude::*};
 use zerocopy::{FromBytes, IntoBytes};
@@ -183,54 +177,21 @@ fn sign_and_certify_key_test_helper(model: &mut DefaultHwModel) {
         )
         .unwrap();
 
-        let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
             profile,
             format: CertifyKeyCommand::FORMAT_X509,
             ..Default::default()
         });
 
-        let certify_key_resp = execute_dpe_cmd(
+        let certify_key_resp = certify_key(model, certify_key_cmd).unwrap();
+
+        verify_sign_and_certify_key(
             model,
             profile,
-            &mut Command::from(&certify_key_cmd),
-            DpeResult::Success,
-        )
-        .unwrap();
-
-        match (profile, sign_resp, certify_key_resp) {
-            (
-                CaliptraDpeProfile::Ecc384,
-                Response::Sign(SignResp::P384(sign_resp)),
-                Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)),
-            ) => {
-                let sig = EcdsaSig::from_private_components(
-                    BigNum::from_slice(&sign_resp.sig_r).unwrap(),
-                    BigNum::from_slice(&sign_resp.sig_s).unwrap(),
-                )
-                .unwrap();
-
-                let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
-                    &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
-                    &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
-                    &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
-                )
-                .unwrap();
-                assert!(sig.verify(data.as_slice(), &ecc_pub_key).unwrap());
-            }
-            (
-                CaliptraDpeProfile::Mldsa87,
-                Response::Sign(SignResp::Mldsa87(sign_resp)),
-                Response::CertifyKey(CertifyKeyResp::Mldsa87(certify_key_resp)),
-            ) => {
-                let encoded_vk =
-                    EncodedVerifyingKey::<ml_dsa_01::MlDsa87>::from(certify_key_resp.pubkey);
-                let vk = VerifyingKey::<ml_dsa_01::MlDsa87>::decode(&encoded_vk);
-                let encoded_sig = EncodedSignature::<ml_dsa_01::MlDsa87>::from(sign_resp.sig);
-                let sig = Signature::decode(&encoded_sig).unwrap();
-                assert!(vk.verify_mu(&TEST_MU.into(), &sig));
-            }
-            _ => panic!("Wrong response type!"),
-        }
+            &sign_resp,
+            &certify_key_resp,
+            data.as_slice(),
+        );
     }
 }
 
@@ -303,18 +264,13 @@ fn test_certify_key_with_max_contexts() {
             CertifyKeyCommand::FORMAT_CSR,
         ];
         for format in formats {
-            let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+            let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
                 profile,
                 format,
                 ..Default::default()
             });
 
-            let _ = execute_dpe_cmd(
-                &mut model,
-                profile,
-                &mut Command::from(&certify_key_cmd),
-                DpeResult::Success,
-            );
+            let _ = certify_key(&mut model, certify_key_cmd).unwrap();
         }
     }
 }
@@ -386,20 +342,12 @@ fn test_invoke_dpe_certify_key_csr() {
     model.step_until_ready_for_runtime();
 
     for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
-        let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
             profile,
             format: CertifyKeyCommand::FORMAT_CSR,
             ..Default::default()
         });
-        let resp = execute_dpe_cmd(
-            &mut model,
-            profile,
-            &mut Command::from(&certify_key_cmd),
-            DpeResult::Success,
-        );
-        let Some(Response::CertifyKey(certify_key_resp)) = resp else {
-            panic!("Wrong response type!");
-        };
+        let certify_key_resp = certify_key(&mut model, certify_key_cmd).unwrap();
 
         let rt_resp = match profile {
             CaliptraDpeProfile::Ecc384 => get_rt_alias_ecc384_cert(&mut model),
@@ -525,23 +473,13 @@ fn test_invoke_dpe_certify_key_with_non_critical_dice_extensions() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
     for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
-        let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
             profile,
             format: CertifyKeyCommand::FORMAT_X509,
             ..Default::default()
         });
 
-        let resp = execute_dpe_cmd(
-            &mut model,
-            profile,
-            &mut Command::from(&certify_key_cmd),
-            DpeResult::Success,
-        )
-        .unwrap();
-
-        let Response::CertifyKey(resp) = resp else {
-            panic!("Wrong response type!");
-        };
+        let resp = certify_key(&mut model, certify_key_cmd).unwrap();
         check_dice_extension_criticality(resp.cert().unwrap(), false);
     }
 }
@@ -734,23 +672,13 @@ fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
     model.step_until_ready_for_runtime();
 
     for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
-        let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
             profile,
             format: CertifyKeyCommand::FORMAT_X509,
             ..Default::default()
         });
 
-        let certify_key_resp = execute_dpe_cmd(
-            &mut model,
-            profile,
-            &mut Command::from(&certify_key_cmd),
-            DpeResult::Success,
-        )
-        .unwrap();
-
-        let Response::CertifyKey(certify_key_resp) = certify_key_resp else {
-            panic!("Wrong response type!");
-        };
+        let certify_key_resp = certify_key(&mut model, certify_key_cmd).unwrap();
 
         let cert_bytes = certify_key_resp.cert().unwrap();
 
@@ -774,4 +702,31 @@ fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
             == 1;
         assert!(found_mcfw);
     }
+}
+
+#[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+fn test_invoke_dpe_external_addr() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        ..Default::default()
+    });
+
+    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+
+    let external_response_info = {
+        let addr = model.staging_physical_address().unwrap();
+        Some(AxiResponseInfo {
+            addr_lo: addr as u32,
+            addr_hi: (addr >> 32) as u32,
+            max_size: size_of::<InvokeDpeResp>() as u32,
+        })
+    };
+    let _resp = execute_dpe_cmd_raw(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&certify_key_cmd),
+        external_response_info,
+    )
+    .unwrap();
 }


### PR DESCRIPTION
The old CertifyKey flow returns the complete DPE leaf certificate in a single response, requiring the MCU SPDM responder to allocate a relatively large buffer to hold it.

This adds a chunked retrieval mechanism which reduces memory pressure while enabling more scalable certificate handling (e.g., for MLDSA and number of contexts) and improving overall efficiency.

Tests have been added to ensure certificate generation is idempotent.