### PR TITLE
use inline assignment to pass data to build info file

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -135,7 +135,11 @@ jobs:
         image_variant: [core, subsystem]
     env:
       IMAGE_VARIANT: ${{ matrix.image_variant }}
-      PR_BASE_COMMIT: ${{github.event.pull_request.base.sha}}
+      PR_BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+      LOCAL_GH_WORKFLOW: ${{ github.workflow }}
+      LOCAL_GH_HEAD_REF: ${{ github.head_ref }}
+      LOCAL_GH_WORKFLOW_SHA: ${{ github.workflow_sha }}
+ 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -164,12 +168,28 @@ jobs:
         run: |
           # Build Dev image
           cd ci-tools/fpga-image
-          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=true IMAGE_VARIANT=${IMAGE_VARIANT} KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
+          sudo PATH="$PATH:/tmp/cross/bin"  \
+              BUILD_DEV_IMAGE=true  \
+              IMAGE_VARIANT="${IMAGE_VARIANT}"  \
+              LOCAL_GH_WORKFLOW="${LOCAL_GH_WORKFLOW}"  \
+              LOCAL_GH_HEAD_REF="${LOCAL_GH_HEAD_REF}"  \
+              LOCAL_GH_WORKFLOW_SHA="${LOCAL_GH_WORKFLOW_SHA}"  \
+              KERNEL_ARCHIVE="/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz"  \
+              KERNEL_MODULE_ARCHIVE="/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko"  \
+              bash build.sh
           # Save Dev image for upload
           sudo mv out/image.img dev-image.img
           sudo rm -rf out/
           # Now build CI image
-          sudo PATH="$PATH:/tmp/cross/bin" BUILD_DEV_IMAGE=false IMAGE_VARIANT=${IMAGE_VARIANT} KERNEL_ARCHIVE=/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz KERNEL_MODULE_ARCHIVE=/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko bash build.sh
+          sudo PATH="$PATH:/tmp/cross/bin"  \
+              BUILD_DEV_IMAGE=false  \
+              IMAGE_VARIANT="${IMAGE_VARIANT}"  \
+              LOCAL_GH_WORKFLOW="${LOCAL_GH_WORKFLOW}"  \
+              LOCAL_GH_HEAD_REF="${LOCAL_GH_HEAD_REF}"  \
+              LOCAL_GH_WORKFLOW_SHA="${LOCAL_GH_WORKFLOW_SHA}"  \
+              KERNEL_ARCHIVE="/tmp/vck190-kernel/vck190-kernel-${IMAGE_VARIANT}.tar.gz"  \
+              KERNEL_MODULE_ARCHIVE="/tmp/vck190-kmod/io-module-${IMAGE_VARIANT}.ko"  \
+              bash build.sh
 
       - name: 'Upload dev-image as artifact'
         uses: actions/upload-artifact@v4

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -157,9 +157,9 @@ else
 fi
 chroot out/rootfs bash -c "echo \"Image variant : ${IMAGE_VARIANT}\" >> /etc/caliptra-build-info"
 chroot out/rootfs bash -c "echo \"Runner version : ${RUNNER_VERSION}\" >> /etc/caliptra-build-info"
-chroot out/rootfs bash -c "echo \"Workflow name : ${GITHUB_WORKFLOW}\" >> /etc/caliptra-build-info"
-chroot out/rootfs bash -c "echo \"Workflow branch : ${GITHUB_HEAD_REF}\" >> /etc/caliptra-build-info"
-chroot out/rootfs bash -c "echo \"Workflow build commit : ${GITHUB_WORKFLOW_SHA}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow name : ${LOCAL_GH_WORKFLOW}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow branch : ${LOCAL_GH_HEAD_REF}\" >> /etc/caliptra-build-info"
+chroot out/rootfs bash -c "echo \"Workflow build commit : ${LOCAL_GH_WORKFLOW_SHA}\" >> /etc/caliptra-build-info"
 HASH=`md5sum out/io-module.ko | awk '{print $1}'`
 chroot out/rootfs bash -c "echo \"Hash io-module.ko : ${HASH}\" >> /etc/caliptra-build-info"
 HASH=`md5sum out/system-boot.tar.gz | awk '{print $1}'`


### PR DESCRIPTION
Update workflow to pass GitHub data by inline assignment.
This data will be used by build script to set it inside image, into "caliptra-build-info" file.