### PR TITLE
[update] Zeroize ROM state before acknowledging SHUTDOWN

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-e64cb7c702787ea8a34254ce05f6bdee2a36c03a3dfc049622a6e122765ddecefee1bbb242a26bc80977f78e8eacb42f  caliptra-rom-no-log.bin
-3d0491bab4bf8a4ebc6064195139e3a06843a6d90b15a4fa477376a90cedb070ce9e0463a2184004aa1204e39df4e138  caliptra-rom-with-log.bin
+4eaac4f4e668e973c89977a38a5419e6a01f2e78b9a36cdbc9ba9d982466da6fff26b18030b1a100d3972f7d62d27ce4  caliptra-rom-no-log.bin
+8e057b92acc9623a67c4a146452562f8eaa344126826eb78407a967c67bd479beae968e29d2e602c8cabbbc4f5f2384a  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-c2c3a1c7c3488f898bcdb785d686fda401f87609b91725a1110dee04e3ea18f2597fef5037b0ae58eeae23c7474a57c8  caliptra-rom-no-log.bin
-62954d1988b66176909d090c66cb82630271af74befa5576e45acf1a737be1890f09914188be419677436255d1ddb398  caliptra-rom-with-log.bin
+a5da1abd359df65d1541665c54475a44a48d15c2d858c2255d335e3ba9aabd95122a1cc1496c70ee804617ea14e83aa8  caliptra-rom-no-log.bin
+f87909b56e6849aac081c3b4930e957ec3f7169a446befac760f8e9c2f96b0b03c6fe9fe6bf4a71fd1338395173ecd84  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-a5da1abd359df65d1541665c54475a44a48d15c2d858c2255d335e3ba9aabd95122a1cc1496c70ee804617ea14e83aa8  caliptra-rom-no-log.bin
-f87909b56e6849aac081c3b4930e957ec3f7169a446befac760f8e9c2f96b0b03c6fe9fe6bf4a71fd1338395173ecd84  caliptra-rom-with-log.bin
+9a1600351c3791b46a998b44f57b6b460c0406fa0aa44da7f166a722317febb4c55301cd76af18b39b6ab7d954c7fee6  caliptra-rom-no-log.bin
+cf715364dab57f68a80c00623f714c8b1f3be6dde836e0dd9de194b9649e375892c6f4761f3a4970243d330ac370c319  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-09179e6efe53f02863283cae3b5850aa3de1f5acd6ccf2da518936b1b30084092cdfc822c4859582973692e3708e8a6e  caliptra-rom-no-log.bin
-212e3f8a8b33a060731b4cc416db1cb3ef9561bea0cd9855b1fa12bfdc4daacdba140e6e4f62465f56a5a445a3950e0b  caliptra-rom-with-log.bin
+e64cb7c702787ea8a34254ce05f6bdee2a36c03a3dfc049622a6e122765ddecefee1bbb242a26bc80977f78e8eacb42f  caliptra-rom-no-log.bin
+3d0491bab4bf8a4ebc6064195139e3a06843a6d90b15a4fa477376a90cedb070ce9e0463a2184004aa1204e39df4e138  caliptra-rom-with-log.bin

--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -217,6 +217,10 @@ impl Csrng {
     pub fn uninstantiate(mut self) {
         let _ = send_command(&mut self.csrng, Command::Uninstantiate);
     }
+
+    pub fn zeroize(&mut self) -> CaliptraResult<()> {
+        send_command(&mut self.csrng, Command::Uninstantiate)
+    }
 }
 
 fn check_for_alert_state(

--- a/drivers/src/trng.rs
+++ b/drivers/src/trng.rs
@@ -150,4 +150,18 @@ impl Trng {
         result.copy_from_slice(&a.0[..8]);
         Ok(crate::Array4x8::from(result))
     }
+
+    pub fn zeroize(&mut self) -> CaliptraResult<()> {
+        extern "C" {
+            fn cfi_panic_handler(code: u32) -> !;
+        }
+
+        match self {
+            Self::Internal(csrng) => csrng.zeroize(),
+            Self::External(_) | Self::MfgMode() => Ok(()),
+            _ => unsafe {
+                cfi_panic_handler(CaliptraError::ROM_CFI_PANIC_UNEXPECTED_MATCH_BRANCH.into())
+            },
+        }
+    }
 }

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -496,7 +496,7 @@ impl FirmwareProcessor {
                     mailbox::populate_checksum(response);
 
                     if CommandId::from(cmd) == CommandId::SHUTDOWN {
-                        Self::zeroize_shutdown_state()?;
+                        Self::zeroize_shutdown_state(env.trng)?;
                     }
 
                     txn.send_response(response)?;
@@ -530,9 +530,10 @@ impl FirmwareProcessor {
         }
     }
 
