### PR TITLE
[caliptra-2.0] Cherry-pick: Modify AuthorizeAndStash command to not skip stash by default (#3402)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,6 +33,10 @@ retries = 3 # the fpga subsystem is a bit flaky with typically 1 test randomly f
 filter = 'test(test_rt_journey_pcr_validation)'
 slow-timeout = { period = "30s", terminate-after = 10 }
 
+[[profile.fpga-subsystem.overrides]]
+filter = 'test(test_preamble_vendor_lms_pubkey_revocation)'
+slow-timeout = { period = "30s", terminate-after = 10 }
+
 [profile.fpga-subsystem.junit]
 path = "/tmp/junit.xml"
 store-success-output = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "arrayvec",
+ "asn1",
  "bitfield",
  "bitflags 2.9.1",
  "caliptra-api",

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -2202,7 +2202,7 @@ impl Default for AuthorizeAndStashReq {
             measurement: [0u8; 48],
             context: [0u8; 48],
             svn: Default::default(),
-            flags: AuthAndStashFlags::SKIP_STASH.bits(),
+            flags: 0,
             source: ImageHashSource::InRequest as u32,
             image_size: 0,
         }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,6 +80,7 @@ rand.workspace = true
 wycheproof.workspace = true
 x509-parser.workspace = true
 x509-cert.workspace = true
+asn1.workspace = true
 
 [features]
 default = ["std"]

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -211,9 +211,14 @@ impl ActivateFirmwareCmd {
                 ..Default::default()
             };
 
-            AuthorizeAndStashCmd::authorize_and_stash(drivers, &auth_and_stash_req)
-                .map(|_| ())
-                .map_err(|_| ())?;
+            let pl0_pauser_locality = drivers.persistent_data.get().manifest1.header.pl0_pauser;
+            AuthorizeAndStashCmd::authorize_and_stash(
+                drivers,
+                &auth_and_stash_req,
+                pl0_pauser_locality,
+            )
+            .map(|_| ())
+            .map_err(|_| ())?;
 
             drivers.persistent_data.get_mut().mcu_firmware_loaded = McuFwStatus::Loaded.into();
         }

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::manifest::find_metadata_entry;
-use crate::{mutrefbytes, Drivers, StashMeasurementCmd};
+use crate::{mutrefbytes, Drivers, PauserPrivileges, StashMeasurementCmd};
 use caliptra_auth_man_types::ImageMetadataFlags;
 use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
