### PR TITLE
[rom] Reduce ROM size ~2.8 KB

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-6e816cd21818dfa42485020d594e41f98728838e87cf90a3702babe60d29d03cb62ccfd06281eef11b08d17b4c4be5c8  caliptra-rom-no-log.bin
-88171c273e48bfb30c7f3d05d913713f7a02dfa25e1b7620319980dafffc75858b9d5d496d88d8c0e6479aeb1f7c02b1  caliptra-rom-with-log.bin
+09179e6efe53f02863283cae3b5850aa3de1f5acd6ccf2da518936b1b30084092cdfc822c4859582973692e3708e8a6e  caliptra-rom-no-log.bin
+212e3f8a8b33a060731b4cc416db1cb3ef9561bea0cd9855b1fa12bfdc4daacdba140e6e4f62465f56a5a445a3950e0b  caliptra-rom-with-log.bin

--- a/common/src/debug_unlock.rs
+++ b/common/src/debug_unlock.rs
@@ -215,9 +215,9 @@ pub fn validate_debug_unlock_token(
     // Convert the digest to little endian format for MLDSA.
     let mldsa_msg: LEArray4x16 = mldsa_msg.into();
 
-    let result = mldsa87.verify(
+    let result = mldsa87.verify_var(
         &Mldsa87PubKey::from(&token.mldsa_public_key),
-        &mldsa_msg,
+        mldsa_msg.as_bytes(),
         &Mldsa87Signature::from(&token.mldsa_signature),
     )?;
 

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -234,7 +234,7 @@ impl<'a> Mldsa87<'a> {
         let pct_msg = Mldsa87Msg::default();
         let pct_sign_rnd = Mldsa87SignRnd::default();
 
-        match self.sign(seed, pubkey, &pct_msg, &pct_sign_rnd, trng) {
+        match self.sign_var(seed, pubkey, pct_msg.as_bytes(), &pct_sign_rnd, trng) {
             Ok(mut sig) => {
                 sig.zeroize();
             }

--- a/kat/src/mldsa87_kat.rs
+++ b/kat/src/mldsa87_kat.rs
@@ -107,10 +107,10 @@ impl Mldsa87Kat {
         let mut sha2 = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
 
         let signature = mldsa87
-            .sign(
+            .sign_var(
                 Mldsa87Seed::Array4x8(&SEED),
                 pub_key,
-                &KAT_MESSAGE.into(),
+                KAT_MESSAGE.as_bytes(),
                 &Mldsa87SignRnd::default(),
                 trng,
             )

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -20,8 +20,6 @@ use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::rom_env::RomEnv;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
-use caliptra_common::cfi_check;
 use caliptra_common::crypto::{Crypto, Ecc384KeyPair, MlDsaKeyPair, PubKey};
 use caliptra_common::keyids::{
     KEY_ID_FMC_ECDSA_PRIV_KEY, KEY_ID_FMC_MLDSA_KEYPAIR_SEED, KEY_ID_ROM_FMC_CDI,
@@ -156,34 +154,15 @@ impl FmcAliasLayer {
         ecc_priv_key: KeyId,
         mldsa_keypair_seed: KeyId,
     ) -> CaliptraResult<(Ecc384KeyPair, MlDsaKeyPair)> {
-        let result = Crypto::ecc384_key_gen(
-            &mut env.ecc384,
-            &mut env.hmac,
-            &mut env.trng,
-            &mut env.key_vault,
+        crate::flow::cold_reset::derive_dice_key_pair(
+            env,
             cdi,
-            b"alias_fmc_ecc_key",
             ecc_priv_key,
-        );
-        cfi_check!(result);
-        let ecc_keypair = result?;
-
-        // Derive the MLDSA Key Pair.
-        let result = env.abr.with_mldsa87(|mut mldsa87| {
-            Crypto::mldsa87_key_gen(
-                &mut mldsa87,
-                &mut env.hmac,
-                &mut env.trng,
-                cdi,
-                b"alias_fmc_mldsa_key",
-                mldsa_keypair_seed,
-            )
-        });
-        cfi_check!(result);
-        let mldsa_keypair = result?;
-
-        report_boot_status(FmcAliasKeyPairDerivationComplete.into());
-        Ok((ecc_keypair, mldsa_keypair))
+            mldsa_keypair_seed,
+            b"alias_fmc_ecc_key",
+            b"alias_fmc_mldsa_key",
+            FmcAliasKeyPairDerivationComplete.into(),
+        )
     }
 
     /// Generate Local Device ID Certificate Signature
@@ -234,7 +213,8 @@ impl FmcAliasLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[afmc] ECC Signing Cert w/ AUTHORITY.KEYID = {}",
+            "[afmc] Signing Cert {} AUTHORITY.KEYID = {}",
+            "ECC",
             auth_priv_key as u8
         );
         let mut sig = Crypto::ecdsa384_sign_and_verify(
@@ -314,7 +294,8 @@ impl FmcAliasLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[afmc] MLDSA Signing Cert w/ AUTHORITY.KEYID = {}",
+            "[afmc] Signing Cert {} AUTHORITY.KEYID = {}",
+            "MLDSA",
             auth_priv_key as u8
         );
         let mut sig = env.abr.with_mldsa87(|mut mldsa87| {
@@ -329,10 +310,6 @@ impl FmcAliasLayer {
         let sig = okmutref(&mut sig)?;
 
         // Clear the authority private key
-        cprintln!(
-            "[afmc] MLDSA Erase AUTHORITY.KEYID = {}",
-            auth_priv_key as u8
-        );
         env.key_vault.erase_key(auth_priv_key).inspect_err(|_err| {
             sig.zeroize();
         })?;

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -467,18 +467,14 @@ impl FirmwareProcessor {
                     CommandId::INSTALL_OWNER_PK_HASH => {
                         InstallOwnerPkHashCmd::execute(cmd_bytes, persistent_data, resp)?
                     }
-                    CommandId::GET_LDEV_ECC384_CERT => GetLdevCertCmd::execute(
-                        cmd_bytes,
-                        persistent_data,
-                        AlgorithmType::Ecc384,
-                        resp,
-                    )?,
-                    CommandId::GET_LDEV_MLDSA87_CERT => GetLdevCertCmd::execute(
-                        cmd_bytes,
-                        persistent_data,
-                        AlgorithmType::Mldsa87,
-                        resp,
-                    )?,
+                    CommandId::GET_LDEV_ECC384_CERT | CommandId::GET_LDEV_MLDSA87_CERT => {
+                        let algo = if CommandId::from(cmd) == CommandId::GET_LDEV_ECC384_CERT {
+                            AlgorithmType::Ecc384
+                        } else {
+                            AlgorithmType::Mldsa87
+                        };
+                        GetLdevCertCmd::execute(cmd_bytes, persistent_data, algo, resp)?
+                    }
                     CommandId::ZEROIZE_UDS_FE => {
                         ZeroizeUdsFeCmd::execute(cmd_bytes, soc_ifc, dma, resp)?
                     }
@@ -709,9 +705,15 @@ impl FirmwareProcessor {
         };
 
         cprintln!(
-            "[fwproc] Img verified w/ Vendor ECC Key Idx {}, PQC Key Type: {}, PQC Key Idx {}, with SVN {} and effective fuse SVN {}",
+            "[fwproc] Img verified ecc={} {}={} svn={} fuse_svn={}",
             info.vendor_ecc_pub_key_idx,
-            if FwVerificationPqcKeyType::from_u8(manifest.pqc_key_type) == Some(FwVerificationPqcKeyType::MLDSA)  { "MLDSA" } else { "LMS" },
+            if FwVerificationPqcKeyType::from_u8(manifest.pqc_key_type)
+                == Some(FwVerificationPqcKeyType::MLDSA)
+            {
+                "MLDSA"
+            } else {
+                "LMS"
+            },
             info.vendor_pqc_pub_key_idx,
             info.fw_svn,
             info.effective_fuse_svn,

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -21,7 +21,6 @@ use crate::print::HexBytes;
 use crate::rom_env::{RomEnv, RomEnvFips};
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 use caliptra_common::{
     crypto::{Crypto, Ecc384KeyPair, MlDsaKeyPair, PubKey},
     keyids::{
@@ -354,42 +353,15 @@ impl InitDevIdLayer {
         ecc_priv_key: KeyId,
         mldsa_keypair_seed: KeyId,
     ) -> CaliptraResult<(Ecc384KeyPair, MlDsaKeyPair)> {
-        let result = Crypto::ecc384_key_gen(
-            &mut env.ecc384,
-            &mut env.hmac,
-            &mut env.trng,
-            &mut env.key_vault,
+        cold_reset::derive_dice_key_pair(
+            env,
             cdi,
-            b"idevid_ecc_key",
             ecc_priv_key,
-        );
-        if cfi_launder(result.is_ok()) {
-            cfi_assert!(result.is_ok());
-        } else {
-            cfi_assert!(result.is_err());
-        }
-        let ecc_keypair = result?;
-
-        // Derive the MLDSA Key Pair.
-        let result = env.abr.with_mldsa87(|mut mldsa87| {
-            Crypto::mldsa87_key_gen(
-                &mut mldsa87,
-                &mut env.hmac,
-                &mut env.trng,
-                cdi,
-                b"idevid_mldsa_key",
-                mldsa_keypair_seed,
-            )
-        });
-        if cfi_launder(result.is_ok()) {
-            cfi_assert!(result.is_ok());
-        } else {
-            cfi_assert!(result.is_err());
-        }
-        let mldsa_keypair = result?;
-
-        report_boot_status(IDevIdKeyPairDerivationComplete.into());
-        Ok((ecc_keypair, mldsa_keypair))
+            mldsa_keypair_seed,
+            b"idevid_ecc_key",
+            b"idevid_mldsa_key",
+            IDevIdKeyPairDerivationComplete.into(),
+        )
     }
 
     /// Generate Local Device ID CSRs
@@ -484,7 +456,8 @@ impl InitDevIdLayer {
         let tbs = InitDevIdCsrTbsEcc384::new(&params);
 
         cprintln!(
-            "[idev] ECC Sign CSR w/ SUBJECT.KEYID = {}",
+            "[idev] Sign CSR {} SUBJECT.KEYID = {}",
+            "ECC",
             key_pair.priv_key as u8
         );
 
@@ -542,7 +515,8 @@ impl InitDevIdLayer {
         let tbs = InitDevIdCsrTbsMlDsa87::new(&params);
 
         cprintln!(
-            "[idev] MLDSA Sign CSR w/ SUBJECT.KEYID = {}",
+            "[idev] Sign CSR {} SUBJECT.KEYID = {}",
+            "MLDSA",
             key_pair.key_pair_seed as u8
         );
 

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -15,11 +15,11 @@ Abstract:
 
 use super::dice::*;
 use crate::cprintln;
+use crate::flow::cold_reset;
 use crate::flow::cold_reset::{copy_tbs, TbsType};
 use crate::rom_env::RomEnv;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 use caliptra_common::keyids::{KEY_ID_STABLE_IDEV, KEY_ID_STABLE_LDEV};
 use caliptra_common::{
     crypto::{Crypto, Ecc384KeyPair, MlDsaKeyPair, PubKey},
@@ -237,42 +237,15 @@ impl LocalDevIdLayer {
         ecc_priv_key: KeyId,
         mldsa_keypair_seed: KeyId,
     ) -> CaliptraResult<(Ecc384KeyPair, MlDsaKeyPair)> {
-        let result = Crypto::ecc384_key_gen(
-            &mut env.ecc384,
-            &mut env.hmac,
-            &mut env.trng,
-            &mut env.key_vault,
+        cold_reset::derive_dice_key_pair(
+            env,
             cdi,
-            b"ldevid_ecc_key",
             ecc_priv_key,
-        );
-        if cfi_launder(result.is_ok()) {
-            cfi_assert!(result.is_ok());
-        } else {
-            cfi_assert!(result.is_err());
-        }
-        let ecc_keypair = result?;
-
-        // Derive the MLDSA Key Pair.
-        let result = env.abr.with_mldsa87(|mut mldsa87| {
-            Crypto::mldsa87_key_gen(
-                &mut mldsa87,
-                &mut env.hmac,
-                &mut env.trng,
-                cdi,
-                b"ldevid_mldsa_key",
-                mldsa_keypair_seed,
-            )
-        });
-        if cfi_launder(result.is_ok()) {
-            cfi_assert!(result.is_ok());
-        } else {
-            cfi_assert!(result.is_err());
-        }
-        let mldsa_keypair = result?;
-
-        report_boot_status(LDevIdKeyPairDerivationComplete.into());
-        Ok((ecc_keypair, mldsa_keypair))
+            mldsa_keypair_seed,
+            b"ldevid_ecc_key",
+            b"ldevid_mldsa_key",
+            LDevIdKeyPairDerivationComplete.into(),
+        )
     }
 
     /// Generate ECC Local Device ID Certificate Signature
@@ -312,7 +285,8 @@ impl LocalDevIdLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[ldev] Signing Cert with ECC AUTHORITY.KEYID = {}",
+            "[ldev] Signing Cert {} AUTHORITY.KEYID = {}",
+            "ECC",
             ecc_auth_priv_key as u8
         );
         let mut sig = Crypto::ecdsa384_sign_and_verify(
@@ -383,7 +357,8 @@ impl LocalDevIdLayer {
 
         // Sign the `To Be Signed` portion
         cprintln!(
-            "[ldev] Signing Cert with MLDSA AUTHORITY.KEYID = {}",
+            "[ldev] Signing Cert {} AUTHORITY.KEYID = {}",
+            "MLDSA",
             mldsa_auth_priv_key as u8
         );
         let mut sig = env.abr.with_mldsa87(|mut mldsa87| {

--- a/rom/dev/src/flow/cold_reset/mod.rs
+++ b/rom/dev/src/flow/cold_reset/mod.rs
@@ -30,6 +30,9 @@ use crate::rom_env::RomEnvFips;
 use crate::{cprintln, rom_env::RomEnv};
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
+use caliptra_common::cfi_check;
+use caliptra_common::crypto::{Crypto, Ecc384KeyPair, MlDsaKeyPair};
 use caliptra_common::RomBootStatus::*;
 use caliptra_drivers::*;
 use zerocopy::transmute;
@@ -179,4 +182,48 @@ fn dice_input_from_output(dice_output: &DiceOutput) -> DiceInput {
         mldsa_auth_sn: &dice_output.mldsa_subj_sn,
         mldsa_auth_key_id: &dice_output.mldsa_subj_key_id,
     }
+}
+
+/// Derive a DICE layer's ECC and MLDSA key pairs from a CDI.
+///
+/// Shared by the IDevID, LDevID, and FmcAlias layers; the labels and
+/// completion-status code differ per layer.
+#[cfg_attr(feature = "cfi", cfi_mod_fn)]
+#[inline(never)]
+pub(crate) fn derive_dice_key_pair(
+    env: &mut RomEnv,
+    cdi: KeyId,
+    ecc_priv_key: KeyId,
+    mldsa_keypair_seed: KeyId,
+    ecc_label: &[u8],
+    mldsa_label: &[u8],
+    done_status: u32,
+) -> CaliptraResult<(Ecc384KeyPair, MlDsaKeyPair)> {
+    let result = Crypto::ecc384_key_gen(
+        &mut env.ecc384,
+        &mut env.hmac,
+        &mut env.trng,
+        &mut env.key_vault,
+        cdi,
+        ecc_label,
+        ecc_priv_key,
+    );
+    cfi_check!(result);
+    let ecc_keypair = result?;
+
+    let result = env.abr.with_mldsa87(|mut mldsa87| {
+        Crypto::mldsa87_key_gen(
+            &mut mldsa87,
+            &mut env.hmac,
+            &mut env.trng,
+            cdi,
+            mldsa_label,
+            mldsa_keypair_seed,
+        )
+    });
+    cfi_check!(result);
+    let mldsa_keypair = result?;
+
+    report_boot_status(done_status);
+    Ok((ecc_keypair, mldsa_keypair))
 }


### PR DESCRIPTION
Combine several small ROM-size wins:

* Use streaming MLDSA-87 sign_var/verify_var for the pairwise consistency test, KAT, and debug-unlock token validation so the non-streaming sign_internal/verify_internal paths get dead-code eliminated.
* Merge GET_LDEV_ECC384_CERT and GET_LDEV_MLDSA87_CERT mailbox arms, unify '[ldev]'/'[afmc]' Signing Cert and InitDevID Sign CSR cprintln strings, and drop the redundant '[afmc] MLDSA Erase AUTHORITY.KEYID' log line.
* Refactor the three identical DICE derive_key_pair routines (IDevID, LDevID, FmcAlias) into a single #[inline(never)] cold_reset::derive_dice_key_pair helper.
* Shorten the verbose '[fwproc] Img verified ...' cprintln to a compact ecc=/svn=/fuse_svn= form.