-    fn zeroize_shutdown_state() -> CaliptraResult<()> {
+    fn zeroize_shutdown_state(trng: &mut Trng) -> CaliptraResult<()> {
         let mut doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
         doe.clear_secrets()?;
+        trng.zeroize()?;
 
         unsafe {
             Aes::zeroize();

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -40,6 +40,7 @@ use caliptra_image_verify::{
     ImageVerificationInfo, ImageVerificationLogInfo, ImageVerifier, MAX_FIRMWARE_SVN,
 };
 use caliptra_kat::KatsEnv;
+use caliptra_registers::doe::DoeReg;
 use caliptra_x509::{NotAfter, NotBefore};
 use core::mem::{size_of, ManuallyDrop};
 use dma::AesDmaMode;
@@ -494,6 +495,10 @@ impl FirmwareProcessor {
                         .ok_or(CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
                     mailbox::populate_checksum(response);
 
+                    if CommandId::from(cmd) == CommandId::SHUTDOWN {
+                        Self::zeroize_shutdown_state()?;
+                    }
+
                     txn.send_response(response)?;
                 } else {
                     // Response length of 0 indicates failure (e.g., self test commands)
@@ -514,7 +519,8 @@ impl FirmwareProcessor {
                         }
                     }
                     CommandId::SHUTDOWN =>
-                    // Causing a ROM Fatal Error will zeroize the module
+                    // Zeroization was performed before acknowledging the command;
+                    // the fatal error parks ROM in the terminal shutdown state.
                     {
                         Err(CaliptraError::RUNTIME_SHUTDOWN)?
                     }
@@ -522,6 +528,27 @@ impl FirmwareProcessor {
                 };
             }
         }
+    }
+
+    fn zeroize_shutdown_state() -> CaliptraResult<()> {
+        let mut doe = unsafe { DeobfuscationEngine::new(DoeReg::new()) };
+        doe.clear_secrets()?;
+
+        unsafe {
+            Aes::zeroize();
+            Ecc384::zeroize();
+            Hmac::zeroize();
+            Mldsa87::zeroize_no_wait();
+            MlKem1024::zeroize_no_wait();
+            Sha256::zeroize();
+            Sha2_512_384::zeroize();
+            Sha2_512_384Acc::zeroize();
+            Sha3::zeroize();
+            KeyVault::zeroize();
+            Sha2_512_384Acc::lock();
+        }
+
+        Ok(())
     }
 
     /// Load the manifest

--- a/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/shutdown.rs
@@ -23,7 +23,8 @@ impl ShutdownCmd {
         MailboxReqHeader::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::FW_PROC_MAILBOX_INVALID_REQUEST_LENGTH)?;
 
-        // Zero value of response buffer is good
+        // The firmware processor zeroizes state before sending this response,
+        // then enters a terminal shutdown state after the response is sent.
         Ok(core::mem::size_of::<MailboxRespHeader>())
     }
 }

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -23,6 +23,7 @@ mod test_ocp_lock;
 mod test_panic_missing;
 mod test_pmp;
 mod test_rom_integrity;
+mod test_shutdown;
 mod test_symbols;
 mod test_uds_fe;
 mod test_update_reset;

--- a/rom/dev/tests/rom_integration_tests/test_shutdown.rs
+++ b/rom/dev/tests/rom_integration_tests/test_shutdown.rs
@@ -1,0 +1,44 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::{
+    mailbox::{CommandId, MailboxReqHeader, MailboxRespHeader},
+    SocManager,
+};
+use caliptra_hw_model::{Fuses, HwModel};
+use caliptra_kat::CaliptraError;
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::helpers;
+
+#[test]
+fn test_shutdown_cmd() {
+    let (mut hw, _image_bundle) =
+        helpers::build_hw_model_and_image_bundle(Fuses::default(), Default::default());
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::SHUTDOWN), &[]),
+    };
+
+    let response = hw
+        .mailbox_execute(CommandId::SHUTDOWN.into(), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let resp_hdr = MailboxRespHeader::ref_from_bytes(response.as_bytes()).unwrap();
+
+    assert!(caliptra_common::checksum::verify_checksum(
+        resp_hdr.chksum,
+        0x0,
+        &response.as_bytes()[core::mem::size_of_val(&resp_hdr.chksum)..],
+    ));
+
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    hw.step_until(|m| m.soc_ifc().cptra_fw_error_fatal().read() != 0);
+    assert_eq!(
+        hw.soc_ifc().cptra_fw_error_fatal().read(),
+        u32::from(CaliptraError::RUNTIME_SHUTDOWN)
+    );
+}


### PR DESCRIPTION
Clear ROM-owned CSP state, including DOE secrets, before sending the successful SHUTDOWN mailbox response. Keep the post-response fatal shutdown path so ROM enters the terminal shutdown state, and add integration coverage for the response-then-shutdown sequence.