@@ -39,10 +39,20 @@ impl AuthorizeAndStashCmd {
         cmd_args: &[u8],
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        let caller_privilege_level = drivers.caller_privilege_level();
+        match caller_privilege_level {
+            // Only PL0 can call STASH_MEASUREMENT
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+        let locality = drivers.mbox.id();
+
         if let Ok(cmd) = AuthorizeAndStashReq::ref_from_bytes(cmd_args) {
             let resp = mutrefbytes::<AuthorizeAndStashResp>(resp)?;
             resp.hdr = MailboxRespHeader::default();
-            resp.auth_req_result = Self::authorize_and_stash(drivers, cmd)?;
+            resp.auth_req_result = Self::authorize_and_stash(drivers, cmd, locality)?;
             Ok(core::mem::size_of::<AuthorizeAndStashResp>())
         } else {
             Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
@@ -54,6 +64,7 @@ impl AuthorizeAndStashCmd {
     pub(crate) fn authorize_and_stash(
         drivers: &mut Drivers,
         cmd: &AuthorizeAndStashReq,
+        locality: u32,
     ) -> CaliptraResult<u32> {
         let source = ImageHashSource::from(cmd.source);
         if source == ImageHashSource::Invalid {
@@ -133,7 +144,7 @@ impl AuthorizeAndStashCmd {
                     &cmd.measurement,
                     cmd.svn,
                     drivers.caller_privilege_level(),
-                    drivers.mbox.id(),
+                    locality,
                 )?;
                 if dpe_result != DpeErrorCode::NoError {
                     drivers

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -84,6 +84,8 @@ impl RecoveryFlow {
             dma_recovery.sha384_mcu_sram(&mut drivers.sha2_512_384_acc, mcu_size_bytes)?
         };
 
+        let pl0_pauser_locality = drivers.persistent_data.get().manifest1.header.pl0_pauser;
+
         let digest: [u8; 48] = digest.into();
         cprintln!("[rt] Verifying MCU digest: {}", HexBytes(&digest));
         // verify the digest
@@ -91,10 +93,16 @@ impl RecoveryFlow {
             fw_id: [2, 0, 0, 0],
             measurement: digest,
             source: ImageHashSource::InRequest.into(),
+            // We want to make sure this measurement is not skipped.
+            flags: 0,
             ..Default::default()
         };
 
-        let auth_result = AuthorizeAndStashCmd::authorize_and_stash(drivers, &auth_and_stash_req)?;
+        let auth_result = AuthorizeAndStashCmd::authorize_and_stash(
+            drivers,
+            &auth_and_stash_req,
+            pl0_pauser_locality,
+        )?;
 
         {
             let dma = &drivers.dma;

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -216,6 +216,11 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     let mut hasher = Sha384::new();
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
+    if model.subsystem_mode() {
+        let mut mcu_hasher = Sha384::new();
+        mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+        hasher.update(mcu_hasher.finalize());
+    }
     let expected_measurement_hash = hasher.finalize();
 
     let dpe_measurement_hash = model.mailbox_execute(0x3000_0000, &[]).unwrap().unwrap();
@@ -277,6 +282,11 @@ fn test_authorize_and_stash_cmd_success() {
     let mut hasher = Sha384::new();
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
+    if model.subsystem_mode() {
+        let mut mcu_hasher = Sha384::new();
+        mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+        hasher.update(mcu_hasher.finalize());
+    }
     hasher.update(IMAGE_DIGEST1);
     let expected_measurement_hash = hasher.finalize();
 

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -187,6 +187,11 @@ fn test_boot_tci_data() {
     let mut hasher = Sha384::new();
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
+    if model.subsystem_mode() {
+        let mut mcu_hasher = Sha384::new();
+        mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+        hasher.update(mcu_hasher.finalize());
+    }
     let expected_measurement_hash = hasher.finalize();
 
     let dpe_measurement_hash = model.mailbox_execute(0x3000_0000, &[]).unwrap().unwrap();
@@ -264,6 +269,11 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
         hasher.update(rt_current_pcr);
         hasher.update(cptra_config_init_vals_hash);
         hasher.update(measurement);
+        if model.subsystem_mode() {
+            let mut mcu_hasher = Sha384::new();
+            mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+            hasher.update(mcu_hasher.finalize());
+        }
         let expected_measurement_hash = hasher.finalize();
 
         let dpe_measurement_hash = model.mailbox_execute(0x3000_0000, &[]).unwrap().unwrap();

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -727,7 +727,13 @@ pub fn test_all_measurement_apis() {
         // COMPARE CERTS
         // Certs should be exactly the same regardless of method
         //
-        assert_eq!(rom_stash_dpe_cert, rt_stash_dpe_cert);
-        assert_eq!(rom_stash_dpe_cert, derive_context_dpe_cert);
+        if hw.subsystem_mode() {
+            // Subsystem will measure & store MCU FW _after_ booting into runtime.
+            // This means the certificate won't match the cert produced with the ROM stashed measurement because the ROM measurement is _before_ the MCU FW measurement.
+            assert_eq!(derive_context_dpe_cert, rt_stash_dpe_cert);
+        } else {
+            assert_eq!(rom_stash_dpe_cert, rt_stash_dpe_cert);
+            assert_eq!(rom_stash_dpe_cert, derive_context_dpe_cert);
+        }
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -172,9 +172,20 @@ fn test_fw_info() {
         };
 
         let update_to = |model: &mut DefaultHwModel, image: &[u8]| {
-            model
-                .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), image)
-                .unwrap();
+            // In subsystem mode, the MCU ROM may hold the mailbox lock
+            // (e.g., for self-measurement hash computation via Caliptra).
+            // Retry until the lock is available.
+            let mut retries = 2000;
+            loop {
+                match model.mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), image) {
+                    Ok(_) => break,
+                    Err(ModelError::UnableToLockMailbox) if retries > 0 => {
+                        retries -= 1;
+                        model.step();
+                    }
+                    Err(e) => panic!("FIRMWARE_LOAD failed: {e}"),
+                }
+            }
 
             model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
         };

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -10,6 +10,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{HwModel, SecurityState};
+use caliptra_runtime::RtBootStatus;
 use caliptra_runtime::{DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
 use cms::{
     cert::x509::der::{Decode, Encode},
@@ -36,6 +37,50 @@ use openssl::{
 use sha2::{Digest, Sha384};
 use x509_parser::{nom::Parser, prelude::*};
 use zerocopy::{FromBytes, IntoBytes};
+
+#[derive(asn1::Asn1Read)]
+struct Fwid<'a> {
+    pub(crate) _hash_alg: asn1::ObjectIdentifier,
+    pub(crate) _digest: &'a [u8],
+}
+
+#[derive(asn1::Asn1Read)]
+struct IntegrityRegister<'a> {
+    #[implicit(0)]
+    _register_name: Option<asn1::IA5String<'a>>,
+    #[implicit(1)]
+    _register_num: Option<u64>,
+    #[implicit(2)]
+    _register_digests: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+}
+
+#[derive(asn1::Asn1Read)]
+struct TcbInfo<'a> {
+    #[implicit(0)]
+    _vendor: Option<asn1::Utf8String<'a>>,
+    #[implicit(1)]
+    _model: Option<asn1::Utf8String<'a>>,
+    #[implicit(2)]
+    _version: Option<asn1::Utf8String<'a>>,
+    #[implicit(3)]
+    _svn: Option<u64>,
+    #[implicit(4)]
+    _layer: Option<u64>,
+    #[implicit(5)]
+    _index: Option<u64>,
+    #[implicit(6)]
+    _fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+    #[implicit(7)]
+    _flags: Option<asn1::BitString<'a>>,
+    #[implicit(8)]
+    _vendor_info: Option<&'a [u8]>,
+    #[implicit(9)]
+    pub tci_type: Option<&'a [u8]>,
+    #[implicit(10)]
+    _operational_flags_mask: Option<asn1::BitString<'a>>,
+    #[implicit(11)]
+    _integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
+}
 
 #[test]
 fn test_invoke_dpe_get_profile_cmd() {
@@ -441,4 +486,57 @@ fn test_export_cdi_destroyed_root_context() {
         CaliptraError::RUNTIME_UNABLE_TO_FIND_DPE_ROOT_CONTEXT.into(),
         30_000_000,
     );
+}
+
+#[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let certify_key_cmd = CertifyKeyCmd {
+        handle: ContextHandle::default(),
+        label: TEST_LABEL,
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+    };
+
+    let certify_key_resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::from(&certify_key_cmd),
+        DpeResult::Success,
+    )
+    .unwrap();
+
+    let Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)) = certify_key_resp else {
+        panic!("Wrong response type!");
+    };
+
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+
+    let (_, cert) = X509CertificateParser::new()
+        .with_deep_parse_extensions(true)
+        .parse(cert_bytes)
+        .unwrap();
+
+    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
+    let ext = cert
+        .get_extension_unique(&multi_tcb_info_oid)
+        .unwrap()
+        .expect("MultiTcbInfo extension missing");
+
+    let parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
+
+    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
+    let found_mcfw = parsed_tcb_infos
+        .filter(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
+        .count()
+        == 1;
+    assert!(found_mcfw);
 }

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -68,7 +68,12 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     // 2 PL0 contexts are used by default by Caliptra. When we initialize DPE, we measure mailbox valid pausers in pl0_pauser's locality.
     // The RT Journey measurement also is counted against PL0's limit. Thus, we can call derive child
     // from PL0 exactly 14 times, and the last iteration of this loop, is expected to throw a threshold reached error.
-    let num_iterations = PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1;
+    let num_iterations = if model.subsystem_mode() {
+        // Subsystem uses a context for the MCU FW
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+    } else {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
+    };
     for i in 0..num_iterations {
         let derive_context_cmd = DeriveContextCmd {
             handle,
@@ -182,7 +187,11 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
     });
 
     // 2 PL0 contexts are used by Caliptra
-    let num_iterations = PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1;
+    let num_iterations = if model.subsystem_mode() {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+    } else {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
+    };
     for i in 0..num_iterations {
         let init_ctx_cmd = InitCtxCmd::new_simulation();
 
@@ -600,7 +609,12 @@ fn test_stash_measurement_pl_context_thresholds() {
     });
 
     // Root node and RT journey (which is technically the Caliptra locality) count as PL0
-    let num_iterations = PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2;
+    // In subsystem mode, the MCU FW is also measured into a PL0 context.
+    let num_iterations = if model.subsystem_mode() {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+    } else {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+    };
     let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
         hdr: MailboxReqHeader { chksum: 0 },
         metadata: [0u8; 4],
@@ -645,7 +659,13 @@ fn test_measurement_log_pl_context_threshold() {
     // Upload (PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1) measurements to measurement log
     // Since 2 measurements taken by Caliptra upon startup, this will cause
     // the PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD to be breached.
-    for idx in 0..(PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1) as u8 {
+    let invocations = if model.subsystem_mode() {
+        // MCU uses an extra DPE context
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+    } else {
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
+    };
+    for idx in 0..invocations as u8 {
         let mut measurement = StashMeasurementReq {
             measurement: [0xdeadbeef_u32; 12].as_bytes().try_into().unwrap(),
             hdr: MailboxReqHeader { chksum: 0 },
@@ -659,7 +679,7 @@ fn test_measurement_log_pl_context_threshold() {
         let mut measurement_req = MailboxReq::StashMeasurement(measurement);
         measurement_req.populate_chksum().unwrap();
 
-        if idx == PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD as u8 - 2 {
+        if idx as usize == invocations - 1 {
             model
                 .upload_measurement(measurement_req.as_bytes().unwrap())
                 .unwrap_err();

--- a/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
+++ b/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
@@ -21,15 +21,13 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
         ..Default::default()
     };
 
-    // MAX_HANDLES contexts = 1 root node (PL0)+
-    //               1 rt_journey (PL0)
-    //               (pl0_limit - 2) PL0 contexts in loop +
-    //               1 PL1 context as transition +
-    //               (pl1_limit - 1) PL1 contexts in loop
+    // In subsystem mode, Caliptra uses 3 base PL0 contexts (root + RT journey + MCU FW);
+    // otherwise, 2 (root + RT journey).
+    let caliptra_base_pl0: u32 = if model.subsystem_mode() { 3 } else { 2 };
 
     // Fill PL0 contexts
     println!("Filling PL0 contexts up to limit {}", pl0_limit);
-    for _ in 0..(pl0_limit - 2) {
+    for _ in 0..(pl0_limit - caliptra_base_pl0) {
         let _ = execute_dpe_cmd(
             model,
             &mut Command::from(&base_derive_context_cmd),
@@ -98,7 +96,13 @@ fn reallocate_pl0_pl1_dpe_contexts(
 
 #[test]
 fn test_pl0_pl1_reallocation_range() {
-    for pl0_limit in 2..dpe::MAX_HANDLES as u32 {
+    // In subsystem mode, Caliptra uses 3 base PL0 contexts (root + RT journey + MCU FW);
+    // we cannot reallocate below the used count.
+    let first_model = run_rt_test(RuntimeTestArgs::default());
+    let min_pl0_limit: u32 = if first_model.subsystem_mode() { 3 } else { 2 };
+    drop(first_model);
+
+    for pl0_limit in min_pl0_limit..dpe::MAX_HANDLES as u32 {
         println!("\n\n\tPL0 Limit {}\n\n", pl0_limit);
         let mut model = run_rt_test(RuntimeTestArgs::default());
         let resp = reallocate_pl0_pl1_dpe_contexts(&mut model, pl0_limit)
@@ -273,8 +277,11 @@ fn test_pl0_pl1_reallocation_warm_reset() {
         .unwrap();
 
     // Use the rest of the PL0 contexts
-    // (2 contexts are used by Caliptra)
-    for _ in 0..10 {
+    // In subsystem mode, 3 contexts are used by Caliptra (root + RT journey + MCU FW);
+    // otherwise, 2 contexts are used (root + RT journey).
+    let caliptra_contexts: u32 = if model.subsystem_mode() { 3 } else { 2 };
+    let remaining = 24 - caliptra_contexts - 12;
+    for _ in 0..remaining {
         let _ = execute_dpe_cmd(
             &mut model,
             &mut Command::from(&derive_context_cmd),

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -226,7 +226,11 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
     let measurement_cmd = DeriveContextCmd {
         data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
-        tci_type: u32::from_be_bytes(*b"CCIV"),
+        tci_type: if model.subsystem_mode() {
+            u32::from_be_bytes(*b"MCFW")
+        } else {
+            u32::from_be_bytes(*b"CCIV")
+        },
         ..Default::default()
     };
 
@@ -302,7 +306,11 @@ fn test_sign_with_exported_cdi_measurement_update() {
     let measurement_cmd = DeriveContextCmd {
         data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
-        tci_type: u32::from_be_bytes(*b"CCIV"),
+        tci_type: if model.subsystem_mode() {
+            u32::from_be_bytes(*b"MCFW")
+        } else {
+            u32::from_be_bytes(*b"CCIV")
+        },
         ..Default::default()
     };
 

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -1,5 +1,8 @@
 // Licensed under the Apache-2.0 license
 
+use crate::common::{
+    calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs, DEFAULT_MCU_FW,
+};
 use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{APP_WITH_UART, FMC_WITH_UART},
@@ -13,8 +16,6 @@ use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
 use zerocopy::{FromBytes, IntoBytes};
-
-use crate::common::{calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs};
 
 #[test]
 fn test_stash_measurement() {
@@ -82,6 +83,11 @@ fn test_stash_measurement() {
     let mut hasher = Sha384::new();
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
+    if model.subsystem_mode() {
+        let mut mcu_hasher = Sha384::new();
+        mcu_hasher.update(DEFAULT_MCU_FW);
+        hasher.update(mcu_hasher.finalize());
+    }
     hasher.update(measurement);
     let expected_measurement_hash = hasher.finalize();
 

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -402,23 +402,50 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
     let dpe_resp = model.mailbox_execute(0xA000_0000, &[]).unwrap().unwrap();
     let mut dpe = dpe::State::try_read_from_bytes(dpe_resp.as_bytes()).unwrap();
 
-    // corrupt DPE structure by creating PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD contexts
     let pl0_pauser = ImageOptions::default().vendor_config.pl0_pauser.unwrap();
-    // make dpe.contexts[1].handle non-default in order to pass dpe state validation
-    dpe.contexts[1].handle = ContextHandle([1u8; ContextHandle::SIZE]);
-    // the mbox valid pausers measurement and RT journey measurement already count as PL0
-    // so creating PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD suffices
-    for i in 0..(PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1) {
-        // skip first two contexts measured by RT
-        let idx = i + 2;
-        // create simulation contexts in PL0
-        dpe.contexts[idx].state = ContextState::Active;
-        dpe.contexts[idx].context_type = ContextType::Simulation;
-        dpe.contexts[idx].locality = pl0_pauser;
-        dpe.contexts[idx].tci.locality = pl0_pauser;
-        dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; TCI_SIZE]);
-        dpe.contexts[idx].tci.tci_cumulative = TciMeasurement([idx as u8; TCI_SIZE]);
-        dpe.contexts[idx].handle = ContextHandle([idx as u8; ContextHandle::SIZE]);
+
+    // Count currently active PL0 contexts
+    let mut pl0_context_count = 0;
+    let mut last_pl0_idx = 0;
+    for (idx, context) in dpe.contexts.iter().enumerate() {
+        if context.state == ContextState::Active && context.locality == pl0_pauser {
+            pl0_context_count += 1;
+            last_pl0_idx = idx;
+        }
+    }
+
+    // Add more PL0 contexts until we hit the threshold
+    let mut current_idx = 0;
+    while pl0_context_count < PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD {
+        if dpe.contexts[current_idx].state == ContextState::Inactive {
+            let idx = current_idx;
+            dpe.contexts[idx].state = ContextState::Active;
+            dpe.contexts[idx].context_type = ContextType::Normal;
+            dpe.contexts[idx].locality = pl0_pauser;
+            dpe.contexts[idx].tci.locality = pl0_pauser;
+            dpe.contexts[idx].tci.tci_current = TciMeasurement([idx as u8; TCI_SIZE]);
+            dpe.contexts[idx].tci.tci_cumulative = TciMeasurement([idx as u8; TCI_SIZE]);
+
+            // Ensure the parent (which might have been the default) now has a non-default handle
+            if dpe.contexts[last_pl0_idx].handle.is_default() {
+                dpe.contexts[last_pl0_idx].handle = ContextHandle([0xEE; ContextHandle::SIZE]);
+            }
+
+            // Use a unique non-default handle
+            let mut handle = [0u8; ContextHandle::SIZE];
+            handle[0] = 0xFF; // Ensure non-default
+            handle[1] = idx as u8;
+            dpe.contexts[idx].handle = ContextHandle(handle);
+
+            // link to previous PL0 context
+            dpe.contexts[idx].parent_idx = last_pl0_idx as u8;
+            dpe.contexts[last_pl0_idx].children.add_child(idx).unwrap();
+
+            last_pl0_idx = idx;
+            pl0_context_count += 1;
+        }
+        current_idx += 1;
+        assert!(current_idx < dpe::MAX_HANDLES);
     }
     let _ = model
         .mailbox_execute(0xB000_0000, dpe.as_bytes())


### PR DESCRIPTION
Cherry-pick of commit 34cf8f10cdbe91061e0dcc131823d95331a4802e from main to caliptra-2.0.

**Original PR:** #3402
**Original commit message:**
> Modify AuthorizeAndStash command to not skip stash by default
> - Modified the TCI type for the MCU FW measurement.
> - Added a test that checks for the presence of the MCU FW TCB node
>
> This resolves https://github.com/chipsalliance/caliptra-sw/issues/3364.

**Conflict resolutions:**
 - .config/nextest.toml: Kept caliptra-2.0 existing override, added only the new test_preamble_vendor_lms_pubkey_revocation override from this commit.
 - runtime/src/authorize_and_stash.rs: Used locality variable (already captured earlier in the function) instead of inline drivers.mbox.id().
 - runtime/src/drivers.rs: Kept caliptra-2.0 buffer implementation ([u8; N] with execute_serialized pattern) as the branch has already evolved this code independently.
 - runtime/tests/runtime_integration_tests/test_certs.rs: Took the incoming subsystem_mode() conditional for cert comparison; removed extra & on rom_stash_dpe_cert to fix type mismatch (already &[u8] oncaliptra-2.0).
 - runtime/tests/runtime_integration_tests/test_invoke_dpe.rs: Kept caliptra-2.0 code for test_invoke_dpe_get_certificate_chain_cmd (the test_certify_key_with_max_contexts function does not exist on thisbranch). Adapted the new test_subsystem_leaf_cert_contains_mcfw_tci_type test to caliptra-2.0 API: use CertifyKeyCmd/CertifyKeyResp::P384 instead of CertifyKeyCommandNoRef/CaliptraDpeProfile, use 3-argexecute_dpe_cmd signature, and added missing RtBootStatus import.
 - runtime/src/activate_firmware.rs: Removed .rom from PersistentData field access path (PersistentData has manifest1 directly on caliptra-2.0, no .rom intermediate).
 - runtime/src/recovery_flow.rs: Same .rom removal as activate_firmware.rs.
 - runtime/tests/runtime_integration_tests/test_stash_measurement.rs: Changed DEFAULT_MCU_FW import from caliptra_test (not available on caliptra-2.0) to crate::common; restored sha2 and zerocopy imports.
 - runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs: Adjusted DPE context limit tests to account for subsystem mode using 3 base PL0 contexts (root + RT journey + MCU FW) instead of
  2. Affected fill_max_dpe_contexts, test_pl0_pl1_reallocation_range, and test_pl0_pl1_reallocation_warm_reset