### PR TITLE
pqc: mldsa x509

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,9 +1820,8 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+version = "0.10.72"
+source = "git+https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if 1.0.0",
@@ -1835,29 +1834,27 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+version = "0.1.1"
+source = "git+https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "openssl-src"
-version = "300.1.5+3.1.3"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+version = "0.9.108"
+source = "git+https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "hex",
  "openssl",
  "quote",
+ "rand",
  "syn 1.0.109",
  "x509-parser",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,10 @@ lto = true
 opt-level = "s"
 codegen-units = 1
 
+[patch.crates-io]
+# Fork of https://github.com/teythoon/rust-openssl.git/justus/pqc
+openssl = { git = "https://github.com/clundin25/rust-openssl.git", rev = "4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7" } # MLDSA
+
 # Always optimize the emulator during tests, as it is a major bottleneck for
 # test speed.
 [profile.test.package.caliptra-emu-bus]

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-07cfa903b5cce8bc5f013e477b6ec9d2cfbef1178735debb9259264f0272fc4257ef71edb5307f44ddca98949b1a98d4  caliptra-rom-no-log.bin
-f0b48ccc093732d3c90bf52f644af1c3cdd21eb626b6abe4b0d61b9b501a473adf4ced1cf5ad89c207353cb4f090c7f9  caliptra-rom-with-log.bin
+703531de1bce136fff26c2b63d57c0d7f6f6914efacfbb54e499c2f89f883879af26df97930f5b92f3c280549a8387dc  caliptra-rom-no-log.bin
+acd823efb48ddfdc8d8270466f73b74ded3bd64f1ed870ba8201aa66710554ffca28796b67f0348f971cc671d0d1a482  caliptra-rom-with-log.bin

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -15,7 +15,7 @@ use caliptra_drivers::okmutref;
 
 use caliptra_drivers::FmcAliasCsr;
 
-use caliptra_x509::{FmcAliasCsrTbs, FmcAliasCsrTbsParams};
+use caliptra_x509::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};
 
 use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult};
 
@@ -100,7 +100,7 @@ pub fn make_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     hasher.finalize(&mut fuse_info_digest)?;
 
     // CSR `To Be Signed` Parameters
-    let params = FmcAliasCsrTbsParams {
+    let params = FmcAliasCsrTbsEcc384Params {
         ueid: &X509::ueid(env)?,
         subject_sn: &output.subj_sn,
         public_key: &key_pair.pub_key.to_der(),
@@ -112,7 +112,7 @@ pub fn make_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     };
 
     // Generate the `To Be Signed` portion of the CSR
-    let tbs = FmcAliasCsrTbs::new(&params);
+    let tbs = FmcAliasCsrTbsEcc384::new(&params);
 
     // Sign the `To Be Signed` portion
     let mut sig =

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -127,7 +127,8 @@ pub fn make_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
 
     // Build the CSR with `To Be Signed` & `Signature`
     let mut csr_buf = [0; caliptra_drivers::MAX_FMC_ALIAS_CSR_SIZE];
-    let result = Ecdsa384CsrBuilder::new(tbs.tbs(), &sig.to_ecdsa())
+    let mut ecdsa_sig = sig.to_ecdsa();
+    let result = Ecdsa384CsrBuilder::new(tbs.tbs(), &ecdsa_sig)
         .ok_or(CaliptraError::FMC_ALIAS_CSR_BUILDER_INIT_FAILURE);
     sig.zeroize();
 
@@ -145,6 +146,7 @@ pub fn make_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     write_csr_to_peristent_storage(env, &fmc_alias_csr);
 
     csr_buf.zeroize();
+    ecdsa_sig.zeroize();
 
     Ok(())
 }

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -29,7 +29,7 @@ use caliptra_drivers::{
     okref, report_boot_status, CaliptraError, CaliptraResult, Ecc384Result, KeyId, PersistentData,
     ResetReason,
 };
-use caliptra_x509::{NotAfter, NotBefore, RtAliasCertTbs, RtAliasCertTbsParams};
+use caliptra_x509::{NotAfter, NotBefore, RtAliasCertTbsEcc384, RtAliasCertTbsEcc384Params};
 
 #[derive(Default)]
 pub struct RtAliasLayer {}
