### PR TITLE
[fix] Mark hash-based ECDSA/LMS verify as FIPS non-approved

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-09179e6efe53f02863283cae3b5850aa3de1f5acd6ccf2da518936b1b30084092cdfc822c4859582973692e3708e8a6e  caliptra-rom-no-log.bin
-212e3f8a8b33a060731b4cc416db1cb3ef9561bea0cd9855b1fa12bfdc4daacdba140e6e4f62465f56a5a445a3950e0b  caliptra-rom-with-log.bin
+614dd1039fa44ba8db666c7b2ed02774ee98871085dc5fb075a4987f7c23810fe9e0d04e7511280ee7ea73eebfef60c6  caliptra-rom-no-log.bin
+60955a9ac9c407f0d2be85b353a6238b13959314f9b2732481e7e5250342dc541bf0e336ddd4c3369429fa610e2cc3ef  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-c2c3a1c7c3488f898bcdb785d686fda401f87609b91725a1110dee04e3ea18f2597fef5037b0ae58eeae23c7474a57c8  caliptra-rom-no-log.bin
-62954d1988b66176909d090c66cb82630271af74befa5576e45acf1a737be1890f09914188be419677436255d1ddb398  caliptra-rom-with-log.bin
+26b85562f85a9aefa63b7bb821d36823007b6fa588c4b7bea3e43c5b6f1af6969891b4cc068065e9b01f72701eb1163b  caliptra-rom-no-log.bin
+0424173d501806ea5b612749a457328c17f5e38d68b35426633c60e65c31a662722f1b27fc90aa91078c7bd8fef33dbc  caliptra-rom-with-log.bin

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1145,7 +1145,7 @@ impl Response for MailboxRespHeader {}
 
 impl MailboxRespHeader {
     pub const FIPS_STATUS_APPROVED: u32 = 0;
-    pub const FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST: u32 = 1;
+    pub const FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST: u32 = 0x5553_5244; // "USRD"
 }
 
 impl Default for MailboxRespHeader {

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1145,6 +1145,7 @@ impl Response for MailboxRespHeader {}
 
 impl MailboxRespHeader {
     pub const FIPS_STATUS_APPROVED: u32 = 0;
+    pub const FIPS_STATUS_NOT_APPROVED: u32 = 1;
 }
 
 impl Default for MailboxRespHeader {

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1145,7 +1145,7 @@ impl Response for MailboxRespHeader {}
 
 impl MailboxRespHeader {
     pub const FIPS_STATUS_APPROVED: u32 = 0;
-    pub const FIPS_STATUS_NOT_APPROVED: u32 = 1;
+    pub const FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST: u32 = 1;
 }
 
 impl Default for MailboxRespHeader {

--- a/api/src/soc_mgr.rs
+++ b/api/src/soc_mgr.rs
@@ -338,7 +338,9 @@ pub trait SocManager {
                 actual: actual_checksum,
             });
         }
-        if response_header.fips_status != MailboxRespHeader::FIPS_STATUS_APPROVED {
+        if response_header.fips_status != MailboxRespHeader::FIPS_STATUS_APPROVED
+            && response_header.fips_status != MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+        {
             return Err(CaliptraApiError::MailboxRespInvalidFipsStatus(
                 response_header.fips_status,
             ));

--- a/api/src/soc_mgr.rs
+++ b/api/src/soc_mgr.rs
@@ -339,7 +339,8 @@ pub trait SocManager {
             });
         }
         if response_header.fips_status != MailboxRespHeader::FIPS_STATUS_APPROVED
-            && response_header.fips_status != MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+            && response_header.fips_status
+                != MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
         {
             return Err(CaliptraApiError::MailboxRespInvalidFipsStatus(
                 response_header.fips_status,

--- a/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
@@ -14,6 +14,7 @@ Abstract:
 
 use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Ecc384};
+use zerocopy::FromBytes;
 
 pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
@@ -21,13 +22,16 @@ impl EcdsaVerifyCmd {
     pub(crate) fn execute(
         cmd_bytes: &[u8],
         ecc384: &mut Ecc384,
-        _resp: &mut [u8],
+        resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let result = caliptra_common::verify::EcdsaVerifyCmd::execute(ecc384, cmd_bytes);
 
         match result {
             Ok(_) => {
-                // Zero value of response buffer is good
+                let resp = MailboxRespHeader::mut_from_prefix(resp)
+                    .map_err(|_| caliptra_drivers::CaliptraError::ROM_GLOBAL_EXCEPTION)?
+                    .0;
+                resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
                 Ok(core::mem::size_of::<MailboxRespHeader>())
             }
             Err(e) => {

--- a/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs
@@ -31,7 +31,7 @@ impl EcdsaVerifyCmd {
                 let resp = MailboxRespHeader::mut_from_prefix(resp)
                     .map_err(|_| caliptra_drivers::CaliptraError::ROM_GLOBAL_EXCEPTION)?
                     .0;
-                resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
+                resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST;
                 Ok(core::mem::size_of::<MailboxRespHeader>())
             }
             Err(e) => {

--- a/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
@@ -134,6 +134,6 @@ fn test_ecdsa_verify_cmd() {
     // Verify FIPS status
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
     );
 }

--- a/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
+++ b/rom/dev/tests/rom_integration_tests/test_ecdsa_verify.rs
@@ -134,6 +134,6 @@ fn test_ecdsa_verify_cmd() {
     // Verify FIPS status
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
     );
 }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -737,7 +737,7 @@ Command Code: `0x4543_5632` ("ECV2")
 | **Name**      | **Type** | **Description**
 | --------      | -------- | ---------------
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| fips\_status  | u32      | `FIPS_NOT_APPROVED`, because the caller supplies the digest.
+| fips\_status  | u32      | `FIPS_NOT_APPROVED_USER_SUPPLIED_DIGEST`, because the caller supplies the digest.
 
 ### LMS\_SIGNATURE\_VERIFY
 
@@ -778,7 +778,7 @@ Command Code: `0x4C4D_5632` ("LMV2")
 | **Name**    | **Type** | **Description**
 | --------    | -------- | ---------------
 | chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| fips\_status | u32      | `FIPS_NOT_APPROVED`, because the caller supplies the digest.
+| fips\_status | u32      | `FIPS_NOT_APPROVED_USER_SUPPLIED_DIGEST`, because the caller supplies the digest.
 
 ### MLDSA87_SIGNATURE_VERIFY
 
@@ -3165,7 +3165,7 @@ For successful commands, the firmware responds with a FIPS status indicating whe
 | **Name**        | **Value**                   | Description                                         |
 | --------------- | --------------------------- | --------------------------------------------------- |
 | `FIPS_APPROVED` | `0x0000_0000`               | Status of command is FIPS approved                  |
-| `FIPS_NOT_APPROVED` | `0x0000_0001`           | Status of command is not FIPS approved              |
+| `FIPS_NOT_APPROVED_USER_SUPPLIED_DIGEST` | `0x0000_0001` | Command is not FIPS approved because the caller supplied the digest instead of the raw message |
 | `RESERVED`      | `0x0000_0002 - 0xFFFF_FFFF` | Other values reserved, will not be sent by Caliptra |
 
 ## Runtime Firmware updates

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -26,6 +26,7 @@ v2.1:
 * [External mailbox commands](#external-mailbox-cmd)
 * [Encrypted firmware support](#encrypted-firmware-support-21-subsystem-mode-only)
 * [OCP LOCK v1.0 commands](#mailbox-commands-ocp-lock-v10)
+* `ECDSA384_SIGNATURE_VERIFY` and `LMS_SIGNATURE_VERIFY` return a non-approved FIPS status because the caller supplies the digest.
 
 
 ## Spec Opens
@@ -736,7 +737,7 @@ Command Code: `0x4543_5632` ("ECV2")
 | **Name**      | **Type** | **Description**
 | --------      | -------- | ---------------
 | chksum        | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| fips\_status  | u32      | Indicates if the command is FIPS approved or an error.
+| fips\_status  | u32      | `FIPS_NOT_APPROVED`, because the caller supplies the digest.
 
 ### LMS\_SIGNATURE\_VERIFY
 
@@ -777,7 +778,7 @@ Command Code: `0x4C4D_5632` ("LMV2")
 | **Name**    | **Type** | **Description**
 | --------    | -------- | ---------------
 | chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
-| fips\_status | u32      | Indicates if the command is FIPS approved or an error.
+| fips\_status | u32      | `FIPS_NOT_APPROVED`, because the caller supplies the digest.
 
 ### MLDSA87_SIGNATURE_VERIFY
 
@@ -3157,15 +3158,15 @@ chksum field.
 
 ## FIPS status
 
-For every command, the firmware responds with a FIPS status of FIPS approved. There is
-currently no use case for any other responses or error values.
+For successful commands, the firmware responds with a FIPS status indicating whether the service is FIPS approved. A non-approved status is not a command error.
 
 *Table: FIPS status codes*
 
 | **Name**        | **Value**                   | Description                                         |
 | --------------- | --------------------------- | --------------------------------------------------- |
 | `FIPS_APPROVED` | `0x0000_0000`               | Status of command is FIPS approved                  |
-| `RESERVED`      | `0x0000_0001 - 0xFFFF_FFFF` | Other values reserved, will not be sent by Caliptra |
+| `FIPS_NOT_APPROVED` | `0x0000_0001`           | Status of command is not FIPS approved              |
+| `RESERVED`      | `0x0000_0002 - 0xFFFF_FFFF` | Other values reserved, will not be sent by Caliptra |
 
 ## Runtime Firmware updates
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -61,7 +61,7 @@ use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter,
 };
 use caliptra_common::cfi_check;
-use caliptra_common::mailbox_api::{ExternalMailboxCmdReq, MailboxReqHeader};
+use caliptra_common::mailbox_api::{ExternalMailboxCmdReq, MailboxReqHeader, MailboxRespHeader};
 use caliptra_dpe::State;
 use caliptra_dpe_crypto::ecdsa::curve_384::EcdsaPub384;
 use caliptra_dpe_crypto::ecdsa::EcdsaPubKey;
@@ -120,6 +120,7 @@ pub use caliptra_dpe::{
 use caliptra_dpe::{dpe_instance::DpeEnv, support::Support};
 use caliptra_drivers::{okref, AxiAddr, CaliptraError, CaliptraResult, ResetReason};
 use caliptra_registers::mbox::enums::MboxStatusE;
+use core::mem::size_of;
 
 use crate::{
     dice::GetRtAliasCertCmd,
@@ -323,9 +324,17 @@ fn execute_command(
         CommandId::INVOKE_DPE_ECC384 => InvokeDpeCmd::execute_ecc384(drivers, cmd_bytes, resp),
         CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeCmd::execute_mldsa87(drivers, cmd_bytes, resp),
         CommandId::ECDSA384_SIGNATURE_VERIFY => {
-            caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)
+            caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)?;
+            let resp = mutrefbytes::<MailboxRespHeader>(resp)?;
+            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
+            Ok(size_of::<MailboxRespHeader>())
         }
-        CommandId::LMS_SIGNATURE_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
+        CommandId::LMS_SIGNATURE_VERIFY => {
+            LmsVerifyCmd::execute(drivers, cmd_bytes)?;
+            let resp = mutrefbytes::<MailboxRespHeader>(resp)?;
+            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
+            Ok(size_of::<MailboxRespHeader>())
+        }
         CommandId::MLDSA87_SIGNATURE_VERIFY => drivers.abr.with_mldsa87(|mut mldsa| {
             caliptra_common::verify::MldsaVerifyCmd::execute(&mut mldsa, cmd_bytes)
         }),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -326,13 +326,13 @@ fn execute_command(
         CommandId::ECDSA384_SIGNATURE_VERIFY => {
             caliptra_common::verify::EcdsaVerifyCmd::execute(&mut drivers.ecc384, cmd_bytes)?;
             let resp = mutrefbytes::<MailboxRespHeader>(resp)?;
-            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
+            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST;
             Ok(size_of::<MailboxRespHeader>())
         }
         CommandId::LMS_SIGNATURE_VERIFY => {
             LmsVerifyCmd::execute(drivers, cmd_bytes)?;
             let resp = mutrefbytes::<MailboxRespHeader>(resp)?;
-            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED;
+            resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST;
             Ok(size_of::<MailboxRespHeader>())
         }
         CommandId::MLDSA87_SIGNATURE_VERIFY => drivers.abr.with_mldsa87(|mut mldsa| {

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -121,10 +121,13 @@ fn ecdsa_cmd_run_wycheproof() {
                         let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
                         assert_eq!(
                             resp_hdr.fips_status,
-                            MailboxRespHeader::FIPS_STATUS_APPROVED
+                            MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
                         );
-                        // Checksum is just going to be 0 because FIPS_STATUS_APPROVED is 0
-                        assert_eq!(resp_hdr.chksum, 0);
+                        assert!(caliptra_common::checksum::verify_checksum(
+                            resp_hdr.chksum,
+                            0x0,
+                            &resp[core::mem::size_of_val(&resp_hdr.chksum)..],
+                        ));
                     }
                 },
                 wycheproof::TestResult::Invalid => {
@@ -214,10 +217,13 @@ fn test_ecdsa_verify_cmd() {
 
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
     );
-    // Checksum is just going to be 0 because FIPS_STATUS_APPROVED is 0
-    assert_eq!(resp_hdr.chksum, 0);
+    assert!(caliptra_common::checksum::verify_checksum(
+        resp_hdr.chksum,
+        0x0,
+        &resp.as_bytes()[core::mem::size_of_val(&resp_hdr.chksum)..],
+    ));
     assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0);
 }
 

--- a/runtime/tests/runtime_integration_tests/test_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_ecdsa.rs
@@ -121,7 +121,7 @@ fn ecdsa_cmd_run_wycheproof() {
                         let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
                         assert_eq!(
                             resp_hdr.fips_status,
-                            MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+                            MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
                         );
                         assert!(caliptra_common::checksum::verify_checksum(
                             resp_hdr.chksum,
@@ -217,7 +217,7 @@ fn test_ecdsa_verify_cmd() {
 
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
     );
     assert!(caliptra_common::checksum::verify_checksum(
         resp_hdr.chksum,

--- a/runtime/tests/runtime_integration_tests/test_lms.rs
+++ b/runtime/tests/runtime_integration_tests/test_lms.rs
@@ -799,10 +799,13 @@ fn execute_lms_cmd<T: HwModel>(
 
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
     );
-    // Checksum is just going to be 0 because FIPS_STATUS_APPROVED is 0
-    assert_eq!(resp_hdr.chksum, 0);
+    assert!(caliptra_common::checksum::verify_checksum(
+        resp_hdr.chksum,
+        0x0,
+        &resp.as_bytes()[core::mem::size_of_val(&resp_hdr.chksum)..],
+    ));
     assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0);
 
     Ok(())

--- a/runtime/tests/runtime_integration_tests/test_lms.rs
+++ b/runtime/tests/runtime_integration_tests/test_lms.rs
@@ -799,7 +799,7 @@ fn execute_lms_cmd<T: HwModel>(
 
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
     );
     assert!(caliptra_common::checksum::verify_checksum(
         resp_hdr.chksum,

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -296,12 +296,27 @@ pub fn exec_cmd_ecdsa_verify<T: HwModel>(hw: &mut T) {
     });
     payload.populate_chksum().unwrap();
 
-    mbx_send_and_check_resp_hdr::<_, MailboxRespHeader>(
-        hw,
-        u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
-        payload.as_bytes().unwrap(),
+    let resp_bytes = hw
+        .mailbox_execute(
+            u32::from(CommandId::ECDSA384_SIGNATURE_VERIFY),
+            payload.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+
+    let resp_hdr = MailboxRespHeader::read_from_bytes(
+        &resp_bytes[..core::mem::size_of::<MailboxRespHeader>()],
     )
     .unwrap();
+    assert!(caliptra_common::checksum::verify_checksum(
+        resp_hdr.chksum,
+        0x0,
+        &resp_bytes[core::mem::size_of_val(&resp_hdr.chksum)..],
+    ));
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+    );
 }
 
 pub fn exec_cmd_stash_measurement<T: HwModel>(hw: &mut T) {

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -315,7 +315,7 @@ pub fn exec_cmd_ecdsa_verify<T: HwModel>(hw: &mut T) {
     ));
     assert_eq!(
         resp_hdr.fips_status,
-        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED
+        MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST
     );
 }
 


### PR DESCRIPTION
Update successful ECDSA384_SIGNATURE_VERIFY and LMS_SIGNATURE_VERIFY responses to report FIPS_NOT_APPROVED because those commands accept a caller-provided digest rather than the raw message. Keep signature failures as command failures, and update tests/docs for the new status.