### PR TITLE
Debug unlock token - move key hash check from mailbox SRAM to stack

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-7976b87943b9e31d0026a3c8998e530cdcf3925e57da99d61d7ad50e7e89fe7c826c6607962d2050618b02ed9fec808d  caliptra-rom-no-log.bin
-dbd9b6898873223047a3578bab1afbb037f39aed8e12a65d60520fa922730d4e0e61df206a6d8c68a59793fa5aaf0414  caliptra-rom-with-log.bin
+6e816cd21818dfa42485020d594e41f98728838e87cf90a3702babe60d29d03cb62ccfd06281eef11b08d17b4c4be5c8  caliptra-rom-no-log.bin
+88171c273e48bfb30c7f3d05d913713f7a02dfa25e1b7620319980dafffc75858b9d5d496d88d8c0e6479aeb1f7c02b1  caliptra-rom-with-log.bin

--- a/common/src/debug_unlock.rs
+++ b/common/src/debug_unlock.rs
@@ -22,11 +22,9 @@ use caliptra_cfi_lib::{cfi_assert_eq_12_words, cfi_assert_eq_8_words, cfi_launde
 use caliptra_drivers::{
     sha2_512_384::Sha2DigestOpTrait, Array4x12, Array4x16, Array4x8, AxiAddr, Dma, Ecc384,
     Ecc384PubKey, Ecc384Result, Ecc384Scalar, Ecc384Signature, LEArray4x16, Mldsa87, Mldsa87PubKey,
-    Mldsa87Result, Mldsa87Signature, Sha2_512_384, Sha2_512_384Acc, ShaAccLockState, SocIfc,
-    StreamEndianness, Trng,
+    Mldsa87Result, Mldsa87Signature, Sha2_512_384, SocIfc, Trng,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
-use memoffset::{offset_of, span_of};
 use zerocopy::IntoBytes;
 
 /// Create a challenge for production debug unlock
@@ -106,7 +104,6 @@ pub fn create_debug_unlock_challenge(
 pub fn validate_debug_unlock_token(
     soc_ifc: &SocIfc,
     sha2_512_384: &mut Sha2_512_384,
-    sha2_512_384_acc: &mut Sha2_512_384Acc,
     ecc384: &mut Ecc384,
     mldsa87: &mut Mldsa87,
     dma: &mut Dma,
@@ -153,27 +150,13 @@ pub fn validate_debug_unlock_token(
         );
     }
 
-    // Hash the ECC and MLDSA public keys in the payload.
+    // Hash the ECC and MLDSA public keys from the local stack copy.
     let pub_keys_digest = {
-        let ecc_public_key_offset = offset_of!(ProductionAuthDebugUnlockToken, ecc_public_key);
-        let combined_len = span_of!(
-            ProductionAuthDebugUnlockToken,
-            ecc_public_key..=mldsa_public_key
-        )
-        .len();
-
         let mut request_digest = Array4x12::default();
-
-        let mut acc_op = sha2_512_384_acc
-            .try_start_operation(ShaAccLockState::NotAcquired)?
-            .ok_or(CaliptraError::SS_DBG_UNLOCK_PROD_INVALID_TOKEN_WRONG_PUBLIC_KEYS)?;
-
-        acc_op.digest_384(
-            combined_len as u32,
-            ecc_public_key_offset as u32,
-            StreamEndianness::Reorder,
-            &mut request_digest,
-        )?;
+        let mut digest_op = sha2_512_384.sha384_digest_init()?;
+        digest_op.update(token.ecc_public_key.as_bytes())?;
+        digest_op.update(token.mldsa_public_key.as_bytes())?;
+        digest_op.finalize(&mut request_digest)?;
         request_digest
     };
 

--- a/rom/dev/src/flow/debug_unlock.rs
+++ b/rom/dev/src/flow/debug_unlock.rs
@@ -214,7 +214,6 @@ fn handle_auth_debug_unlock_token(
         debug_unlock::validate_debug_unlock_token(
             &env.soc_ifc,
             &mut env.sha2_512_384,
-            &mut env.sha2_512_384_acc,
             &mut env.ecc384,
             &mut mldsa87,
             &mut env.dma,

--- a/runtime/src/debug_unlock.rs
+++ b/runtime/src/debug_unlock.rs
@@ -107,7 +107,6 @@ impl ProductionDebugUnlock {
         &mut self,
         soc_ifc: &mut caliptra_drivers::SocIfc,
         sha2_512_384: &mut caliptra_drivers::Sha2_512_384,
-        sha2_512_384_acc: &mut caliptra_drivers::Sha2_512_384Acc,
         ecc384: &mut caliptra_drivers::Ecc384,
         mldsa87: &mut caliptra_drivers::Mldsa87,
         dma: &mut caliptra_drivers::Dma,
@@ -143,7 +142,6 @@ impl ProductionDebugUnlock {
         let result = caliptra_common::debug_unlock::validate_debug_unlock_token(
             soc_ifc,
             sha2_512_384,
-            sha2_512_384_acc,
             ecc384,
             mldsa87,
             dma,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -539,7 +539,6 @@ fn execute_command(
             drivers.debug_unlock.handle_token(
                 &mut drivers.soc_ifc,
                 &mut drivers.sha2_512_384,
-                &mut drivers.sha2_512_384_acc,
                 &mut drivers.ecc384,
                 &mut mldsa,
                 &mut drivers.dma,


### PR DESCRIPTION
Previously, some portions of the check for the debug unlock token were read from the stack copy of the mailbox message while some were read from mailbox SRAM. The mailbox protections guarantee these will be the same. But reading everything from the same location is a safer practice.