### PR TITLE
[fix] Disallow UDS programming when debug intent is set

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-09179e6efe53f02863283cae3b5850aa3de1f5acd6ccf2da518936b1b30084092cdfc822c4859582973692e3708e8a6e  caliptra-rom-no-log.bin
-212e3f8a8b33a060731b4cc416db1cb3ef9561bea0cd9855b1fa12bfdc4daacdba140e6e4f62465f56a5a445a3950e0b  caliptra-rom-with-log.bin
+c2c3a1c7c3488f898bcdb785d686fda401f87609b91725a1110dee04e3ea18f2597fef5037b0ae58eeae23c7474a57c8  caliptra-rom-no-log.bin
+62954d1988b66176909d090c66cb82630271af74befa5576e45acf1a737be1890f09914188be419677436255d1ddb398  caliptra-rom-with-log.bin

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2232,6 +2232,11 @@ impl CaliptraError {
             0x01045001,
             "ROM UDS Programming Error: In passive mode"
         ),
+        (
+            ROM_UDS_PROG_DEBUG_INTENT_SET,
+            0x01045002,
+            "ROM UDS Programming Error: Debug intent set"
+        ),
         (ROM_GLOBAL_NMI, 0x01050001, "ROM Global Error: NMI"),
         (
             ROM_GLOBAL_EXCEPTION,

--- a/rom/dev/src/flow/uds_programming.rs
+++ b/rom/dev/src/flow/uds_programming.rs
@@ -30,6 +30,11 @@ impl UdsProgrammingFlow {
             return Ok(());
         }
 
+        if env.soc_ifc.ss_debug_intent() {
+            cprintln!("[uds] Debug intent is set.");
+            Err(CaliptraError::ROM_UDS_PROG_DEBUG_INTENT_SET)?;
+        }
+
         // Check if ROM is running in Subsystem mode.
         if !env.soc_ifc.subsystem_mode() {
             cprintln!("[uds] ROM is not in Active mode.");

--- a/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
+++ b/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
@@ -59,6 +59,39 @@ fn test_uds_programming_no_active_mode() {
 
 #[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI
 #[test]
+fn test_uds_programming_debug_intent_set() {
+    let security_state =
+        *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing);
+    let dbg_manuf_service = *DbgManufServiceRegReq::default().set_uds_program_req(true);
+    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env_fpga(cfg!(
+        feature = "fpga_subsystem"
+    )))
+    .unwrap();
+    let mut hw = caliptra_hw_model::new(
+        caliptra_hw_model::InitParams {
+            rom: &rom,
+            security_state,
+            dbg_manuf_service,
+            debug_intent: true,
+            subsystem_mode: true,
+            ..Default::default()
+        },
+        caliptra_hw_model::BootParams::default(),
+    )
+    .unwrap();
+
+    // Wait for fatal error
+    hw.step_until(|m| m.soc_ifc().cptra_fw_error_fatal().read() != 0);
+
+    // Verify fatal code is correct
+    assert_eq!(
+        hw.soc_ifc().cptra_fw_error_fatal().read(),
+        u32::from(CaliptraError::ROM_UDS_PROG_DEBUG_INTENT_SET)
+    );
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)] // No fuse controller in FPGA without MCI
+#[test]
 fn test_uds_programming_granularity_64bit() {
     let security_state =
         *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing);


### PR DESCRIPTION
Reject UDS programming when SS_DEBUG_INTENT.DEBUG_INTENT is set to avoid programming UDS from deterministic/fake RNG output in debug-intent flows.

Adds a ROM error code and regression coverage for the debug-intent case.