### PR TITLE
update download-artifact action to v8

### DIFF
--- a/.github/workflows/fpga-image.yml
+++ b/.github/workflows/fpga-image.yml
@@ -147,13 +147,13 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: 'Download kernel artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vck190-kernel-${{ matrix.image_variant }}
           path: /tmp/vck190-kernel/
 
       - name: 'Download kernel module artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vck190-kernel-module-${{ matrix.image_variant }}
           path: /tmp/vck190-kmod/

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -304,19 +304,19 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: 'Download Test Binaries Artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
 
       - name: 'Download Test Firmware Artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
 
       - name: 'Download Bitstream'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-bitstream
@@ -417,7 +417,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: 'Download test results'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: caliptra-test-results${{ inputs.artifact-suffix }}-*
           merge-multiple: true

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -235,19 +235,19 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: 'Download Test Binaries Artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-test-binaries${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-binaries.sqsh
 
       - name: 'Download Test Firmware Artifact'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-test-firmware${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-test-firmware
 
       - name: 'Download Bitstream'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: caliptra-bitstream${{ inputs.artifact-suffix }}
           path: /tmp/caliptra-bitstream
@@ -345,7 +345,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: 'Download test results'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: caliptra-test-results${{ inputs.artifact-suffix }}-*
           merge-multiple: true

--- a/.github/workflows/nightly-release-1.x.yml
+++ b/.github/workflows/nightly-release-1.x.yml
@@ -141,7 +141,7 @@ jobs:
           mv ./release/release.zip ./release/caliptra_${{ needs.find-latest-release.outputs.new_release_tag }}.zip
 
       - name: 'Download all artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/artifacts
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -173,7 +173,7 @@ jobs:
           mv ./release/release.zip ./release/caliptra_${{ needs.find-latest-release-2-x.outputs.new_release_tag }}.zip
 
       - name: 'Download all artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/artifacts
 


### PR DESCRIPTION
Updating GitHub action "download-artifact" to [v8](https://github.com/actions/download-artifact/releases/tag/v8.0.0)  , to take advantage of new option [digest-mismatch](https://github.com/marketplace/actions/download-a-build-artifact):
```
What to do if the action detects a mismatch between the downloaded hash and the expected hash from the server.
Can be one of: 'ignore', 'info', 'warn', 'error'
Optional. Default is 'error'
```