@@ -295,8 +295,8 @@ impl RtAliasLayer {
         env: &mut FmcEnv,
         input: &DiceInput,
         output: &DiceOutput,
-        not_before: &[u8; RtAliasCertTbsParams::NOT_BEFORE_LEN],
-        not_after: &[u8; RtAliasCertTbsParams::NOT_AFTER_LEN],
+        not_before: &[u8; RtAliasCertTbsEcc384Params::NOT_BEFORE_LEN],
+        not_after: &[u8; RtAliasCertTbsEcc384Params::NOT_AFTER_LEN],
     ) -> CaliptraResult<()> {
         let auth_priv_key = input.auth_key_pair.priv_key;
         let auth_pub_key = &input.auth_key_pair.pub_key;
@@ -308,7 +308,7 @@ impl RtAliasLayer {
         let rt_svn = HandOff::rt_svn(env) as u8;
 
         // Certificate `To Be Signed` Parameters
-        let params = RtAliasCertTbsParams {
+        let params = RtAliasCertTbsEcc384Params {
             // Do we need the UEID here?
             ueid: &X509::ueid(env)?,
             subject_sn: &output.subj_sn,
@@ -325,7 +325,7 @@ impl RtAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = RtAliasCertTbs::new(&params);
+        let tbs = RtAliasCertTbsEcc384::new(&params);
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -28,7 +28,7 @@ use caliptra_common::keyids::{KEY_ID_FMC_PRIV_KEY, KEY_ID_ROM_FMC_CDI};
 use caliptra_common::pcr::PCR_ID_FMC_CURRENT;
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::{okmutref, report_boot_status, Array4x12, CaliptraResult, KeyId};
-use caliptra_x509::{FmcAliasCertTbs, FmcAliasCertTbsParams};
+use caliptra_x509::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
 use zeroize::Zeroize;
 
 #[derive(Default)]
@@ -174,7 +174,7 @@ impl FmcAliasLayer {
         hasher.finalize(&mut fuse_info_digest)?;
 
         // Certificate `To Be Signed` Parameters
-        let params = FmcAliasCertTbsParams {
+        let params = FmcAliasCertTbsEcc384Params {
             ueid: &X509::ueid(env)?,
             subject_sn: &output.subj_sn,
             subject_key_id: &output.subj_key_id,
@@ -192,7 +192,7 @@ impl FmcAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = FmcAliasCertTbs::new(&params);
+        let tbs = FmcAliasCertTbsEcc384::new(&params);
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -261,7 +261,8 @@ impl InitDevIdLayer {
 
         // Build the CSR with `To Be Signed` & `Signature`
         let mut csr_buf = [0; MAX_IDEVID_CSR_SIZE];
-        let result = Ecdsa384CsrBuilder::new(tbs.tbs(), &sig.to_ecdsa())
+        let mut ecdsa_sig = sig.to_ecdsa();
+        let result = Ecdsa384CsrBuilder::new(tbs.tbs(), &ecdsa_sig)
             .ok_or(CaliptraError::ROM_IDEVID_CSR_BUILDER_INIT_FAILURE);
         sig.zeroize();
 
@@ -285,6 +286,7 @@ impl InitDevIdLayer {
             result = Self::write_csr_to_peristent_storage(env, &dev_id_csr);
         }
         csr_buf.zeroize();
+        ecdsa_sig.zeroize();
 
         result
     }

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -225,7 +225,7 @@ impl InitDevIdLayer {
         let key_pair = &output.subj_key_pair;
 
         // CSR `To Be Signed` Parameters
-        let params = InitDevIdCsrTbsParams {
+        let params = InitDevIdCsrTbsEcc384Params {
             // Unique Endpoint Identifier
             ueid: &X509::ueid(env)?,
 
@@ -237,7 +237,7 @@ impl InitDevIdLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = InitDevIdCsrTbs::new(&params);
+        let tbs = InitDevIdCsrTbsEcc384::new(&params);
 
         cprintln!(
             "[idev] Sign CSR w/ SUBJECT.KEYID = {}",

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -154,7 +154,7 @@ impl LocalDevIdLayer {
         let serial_number = okref(&serial_number)?;
 
         // CSR `To Be Signed` Parameters
-        let params = LocalDevIdCertTbsParams {
+        let params = LocalDevIdCertTbsEcc384Params {
             ueid: &X509::ueid(env)?,
             subject_sn: &output.subj_sn,
             subject_key_id: &output.subj_key_id,
@@ -167,7 +167,7 @@ impl LocalDevIdLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = LocalDevIdCertTbs::new(&params);
+        let tbs = LocalDevIdCertTbsEcc384::new(&params);
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -25,7 +25,9 @@ use caliptra_drivers::{
 use caliptra_registers::dv::DvReg;
 use caliptra_registers::pv::PvReg;
 use caliptra_registers::soc_ifc::SocIfcReg;
-use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbs, LocalDevIdCertTbs};
+use caliptra_x509::{
+    Ecdsa384CertBuilder, Ecdsa384Signature, FmcAliasCertTbsEcc384, LocalDevIdCertTbsEcc384,
+};
 use ureg::RealMmioMut;
 use zerocopy::IntoBytes;
 
@@ -137,13 +139,13 @@ fn create_certs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
         r: sig.r.into(),
         s: sig.s.into(),
     };
-    let mut tbs: [u8; core::mem::size_of::<LocalDevIdCertTbs>()] =
-        [0u8; core::mem::size_of::<LocalDevIdCertTbs>()];
+    let mut tbs: [u8; core::mem::size_of::<LocalDevIdCertTbsEcc384>()] =
+        [0u8; core::mem::size_of::<LocalDevIdCertTbsEcc384>()];
     copy_tbs(&mut tbs, true);
 
     let mut cert: [u8; 1024] = [0u8; 1024];
     let builder = Ecdsa384CertBuilder::new(
-        &tbs[..core::mem::size_of::<LocalDevIdCertTbs>()],
+        &tbs[..core::mem::size_of::<LocalDevIdCertTbsEcc384>()],
         &ecdsa_sig,
     )
     .unwrap();
@@ -165,14 +167,16 @@ fn create_certs(mbox: &caliptra_registers::mbox::RegisterBlock<RealMmioMut>) {
         s: sig.s.into(),
     };
 
-    let mut tbs: [u8; core::mem::size_of::<FmcAliasCertTbs>()] =
-        [0u8; core::mem::size_of::<FmcAliasCertTbs>()];
+    let mut tbs: [u8; core::mem::size_of::<FmcAliasCertTbsEcc384>()] =
+        [0u8; core::mem::size_of::<FmcAliasCertTbsEcc384>()];
     copy_tbs(&mut tbs, false);
 
     let mut cert: [u8; 1024] = [0u8; 1024];
-    let builder =
-        Ecdsa384CertBuilder::new(&tbs[..core::mem::size_of::<FmcAliasCertTbs>()], &ecdsa_sig)
-            .unwrap();
+    let builder = Ecdsa384CertBuilder::new(
+        &tbs[..core::mem::size_of::<FmcAliasCertTbsEcc384>()],
+        &ecdsa_sig,
+    )
+    .unwrap();
     let _cert_len = builder.build(&mut cert).unwrap();
     cprint_slice_ref!("[fmc] FMCALIAS cert", &cert[.._cert_len]);
 

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -45,13 +45,20 @@ pub fn main() {}
 // Dummy RO data to max out FMC image size to 16K.
 // Note: Adjust this value to account for new changes in this FMC image.
 #[cfg(all(feature = "interactive_test_fmc", not(feature = "fake-fmc")))]
-const PAD_LEN: usize = 9488; // TEST_FMC_INTERACTIVE
+const PAD_LEN: usize = 9624; // TEST_FMC_INTERACTIVE
 #[cfg(all(feature = "fake-fmc", not(feature = "interactive_test_fmc")))]
-const PAD_LEN: usize = 9724; // FAKE_TEST_FMC_WITH_UART
+const PAD_LEN: usize = 9904; // FAKE_TEST_FMC_WITH_UART
 #[cfg(all(feature = "interactive_test_fmc", feature = "fake-fmc"))]
-const PAD_LEN: usize = 9832; // FAKE_TEST_FMC_INTERACTIVE
+const PAD_LEN: usize = 9976; // FAKE_TEST_FMC_INTERACTIVE
 #[cfg(not(any(feature = "interactive_test_fmc", feature = "fake-fmc")))]
 const PAD_LEN: usize = 0;
+
+// 4-byte cfg-gated filler that nudges FAKE_TEST_FMC_INTERACTIVE's binary layout
+// past an ELF alignment plateau so PAD_LEN can land bundle.fmc.len() at exactly 16K.
+// The other three variants (incl. the empty-PAD case) hit 16K without it.
+#[cfg(all(feature = "fake-fmc", feature = "interactive_test_fmc"))]
+#[used]
+static FAKE_INT_FILLER: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
 
 static PAD: [u32; PAD_LEN / 4] = {
     let mut result = [0xdeadbeef_u32; PAD_LEN / 4];
@@ -64,7 +71,7 @@ static PAD: [u32; PAD_LEN / 4] = {
 };
 
 const BANNER: &str = r#"
-Running Caliptra FMC .......
+Running Caliptra FMC ...
 "#;
 
 #[no_mangle]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -30,4 +30,5 @@ x509-parser.workspace = true
 [features]
 default = ["std"]
 std = []
+mldsa_attestation = []
 generate_templates = ["dep:asn1", "dep:bitfield", "dep:caliptra_common", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn"]

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -20,15 +20,17 @@ convert_case = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 openssl = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 syn = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true
 openssl.workspace = true
+rand.workspace = true
 x509-parser.workspace = true
 
 [features]
 default = ["std"]
 std = []
 mldsa_attestation = []
-generate_templates = ["dep:asn1", "dep:bitfield", "dep:caliptra_common", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:syn"]
+generate_templates = ["dep:asn1", "dep:bitfield", "dep:caliptra_common", "dep:convert_case", "dep:hex", "dep:openssl", "dep:quote", "dep:rand", "dep:syn"]

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -56,7 +56,7 @@ fn gen_init_devid_csr(out_dir: &str) {
         .add_key_usage_ext(usage)
         .add_ueid_ext(&[0xFF; 17]);
     let template = bldr.tbs_template("Caliptra 1.0 IDevID");
-    CodeGen::gen_code("InitDevIdCsrTbs", template, out_dir);
+    CodeGen::gen_code("InitDevIdCsrTbsEcc384", template, out_dir);
 }
 
 #[cfg(feature = "generate_templates")]
@@ -86,7 +86,7 @@ fn gen_fmc_alias_csr(out_dir: &str) {
             }],
         );
     let template = bldr.tbs_template("Caliptra 1.0 FMC Alias");
-    CodeGen::gen_code("FmcAliasCsrTbs", template, out_dir);
+    CodeGen::gen_code("FmcAliasCsrTbsEcc384", template, out_dir);
 }
 
 /// Generate Local DeviceId Certificate Template
@@ -99,7 +99,7 @@ fn gen_local_devid_cert(out_dir: &str) {
         .add_key_usage_ext(usage)
         .add_ueid_ext(&[0xFF; 17]);
     let template = bldr.tbs_template("Caliptra 1.0 LDevID", "Caliptra 1.0 IDevID");
-    CodeGen::gen_code("LocalDevIdCertTbs", template, out_dir);
+    CodeGen::gen_code("LocalDevIdCertTbsEcc384", template, out_dir);
 }
 
 /// Generate FMC Alias Certificate Template
@@ -130,7 +130,7 @@ fn gen_fmc_alias_cert(out_dir: &str) {
             }],
         );
     let template = bldr.tbs_template("Caliptra 1.0 FMC Alias", "Caliptra 1.0 LDevID");
-    CodeGen::gen_code("FmcAliasCertTbs", template, out_dir);
+    CodeGen::gen_code("FmcAliasCertTbsEcc384", template, out_dir);
 }
 
 /// Generate FMC Alias Certificate Template
@@ -154,5 +154,5 @@ fn gen_rt_alias_cert(out_dir: &str) {
             },
         }]);
     let template = bldr.tbs_template("Caliptra 1.0 Rt Alias", "Caliptra 1.0 FMC Alias");
-    CodeGen::gen_code("RtAliasCertTbs", template, out_dir);
+    CodeGen::gen_code("RtAliasCertTbsEcc384", template, out_dir);
 }

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -28,7 +28,7 @@ mod x509;
 use {
     code_gen::CodeGen,
     std::env,
-    x509::{EcdsaSha384Algo, Fwid, FwidParam, KeyUsage},
+    x509::{EcdsaSha384Algo, Fwid, FwidParam, KeyUsage, MlDsa87Algo},
 };
 
 // Main Entry point
@@ -51,12 +51,20 @@ fn main() {
 fn gen_init_devid_csr(out_dir: &str) {
     let mut usage = KeyUsage::default();
     usage.set_key_cert_sign(true);
+
     let bldr = csr::CsrTemplateBuilder::<EcdsaSha384Algo>::new()
         .add_basic_constraints_ext(true, 5)
         .add_key_usage_ext(usage)
         .add_ueid_ext(&[0xFF; 17]);
     let template = bldr.tbs_template("Caliptra 1.0 IDevID");
     CodeGen::gen_code("InitDevIdCsrTbsEcc384", template, out_dir);
+
+    let bldr = csr::CsrTemplateBuilder::<MlDsa87Algo>::new()
+        .add_basic_constraints_ext(true, 5)
+        .add_key_usage_ext(usage)
+        .add_ueid_ext(&[0xFF; 17]);
+    let template = bldr.tbs_template("Caliptra 1.0 MlDsa87 IDevID");
+    CodeGen::gen_code("InitDevIdCsrTbsMlDsa87", template, out_dir);
 }
 
 #[cfg(feature = "generate_templates")]

--- a/x509/build/build.rs
+++ b/x509/build/build.rs
@@ -63,8 +63,8 @@ fn gen_init_devid_csr(out_dir: &str) {
         .add_basic_constraints_ext(true, 5)
         .add_key_usage_ext(usage)
         .add_ueid_ext(&[0xFF; 17]);
-    let template = bldr.tbs_template("Caliptra 1.0 MlDsa87 IDevID");
-    CodeGen::gen_code("InitDevIdCsrTbsMlDsa87", template, out_dir);
+    let template = bldr.tbs_template("Caliptra 1.0 MlDsa87 PQDevID");
+    CodeGen::gen_code("PqDevIdCsrTbsMlDsa87", template, out_dir);
 }
 
 #[cfg(feature = "generate_templates")]

--- a/x509/build/code_gen.rs
+++ b/x509/build/code_gen.rs
@@ -17,6 +17,37 @@ use convert_case::{Case, Casing};
 use quote::{__private::TokenStream, format_ident, quote};
 use std::{path::Path, process::Command};
 
+/// Templates whose largest placeholder run is at least this many bytes are emitted
+/// as a BEFORE/AFTER split rather than a single inline TBS_TEMPLATE const, to avoid
+/// inlining large stretches of `0x5F` filler into `.rodata`. Below this threshold,
+/// the savings don't justify the extra indirection.
+const SPLIT_THRESHOLD: usize = 512;
+
+/// Locate the longest contiguous run of `0x5F` placeholder bytes in a TBS template.
+/// Returns `Some((offset, len))` of the longest run, or `None` if there are none.
+fn longest_placeholder_run(tbs: &[u8]) -> Option<(usize, usize)> {
+    let mut best: (usize, usize) = (0, 0);
+    let mut cur_start = 0;
+    let mut cur_len = 0;
+    for (i, &b) in tbs.iter().enumerate() {
+        if b == 0x5F {
+            if cur_len == 0 {
+                cur_start = i;
+            }
+            cur_len += 1;
+        } else {
+            if cur_len > best.1 {
+                best = (cur_start, cur_len);
+            }
+            cur_len = 0;
+        }
+    }
+    if cur_len > best.1 {
+        best = (cur_start, cur_len);
+    }
+    (best.1 > 0).then_some(best)
+}
+
 // Code Generator
 pub struct CodeGen {}
 
@@ -89,6 +120,65 @@ impl CodeGen {
 
         let tbs = template.tbs();
 
+        let (template_consts, new_body) = match longest_placeholder_run(tbs)
+            .filter(|(_, len)| *len >= SPLIT_THRESHOLD)
+        {
+            Some((split_offset, split_len)) => {
+                let before = &tbs[..split_offset];
+                let after = &tbs[split_offset + split_len..];
+                let before_len = before.len();
+                let after_len = after.len();
+                let placeholder_end = split_offset + split_len;
+
+                let consts = quote!(
+                    const TBS_TEMPLATE_BEFORE_PLACEHOLDER: [u8; #before_len] = [#(#before,)*];
+                    const TBS_TEMPLATE_AFTER_PLACEHOLDER: [u8; #after_len] = [#(#after,)*];
+
+                    #[cfg(test)]
+                    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+                        let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
+                        let before = Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER;
+                        let after = Self::TBS_TEMPLATE_AFTER_PLACEHOLDER;
+                        let mut i = 0;
+                        while i < before.len() {
+                            result[i] = before[i];
+                            i += 1;
+                        }
+                        let mut i = 0;
+                        while i < after.len() {
+                            result[#placeholder_end + i] = after[i];
+                            i += 1;
+                        }
+                        result
+                    };
+                );
+
+                let body = quote!(
+                    let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
+                    tbs[..#before_len].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER);
+                    tbs[#placeholder_end..].copy_from_slice(&Self::TBS_TEMPLATE_AFTER_PLACEHOLDER);
+                    let mut template = Self { tbs };
+                    template.apply(params);
+                    template
+                );
+
+                (consts, body)
+            }
+            None => {
+                let consts = quote!(
+                    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [#(#tbs,)*];
+                );
+                let body = quote!(
+                    let mut template = Self {
+                        tbs: Self::TBS_TEMPLATE,
+                    };
+                    template.apply(params);
+                    template
+                );
+                (consts, body)
+            }
+        };
+
         quote!(
             #[doc = "++
 
@@ -116,14 +206,10 @@ Abstract:
                 #(#offset_consts)*
                 #(#len_consts)*
                 #tbs_len_const
-                const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [#(#tbs,)*];
+                #template_consts
 
                 pub fn new(params: &#param_name) -> Self {
-                    let mut template = Self {
-                        tbs: Self::TBS_TEMPLATE,
-                    };
-                    template.apply(params);
-                    template
+                    #new_body
                 }
 
                 pub fn sign<Sig, Error>(

--- a/x509/build/fmc_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_cert_tbs_ecc_384.rs
@@ -7,7 +7,7 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct FmcAliasCertTbsParams<'a> {
+pub struct FmcAliasCertTbsEcc384Params<'a> {
     pub public_key: &'a [u8; 97usize],
     pub subject_sn: &'a [u8; 64usize],
     pub issuer_sn: &'a [u8; 64usize],
@@ -23,7 +23,7 @@ pub struct FmcAliasCertTbsParams<'a> {
     pub tcb_info_fmc_svn: &'a [u8; 1usize],
     pub tcb_info_fmc_svn_fuses: &'a [u8; 1usize],
 }
-impl<'a> FmcAliasCertTbsParams<'a> {
+impl<'a> FmcAliasCertTbsEcc384Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 97usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const ISSUER_SN_LEN: usize = 64usize;
@@ -39,10 +39,10 @@ impl<'a> FmcAliasCertTbsParams<'a> {
     pub const TCB_INFO_FMC_SVN_LEN: usize = 1usize;
     pub const TCB_INFO_FMC_SVN_FUSES_LEN: usize = 1usize;
 }
-pub struct FmcAliasCertTbs {
+pub struct FmcAliasCertTbsEcc384 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl FmcAliasCertTbs {
+impl FmcAliasCertTbsEcc384 {
     const PUBLIC_KEY_OFFSET: usize = 319usize;
     const SUBJECT_SN_OFFSET: usize = 232usize;
     const ISSUER_SN_OFFSET: usize = 86usize;
@@ -124,7 +124,7 @@ impl FmcAliasCertTbs {
         4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
-    pub fn new(params: &FmcAliasCertTbsParams) -> Self {
+    pub fn new(params: &FmcAliasCertTbsEcc384Params) -> Self {
         let mut template = Self {
             tbs: Self::TBS_TEMPLATE,
         };
@@ -140,7 +140,7 @@ impl FmcAliasCertTbs {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &FmcAliasCertTbsParams) {
+    fn apply(&mut self, params: &FmcAliasCertTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
             buf: &mut [u8; 753usize],

--- a/x509/build/fmc_alias_csr_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_csr_tbs_ecc_384.rs
@@ -7,7 +7,7 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct FmcAliasCsrTbsParams<'a> {
+pub struct FmcAliasCsrTbsEcc384Params<'a> {
     pub public_key: &'a [u8; 97usize],
     pub subject_sn: &'a [u8; 64usize],
     pub tcb_info_device_info_hash: &'a [u8; 48usize],
@@ -17,7 +17,7 @@ pub struct FmcAliasCsrTbsParams<'a> {
     pub tcb_info_fmc_svn: &'a [u8; 1usize],
     pub tcb_info_fmc_svn_fuses: &'a [u8; 1usize],
 }
-impl<'a> FmcAliasCsrTbsParams<'a> {
+impl<'a> FmcAliasCsrTbsEcc384Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 97usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const TCB_INFO_DEVICE_INFO_HASH_LEN: usize = 48usize;
@@ -27,10 +27,10 @@ impl<'a> FmcAliasCsrTbsParams<'a> {
     pub const TCB_INFO_FMC_SVN_LEN: usize = 1usize;
     pub const TCB_INFO_FMC_SVN_FUSES_LEN: usize = 1usize;
 }
-pub struct FmcAliasCsrTbs {
+pub struct FmcAliasCsrTbsEcc384 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl FmcAliasCsrTbs {
+impl FmcAliasCsrTbsEcc384 {
     const PUBLIC_KEY_OFFSET: usize = 140usize;
     const SUBJECT_SN_OFFSET: usize = 53usize;
     const TCB_INFO_DEVICE_INFO_HASH_OFFSET: usize = 373usize;
@@ -85,7 +85,7 @@ impl FmcAliasCsrTbs {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 137u8, 8u8, 70u8, 77u8, 67u8, 95u8, 73u8, 78u8, 70u8, 79u8,
     ];
-    pub fn new(params: &FmcAliasCsrTbsParams) -> Self {
+    pub fn new(params: &FmcAliasCsrTbsEcc384Params) -> Self {
         let mut template = Self {
             tbs: Self::TBS_TEMPLATE,
         };
@@ -101,7 +101,7 @@ impl FmcAliasCsrTbs {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &FmcAliasCsrTbsParams) {
+    fn apply(&mut self, params: &FmcAliasCsrTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
             buf: &mut [u8; 529usize],

--- a/x509/build/init_dev_id_csr_tbs_ecc_384.rs
+++ b/x509/build/init_dev_id_csr_tbs_ecc_384.rs
@@ -7,20 +7,20 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct InitDevIdCsrTbsParams<'a> {
+pub struct InitDevIdCsrTbsEcc384Params<'a> {
     pub public_key: &'a [u8; 97usize],
     pub subject_sn: &'a [u8; 64usize],
     pub ueid: &'a [u8; 17usize],
 }
-impl<'a> InitDevIdCsrTbsParams<'a> {
+impl<'a> InitDevIdCsrTbsEcc384Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 97usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const UEID_LEN: usize = 17usize;
 }
-pub struct InitDevIdCsrTbs {
+pub struct InitDevIdCsrTbsEcc384 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl InitDevIdCsrTbs {
+impl InitDevIdCsrTbsEcc384 {
     const PUBLIC_KEY_OFFSET: usize = 137usize;
     const SUBJECT_SN_OFFSET: usize = 50usize;
     const UEID_OFFSET: usize = 305usize;
@@ -52,7 +52,7 @@ impl InitDevIdCsrTbs {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8,
     ];
-    pub fn new(params: &InitDevIdCsrTbsParams) -> Self {
+    pub fn new(params: &InitDevIdCsrTbsEcc384Params) -> Self {
         let mut template = Self {
             tbs: Self::TBS_TEMPLATE,
         };
@@ -68,7 +68,7 @@ impl InitDevIdCsrTbs {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &InitDevIdCsrTbsParams) {
+    fn apply(&mut self, params: &InitDevIdCsrTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
             buf: &mut [u8; 322usize],

--- a/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
@@ -1,0 +1,103 @@
+#[doc = "++
+
+Licensed under the Apache-2.0 license.
+
+Abstract:
+
+    Regenerate the template by building caliptra-x509-build with the generate-templates flag.
+
+--"]
+pub struct InitDevIdCsrTbsMlDsa87Params<'a> {
+    pub public_key: &'a [u8; 2592usize],
+    pub subject_sn: &'a [u8; 64usize],
+    pub ueid: &'a [u8; 17usize],
+}
+impl<'a> InitDevIdCsrTbsMlDsa87Params<'a> {
+    pub const PUBLIC_KEY_LEN: usize = 2592usize;
+    pub const SUBJECT_SN_LEN: usize = 64usize;
+    pub const UEID_LEN: usize = 17usize;
+}
+pub struct InitDevIdCsrTbsMlDsa87 {
+    tbs: [u8; Self::TBS_TEMPLATE_LEN],
+}
+impl InitDevIdCsrTbsMlDsa87 {
+    const PUBLIC_KEY_OFFSET: usize = 144usize;
+    const SUBJECT_SN_OFFSET: usize = 58usize;
+    const UEID_OFFSET: usize = 2807usize;
+    const PUBLIC_KEY_LEN: usize = 2592usize;
+    const SUBJECT_SN_LEN: usize = 64usize;
+    const UEID_LEN: usize = 17usize;
+    pub const TBS_TEMPLATE_LEN: usize = 2824usize;
+    const TBS_TEMPLATE_BEFORE_PLACEHOLDER: [u8; 144usize] = [
+        48u8, 130u8, 11u8, 4u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8,
+        4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8,
+        46u8, 48u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8, 101u8,
+        118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
+        101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    ];
+    const TBS_TEMPLATE_AFTER_PLACEHOLDER: [u8; 88usize] = [
+        160u8, 86u8, 48u8, 84u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
+        49u8, 71u8, 48u8, 69u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
+        48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
+        1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8,
+        4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+    ];
+    #[cfg(test)]
+    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+        let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
+        let before = Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER;
+        let after = Self::TBS_TEMPLATE_AFTER_PLACEHOLDER;
+        let mut i = 0;
+        while i < before.len() {
+            result[i] = before[i];
+            i += 1;
+        }
+        let mut i = 0;
+        while i < after.len() {
+            result[2736usize + i] = after[i];
+            i += 1;
+        }
+        result
+    };
+    pub fn new(params: &InitDevIdCsrTbsMlDsa87Params) -> Self {
+        let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
+        tbs[..144usize].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER);
+        tbs[2736usize..].copy_from_slice(&Self::TBS_TEMPLATE_AFTER_PLACEHOLDER);
+        let mut template = Self { tbs };
+        template.apply(params);
+        template
+    }
+    pub fn sign<Sig, Error>(
+        &self,
+        sign_fn: impl Fn(&[u8]) -> Result<Sig, Error>,
+    ) -> Result<Sig, Error> {
+        sign_fn(&self.tbs)
+    }
+    pub fn tbs(&self) -> &[u8] {
+        &self.tbs
+    }
+    fn apply(&mut self, params: &InitDevIdCsrTbsMlDsa87Params) {
+        #[inline(always)]
+        fn apply_slice<const OFFSET: usize, const LEN: usize>(
+            buf: &mut [u8; 2824usize],
+            val: &[u8; LEN],
+        ) {
+            buf[OFFSET..OFFSET + LEN].copy_from_slice(val);
+        }
+        apply_slice::<{ Self::PUBLIC_KEY_OFFSET }, { Self::PUBLIC_KEY_LEN }>(
+            &mut self.tbs,
+            params.public_key,
+        );
+        apply_slice::<{ Self::SUBJECT_SN_OFFSET }, { Self::SUBJECT_SN_LEN }>(
+            &mut self.tbs,
+            params.subject_sn,
+        );
+        apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}

--- a/x509/build/local_dev_id_cert_tbs_ecc_384.rs
+++ b/x509/build/local_dev_id_cert_tbs_ecc_384.rs
@@ -7,7 +7,7 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct LocalDevIdCertTbsParams<'a> {
+pub struct LocalDevIdCertTbsEcc384Params<'a> {
     pub public_key: &'a [u8; 97usize],
     pub subject_sn: &'a [u8; 64usize],
     pub issuer_sn: &'a [u8; 64usize],
@@ -18,7 +18,7 @@ pub struct LocalDevIdCertTbsParams<'a> {
     pub not_before: &'a [u8; 15usize],
     pub not_after: &'a [u8; 15usize],
 }
-impl<'a> LocalDevIdCertTbsParams<'a> {
+impl<'a> LocalDevIdCertTbsEcc384Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 97usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const ISSUER_SN_LEN: usize = 64usize;
@@ -29,10 +29,10 @@ impl<'a> LocalDevIdCertTbsParams<'a> {
     pub const NOT_BEFORE_LEN: usize = 15usize;
     pub const NOT_AFTER_LEN: usize = 15usize;
 }
-pub struct LocalDevIdCertTbs {
+pub struct LocalDevIdCertTbsEcc384 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl LocalDevIdCertTbs {
+impl LocalDevIdCertTbsEcc384 {
     const PUBLIC_KEY_OFFSET: usize = 316usize;
     const SUBJECT_SN_OFFSET: usize = 229usize;
     const ISSUER_SN_OFFSET: usize = 86usize;
@@ -91,7 +91,7 @@ impl LocalDevIdCertTbs {
         128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
-    pub fn new(params: &LocalDevIdCertTbsParams) -> Self {
+    pub fn new(params: &LocalDevIdCertTbsEcc384Params) -> Self {
         let mut template = Self {
             tbs: Self::TBS_TEMPLATE,
         };
@@ -107,7 +107,7 @@ impl LocalDevIdCertTbs {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &LocalDevIdCertTbsParams) {
+    fn apply(&mut self, params: &LocalDevIdCertTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
             buf: &mut [u8; 552usize],

--- a/x509/build/pq_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/pq_dev_id_csr_tbs_ml_dsa_87.rs
@@ -7,38 +7,38 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct InitDevIdCsrTbsMlDsa87Params<'a> {
+pub struct PqDevIdCsrTbsMlDsa87Params<'a> {
     pub public_key: &'a [u8; 2592usize],
     pub subject_sn: &'a [u8; 64usize],
     pub ueid: &'a [u8; 17usize],
 }
-impl<'a> InitDevIdCsrTbsMlDsa87Params<'a> {
+impl<'a> PqDevIdCsrTbsMlDsa87Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 2592usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const UEID_LEN: usize = 17usize;
 }
-pub struct InitDevIdCsrTbsMlDsa87 {
+pub struct PqDevIdCsrTbsMlDsa87 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl InitDevIdCsrTbsMlDsa87 {
-    const PUBLIC_KEY_OFFSET: usize = 144usize;
-    const SUBJECT_SN_OFFSET: usize = 58usize;
-    const UEID_OFFSET: usize = 2807usize;
+impl PqDevIdCsrTbsMlDsa87 {
+    const PUBLIC_KEY_OFFSET: usize = 145usize;
+    const SUBJECT_SN_OFFSET: usize = 59usize;
+    const UEID_OFFSET: usize = 2808usize;
     const PUBLIC_KEY_LEN: usize = 2592usize;
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
-    pub const TBS_TEMPLATE_LEN: usize = 2824usize;
-    const TBS_TEMPLATE_BEFORE_PLACEHOLDER: [u8; 144usize] = [
-        48u8, 130u8, 11u8, 4u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8,
-        4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8,
-        46u8, 48u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8, 101u8,
-        118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
+    pub const TBS_TEMPLATE_LEN: usize = 2825usize;
+    const TBS_TEMPLATE_BEFORE_PLACEHOLDER: [u8; 145usize] = [
+        48u8, 130u8, 11u8, 5u8, 2u8, 1u8, 0u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8,
+        4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 49u8,
+        46u8, 48u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 80u8, 81u8, 68u8,
+        101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+        95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+        1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
     const TBS_TEMPLATE_AFTER_PLACEHOLDER: [u8; 88usize] = [
         160u8, 86u8, 48u8, 84u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
@@ -60,15 +60,15 @@ impl InitDevIdCsrTbsMlDsa87 {
         }
         let mut i = 0;
         while i < after.len() {
-            result[2736usize + i] = after[i];
+            result[2737usize + i] = after[i];
             i += 1;
         }
         result
     };
-    pub fn new(params: &InitDevIdCsrTbsMlDsa87Params) -> Self {
+    pub fn new(params: &PqDevIdCsrTbsMlDsa87Params) -> Self {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..144usize].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER);
-        tbs[2736usize..].copy_from_slice(&Self::TBS_TEMPLATE_AFTER_PLACEHOLDER);
+        tbs[..145usize].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_PLACEHOLDER);
+        tbs[2737usize..].copy_from_slice(&Self::TBS_TEMPLATE_AFTER_PLACEHOLDER);
         let mut template = Self { tbs };
         template.apply(params);
         template
@@ -82,10 +82,10 @@ impl InitDevIdCsrTbsMlDsa87 {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &InitDevIdCsrTbsMlDsa87Params) {
+    fn apply(&mut self, params: &PqDevIdCsrTbsMlDsa87Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
-            buf: &mut [u8; 2824usize],
+            buf: &mut [u8; 2825usize],
             val: &[u8; LEN],
         ) {
             buf[OFFSET..OFFSET + LEN].copy_from_slice(val);

--- a/x509/build/rt_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/rt_alias_cert_tbs_ecc_384.rs
@@ -7,7 +7,7 @@ Abstract:
     Regenerate the template by building caliptra-x509-build with the generate-templates flag.
 
 --"]
-pub struct RtAliasCertTbsParams<'a> {
+pub struct RtAliasCertTbsEcc384Params<'a> {
     pub public_key: &'a [u8; 97usize],
     pub subject_sn: &'a [u8; 64usize],
     pub issuer_sn: &'a [u8; 64usize],
@@ -20,7 +20,7 @@ pub struct RtAliasCertTbsParams<'a> {
     pub not_after: &'a [u8; 15usize],
     pub tcb_info_rt_svn: &'a [u8; 1usize],
 }
-impl<'a> RtAliasCertTbsParams<'a> {
+impl<'a> RtAliasCertTbsEcc384Params<'a> {
     pub const PUBLIC_KEY_LEN: usize = 97usize;
     pub const SUBJECT_SN_LEN: usize = 64usize;
     pub const ISSUER_SN_LEN: usize = 64usize;
@@ -33,10 +33,10 @@ impl<'a> RtAliasCertTbsParams<'a> {
     pub const NOT_AFTER_LEN: usize = 15usize;
     pub const TCB_INFO_RT_SVN_LEN: usize = 1usize;
 }
-pub struct RtAliasCertTbs {
+pub struct RtAliasCertTbsEcc384 {
     tbs: [u8; Self::TBS_TEMPLATE_LEN],
 }
-impl RtAliasCertTbs {
+impl RtAliasCertTbsEcc384 {
     const PUBLIC_KEY_OFFSET: usize = 321usize;
     const SUBJECT_SN_OFFSET: usize = 234usize;
     const ISSUER_SN_OFFSET: usize = 89usize;
@@ -106,7 +106,7 @@ impl RtAliasCertTbs {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8,
     ];
-    pub fn new(params: &RtAliasCertTbsParams) -> Self {
+    pub fn new(params: &RtAliasCertTbsEcc384Params) -> Self {
         let mut template = Self {
             tbs: Self::TBS_TEMPLATE,
         };
@@ -122,7 +122,7 @@ impl RtAliasCertTbs {
     pub fn tbs(&self) -> &[u8] {
         &self.tbs
     }
-    fn apply(&mut self, params: &RtAliasCertTbsParams) {
+    fn apply(&mut self, params: &RtAliasCertTbsEcc384Params) {
         #[inline(always)]
         fn apply_slice<const OFFSET: usize, const LEN: usize>(
             buf: &mut [u8; 649usize],

--- a/x509/build/x509.rs
+++ b/x509/build/x509.rs
@@ -24,7 +24,8 @@ use openssl::ec::PointConversionForm;
 use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
 use openssl::pkey::PKey;
-use openssl::pkey::Private;
+use openssl::pkey::{Private, Public};
+use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVariant};
 use openssl::sha::Sha1;
 use openssl::sha::Sha256;
 use openssl::x509::extension::BasicConstraints;
@@ -32,6 +33,7 @@ use openssl::x509::extension::KeyUsage as Usage;
 use openssl::x509::extension::SubjectKeyIdentifier;
 use openssl::x509::X509Extension;
 use openssl::x509::X509v3Context;
+use rand::Rng;
 
 use crate::tbs::TbsParam;
 
@@ -170,6 +172,60 @@ pub struct EcdsaSha384Algo {}
 impl SigningAlgorithm for EcdsaSha384Algo {
     type AsymKey = Ecc384AsymKey;
     type Digest = Sha384;
+
+    fn gen_key(&self) -> Self::AsymKey {
+        Self::AsymKey::default()
+    }
+}
+
+/// ML-DSA-87 Asymmetric Key Pair
+pub struct MlDsa87AsymKey {
+    priv_key: PKey<Private>,
+    pub_key: Vec<u8>,
+}
+
+impl AsymKey for MlDsa87AsymKey {
+    fn priv_key(&self) -> &PKey<Private> {
+        &self.priv_key
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        &self.pub_key
+    }
+}
+
+impl Default for MlDsa87AsymKey {
+    fn default() -> Self {
+        let mut random_bytes: [u8; 32] = [0; 32];
+        let mut rng = rand::thread_rng();
+        rng.fill(&mut random_bytes);
+        let pk_builder =
+            PKeyMlDsaBuilder::<Private>::from_seed(MlDsaVariant::MlDsa87, &random_bytes).unwrap();
+        let priv_key = pk_builder.build().unwrap();
+        let pub_params = PKeyMlDsaParams::<Public>::from_pkey(&priv_key).unwrap();
+        let pub_key = pub_params.public_key().unwrap();
+        Self {
+            priv_key,
+            pub_key: pub_key.to_vec(),
+        }
+    }
+}
+
+/// No-op digest used for sign-the-message algorithms (e.g. ML-DSA).
+pub struct Noop {}
+
+impl Digest for Noop {
+    fn algo() -> MessageDigest {
+        MessageDigest::null()
+    }
+}
+
+#[derive(Default)]
+pub struct MlDsa87Algo {}
+
+impl SigningAlgorithm for MlDsa87Algo {
+    type AsymKey = MlDsa87AsymKey;
+    type Digest = Noop;
 
     fn gen_key(&self) -> Self::AsymKey {
         Self::AsymKey::default()

--- a/x509/src/cert_bldr.rs
+++ b/x509/src/cert_bldr.rs
@@ -26,6 +26,10 @@ const DER_SEQ_TAG: u8 = 0x30;
 /// MAX Signature length
 const MAX_ECDSA384_SIG_LEN: usize = 108;
 
+/// MAX ML-DSA-87 signature DER length
+#[cfg(feature = "mldsa_attestation")]
+const MAX_MLDSA87_SIG_DER_LEN: usize = 4641;
+
 /// Trait for signature types
 pub trait Signature<const MAX_DER_SIZE: usize> {
     /// Convert the signature to DER format
@@ -210,3 +214,61 @@ impl<'a, S: Signature<MAX_DER_SIZE>, const MAX_DER_SIZE: usize> CertBuilder<'a, 
 // Type alias for ECDSA-384 Certificate Builder
 pub type Ecdsa384CertBuilder<'a> = CertBuilder<'a, Ecdsa384Signature, MAX_ECDSA384_SIG_LEN>;
 pub type Ecdsa384CsrBuilder<'a> = Ecdsa384CertBuilder<'a>;
+
+/// Ml-Dsa87 Signature
+#[cfg(feature = "mldsa_attestation")]
+pub struct MlDsa87Signature {
+    pub sig: [u8; Self::MLDSA87_SIG_LEN],
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for MlDsa87Signature {
+    fn default() -> Self {
+        Self {
+            sig: [0; Self::MLDSA87_SIG_LEN],
+        }
+    }
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl MlDsa87Signature {
+    /// ML-DSA-87 raw signature length (FIPS 204)
+    pub const MLDSA87_SIG_LEN: usize = 4627;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Signature<MAX_MLDSA87_SIG_DER_LEN> for MlDsa87Signature {
+    fn to_der(&self, buf: &mut [u8; MAX_MLDSA87_SIG_DER_LEN]) -> Option<usize> {
+        //
+        // Signature DER Sequence encoding
+        //
+        let sig_seq_len = self.sig.len();
+        let mut pos = 0;
+
+        // Encode Signature DER Bit String
+        *buf.get_mut(pos)? = DER_BIT_STR_TAG;
+        pos += 1;
+        pos += der_encode_len(1 + sig_seq_len, buf.get_mut(pos..)?)?;
+        *buf.get_mut(pos)? = 0x0;
+        pos += 1;
+
+        buf.get_mut(pos..pos + self.sig.len())?
+            .copy_from_slice(&self.sig);
+        pos += sig_seq_len;
+
+        Some(pos)
+    }
+
+    fn oid_der() -> &'static [u8] {
+        // id-ml-dsa-87: 2.16.840.1.101.3.4.3.19
+        &[
+            0x30, 0x0b, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13,
+        ]
+    }
+}
+
+// Type alias for Ml-Dsa87 Certificate Builder
+#[cfg(feature = "mldsa_attestation")]
+pub type MlDsa87CertBuilder<'a> = CertBuilder<'a, MlDsa87Signature, MAX_MLDSA87_SIG_DER_LEN>;
+#[cfg(feature = "mldsa_attestation")]
+pub type MlDsa87CsrBuilder<'a> = MlDsa87CertBuilder<'a>;

--- a/x509/src/cert_bldr.rs
+++ b/x509/src/cert_bldr.rs
@@ -9,17 +9,13 @@ File Name:
 Abstract:
 
     X509 API to construct Certificate or Certificate Signing Request
-    from "To Be Signed" blob and ECDSA-384 Signature.
+    from "To Be Signed" blob and a generic signature type.
 
 --*/
 
-pub type Ecdsa384CsrBuilder<'a> = Ecdsa384CertBuilder<'a>;
+use crate::{der_encode_len, der_encode_uint, der_uint_len};
 
-/// MAX Signature length
-const MAX_ECDSA384_SIG_LEN: usize = 108;
-
-/// DER Integer Tag
-const DER_INTEGER_TAG: u8 = 0x02;
+use zeroize::Zeroize;
 
 /// DER Bit String Tag
 const DER_BIT_STR_TAG: u8 = 0x03;
@@ -27,8 +23,20 @@ const DER_BIT_STR_TAG: u8 = 0x03;
 /// DER Sequence Tag
 const DER_SEQ_TAG: u8 = 0x30;
 
+/// MAX Signature length
+const MAX_ECDSA384_SIG_LEN: usize = 108;
+
+/// Trait for signature types
+pub trait Signature<const MAX_DER_SIZE: usize> {
+    /// Convert the signature to DER format
+    fn to_der(&self, buf: &mut [u8; MAX_DER_SIZE]) -> Option<usize>;
+
+    /// DER Encoded Sequence with signature algorithm OID
+    fn oid_der() -> &'static [u8];
+}
+
 /// ECDSA-384 Signature
-#[derive(Debug)]
+#[derive(Debug, Zeroize)]
 pub struct Ecdsa384Signature {
     /// Signature R-Coordinate
     pub r: [u8; Self::ECDSA_COORD_LEN],
@@ -38,11 +46,10 @@ pub struct Ecdsa384Signature {
 }
 
 impl Default for Ecdsa384Signature {
-    /// Returns the "default value" for a type.
     fn default() -> Self {
         Self {
-            r: [0u8; Self::ECDSA_COORD_LEN],
-            s: [0u8; Self::ECDSA_COORD_LEN],
+            r: [0; Self::ECDSA_COORD_LEN],
+            s: [0; Self::ECDSA_COORD_LEN],
         }
     }
 }
@@ -50,77 +57,15 @@ impl Default for Ecdsa384Signature {
 impl Ecdsa384Signature {
     /// ECDSA Coordinate length
     pub const ECDSA_COORD_LEN: usize = 48;
+}
 
-    /// Get the length of DER encoded unsigned integer
-    #[inline(never)]
-    #[allow(clippy::needless_return)]
-    fn der_uint_len(&self, val: &[u8; Self::ECDSA_COORD_LEN]) -> usize {
-        //
-        // len = TAG (1 byte) + LEN (1 byte) + Coordinate Len
-        //
-        for (idx, byte) in val.iter().enumerate() {
-            if *byte != 0x00 {
-                return 2 + val.len() - idx + if *byte > 127 { 1 } else { 0 };
-            }
-        }
-
-        return 2 + 1;
-    }
-
-    // DER Encode unsigned integer
-    fn der_encode_uint(&self, val: &[u8; Self::ECDSA_COORD_LEN], buf: &mut [u8]) -> Option<usize> {
-        let mut pos = 0;
-
-        // Count the leading zeros
-        let clz = val
-            .iter()
-            .enumerate()
-            .find(|(_, byte)| **byte != 0)
-            .map_or(val.len(), |(idx, _)| idx);
-
-        *buf.get_mut(pos)? = DER_INTEGER_TAG;
-        pos += 1;
-
-        if clz == val.len() {
-            // Encode length
-            *buf.get_mut(pos)? = 1;
-
-            // Encode Value
-            *buf.get_mut(pos + 1)? = 0;
-
-            pos += 2;
-        } else {
-            // Check if the most significant bit is set
-            let msb_set = *val.get(clz)? > 127_u8;
-
-            // Encode length
-            let val_size = val.len() - clz + if msb_set { 1 } else { 0 };
-            *buf.get_mut(pos)? = val_size as u8;
-            pos += 1;
-
-            // Encode the value
-
-            // If MSB is set encode extra zero to indicate it is positive unsigned integer
-            if msb_set {
-                *buf.get_mut(pos)? = 0;
-                pos += 1;
-            }
-
-            let val = val.get(clz..)?;
-            buf.get_mut(pos..pos + val.len())?.copy_from_slice(val);
-            pos += val.len();
-        };
-
-        Some(pos)
-    }
-
-    /// Convert the signature to DER format
-    fn to_der(&self) -> Option<([u8; MAX_ECDSA384_SIG_LEN], usize)> {
+impl Signature<MAX_ECDSA384_SIG_LEN> for Ecdsa384Signature {
+    fn to_der(&self, buf: &mut [u8; MAX_ECDSA384_SIG_LEN]) -> Option<usize> {
         // Encode Signature R Coordinate
-        let r_uint_len = self.der_uint_len(&self.r);
+        let r_uint_len = der_uint_len(&self.r);
 
         // Encode Signature S Coordinate
-        let s_uint_len = self.der_uint_len(&self.s);
+        let s_uint_len = der_uint_len(&self.s);
 
         //
         // Signature DER Sequence encoding
@@ -129,7 +74,6 @@ impl Ecdsa384Signature {
         //
         let sig_seq_len = 2 + r_uint_len + s_uint_len;
 
-        let mut buf = [0u8; MAX_ECDSA384_SIG_LEN];
         let mut pos = 0;
 
         // Encode Signature DER Bit String
@@ -147,52 +91,46 @@ impl Ecdsa384Signature {
         pos += 1;
 
         // Encode R-Coordinate
-        pos += self.der_encode_uint(&self.r, buf.get_mut(pos..)?)?;
+        pos += der_encode_uint(&self.r, buf.get_mut(pos..)?)?;
 
         // Encode S-Coordinate
-        pos += self.der_encode_uint(&self.s, buf.get_mut(pos..)?)?;
+        pos += der_encode_uint(&self.s, buf.get_mut(pos..)?)?;
 
-        Some((buf, pos))
+        Some(pos)
+    }
+
+    fn oid_der() -> &'static [u8] {
+        &[
+            0x30, 0x0A, 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x03,
+        ]
     }
 }
 
-/// ECDSA-384 Certificate Builder
+/// Generic Certificate Builder
 #[derive(Debug)]
-pub struct Ecdsa384CertBuilder<'a> {
+pub struct CertBuilder<'a, S: Signature<MAX_DER_SIZE>, const MAX_DER_SIZE: usize> {
     /// DER encoded To be signed portion
     tbs: &'a [u8],
 
-    /// DER encoded Signature
-    sig: [u8; MAX_ECDSA384_SIG_LEN],
-
-    /// DER encoded Signature length
-    sig_len: usize,
+    /// Signature of the To be signed portion
+    sig: &'a S,
 
     /// Length of the signed Cert/CSR
     len: usize,
 }
 
-impl<'a> Ecdsa384CertBuilder<'a> {
-    // DER Encoded Sequence with ecdsa-with-SHA384 OID
-    const OID_DER: [u8; 12] = [
-        0x30, 0x0A, 0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x03,
-    ];
-
-    /// Create an instance of `Ecdsa384CertBuilder`
+impl<'a, S: Signature<MAX_DER_SIZE>, const MAX_DER_SIZE: usize> CertBuilder<'a, S, MAX_DER_SIZE> {
+    /// Create an instance of `CertBuilder`
     ///
     /// # Arguments
     ///
     /// * `tbs` - DER encoded To be signed portion
     /// * `sig` - Signature of the To be signed portion
-    pub fn new(tbs: &'a [u8], sig: &Ecdsa384Signature) -> Option<Self> {
-        let (sig, sig_len) = sig.to_der()?;
-        let len = Self::compute_len(tbs.len(), sig_len)?;
-        Some(Self {
-            tbs,
-            sig,
-            sig_len,
-            len,
-        })
+    pub fn new(tbs: &'a [u8], sig: &'a S) -> Option<Self> {
+        let mut sig_buf = [0u8; MAX_DER_SIZE];
+        let sig_len = sig.to_der(&mut sig_buf)?;
+        let len = Self::compute_len(tbs.len(), sig_len, S::oid_der().len())?;
+        Some(Self { tbs, sig, len })
     }
 
     /// Build the Certificate or Certificate Signing Request
@@ -202,7 +140,7 @@ impl<'a> Ecdsa384CertBuilder<'a> {
     /// * `buf` - Buffer to construct the certificate in
     pub fn build(&self, buf: &mut [u8]) -> Option<usize> {
         if buf.len() < self.len {
-            None?;
+            return None;
         }
 
         let mut pos = 0;
@@ -212,30 +150,15 @@ impl<'a> Ecdsa384CertBuilder<'a> {
         pos += 1;
 
         // Copy Length
-        let len = self.tbs.len() + Self::OID_DER.len() + self.sig_len;
+        let mut sig_buf = [0u8; MAX_DER_SIZE];
+        let sig_len = self.sig.to_der(&mut sig_buf)?;
+        let len = self.tbs.len() + S::oid_der().len() + sig_len;
 
         if buf.len() < len + 4 {
-            None?;
+            return None;
         }
 
-        match len {
-            0..=127 => {
-                *buf.get_mut(pos)? = len as u8;
-                pos += 1;
-            }
-            128..=255 => {
-                *buf.get_mut(pos)? = 0x81;
-                *buf.get_mut(pos + 1)? = len as u8;
-                pos += 2;
-            }
-            256..=4096 => {
-                *buf.get_mut(pos)? = 0x82;
-                *buf.get_mut(pos + 1)? = (len >> u8::BITS) as u8;
-                *buf.get_mut(pos + 2)? = len as u8;
-                pos += 3;
-            }
-            _ => None?,
-        }
+        pos += der_encode_len(len, buf.get_mut(pos..)?)?;
 
         // Copy Value
 
@@ -245,14 +168,14 @@ impl<'a> Ecdsa384CertBuilder<'a> {
         pos += self.tbs.len();
 
         // Copy OID DER
-        buf.get_mut(pos..pos + Self::OID_DER.len())?
-            .copy_from_slice(&Self::OID_DER);
-        pos += Self::OID_DER.len();
+        buf.get_mut(pos..pos + S::oid_der().len())?
+            .copy_from_slice(S::oid_der());
+        pos += S::oid_der().len();
 
         // Copy Signature DER
-        let sig = &self.sig.get(..self.sig_len)?;
-        buf.get_mut(pos..pos + sig.len())?.copy_from_slice(sig);
-        pos += sig.len();
+        buf.get_mut(pos..pos + sig_len)?
+            .copy_from_slice(sig_buf.get(..sig_len)?);
+        pos += sig_len;
 
         Some(pos)
     }
@@ -264,14 +187,14 @@ impl<'a> Ecdsa384CertBuilder<'a> {
     }
 
     // Compute length of the X509 certificate or cert signing request
-    fn compute_len(tbs_len: usize, sig_der_len: usize) -> Option<usize> {
-        let len = tbs_len + Self::OID_DER.len() + sig_der_len;
+    fn compute_len(tbs_len: usize, sig_der_len: usize, oid_len: usize) -> Option<usize> {
+        let len = tbs_len + oid_len + sig_der_len;
 
-        // Max Cert or CSR size is 4096 bytes
+        // Max Cert or CSR size is 0xffff bytes
         let len_bytes = match len {
-            0..=127 => 1_usize,
-            128..=255 => 2,
-            256..=4096 => 3,
+            0..=0x7f => 1_usize,
+            0x80..=0xff => 2,
+            0x100..=0xffff => 3,
             _ => None?,
         };
 
@@ -283,3 +206,7 @@ impl<'a> Ecdsa384CertBuilder<'a> {
         Some(1 + len_bytes + len)
     }
 }
+
+// Type alias for ECDSA-384 Certificate Builder
+pub type Ecdsa384CertBuilder<'a> = CertBuilder<'a, Ecdsa384Signature, MAX_ECDSA384_SIG_LEN>;
+pub type Ecdsa384CsrBuilder<'a> = Ecdsa384CertBuilder<'a>;

--- a/x509/src/der_helper.rs
+++ b/x509/src/der_helper.rs
@@ -1,0 +1,99 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    der_helper.rs
+
+Abstract:
+
+    Helpers for encoding DER unsigned integers
+
+--*/
+
+/// DER Integer Tag
+const DER_INTEGER_TAG: u8 = 0x02;
+
+fn trim_leading_zeros(val: &[u8]) -> &[u8] {
+    // Count the leading zeros
+    for i in 0..val.len() {
+        if val[i] != 0 {
+            return &val[i..];
+        }
+    }
+    // If everything is 0, then we need len 1, and 0 as value
+    &val[0..1] // single 0
+}
+
+#[inline(always)]
+fn encode_length(val: &[u8]) -> usize {
+    for i in 0..val.len() {
+        if val[i] != 0 {
+            return val.len() - i + (val[i] >> 7) as usize;
+        }
+    }
+    1
+}
+
+/// Compute len of DER encoding of an unsinged integer
+#[inline(always)]
+pub fn der_uint_len(val: &[u8]) -> usize {
+    let encode_length = encode_length(val);
+
+    let len_field_size = match encode_length {
+        0..=127 => 1,
+        128.. => trim_leading_zeros(&encode_length.to_be_bytes()).len(),
+    };
+
+    // Tag + len + int
+    1 + len_field_size + encode_length
+}
+
+/// Encode a DER length
+#[inline(always)]
+pub fn der_encode_len(len: usize, buf: &mut [u8]) -> Option<usize> {
+    match len {
+        1..=127 => {
+            *buf.get_mut(0)? = len as u8;
+            Some(1)
+        }
+        128.. => {
+            let encode_len_be_bytes = len.to_be_bytes();
+            let len_in_be_bytes = trim_leading_zeros(&encode_len_be_bytes);
+            let len = len_in_be_bytes.len();
+            *buf.get_mut(0)? = 0x80 | (len as u8);
+            buf.get_mut(1..)?
+                .get_mut(..len)?
+                .copy_from_slice(len_in_be_bytes);
+            Some(len + 1)
+        }
+        _ => None?,
+    }
+}
+
+/// DER Encode unsigned integer
+#[inline(always)]
+pub fn der_encode_uint(val: &[u8], buf: &mut [u8]) -> Option<usize> {
+    let mut pos = 0;
+
+    *buf.get_mut(pos)? = DER_INTEGER_TAG;
+    pos += 1;
+
+    let sub_val = trim_leading_zeros(val);
+    let encode_len = encode_length(val);
+
+    pos += der_encode_len(encode_len, buf.get_mut(pos..)?)?;
+
+    if *sub_val.first()? > 127 {
+        *buf.get_mut(pos)? = 0;
+        pos += 1;
+    }
+
+    buf.get_mut(pos..)?
+        .get_mut(..sub_val.len())?
+        .copy_from_slice(sub_val);
+    pos += sub_val.len();
+
+    Some(pos)
+}

--- a/x509/src/fmc_alias_cert_ecc_384.rs
+++ b/x509/src/fmc_alias_cert_ecc_384.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    fmc_alias_cert.rs
+    fmc_alias_cert_ecc_384.rs
 
 Abstract:
 
@@ -14,9 +14,9 @@ Abstract:
 
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(env!("OUT_DIR"), "/fmc_alias_cert_tbs.rs"));
+include!(concat!(env!("OUT_DIR"), "/fmc_alias_cert_tbs_ecc_384.rs"));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/fmc_alias_cert_tbs.rs"}
+include! {"../build/fmc_alias_cert_tbs_ecc_384.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -35,16 +35,19 @@ mod tests {
     use x509_parser::x509::X509Version;
 
     const TEST_DEVICE_INFO_HASH: &[u8] =
-        &[0xCDu8; FmcAliasCertTbsParams::TCB_INFO_DEVICE_INFO_HASH_LEN];
-    const TEST_FMC_HASH: &[u8] = &[0xEFu8; FmcAliasCertTbsParams::TCB_INFO_FMC_TCI_LEN];
-    const TEST_UEID: &[u8] = &[0xABu8; FmcAliasCertTbsParams::UEID_LEN];
+        &[0xCDu8; FmcAliasCertTbsEcc384Params::TCB_INFO_DEVICE_INFO_HASH_LEN];
+    const TEST_FMC_HASH: &[u8] = &[0xEFu8; FmcAliasCertTbsEcc384Params::TCB_INFO_FMC_TCI_LEN];
+    const TEST_UEID: &[u8] = &[0xABu8; FmcAliasCertTbsEcc384Params::UEID_LEN];
     const TEST_TCB_INFO_FLAGS: &[u8] = &[0xB0, 0xB1, 0xB2, 0xB3];
     const TEST_TCB_INFO_FMC_SVN: &[u8] = &[0xB7];
     const TEST_TCB_INFO_FMC_SVN_FUSES: &[u8] = &[0xB8];
 
-    fn make_test_cert(subject_key: &Ecc384AsymKey, issuer_key: &Ecc384AsymKey) -> FmcAliasCertTbs {
-        let params = FmcAliasCertTbsParams {
-            serial_number: &[0xABu8; FmcAliasCertTbsParams::SERIAL_NUMBER_LEN],
+    fn make_test_cert(
+        subject_key: &Ecc384AsymKey,
+        issuer_key: &Ecc384AsymKey,
+    ) -> FmcAliasCertTbsEcc384 {
+        let params = FmcAliasCertTbsEcc384Params {
+            serial_number: &[0xABu8; FmcAliasCertTbsEcc384Params::SERIAL_NUMBER_LEN],
             public_key: &subject_key.pub_key().try_into().unwrap(),
             subject_sn: &subject_key
                 .hex_str()
@@ -70,7 +73,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        FmcAliasCertTbs::new(&params)
+        FmcAliasCertTbsEcc384::new(&params)
     }
 
     #[test]
@@ -88,62 +91,67 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(cert.tbs(), FmcAliasCertTbs::TBS_TEMPLATE);
+        assert_ne!(cert.tbs(), FmcAliasCertTbsEcc384::TBS_TEMPLATE);
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::PUBLIC_KEY_OFFSET
-                ..FmcAliasCertTbs::PUBLIC_KEY_OFFSET + FmcAliasCertTbs::PUBLIC_KEY_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+                ..FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET + FmcAliasCertTbsEcc384::PUBLIC_KEY_LEN],
             subject_key.pub_key(),
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::SUBJECT_SN_OFFSET
-                ..FmcAliasCertTbs::SUBJECT_SN_OFFSET + FmcAliasCertTbs::SUBJECT_SN_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::SUBJECT_SN_OFFSET
+                ..FmcAliasCertTbsEcc384::SUBJECT_SN_OFFSET + FmcAliasCertTbsEcc384::SUBJECT_SN_LEN],
             subject_key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::ISSUER_SN_OFFSET
-                ..FmcAliasCertTbs::ISSUER_SN_OFFSET + FmcAliasCertTbs::ISSUER_SN_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::ISSUER_SN_OFFSET
+                ..FmcAliasCertTbsEcc384::ISSUER_SN_OFFSET + FmcAliasCertTbsEcc384::ISSUER_SN_LEN],
             issuer_key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::UEID_OFFSET
-                ..FmcAliasCertTbs::UEID_OFFSET + FmcAliasCertTbs::UEID_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::UEID_OFFSET
+                ..FmcAliasCertTbsEcc384::UEID_OFFSET + FmcAliasCertTbsEcc384::UEID_LEN],
             TEST_UEID,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::SUBJECT_KEY_ID_OFFSET
-                ..FmcAliasCertTbs::SUBJECT_KEY_ID_OFFSET + FmcAliasCertTbs::SUBJECT_KEY_ID_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                ..FmcAliasCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                    + FmcAliasCertTbsEcc384::SUBJECT_KEY_ID_LEN],
             subject_key.sha1(),
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::AUTHORITY_KEY_ID_OFFSET
-                ..FmcAliasCertTbs::AUTHORITY_KEY_ID_OFFSET + FmcAliasCertTbs::AUTHORITY_KEY_ID_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                ..FmcAliasCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                    + FmcAliasCertTbsEcc384::AUTHORITY_KEY_ID_LEN],
             issuer_key.sha1(),
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FLAGS_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_FLAGS_OFFSET + FmcAliasCertTbs::TCB_INFO_FLAGS_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::TCB_INFO_FLAGS_OFFSET
+                ..FmcAliasCertTbsEcc384::TCB_INFO_FLAGS_OFFSET
+                    + FmcAliasCertTbsEcc384::TCB_INFO_FLAGS_LEN],
             TEST_TCB_INFO_FLAGS,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
-                    + FmcAliasCertTbs::TCB_INFO_DEVICE_INFO_HASH_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                ..FmcAliasCertTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                    + FmcAliasCertTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_LEN],
             TEST_DEVICE_INFO_HASH,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_TCI_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_FMC_TCI_OFFSET + FmcAliasCertTbs::TCB_INFO_FMC_TCI_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::TCB_INFO_FMC_TCI_OFFSET
+                ..FmcAliasCertTbsEcc384::TCB_INFO_FMC_TCI_OFFSET
+                    + FmcAliasCertTbsEcc384::TCB_INFO_FMC_TCI_LEN],
             TEST_FMC_HASH,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_SVN_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_FMC_SVN_OFFSET + FmcAliasCertTbs::TCB_INFO_FMC_SVN_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_OFFSET
+                ..FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_OFFSET
+                    + FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_LEN],
             TEST_TCB_INFO_FMC_SVN,
         );
         assert_eq!(
-            &cert.tbs()[FmcAliasCertTbs::TCB_INFO_FMC_SVN_FUSES_OFFSET
-                ..FmcAliasCertTbs::TCB_INFO_FMC_SVN_FUSES_OFFSET
-                    + FmcAliasCertTbs::TCB_INFO_FMC_SVN_FUSES_LEN],
+            &cert.tbs()[FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_FUSES_OFFSET
+                ..FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_FUSES_OFFSET
+                    + FmcAliasCertTbsEcc384::TCB_INFO_FMC_SVN_FUSES_LEN],
             TEST_TCB_INFO_FMC_SVN_FUSES,
         );
 
@@ -213,11 +221,13 @@ mod tests {
     #[test]
     #[cfg(feature = "generate_templates")]
     fn test_fmc_alias_template() {
-        let manual_template =
-            std::fs::read(std::path::Path::new("./build/fmc_alias_cert_tbs.rs")).unwrap();
+        let manual_template = std::fs::read(std::path::Path::new(
+            "./build/fmc_alias_cert_tbs_ecc_384.rs",
+        ))
+        .unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/fmc_alias_cert_tbs.rs"
+            "/fmc_alias_cert_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/fmc_alias_csr_ecc_384.rs
+++ b/x509/src/fmc_alias_csr_ecc_384.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    fmc_alis_csr.rs
+    fmc_alias_csr_ecc_384.rs
 
 Abstract:
 
@@ -14,9 +14,9 @@ Abstract:
 
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(env!("OUT_DIR"), "/fmc_alias_csr_tbs.rs"));
+include!(concat!(env!("OUT_DIR"), "/fmc_alias_csr_tbs_ecc_384.rs"));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/fmc_alias_csr_tbs.rs"}
+include! {"../build/fmc_alias_csr_tbs_ecc_384.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -32,16 +32,16 @@ mod tests {
     use crate::test_util::tests::*;
     use crate::{Ecdsa384CsrBuilder, Ecdsa384Signature};
 
-    const TEST_UEID: &[u8] = &[0xAB; FmcAliasCsrTbs::UEID_LEN];
+    const TEST_UEID: &[u8] = &[0xAB; FmcAliasCsrTbsEcc384::UEID_LEN];
     const TEST_DEVICE_INFO_HASH: &[u8] =
-        &[0xCDu8; FmcAliasCsrTbsParams::TCB_INFO_DEVICE_INFO_HASH_LEN];
-    const TEST_FMC_HASH: &[u8] = &[0xEFu8; FmcAliasCsrTbsParams::TCB_INFO_FMC_TCI_LEN];
+        &[0xCDu8; FmcAliasCsrTbsEcc384Params::TCB_INFO_DEVICE_INFO_HASH_LEN];
+    const TEST_FMC_HASH: &[u8] = &[0xEFu8; FmcAliasCsrTbsEcc384Params::TCB_INFO_FMC_TCI_LEN];
     const TEST_TCB_INFO_FLAGS: &[u8] = &[0xB0, 0xB1, 0xB2, 0xB3];
     const TEST_TCB_INFO_FMC_SVN: &[u8] = &[0xB7];
     const TEST_TCB_INFO_FMC_SVN_FUSES: &[u8] = &[0xB8];
 
-    fn make_test_csr(subject_key: &Ecc384AsymKey) -> FmcAliasCsrTbs {
-        let params = FmcAliasCsrTbsParams {
+    fn make_test_csr(subject_key: &Ecc384AsymKey) -> FmcAliasCsrTbsEcc384 {
+        let params = FmcAliasCsrTbsEcc384Params {
             public_key: &subject_key.pub_key().try_into().unwrap(),
             subject_sn: &subject_key.hex_str().into_bytes().try_into().unwrap(),
             ueid: &TEST_UEID.try_into().unwrap(),
@@ -52,7 +52,7 @@ mod tests {
             tcb_info_fmc_svn_fuses: &TEST_TCB_INFO_FMC_SVN_FUSES.try_into().unwrap(),
         };
 
-        FmcAliasCsrTbs::new(&params)
+        FmcAliasCsrTbsEcc384::new(&params)
     }
 
     #[test]
@@ -69,47 +69,50 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(csr.tbs(), FmcAliasCsrTbs::TBS_TEMPLATE);
+        assert_ne!(csr.tbs(), FmcAliasCsrTbsEcc384::TBS_TEMPLATE);
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::PUBLIC_KEY_OFFSET
-                ..FmcAliasCsrTbs::PUBLIC_KEY_OFFSET + FmcAliasCsrTbs::PUBLIC_KEY_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                ..FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET + FmcAliasCsrTbsEcc384::PUBLIC_KEY_LEN],
             key.pub_key(),
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::SUBJECT_SN_OFFSET
-                ..FmcAliasCsrTbs::SUBJECT_SN_OFFSET + FmcAliasCsrTbs::SUBJECT_SN_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::SUBJECT_SN_OFFSET
+                ..FmcAliasCsrTbsEcc384::SUBJECT_SN_OFFSET + FmcAliasCsrTbsEcc384::SUBJECT_SN_LEN],
             key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::UEID_OFFSET
-                ..FmcAliasCsrTbs::UEID_OFFSET + FmcAliasCsrTbs::UEID_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::UEID_OFFSET
+                ..FmcAliasCsrTbsEcc384::UEID_OFFSET + FmcAliasCsrTbsEcc384::UEID_LEN],
             TEST_UEID,
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
-                ..FmcAliasCsrTbs::TCB_INFO_DEVICE_INFO_HASH_OFFSET
-                    + FmcAliasCsrTbs::TCB_INFO_DEVICE_INFO_HASH_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                ..FmcAliasCsrTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_OFFSET
+                    + FmcAliasCsrTbsEcc384::TCB_INFO_DEVICE_INFO_HASH_LEN],
             TEST_DEVICE_INFO_HASH,
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::TCB_INFO_FMC_TCI_OFFSET
-                ..FmcAliasCsrTbs::TCB_INFO_FMC_TCI_OFFSET + FmcAliasCsrTbs::TCB_INFO_FMC_TCI_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::TCB_INFO_FMC_TCI_OFFSET
+                ..FmcAliasCsrTbsEcc384::TCB_INFO_FMC_TCI_OFFSET
+                    + FmcAliasCsrTbsEcc384::TCB_INFO_FMC_TCI_LEN],
             TEST_FMC_HASH,
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::TCB_INFO_FLAGS_OFFSET
-                ..FmcAliasCsrTbs::TCB_INFO_FLAGS_OFFSET + FmcAliasCsrTbs::TCB_INFO_FLAGS_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::TCB_INFO_FLAGS_OFFSET
+                ..FmcAliasCsrTbsEcc384::TCB_INFO_FLAGS_OFFSET
+                    + FmcAliasCsrTbsEcc384::TCB_INFO_FLAGS_LEN],
             TEST_TCB_INFO_FLAGS,
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::TCB_INFO_FMC_SVN_OFFSET
-                ..FmcAliasCsrTbs::TCB_INFO_FMC_SVN_OFFSET + FmcAliasCsrTbs::TCB_INFO_FMC_SVN_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_OFFSET
+                ..FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_OFFSET
+                    + FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_LEN],
             TEST_TCB_INFO_FMC_SVN,
         );
         assert_eq!(
-            &csr.tbs()[FmcAliasCsrTbs::TCB_INFO_FMC_SVN_FUSES_OFFSET
-                ..FmcAliasCsrTbs::TCB_INFO_FMC_SVN_FUSES_OFFSET
-                    + FmcAliasCsrTbs::TCB_INFO_FMC_SVN_FUSES_LEN],
+            &csr.tbs()[FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_FUSES_OFFSET
+                ..FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_FUSES_OFFSET
+                    + FmcAliasCsrTbsEcc384::TCB_INFO_FMC_SVN_FUSES_LEN],
             TEST_TCB_INFO_FMC_SVN_FUSES,
         );
 
@@ -215,10 +218,10 @@ mod tests {
     #[cfg(feature = "generate_templates")]
     fn test_fmc_alias_csr_template() {
         let manual_template =
-            std::fs::read(std::path::Path::new("./build/fmc_alias_cert_tbs.rs")).unwrap();
+            std::fs::read(std::path::Path::new("./build/fmc_alias_csr_tbs_ecc_384.rs")).unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/fmc_alias_cert_tbs.rs"
+            "/fmc_alias_csr_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/idevid_csr_ecc_384.rs
+++ b/x509/src/idevid_csr_ecc_384.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    idevid_csr.rs
+    idevid_csr_ecc_384.rs
 
 Abstract:
 
@@ -14,9 +14,9 @@ Abstract:
 
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(env!("OUT_DIR"), "/init_dev_id_csr_tbs.rs"));
+include!(concat!(env!("OUT_DIR"), "/init_dev_id_csr_tbs_ecc_384.rs"));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/init_dev_id_csr_tbs.rs"}
+include! {"../build/init_dev_id_csr_tbs_ecc_384.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -32,16 +32,16 @@ mod tests {
     use crate::test_util::tests::*;
     use crate::{Ecdsa384CsrBuilder, Ecdsa384Signature};
 
-    const TEST_UEID: &[u8] = &[0xAB; InitDevIdCsrTbs::UEID_LEN];
+    const TEST_UEID: &[u8] = &[0xAB; InitDevIdCsrTbsEcc384::UEID_LEN];
 
-    fn make_test_csr(subject_key: &Ecc384AsymKey) -> InitDevIdCsrTbs {
-        let params = InitDevIdCsrTbsParams {
+    fn make_test_csr(subject_key: &Ecc384AsymKey) -> InitDevIdCsrTbsEcc384 {
+        let params = InitDevIdCsrTbsEcc384Params {
             public_key: &subject_key.pub_key().try_into().unwrap(),
             subject_sn: &subject_key.hex_str().into_bytes().try_into().unwrap(),
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        InitDevIdCsrTbs::new(&params)
+        InitDevIdCsrTbsEcc384::new(&params)
     }
 
     #[test]
@@ -58,20 +58,20 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(csr.tbs(), InitDevIdCsrTbs::TBS_TEMPLATE);
+        assert_ne!(csr.tbs(), InitDevIdCsrTbsEcc384::TBS_TEMPLATE);
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbs::PUBLIC_KEY_OFFSET
-                ..InitDevIdCsrTbs::PUBLIC_KEY_OFFSET + InitDevIdCsrTbs::PUBLIC_KEY_LEN],
+            &csr.tbs()[InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                ..InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET + InitDevIdCsrTbsEcc384::PUBLIC_KEY_LEN],
             key.pub_key(),
         );
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbs::SUBJECT_SN_OFFSET
-                ..InitDevIdCsrTbs::SUBJECT_SN_OFFSET + InitDevIdCsrTbs::SUBJECT_SN_LEN],
+            &csr.tbs()[InitDevIdCsrTbsEcc384::SUBJECT_SN_OFFSET
+                ..InitDevIdCsrTbsEcc384::SUBJECT_SN_OFFSET + InitDevIdCsrTbsEcc384::SUBJECT_SN_LEN],
             key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbs::UEID_OFFSET
-                ..InitDevIdCsrTbs::UEID_OFFSET + InitDevIdCsrTbs::UEID_LEN],
+            &csr.tbs()[InitDevIdCsrTbsEcc384::UEID_OFFSET
+                ..InitDevIdCsrTbsEcc384::UEID_OFFSET + InitDevIdCsrTbsEcc384::UEID_LEN],
             TEST_UEID,
         );
 
@@ -163,11 +163,13 @@ mod tests {
     #[test]
     #[cfg(feature = "generate_templates")]
     fn test_idevid_template() {
-        let manual_template =
-            std::fs::read(std::path::Path::new("./build/init_dev_id_csr_tbs.rs")).unwrap();
+        let manual_template = std::fs::read(std::path::Path::new(
+            "./build/init_dev_id_csr_tbs_ecc_384.rs",
+        ))
+        .unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/init_dev_id_csr_tbs.rs"
+            "/init_dev_id_csr_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/idevid_csr_mldsa_87.rs
+++ b/x509/src/idevid_csr_mldsa_87.rs
@@ -1,0 +1,191 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    idevid_csr_mldsa_87.rs
+
+Abstract:
+
+    Initial Device ID Certificate Signing Request related code (ML-DSA-87).
+
+--*/
+// Note: All the necessary code is auto generated
+#[cfg(feature = "generate_templates")]
+include!(concat!(
+    env!("OUT_DIR"),
+    "/init_dev_id_csr_tbs_ml_dsa_87.rs"
+));
+#[cfg(not(feature = "generate_templates"))]
+include! {"../build/init_dev_id_csr_tbs_ml_dsa_87.rs"}
+
+#[cfg(all(test, target_family = "unix"))]
+mod tests {
+    use openssl::pkey_ctx::PkeyCtx;
+    use openssl::pkey_ml_dsa::Variant;
+    use openssl::signature::Signature;
+    use openssl::x509::X509Req;
+
+    use x509_parser::cri_attributes::ParsedCriAttribute;
+    use x509_parser::extensions::ParsedExtension;
+    use x509_parser::oid_registry::asn1_rs::oid;
+    use x509_parser::prelude::{FromDer, X509CertificationRequest};
+
+    use super::*;
+    use crate::test_util::tests::*;
+    use crate::{MlDsa87CsrBuilder, MlDsa87Signature};
+
+    const TEST_UEID: &[u8] = &[0xAB; InitDevIdCsrTbsMlDsa87::UEID_LEN];
+
+    fn make_test_csr(subject_key: &MlDsa87AsymKey) -> InitDevIdCsrTbsMlDsa87 {
+        let params = InitDevIdCsrTbsMlDsa87Params {
+            public_key: &subject_key.pub_key().try_into().unwrap(),
+            subject_sn: &subject_key.hex_str().into_bytes().try_into().unwrap(),
+            ueid: &TEST_UEID.try_into().unwrap(),
+        };
+
+        InitDevIdCsrTbsMlDsa87::new(&params)
+    }
+
+    #[test]
+    fn test_csr_signing() {
+        let key = MlDsa87AsymKey::default();
+        let mldsa_key = key.priv_key();
+        let csr = make_test_csr(&key);
+
+        let sig = csr
+            .sign(|b| {
+                let mut signature = vec![];
+                let mut ctx = PkeyCtx::new(mldsa_key)?;
+                let mut algo = Signature::for_ml_dsa(Variant::MlDsa87)?;
+                ctx.sign_message_init(&mut algo)?;
+                ctx.sign_to_vec(b, &mut signature)?;
+                Ok::<Vec<u8>, openssl::error::ErrorStack>(signature)
+            })
+            .unwrap();
+
+        assert_ne!(csr.tbs(), InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE);
+        assert_eq!(
+            &csr.tbs()[InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                ..InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                    + InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN],
+            key.pub_key(),
+        );
+        assert_eq!(
+            &csr.tbs()[InitDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET
+                ..InitDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET
+                    + InitDevIdCsrTbsMlDsa87::SUBJECT_SN_LEN],
+            key.hex_str().into_bytes(),
+        );
+        assert_eq!(
+            &csr.tbs()[InitDevIdCsrTbsMlDsa87::UEID_OFFSET
+                ..InitDevIdCsrTbsMlDsa87::UEID_OFFSET + InitDevIdCsrTbsMlDsa87::UEID_LEN],
+            TEST_UEID,
+        );
+
+        let mldsa_sig = MlDsa87Signature {
+            sig: sig.try_into().unwrap(),
+        };
+
+        let builder = crate::MlDsa87CsrBuilder::new(csr.tbs(), &mldsa_sig).unwrap();
+        let mut buf = vec![0u8; builder.len()];
+        builder.build(&mut buf).unwrap();
+
+        let req: X509Req = X509Req::from_der(&buf).unwrap();
+        assert!(req.verify(&req.public_key().unwrap()).unwrap());
+        assert!(req.verify(key.priv_key()).unwrap());
+    }
+
+    #[test]
+    fn test_extensions() {
+        let key = MlDsa87AsymKey::default();
+        let mldsa_key = key.priv_key();
+        let csr = make_test_csr(&key);
+
+        let sig = csr
+            .sign(|b| {
+                let mut signature = vec![];
+                let mut ctx = PkeyCtx::new(mldsa_key)?;
+                let mut algo = Signature::for_ml_dsa(Variant::MlDsa87)?;
+                ctx.sign_message_init(&mut algo)?;
+                ctx.sign_to_vec(b, &mut signature)?;
+                Ok::<Vec<u8>, openssl::error::ErrorStack>(signature)
+            })
+            .unwrap();
+
+        let mldsa_sig = MlDsa87Signature {
+            sig: sig.try_into().unwrap(),
+        };
+
+        let builder = MlDsa87CsrBuilder::new(csr.tbs(), &mldsa_sig).unwrap();
+        let mut buf = vec![0u8; builder.len()];
+        builder.build(&mut buf).unwrap();
+
+        let (_, parsed_csr) = X509CertificationRequest::from_der(&buf).unwrap();
+
+        let requested_extensions = parsed_csr
+            .certification_request_info
+            .iter_attributes()
+            .find_map(|attr| {
+                if let ParsedCriAttribute::ExtensionRequest(requested) = attr.parsed_attribute() {
+                    Some(&requested.extensions)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        // BasicConstraints
+        let bc_ext = requested_extensions
+            .iter()
+            .find(|ext| matches!(ext.parsed_extension(), ParsedExtension::BasicConstraints(_)))
+            .unwrap();
+        let ParsedExtension::BasicConstraints(bc) = bc_ext.parsed_extension() else {
+            panic!("Extension is not BasicConstraints");
+        };
+
+        assert!(bc_ext.critical);
+        assert!(bc.ca);
+
+        // KeyUsage
+        let ku_ext = requested_extensions
+            .iter()
+            .find(|ext| matches!(ext.parsed_extension(), ParsedExtension::KeyUsage(_)))
+            .unwrap();
+
+        assert!(ku_ext.critical);
+
+        // UEID
+        let ueid_ext = requested_extensions
+            .iter()
+            .find(|ext| {
+                if let ParsedExtension::UnsupportedExtension { oid } = ext.parsed_extension() {
+                    oid == &oid!(2.23.133 .5 .4 .4)
+                } else {
+                    false
+                }
+            })
+            .unwrap();
+        assert!(!ueid_ext.critical);
+    }
+
+    #[test]
+    #[cfg(feature = "generate_templates")]
+    fn test_idevid_mldsa87_template() {
+        let manual_template = std::fs::read(std::path::Path::new(
+            "./build/init_dev_id_csr_tbs_ml_dsa_87.rs",
+        ))
+        .unwrap();
+        let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
+            env!("OUT_DIR"),
+            "/init_dev_id_csr_tbs_ml_dsa_87.rs"
+        )))
+        .unwrap();
+        if auto_generated_template != manual_template {
+            panic!(
+                "Auto-generated IDevID ML-DSA-87 CSR template is not equal to the manual template."
+            )
+        }
+    }
+}

--- a/x509/src/ldevid_cert_ecc_384.rs
+++ b/x509/src/ldevid_cert_ecc_384.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    ldevid_cert.rs
+    ldevid_cert_ecc_384.rs
 
 Abstract:
 
@@ -14,9 +14,12 @@ Abstract:
 
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(env!("OUT_DIR"), "/local_dev_id_cert_tbs.rs"));
+include!(concat!(
+    env!("OUT_DIR"),
+    "/local_dev_id_cert_tbs_ecc_384.rs"
+));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/local_dev_id_cert_tbs.rs"}
+include! {"../build/local_dev_id_cert_tbs_ecc_384.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -34,14 +37,14 @@ mod tests {
     use crate::test_util::tests::*;
     use crate::{NotAfter, NotBefore};
 
-    const TEST_UEID: &[u8] = &[0xAB; LocalDevIdCertTbsParams::UEID_LEN];
+    const TEST_UEID: &[u8] = &[0xAB; LocalDevIdCertTbsEcc384Params::UEID_LEN];
 
     fn make_test_cert(
         subject_key: &Ecc384AsymKey,
         issuer_key: &Ecc384AsymKey,
-    ) -> LocalDevIdCertTbs {
-        let params = LocalDevIdCertTbsParams {
-            serial_number: &[0xABu8; LocalDevIdCertTbsParams::SERIAL_NUMBER_LEN],
+    ) -> LocalDevIdCertTbsEcc384 {
+        let params = LocalDevIdCertTbsEcc384Params {
+            serial_number: &[0xABu8; LocalDevIdCertTbsEcc384Params::SERIAL_NUMBER_LEN],
             public_key: &subject_key.pub_key().try_into().unwrap(),
             subject_sn: &subject_key
                 .hex_str()
@@ -57,7 +60,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        LocalDevIdCertTbs::new(&params)
+        LocalDevIdCertTbsEcc384::new(&params)
     }
 
     #[test]
@@ -75,36 +78,40 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(cert.tbs(), LocalDevIdCertTbs::TBS_TEMPLATE);
+        assert_ne!(cert.tbs(), LocalDevIdCertTbsEcc384::TBS_TEMPLATE);
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::PUBLIC_KEY_OFFSET
-                ..LocalDevIdCertTbs::PUBLIC_KEY_OFFSET + LocalDevIdCertTbs::PUBLIC_KEY_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET
+                ..LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET
+                    + LocalDevIdCertTbsEcc384::PUBLIC_KEY_LEN],
             subject_key.pub_key(),
         );
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::SUBJECT_SN_OFFSET
-                ..LocalDevIdCertTbs::SUBJECT_SN_OFFSET + LocalDevIdCertTbs::SUBJECT_SN_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::SUBJECT_SN_OFFSET
+                ..LocalDevIdCertTbsEcc384::SUBJECT_SN_OFFSET
+                    + LocalDevIdCertTbsEcc384::SUBJECT_SN_LEN],
             subject_key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::ISSUER_SN_OFFSET
-                ..LocalDevIdCertTbs::ISSUER_SN_OFFSET + LocalDevIdCertTbs::ISSUER_SN_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::ISSUER_SN_OFFSET
+                ..LocalDevIdCertTbsEcc384::ISSUER_SN_OFFSET
+                    + LocalDevIdCertTbsEcc384::ISSUER_SN_LEN],
             issuer_key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::UEID_OFFSET
-                ..LocalDevIdCertTbs::UEID_OFFSET + LocalDevIdCertTbs::UEID_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::UEID_OFFSET
+                ..LocalDevIdCertTbsEcc384::UEID_OFFSET + LocalDevIdCertTbsEcc384::UEID_LEN],
             TEST_UEID,
         );
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::SUBJECT_KEY_ID_OFFSET
-                ..LocalDevIdCertTbs::SUBJECT_KEY_ID_OFFSET + LocalDevIdCertTbs::SUBJECT_KEY_ID_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                ..LocalDevIdCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                    + LocalDevIdCertTbsEcc384::SUBJECT_KEY_ID_LEN],
             subject_key.sha1(),
         );
         assert_eq!(
-            &cert.tbs()[LocalDevIdCertTbs::AUTHORITY_KEY_ID_OFFSET
-                ..LocalDevIdCertTbs::AUTHORITY_KEY_ID_OFFSET
-                    + LocalDevIdCertTbs::AUTHORITY_KEY_ID_LEN],
+            &cert.tbs()[LocalDevIdCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                ..LocalDevIdCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                    + LocalDevIdCertTbsEcc384::AUTHORITY_KEY_ID_LEN],
             issuer_key.sha1(),
         );
         let ecdsa_sig = crate::Ecdsa384Signature {
@@ -170,11 +177,13 @@ mod tests {
     #[test]
     #[cfg(feature = "generate_templates")]
     fn test_ldevid_template() {
-        let manual_template =
-            std::fs::read(std::path::Path::new("./build/local_dev_id_cert_tbs.rs")).unwrap();
+        let manual_template = std::fs::read(std::path::Path::new(
+            "./build/local_dev_id_cert_tbs_ecc_384.rs",
+        ))
+        .unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/local_dev_id_cert_tbs.rs"
+            "/local_dev_id_cert_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -24,6 +24,8 @@ mod rt_alias_cert_ecc_384;
 mod test_util;
 
 pub use cert_bldr::{Ecdsa384CertBuilder, Ecdsa384CsrBuilder, Ecdsa384Signature};
+#[cfg(feature = "mldsa_attestation")]
+pub use cert_bldr::{MlDsa87CertBuilder, MlDsa87CsrBuilder, MlDsa87Signature};
 pub use der_helper::{der_encode_len, der_encode_uint, der_uint_len};
 pub use fmc_alias_cert_ecc_384::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
 pub use fmc_alias_csr_ecc_384::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -15,6 +15,7 @@ Abstract:
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod cert_bldr;
+mod der_helper;
 mod fmc_alias_cert_ecc_384;
 mod fmc_alias_csr_ecc_384;
 mod idevid_csr_ecc_384;
@@ -23,6 +24,7 @@ mod rt_alias_cert_ecc_384;
 mod test_util;
 
 pub use cert_bldr::{Ecdsa384CertBuilder, Ecdsa384CsrBuilder, Ecdsa384Signature};
+pub use der_helper::{der_encode_len, der_encode_uint, der_uint_len};
 pub use fmc_alias_cert_ecc_384::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
 pub use fmc_alias_csr_ecc_384::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};
 pub use idevid_csr_ecc_384::{InitDevIdCsrTbsEcc384, InitDevIdCsrTbsEcc384Params};

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -15,19 +15,19 @@ Abstract:
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod cert_bldr;
-mod fmc_alias_cert;
-mod fmc_alias_csr;
-mod idevid_csr;
-mod ldevid_cert;
-mod rt_alias_cert;
+mod fmc_alias_cert_ecc_384;
+mod fmc_alias_csr_ecc_384;
+mod idevid_csr_ecc_384;
+mod ldevid_cert_ecc_384;
+mod rt_alias_cert_ecc_384;
 mod test_util;
 
 pub use cert_bldr::{Ecdsa384CertBuilder, Ecdsa384CsrBuilder, Ecdsa384Signature};
-pub use fmc_alias_cert::{FmcAliasCertTbs, FmcAliasCertTbsParams};
-pub use fmc_alias_csr::{FmcAliasCsrTbs, FmcAliasCsrTbsParams};
-pub use idevid_csr::{InitDevIdCsrTbs, InitDevIdCsrTbsParams};
-pub use ldevid_cert::{LocalDevIdCertTbs, LocalDevIdCertTbsParams};
-pub use rt_alias_cert::{RtAliasCertTbs, RtAliasCertTbsParams};
+pub use fmc_alias_cert_ecc_384::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
+pub use fmc_alias_csr_ecc_384::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};
+pub use idevid_csr_ecc_384::{InitDevIdCsrTbsEcc384, InitDevIdCsrTbsEcc384Params};
+pub use ldevid_cert_ecc_384::{LocalDevIdCertTbsEcc384, LocalDevIdCertTbsEcc384Params};
+pub use rt_alias_cert_ecc_384::{RtAliasCertTbsEcc384, RtAliasCertTbsEcc384Params};
 use zeroize::Zeroize;
 
 pub const NOT_BEFORE: &str = "20230101000000Z";

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -19,6 +19,8 @@ mod der_helper;
 mod fmc_alias_cert_ecc_384;
 mod fmc_alias_csr_ecc_384;
 mod idevid_csr_ecc_384;
+#[cfg(feature = "mldsa_attestation")]
+mod idevid_csr_mldsa_87;
 mod ldevid_cert_ecc_384;
 mod rt_alias_cert_ecc_384;
 mod test_util;
@@ -30,6 +32,8 @@ pub use der_helper::{der_encode_len, der_encode_uint, der_uint_len};
 pub use fmc_alias_cert_ecc_384::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
 pub use fmc_alias_csr_ecc_384::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};
 pub use idevid_csr_ecc_384::{InitDevIdCsrTbsEcc384, InitDevIdCsrTbsEcc384Params};
+#[cfg(feature = "mldsa_attestation")]
+pub use idevid_csr_mldsa_87::{InitDevIdCsrTbsMlDsa87, InitDevIdCsrTbsMlDsa87Params};
 pub use ldevid_cert_ecc_384::{LocalDevIdCertTbsEcc384, LocalDevIdCertTbsEcc384Params};
 pub use rt_alias_cert_ecc_384::{RtAliasCertTbsEcc384, RtAliasCertTbsEcc384Params};
 use zeroize::Zeroize;

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -19,9 +19,9 @@ mod der_helper;
 mod fmc_alias_cert_ecc_384;
 mod fmc_alias_csr_ecc_384;
 mod idevid_csr_ecc_384;
-#[cfg(feature = "mldsa_attestation")]
-mod idevid_csr_mldsa_87;
 mod ldevid_cert_ecc_384;
+#[cfg(feature = "mldsa_attestation")]
+mod pq_dev_id_csr_mldsa_87;
 mod rt_alias_cert_ecc_384;
 mod test_util;
 
@@ -32,9 +32,9 @@ pub use der_helper::{der_encode_len, der_encode_uint, der_uint_len};
 pub use fmc_alias_cert_ecc_384::{FmcAliasCertTbsEcc384, FmcAliasCertTbsEcc384Params};
 pub use fmc_alias_csr_ecc_384::{FmcAliasCsrTbsEcc384, FmcAliasCsrTbsEcc384Params};
 pub use idevid_csr_ecc_384::{InitDevIdCsrTbsEcc384, InitDevIdCsrTbsEcc384Params};
-#[cfg(feature = "mldsa_attestation")]
-pub use idevid_csr_mldsa_87::{InitDevIdCsrTbsMlDsa87, InitDevIdCsrTbsMlDsa87Params};
 pub use ldevid_cert_ecc_384::{LocalDevIdCertTbsEcc384, LocalDevIdCertTbsEcc384Params};
+#[cfg(feature = "mldsa_attestation")]
+pub use pq_dev_id_csr_mldsa_87::{PqDevIdCsrTbsMlDsa87, PqDevIdCsrTbsMlDsa87Params};
 pub use rt_alias_cert_ecc_384::{RtAliasCertTbsEcc384, RtAliasCertTbsEcc384Params};
 use zeroize::Zeroize;
 

--- a/x509/src/pq_dev_id_csr_mldsa_87.rs
+++ b/x509/src/pq_dev_id_csr_mldsa_87.rs
@@ -4,21 +4,18 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    idevid_csr_mldsa_87.rs
+    pq_dev_id_csr_mldsa_87.rs
 
 Abstract:
 
-    Initial Device ID Certificate Signing Request related code (ML-DSA-87).
+    Post-Quantum Device ID Certificate Signing Request related code (ML-DSA-87).
 
 --*/
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(
-    env!("OUT_DIR"),
-    "/init_dev_id_csr_tbs_ml_dsa_87.rs"
-));
+include!(concat!(env!("OUT_DIR"), "/pq_dev_id_csr_tbs_ml_dsa_87.rs"));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/init_dev_id_csr_tbs_ml_dsa_87.rs"}
+include! {"../build/pq_dev_id_csr_tbs_ml_dsa_87.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -36,16 +33,16 @@ mod tests {
     use crate::test_util::tests::*;
     use crate::{MlDsa87CsrBuilder, MlDsa87Signature};
 
-    const TEST_UEID: &[u8] = &[0xAB; InitDevIdCsrTbsMlDsa87::UEID_LEN];
+    const TEST_UEID: &[u8] = &[0xAB; PqDevIdCsrTbsMlDsa87::UEID_LEN];
 
-    fn make_test_csr(subject_key: &MlDsa87AsymKey) -> InitDevIdCsrTbsMlDsa87 {
-        let params = InitDevIdCsrTbsMlDsa87Params {
+    fn make_test_csr(subject_key: &MlDsa87AsymKey) -> PqDevIdCsrTbsMlDsa87 {
+        let params = PqDevIdCsrTbsMlDsa87Params {
             public_key: &subject_key.pub_key().try_into().unwrap(),
             subject_sn: &subject_key.hex_str().into_bytes().try_into().unwrap(),
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        InitDevIdCsrTbsMlDsa87::new(&params)
+        PqDevIdCsrTbsMlDsa87::new(&params)
     }
 
     #[test]
@@ -65,22 +62,20 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(csr.tbs(), InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE);
+        assert_ne!(csr.tbs(), PqDevIdCsrTbsMlDsa87::TBS_TEMPLATE);
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
-                ..InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
-                    + InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN],
+            &csr.tbs()[PqDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                ..PqDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET + PqDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN],
             key.pub_key(),
         );
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET
-                ..InitDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET
-                    + InitDevIdCsrTbsMlDsa87::SUBJECT_SN_LEN],
+            &csr.tbs()[PqDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET
+                ..PqDevIdCsrTbsMlDsa87::SUBJECT_SN_OFFSET + PqDevIdCsrTbsMlDsa87::SUBJECT_SN_LEN],
             key.hex_str().into_bytes(),
         );
         assert_eq!(
-            &csr.tbs()[InitDevIdCsrTbsMlDsa87::UEID_OFFSET
-                ..InitDevIdCsrTbsMlDsa87::UEID_OFFSET + InitDevIdCsrTbsMlDsa87::UEID_LEN],
+            &csr.tbs()[PqDevIdCsrTbsMlDsa87::UEID_OFFSET
+                ..PqDevIdCsrTbsMlDsa87::UEID_OFFSET + PqDevIdCsrTbsMlDsa87::UEID_LEN],
             TEST_UEID,
         );
 
@@ -172,19 +167,19 @@ mod tests {
 
     #[test]
     #[cfg(feature = "generate_templates")]
-    fn test_idevid_mldsa87_template() {
+    fn test_pq_dev_id_mldsa87_template() {
         let manual_template = std::fs::read(std::path::Path::new(
-            "./build/init_dev_id_csr_tbs_ml_dsa_87.rs",
+            "./build/pq_dev_id_csr_tbs_ml_dsa_87.rs",
         ))
         .unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/init_dev_id_csr_tbs_ml_dsa_87.rs"
+            "/pq_dev_id_csr_tbs_ml_dsa_87.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {
             panic!(
-                "Auto-generated IDevID ML-DSA-87 CSR template is not equal to the manual template."
+                "Auto-generated PQDevID ML-DSA-87 CSR template is not equal to the manual template."
             )
         }
     }

--- a/x509/src/rt_alias_cert_ecc_384.rs
+++ b/x509/src/rt_alias_cert_ecc_384.rs
@@ -4,7 +4,7 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    rt_alias_cert.rs
+    rt_alias_cert_ecc_384.rs
 
 Abstract:
 
@@ -14,9 +14,9 @@ Abstract:
 
 // Note: All the necessary code is auto generated
 #[cfg(feature = "generate_templates")]
-include!(concat!(env!("OUT_DIR"), "/rt_alias_cert_tbs.rs"));
+include!(concat!(env!("OUT_DIR"), "/rt_alias_cert_tbs_ecc_384.rs"));
 #[cfg(not(feature = "generate_templates"))]
-include! {"../build/rt_alias_cert_tbs.rs"}
+include! {"../build/rt_alias_cert_tbs_ecc_384.rs"}
 
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
@@ -34,36 +34,38 @@ mod tests {
         let issuer_key = Ecc384AsymKey::default();
         let ec_key = issuer_key.priv_key().ec_key().unwrap();
 
-        let params = RtAliasCertTbsParams {
-            serial_number: &[0xABu8; RtAliasCertTbsParams::SERIAL_NUMBER_LEN],
-            public_key: TryInto::<&[u8; RtAliasCertTbsParams::PUBLIC_KEY_LEN]>::try_into(
+        let params = RtAliasCertTbsEcc384Params {
+            serial_number: &[0xABu8; RtAliasCertTbsEcc384Params::SERIAL_NUMBER_LEN],
+            public_key: TryInto::<&[u8; RtAliasCertTbsEcc384Params::PUBLIC_KEY_LEN]>::try_into(
                 subject_key.pub_key(),
             )
             .unwrap(),
-            subject_sn: &TryInto::<[u8; RtAliasCertTbsParams::SUBJECT_SN_LEN]>::try_into(
+            subject_sn: &TryInto::<[u8; RtAliasCertTbsEcc384Params::SUBJECT_SN_LEN]>::try_into(
                 subject_key.hex_str().into_bytes(),
             )
             .unwrap(),
-            issuer_sn: &TryInto::<[u8; RtAliasCertTbsParams::ISSUER_SN_LEN]>::try_into(
+            issuer_sn: &TryInto::<[u8; RtAliasCertTbsEcc384Params::ISSUER_SN_LEN]>::try_into(
                 issuer_key.hex_str().into_bytes(),
             )
             .unwrap(),
-            ueid: &[0xAB; RtAliasCertTbsParams::UEID_LEN],
-            subject_key_id: &TryInto::<[u8; RtAliasCertTbsParams::SUBJECT_KEY_ID_LEN]>::try_into(
-                subject_key.sha1(),
-            )
-            .unwrap(),
-            authority_key_id: &TryInto::<[u8; RtAliasCertTbsParams::SUBJECT_KEY_ID_LEN]>::try_into(
-                issuer_key.sha1(),
-            )
-            .unwrap(),
+            ueid: &[0xAB; RtAliasCertTbsEcc384Params::UEID_LEN],
+            subject_key_id:
+                &TryInto::<[u8; RtAliasCertTbsEcc384Params::SUBJECT_KEY_ID_LEN]>::try_into(
+                    subject_key.sha1(),
+                )
+                .unwrap(),
+            authority_key_id:
+                &TryInto::<[u8; RtAliasCertTbsEcc384Params::SUBJECT_KEY_ID_LEN]>::try_into(
+                    issuer_key.sha1(),
+                )
+                .unwrap(),
             tcb_info_rt_svn: &[0xE3],
-            tcb_info_rt_tci: &[0xEFu8; RtAliasCertTbsParams::TCB_INFO_RT_TCI_LEN],
+            tcb_info_rt_tci: &[0xEFu8; RtAliasCertTbsEcc384Params::TCB_INFO_RT_TCI_LEN],
             not_before: &NotBefore::default().value,
             not_after: &NotAfter::default().value,
         };
 
-        let cert = RtAliasCertTbs::new(&params);
+        let cert = RtAliasCertTbsEcc384::new(&params);
 
         let sig = cert
             .sign(|b| {
@@ -73,45 +75,49 @@ mod tests {
             })
             .unwrap();
 
-        assert_ne!(cert.tbs(), RtAliasCertTbs::TBS_TEMPLATE);
+        assert_ne!(cert.tbs(), RtAliasCertTbsEcc384::TBS_TEMPLATE);
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::PUBLIC_KEY_OFFSET
-                ..RtAliasCertTbs::PUBLIC_KEY_OFFSET + RtAliasCertTbs::PUBLIC_KEY_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+                ..RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET + RtAliasCertTbsEcc384::PUBLIC_KEY_LEN],
             params.public_key,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::SUBJECT_SN_OFFSET
-                ..RtAliasCertTbs::SUBJECT_SN_OFFSET + RtAliasCertTbs::SUBJECT_SN_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::SUBJECT_SN_OFFSET
+                ..RtAliasCertTbsEcc384::SUBJECT_SN_OFFSET + RtAliasCertTbsEcc384::SUBJECT_SN_LEN],
             params.subject_sn,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::ISSUER_SN_OFFSET
-                ..RtAliasCertTbs::ISSUER_SN_OFFSET + RtAliasCertTbs::ISSUER_SN_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::ISSUER_SN_OFFSET
+                ..RtAliasCertTbsEcc384::ISSUER_SN_OFFSET + RtAliasCertTbsEcc384::ISSUER_SN_LEN],
             params.issuer_sn,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::UEID_OFFSET
-                ..RtAliasCertTbs::UEID_OFFSET + RtAliasCertTbs::UEID_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::UEID_OFFSET
+                ..RtAliasCertTbsEcc384::UEID_OFFSET + RtAliasCertTbsEcc384::UEID_LEN],
             params.ueid,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::SUBJECT_KEY_ID_OFFSET
-                ..RtAliasCertTbs::SUBJECT_KEY_ID_OFFSET + RtAliasCertTbs::SUBJECT_KEY_ID_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                ..RtAliasCertTbsEcc384::SUBJECT_KEY_ID_OFFSET
+                    + RtAliasCertTbsEcc384::SUBJECT_KEY_ID_LEN],
             params.subject_key_id,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::AUTHORITY_KEY_ID_OFFSET
-                ..RtAliasCertTbs::AUTHORITY_KEY_ID_OFFSET + RtAliasCertTbs::AUTHORITY_KEY_ID_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                ..RtAliasCertTbsEcc384::AUTHORITY_KEY_ID_OFFSET
+                    + RtAliasCertTbsEcc384::AUTHORITY_KEY_ID_LEN],
             params.authority_key_id,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::TCB_INFO_RT_SVN_OFFSET
-                ..RtAliasCertTbs::TCB_INFO_RT_SVN_OFFSET + RtAliasCertTbs::TCB_INFO_RT_SVN_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::TCB_INFO_RT_SVN_OFFSET
+                ..RtAliasCertTbsEcc384::TCB_INFO_RT_SVN_OFFSET
+                    + RtAliasCertTbsEcc384::TCB_INFO_RT_SVN_LEN],
             params.tcb_info_rt_svn,
         );
         assert_eq!(
-            &cert.tbs()[RtAliasCertTbs::TCB_INFO_RT_TCI_OFFSET
-                ..RtAliasCertTbs::TCB_INFO_RT_TCI_OFFSET + RtAliasCertTbs::TCB_INFO_RT_TCI_LEN],
+            &cert.tbs()[RtAliasCertTbsEcc384::TCB_INFO_RT_TCI_OFFSET
+                ..RtAliasCertTbsEcc384::TCB_INFO_RT_TCI_OFFSET
+                    + RtAliasCertTbsEcc384::TCB_INFO_RT_TCI_LEN],
             params.tcb_info_rt_tci,
         );
 
@@ -132,10 +138,10 @@ mod tests {
     #[cfg(feature = "generate_templates")]
     fn test_rt_alias_template() {
         let manual_template =
-            std::fs::read(std::path::Path::new("./build/rt_alias_cert_tbs.rs")).unwrap();
+            std::fs::read(std::path::Path::new("./build/rt_alias_cert_tbs_ecc_384.rs")).unwrap();
         let auto_generated_template = std::fs::read(std::path::Path::new(concat!(
             env!("OUT_DIR"),
-            "/rt_alias_cert_tbs.rs"
+            "/rt_alias_cert_tbs_ecc_384.rs"
         )))
         .unwrap();
         if auto_generated_template != manual_template {

--- a/x509/src/test_util.rs
+++ b/x509/src/test_util.rs
@@ -22,6 +22,13 @@ pub mod tests {
         pkey::{PKey, Private},
         sha::{Sha1, Sha256},
     };
+    #[cfg(feature = "mldsa_attestation")]
+    use openssl::{
+        pkey::Public,
+        pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVariant},
+    };
+    #[cfg(feature = "mldsa_attestation")]
+    use rand::Rng;
 
     pub struct Ecc384AsymKey {
         priv_key: PKey<Private>,
@@ -66,6 +73,61 @@ pub mod tests {
             Self {
                 priv_key: PKey::from_ec_key(priv_key).unwrap(),
                 pub_key,
+            }
+        }
+    }
+
+    #[cfg(feature = "mldsa_attestation")]
+    pub struct MlDsa87AsymKey {
+        priv_key: PKey<Private>,
+        pub_key: Vec<u8>,
+    }
+
+    #[cfg(feature = "mldsa_attestation")]
+    impl MlDsa87AsymKey {
+        pub fn priv_key(&self) -> &PKey<Private> {
+            &self.priv_key
+        }
+
+        pub fn pub_key(&self) -> &[u8] {
+            &self.pub_key
+        }
+
+        pub fn sha256(&self) -> [u8; 32] {
+            let mut sha = Sha256::new();
+            sha.update(self.pub_key());
+            sha.finish()
+        }
+
+        // Used by future ML-DSA cert templates (AuthorityKeyId / SubjectKeyId);
+        // unused for the IDevID CSR which doesn't carry those extensions.
+        #[allow(dead_code)]
+        pub fn sha1(&self) -> [u8; 20] {
+            let mut sha = Sha1::new();
+            sha.update(self.pub_key());
+            sha.finish()
+        }
+
+        pub fn hex_str(&self) -> String {
+            hex::encode(self.sha256()).to_uppercase()
+        }
+    }
+
+    #[cfg(feature = "mldsa_attestation")]
+    impl Default for MlDsa87AsymKey {
+        fn default() -> Self {
+            let mut random_bytes: [u8; 32] = [0; 32];
+            let mut rng = rand::thread_rng();
+            rng.fill(&mut random_bytes);
+            let pk_builder =
+                PKeyMlDsaBuilder::<Private>::from_seed(MlDsaVariant::MlDsa87, &random_bytes)
+                    .unwrap();
+            let private_key = pk_builder.build().unwrap();
+            let public_params = PKeyMlDsaParams::<Public>::from_pkey(&private_key).unwrap();
+            let public_key = public_params.public_key().unwrap();
+            Self {
+                priv_key: private_key,
+                pub_key: public_key.to_vec(),
             }
         }
     }


### PR DESCRIPTION
Implement support for MLDSA-87 x509 creation.  This includes a number of steps, including renaming the existing solution to support both, supporting a new openssl library for testing purposes, as well as altering the x509 generator to handle both ECDSA and MLDSA-87.  

The bulk of the generator and MLDSA-87 certificate changes were ported from the main branch supporting MLDSA-87 in hardware.