### PR TITLE
[nightly]: Update DPE cert retrieval in tests

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -656,7 +656,7 @@ pub fn test_all_measurement_apis() {
 
         // Get DPE cert
         let dpe_cert_resp = get_dpe_leaf_cert(&mut hw);
-        let rom_stash_dpe_cert = dpe_cert_resp.cert().unwrap();
+        let rom_stash_dpe_cert = &dpe_cert_resp.cert[..dpe_cert_resp.cert_size as usize];
 
         //
         // 2. RUNTIME STASH MEASUREMENT
@@ -677,7 +677,7 @@ pub fn test_all_measurement_apis() {
 
         // Get DPE cert
         let dpe_cert_resp = get_dpe_leaf_cert(&mut hw);
-        let rt_stash_dpe_cert = &dpe_cert_resp.cert().unwrap();
+        let rt_stash_dpe_cert = &dpe_cert_resp.cert[..dpe_cert_resp.cert_size as usize];
 
         //
         // 3. DPE DERIVE CONTEXT
@@ -710,7 +710,7 @@ pub fn test_all_measurement_apis() {
 
         // Get DPE cert
         let dpe_cert_resp = get_dpe_leaf_cert(&mut hw);
-        let derive_context_dpe_cert = &dpe_cert_resp.cert().unwrap();
+        let derive_context_dpe_cert = &dpe_cert_resp.cert[..dpe_cert_resp.cert_size as usize];
 
         //
         // COMPARE CERTS
@@ -721,8 +721,8 @@ pub fn test_all_measurement_apis() {
             // This means the certificate won't match the cert produced with the ROM stashed measurement because the ROM measurement is _before_ the MCU FW measurement.
             assert_eq!(derive_context_dpe_cert, rt_stash_dpe_cert);
         } else {
-            assert_eq!(&rom_stash_dpe_cert, rt_stash_dpe_cert);
-            assert_eq!(&rom_stash_dpe_cert, derive_context_dpe_cert);
+            assert_eq!(rom_stash_dpe_cert, rt_stash_dpe_cert);
+            assert_eq!(rom_stash_dpe_cert, derive_context_dpe_cert);
         }
     }
 }


### PR DESCRIPTION
The nightly release was failing due to compilation errors in `runtime_integration_tests`. A previous commit updated `get_dpe_leaf_cert` to return `CertifyKeyP384Resp` instead of `CertifyKeyResp`, but did not update all callers. This PR fixes the compilation by accessing the `cert` field directly on `CertifyKeyP384Resp` and slicing it with `cert_size`, instead of calling the non-existent `cert()` method.