### PR TITLE
cherry-pick 2.0: test and reset fixes

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -883,6 +883,23 @@ pub trait HwModel: SocManager {
         self.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
     }
 
+    // TODO: refactor all uses of ready_for_fw() to use this method,
+    // since otherwise resets can be flaky.
+    /// Returns true if Caliptra core (and MCU if applicable) have completed
+    /// their boot flows.
+    fn boot_complete(&mut self) -> bool {
+        self.soc_ifc()
+            .cptra_flow_status()
+            .read()
+            .ready_for_runtime()
+            && self.boot_complete_mcu()
+    }
+
+    /// Returns true if MCU (if present) has complete its firmware boot flow.
+    fn boot_complete_mcu(&mut self) -> bool {
+        true
+    }
+
     /// Initializes the fuse values and locks them in until the next reset. This
     /// function can only be called during early boot, shortly after the model
     /// is created with `new_unbooted()`.

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -1308,6 +1308,11 @@ pub trait HwModel: SocManager {
     fn fuses(&self) -> &Fuses;
     /// Set the fuse settings. A cold boot will need to be done to take affect.
     fn set_fuses(&mut self, fuses: Fuses);
+
+    /// Get MCI BusMmio
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        panic!("mci unimplemented");
+    }
 }
 
 #[cfg(test)]

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -42,14 +42,23 @@ use crate::ModelError;
 use crate::Output;
 use crate::TrngMode;
 
+const EMULATOR_MCI_ADDR: u32 = 0x2100_0000;
+const EMULATOR_MCI_ADDR_RANGE_SIZE: u32 = 0xe0_0000;
+const EMULATOR_MCI_END_ADDR: u32 = EMULATOR_MCI_ADDR + EMULATOR_MCI_ADDR_RANGE_SIZE - 1;
+
 pub struct EmulatedApbBus<'a> {
     model: &'a mut ModelEmulated,
 }
 
 impl Bus for EmulatedApbBus<'_> {
     fn read(&mut self, size: RvSize, addr: RvAddr) -> Result<RvData, caliptra_emu_bus::BusError> {
-        let result = self.model.soc_to_caliptra_bus.read(size, addr);
-        self.model.cpu.bus.log_read("SoC", size, addr, result);
+        let (result, name) = match addr {
+            EMULATOR_MCI_ADDR..=EMULATOR_MCI_END_ADDR => {
+                (self.model.mci.read(size, addr - EMULATOR_MCI_ADDR), "MCI")
+            }
+            _ => (self.model.soc_to_caliptra_bus.read(size, addr), "SoC"),
+        };
+        self.model.cpu.bus.log_read(name, size, addr, result);
         result
     }
     fn write(
@@ -58,8 +67,14 @@ impl Bus for EmulatedApbBus<'_> {
         addr: RvAddr,
         val: RvData,
     ) -> Result<(), caliptra_emu_bus::BusError> {
-        let result = self.model.soc_to_caliptra_bus.write(size, addr, val);
-        self.model.cpu.bus.log_write("SoC", size, addr, val, result);
+        let (result, name) = match addr {
+            EMULATOR_MCI_ADDR..=EMULATOR_MCI_END_ADDR => (
+                self.model.mci.write(size, addr - EMULATOR_MCI_ADDR, val),
+                "MCI",
+            ),
+            _ => (self.model.soc_to_caliptra_bus.write(size, addr, val), "SoC"),
+        };
+        self.model.cpu.bus.log_write(name, size, addr, val, result);
         result
     }
 }
@@ -279,6 +294,18 @@ impl HwModel for ModelEmulated {
     }
     fn apb_bus(&mut self) -> Self::TBus<'_> {
         EmulatedApbBus { model: self }
+    }
+
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        if !self.subsystem_mode() {
+            panic!("Tried to use the MCI interface in Core only mode")
+        }
+        unsafe {
+            caliptra_registers::mci::RegisterBlock::new_with_mmio(
+                EMULATOR_MCI_ADDR as *mut u32,
+                self.mmio_mut(),
+            )
+        }
     }
 
     fn step(&mut self) {

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1630,6 +1630,22 @@ impl ModelFpgaSubsystem {
         unsafe { core::slice::from_raw_parts_mut(self.otp_mem_backdoor, OTP_SIZE) }
     }
 
+    /// Override the lifecycle controller state that will be provisioned into
+    /// OTP on the next `cold_reset()`. Useful for tests that perform JTAG
+    /// lifecycle transitions and need the new state to survive a cold reset.
+    pub fn set_saved_lc_state(&mut self, lc_state: Option<LifecycleControllerState>) {
+        self.saved_lc_state = lc_state;
+    }
+
+    /// Replace the OTP initialization bytes used on the next `cold_reset()`.
+    /// `setup_hardware_registers()` zeros the OTP slice and then re-provisions
+    /// it from `otp_init` (when non-empty) plus the saved init params, so
+    /// callers can use this to seed OTP contents that should survive a cold
+    /// reset (e.g., to simulate persistent OTP state across boots in tests).
+    pub fn set_otp_init(&mut self, otp_init: Vec<u8>) {
+        self.otp_init = otp_init;
+    }
+
     pub fn flash_slice(&self) -> &mut [u8] {
         unsafe {
             core::slice::from_raw_parts_mut(

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2172,6 +2172,11 @@ impl HwModel for ModelFpgaSubsystem {
     fn set_fuses(&mut self, fuses: Fuses) {
         self.fuses = fuses;
     }
+
+    fn boot_complete_mcu(&mut self) -> bool {
+        self.mci_boot_milestones()
+            .contains(McuBootMilestones::FIRMWARE_BOOT_FLOW_COMPLETE)
+    }
 }
 
 pub struct FpgaRealtimeBus<'a> {

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -417,6 +417,9 @@ pub struct ModelFpgaSubsystem {
 
     pub realtime_thread: Option<thread::JoinHandle<()>>,
     pub realtime_thread_exit_flag: Arc<AtomicBool>,
+    /// Set while a cold reset is in progress so the realtime thread does not
+    /// touch the AXI bus and crash the FPGA driver. Adapted from #3413.
+    pub realtime_thread_paused: Arc<AtomicBool>,
 
     pub fuses: Fuses,
     pub otp_init: Vec<u8>,
@@ -437,6 +440,23 @@ pub struct ModelFpgaSubsystem {
     pub secondary_flash: Vec<u8>,
     // whether or not to attempt flash boot instead of streaming boot
     pub flash_boot: bool,
+
+    // Init params saved at construction time so that `cold_reset()` can
+    // re-program every FPGA wrapper register that AXI reset clears. Adapted
+    // from #3413.
+    saved_input_wires: [u32; 2],
+    saved_cptra_obf_key: [u32; 8],
+    saved_csr_hmac_key: [u32; 16],
+    saved_uds_seed: [u32; 16],
+    saved_field_entropy: [u32; 8],
+    saved_use_strap_secrets: bool,
+    saved_raw_unlock_token_hash: [u32; 4],
+    saved_rma_or_scrap_ppd: bool,
+    saved_debug_intent: bool,
+    saved_prod_dbg_unlock_pk_hashes_offset: u32,
+    saved_num_prod_dbg_unlock_pk_hashes: u32,
+    saved_security_state: SecurityState,
+    saved_lc_state: Option<LifecycleControllerState>,
 }
 
 impl ModelFpgaSubsystem {
@@ -492,6 +512,77 @@ impl ModelFpgaSubsystem {
         self.wrapper.regs().control.modify(Control::AxiReset.val(1));
         // wait a few clock cycles or we can crash the FPGA
         std::thread::sleep(std::time::Duration::from_micros(1));
+    }
+
+    /// Re-program every FPGA wrapper register that AXI reset clears. Used at
+    /// both initial boot and after `cold_reset()`. Adapted from #3413.
+    fn setup_hardware_registers(&mut self) {
+        let input_wires = self.saved_input_wires;
+        let cptra_obf_key = self.saved_cptra_obf_key;
+        let csr_hmac_key = self.saved_csr_hmac_key;
+        let uds_seed = self.saved_uds_seed;
+        let field_entropy = self.saved_field_entropy;
+        let use_strap_secrets = self.saved_use_strap_secrets;
+        let raw_unlock_token_hash = self.saved_raw_unlock_token_hash;
+        let rma_or_scrap_ppd = self.saved_rma_or_scrap_ppd;
+        let debug_intent = self.saved_debug_intent;
+        let bootfsm_break = self.bootfsm_break;
+        let prod_dbg_offset = self.saved_prod_dbg_unlock_pk_hashes_offset;
+        let num_prod_dbg = self.saved_num_prod_dbg_unlock_pk_hashes;
+        let security_state = self.saved_security_state;
+        let lc_state = self.saved_lc_state;
+
+        self.set_generic_input_wires(&input_wires);
+        self.set_mci_generic_input_wires(&[0, 0]);
+
+        self.set_itrng_divider(ITRNG_DIVISOR);
+
+        for i in 0..8 {
+            self.wrapper.regs().cptra_obf_key[i].set(cptra_obf_key[i]);
+        }
+        for i in 0..16 {
+            self.wrapper.regs().cptra_csr_hmac_key[i].set(csr_hmac_key[i]);
+        }
+        for (i, udsi) in uds_seed.iter().copied().enumerate() {
+            self.wrapper.regs().cptra_obf_uds_seed[i].set(udsi);
+        }
+        for (i, fei) in field_entropy.iter().copied().enumerate() {
+            self.wrapper.regs().cptra_obf_field_entropy[i].set(fei);
+        }
+        self.set_secrets_valid(use_strap_secrets);
+
+        self.set_subsystem_reset(true);
+
+        // Declaring this vec! gets LLVM to emit a memcpy. Otherwise, writes
+        // to the FPGA block RAM fail with a SIGBUS fault.
+        let zeroed_otp = vec![0u8; OTP_SIZE];
+        self.otp_slice().copy_from_slice(&zeroed_otp);
+        self.init_otp_with_lc_override(Some(&security_state), lc_state)
+            .expect("Failed to re-initialize OTP after cold reset");
+
+        self.clear_logs();
+
+        self.set_axi_user(DEFAULT_AXI_PAUSER);
+
+        self.set_raw_unlock_token_hash(&raw_unlock_token_hash);
+        self.set_ss_rma_or_scrap_ppd(rma_or_scrap_ppd);
+        self.set_ss_debug_intent(debug_intent);
+        self.set_bootfsm_break(bootfsm_break);
+        self.wrapper
+            .regs()
+            .prod_debug_unlock_auth_pk_hash_reg_bank_offset
+            .set(prod_dbg_offset);
+        self.wrapper
+            .regs()
+            .num_of_prod_debug_unlock_auth_pk_hashes
+            .set(num_prod_dbg);
+
+        self.wrapper
+            .regs()
+            .mcu_reset_vector
+            .set(FPGA_MEMORY_MAP.rom_offset);
+
+        self.set_subsystem_reset(false);
     }
 
     pub fn set_subsystem_reset(&mut self, reset: bool) {
@@ -744,6 +835,7 @@ impl ModelFpgaSubsystem {
     fn realtime_thread_itrng_fn(
         wrapper: Arc<Wrapper>,
         running: Arc<AtomicBool>,
+        paused: Arc<AtomicBool>,
         mut itrng_nibbles: Box<dyn Iterator<Item = u8> + Send>,
     ) {
         // Reset ITRNG FIFO to clear out old data
@@ -761,6 +853,11 @@ impl ModelFpgaSubsystem {
         thread::sleep(Duration::from_millis(1));
 
         while running.load(Ordering::Relaxed) {
+            if paused.load(Ordering::Relaxed) {
+                // Cold reset is in progress; do not touch the AXI bus.
+                thread::sleep(Duration::from_millis(1));
+                continue;
+            }
             // Once TRNG data is requested the FIFO will continously empty. Load at max one FIFO load at a time.
             // FPGA ITRNG FIFO is 1024 DW deep.
             for _ in 0..FPGA_ITRNG_FIFO_SIZE {
@@ -1682,6 +1779,8 @@ impl HwModel for ModelFpgaSubsystem {
 
         let realtime_thread_exit_flag = Arc::new(AtomicBool::new(true));
         let realtime_thread_exit_flag2 = realtime_thread_exit_flag.clone();
+        let realtime_thread_paused = Arc::new(AtomicBool::new(false));
+        let realtime_thread_paused2 = realtime_thread_paused.clone();
         let realtime_wrapper = wrapper.clone();
 
         let xi3c_config = xi3c::Config {
@@ -1736,6 +1835,7 @@ impl HwModel for ModelFpgaSubsystem {
             fuses: params.fuses,
             realtime_thread: None,
             realtime_thread_exit_flag,
+            realtime_thread_paused,
 
             output,
             recovery_started: false,
@@ -1766,6 +1866,24 @@ impl HwModel for ModelFpgaSubsystem {
                 .ss_init_params
                 .primary_flash_initial_contents
                 .is_some(),
+
+            saved_input_wires: [(!params.uds_granularity_64 as u32) << 31, 0],
+            saved_cptra_obf_key: params.cptra_obf_key,
+            saved_csr_hmac_key: params.csr_hmac_key,
+            saved_uds_seed: DEFAULT_UDS_SEED,
+            saved_field_entropy: DEFAULT_FIELD_ENTROPY,
+            saved_use_strap_secrets: params.ss_init_params.use_strap_secrets,
+            saved_raw_unlock_token_hash: params.ss_init_params.raw_unlock_token_hash,
+            saved_rma_or_scrap_ppd: params.ss_init_params.rma_or_scrap_ppd,
+            saved_debug_intent: params.debug_intent,
+            saved_prod_dbg_unlock_pk_hashes_offset: params
+                .ss_init_params
+                .prod_dbg_unlock_pk_hashes_offset,
+            saved_num_prod_dbg_unlock_pk_hashes: params
+                .ss_init_params
+                .num_prod_dbg_unlock_pk_hashes,
+            saved_security_state: params.security_state,
+            saved_lc_state: params.ss_init_params.lc_state,
         };
 
         println!("AXI reset");
@@ -1777,6 +1895,7 @@ impl HwModel for ModelFpgaSubsystem {
             Self::realtime_thread_itrng_fn(
                 realtime_wrapper,
                 realtime_thread_exit_flag2,
+                realtime_thread_paused2,
                 params.itrng_nibbles,
             )
         }));
@@ -2162,11 +2281,31 @@ impl HwModel for ModelFpgaSubsystem {
     }
 
     fn cold_reset(&mut self) {
-        self.set_subsystem_reset(true);
-        std::thread::sleep(std::time::Duration::from_micros(1));
-        self.init_otp(None)
-            .expect("Failed to initialize OTP after cold reset");
-        self.set_subsystem_reset(false);
+        // Adapted from #3413: pause the realtime TRNG thread so it does not
+        // touch the AXI bus during the reset, perform a full AXI reset to
+        // clear all subsystem state (the prior implementation only toggled
+        // CptraSsRstB/CptraPwrgood and the subsystem would intermittently
+        // fail to come out of reset on FPGA), then re-program every FPGA
+        // wrapper register that AXI reset clears.
+
+        // wait a bit for MCU to finish writing any pending log/exit status
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        // Pause the TRNG thread so it doesn't access the AXI bus during reset
+        self.realtime_thread_paused
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+
+        // Full AXI reset to clear all subsystem state including MCU
+        println!("AXI reset");
+        self.axi_reset();
+
+        // Re-program all hardware registers cleared by AXI reset
+        self.setup_hardware_registers();
+
+        // Resume the TRNG thread
+        self.realtime_thread_paused
+            .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn fuses(&self) -> &Fuses {

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -205,7 +205,7 @@ pub struct Mci {
 }
 
 impl Mci {
-    pub fn regs(&self) -> caliptra_registers::mci::RegisterBlock<BusMmio<FpgaRealtimeBus<'_>>> {
+    pub fn regs<'a>(&self) -> caliptra_registers::mci::RegisterBlock<BusMmio<FpgaRealtimeBus<'a>>> {
         unsafe {
             caliptra_registers::mci::RegisterBlock::new_with_mmio(
                 EMULATOR_MCI_ADDR as *mut u32,
@@ -1608,6 +1608,10 @@ impl HwModel for ModelFpgaSubsystem {
             mmio: self.mmio.caliptra_mmio().unwrap(),
             phantom: Default::default(),
         }
+    }
+
+    fn mci(&mut self) -> caliptra_registers::mci::RegisterBlock<Self::TMmio<'_>> {
+        self.mmio.mci().unwrap().regs()
     }
 
     fn step(&mut self) {

--- a/hw-model/src/output.rs
+++ b/hw-model/src/output.rs
@@ -24,6 +24,17 @@ struct OutputSinkImpl {
     char_buffer: Cell<PartialUtf8>, // it's faster to copy than to manage a RefCell
 }
 
+/// Returns the largest byte index `<= pos` that lies on a UTF-8 character
+/// boundary in `s`. This is a stable replacement for the still-unstable
+/// `str::floor_char_boundary`.
+fn floor_char_boundary(s: &str, pos: usize) -> usize {
+    let mut pos = pos.min(s.len());
+    while pos > 0 && !s.is_char_boundary(pos) {
+        pos -= 1;
+    }
+    pos
+}
+
 struct PrettyU64(u64);
 impl Display for PrettyU64 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -355,7 +366,8 @@ impl Output {
         if let Some(term) = &self.search_term {
             if !self.search_matched {
                 self.search_matched = self.output[self.search_pos..].contains(term);
-                self.search_pos = self.output.len().saturating_sub(term.len());
+                self.search_pos =
+                    floor_char_boundary(&self.output, self.output.len().saturating_sub(term.len()));
                 if self.search_matched {
                     self.search_term = None;
                 }
@@ -537,5 +549,70 @@ mod tests {
         assert!(out.search_matched);
         out.set_search_term("string");
         assert!(!out.search_matched);
+    }
+
+    #[test]
+    fn test_search_with_utf8_output() {
+        // Regression test: previously, process_new_data() set search_pos to
+        // `output.len() - term.len()` without aligning to a UTF-8 character
+        // boundary. If the UART output contained multi-byte UTF-8 characters,
+        // a later read of `self.output[self.search_pos..]` would panic.
+
+        let mut out = Output::new(Log::new());
+        out.set_search_term("xx");
+        assert!(!out.search_matched());
+
+        // Push a 3-byte snowman codepoint: ☃ = 0xE2 0x98 0x83.
+        // After process_new_data(), the buggy code sets
+        // search_pos = 3 - 2 = 1, which is in the middle of ☃.
+        for &ch in "☃".as_bytes() {
+            out.sink.push_uart_char(ch);
+        }
+        // Force the search bookkeeping to run; this also exercises the
+        // path that previously left search_pos at a non-boundary index.
+        let _ = out.peek();
+        assert!(!out.search_matched());
+
+        // Push another byte. The buggy code now slices output[1..],
+        // which panics because byte 1 is mid-codepoint.
+        out.sink.push_uart_char(b'a');
+        let _ = out.peek();
+        assert!(!out.search_matched());
+
+        // The search should still be able to match after the multi-byte
+        // character.
+        for &ch in b"xx" {
+            out.sink.push_uart_char(ch);
+        }
+        let _ = out.peek();
+        assert!(out.search_matched());
+    }
+
+    #[test]
+    fn test_search_match_spanning_utf8_boundary() {
+        // Ensure that aligning search_pos down to a char boundary doesn't
+        // cause us to miss a match whose tail lands in subsequent data after
+        // the boundary is clamped back past a multi-byte character.
+        let mut out = Output::new(Log::new());
+        for &ch in b"abc" {
+            out.sink.push_uart_char(ch);
+        }
+        out.set_search_term("xx");
+        // Push a 3-byte snowman: ☃. The buggy code would set
+        // search_pos = output.len() - term.len() = 6 - 2 = 4, which is
+        // mid-codepoint. After the fix, search_pos is clamped down to 3.
+        for &ch in "☃".as_bytes() {
+            out.sink.push_uart_char(ch);
+        }
+        let _ = out.peek();
+        assert!(!out.search_matched());
+
+        // Now push "xx"; the match must still be found even though the
+        // previous search_pos was adjacent to a multi-byte boundary.
+        for &ch in b"xx" {
+            out.sink.push_uart_char(ch);
+        }
+        let _ = out.peek();
+        assert!(out.search_matched());
     }
 }

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use core::mem::offset_of;
 
-use crate::authorize_and_stash::AuthorizeAndStashCmd;
+use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
 use crate::drivers::{McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
@@ -208,17 +208,22 @@ impl ActivateFirmwareCmd {
                 measurement: [0; 48],
                 source: ImageHashSource::LoadAddress.into(),
                 flags: AuthAndStashFlags::SKIP_STASH.bits(),
+                image_size: mcu_image_size,
                 ..Default::default()
             };
 
             let pl0_pauser_locality = drivers.persistent_data.get().manifest1.header.pl0_pauser;
-            AuthorizeAndStashCmd::authorize_and_stash(
+            let authorization_result = AuthorizeAndStashCmd::authorize_and_stash(
                 drivers,
                 &auth_and_stash_req,
                 pl0_pauser_locality,
             )
-            .map(|_| ())
             .map_err(|_| ())?;
+
+            // Make sure the image was properly authorized.
+            if authorization_result != authorize_and_stash::IMAGE_AUTHORIZED {
+                return Err(());
+            }
 
             drivers.persistent_data.get_mut().mcu_firmware_loaded = McuFwStatus::Loaded.into();
         }

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -17,11 +17,17 @@ pub const TEST_SRAM_SIZE: usize = 0x1000;
 
 #[cfg(feature = "fpga_subsystem")]
 const MCI_BASE: u32 = 0xA8000000;
+// On the FPGA subsystem the test stages firmware in MCU SRAM directly (the
+// same region the production DMA in `ActivateFirmware` writes to). This way
+// the post-DMA `AuthorizeAndStash(LoadAddress)` (added in #3719) reads from
+// the same address Caliptra just DMA'd into, and the test never has to
+// acquire the MCU mailbox SRAM lock (which would block the MCU ROM's
+// hitless-update flow when MCU comes out of reset).
 #[cfg(feature = "fpga_subsystem")]
-const MCU_MBOX_SRAM_BASE: u32 = MCI_BASE + 0x400000;
+const MCU_SRAM_BASE: u32 = MCI_BASE + 0xC00000;
 #[cfg(feature = "fpga_subsystem")]
 pub const TEST_SRAM_BASE: Addr64 = Addr64 {
-    lo: MCU_MBOX_SRAM_BASE,
+    lo: MCU_SRAM_BASE,
     hi: 0x0000_0000,
 };
 
@@ -97,6 +103,21 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
         assert!(staging_address + image_size <= TEST_SRAM_SIZE);
         test_sram_contents[staging_address..staging_address + image_size]
             .copy_from_slice(&image.contents);
+
+        // On the emulator, the test SRAM (where staging lives) and MCU SRAM
+        // (the DMA destination used by `ActivateFirmware`) are distinct
+        // regions, so the post-DMA `AuthorizeAndStash(LoadAddress)` added in
+        // #3719 would otherwise read zeros at `load_address`. Seed the test
+        // SRAM at the load offset so the hash matches. On the FPGA subsystem
+        // the staging area *is* MCU SRAM, so Caliptra's DMA fills the load
+        // address for us and no seeding is needed.
+        #[cfg(not(feature = "fpga_subsystem"))]
+        {
+            let load_address = image.load_address.lo as usize - TEST_SRAM_BASE.lo as usize;
+            assert!(load_address + image_size <= TEST_SRAM_SIZE);
+            test_sram_contents[load_address..load_address + image_size]
+                .copy_from_slice(&image.contents);
+        }
     }
 
     let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
@@ -108,7 +129,7 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
 
     #[cfg(feature = "fpga_subsystem")]
     {
-        crate::test_authorize_and_stash::write_mcu_mbox_sram(&mut model, &test_sram_contents);
+        write_payload_to_mcu_sram(&mut model, &test_sram_contents);
     }
 
     for image in images {
@@ -137,6 +158,25 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
         assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
     }
     model
+}
+
+// Write the staged test payload directly into MCU SRAM (the same region
+// Caliptra's `ActivateFirmware` DMAs into). Unlike `write_mcu_mbox_sram`,
+// this does not acquire the MCU mailbox SRAM lock, so the MCU ROM remains
+// free to use its mailbox during the hitless-update flow that ACTF triggers.
+#[cfg(feature = "fpga_subsystem")]
+fn write_payload_to_mcu_sram(model: &mut DefaultHwModel, data: &[u8]) {
+    assert!(data.len() % 4 == 0, "payload length must be 4-byte aligned");
+    unsafe {
+        let mcu_sram_ptr = model.mmio.mci().unwrap().ptr.add(0xC00000 / 4) as *mut u32;
+        for (count, chunk) in data.chunks(4).enumerate() {
+            // Match the byte ordering used by `write_mcu_mbox_sram` for the
+            // sibling MCU mailbox SRAM region on this same MCI MMIO window.
+            mcu_sram_ptr
+                .add(count)
+                .write_volatile(u32::from_be_bytes(chunk.try_into().unwrap()));
+        }
+    }
 }
 
 fn send_activate_firmware_cmd(

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -1,22 +1,19 @@
 // Licensed under the Apache-2.0 license
-use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::test_authorize_and_stash::set_auth_manifest_with_test_sram;
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_api::mailbox::{ActivateFirmwareFlags, ActivateFirmwareReq};
-use caliptra_api::SocManager;
+use caliptra_api::mailbox::ActivateFirmwareReq;
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
-use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
     MailboxReqHeader,
 };
-use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, ModelError};
-use caliptra_kat::CaliptraError;
+use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
 use caliptra_runtime::IMAGE_AUTHORIZED;
 use sha2::{Digest, Sha384};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::FromBytes;
 
-pub const TEST_SRAM_SIZE: usize = 64 * 1024; // 64 KB
+pub const TEST_SRAM_SIZE: usize = 0x1000;
 
 #[cfg(feature = "fpga_subsystem")]
 const MCI_BASE: u32 = 0xA8000000;
@@ -38,13 +35,25 @@ pub const MCU_FW_ID_1: u32 = 0x2;
 pub const SOC_FW_ID_1: u32 = 0x3;
 pub const INVALID_FW_ID: u32 = 128;
 
-pub const MCU_LOAD_OFFSET: usize = 0x000;
+pub const MCU_LOAD_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo,
+    hi: 0x0000_0000,
+};
 
-pub const MCU_STAGING_OFFSET: usize = 0x200;
+pub const MCU_STAGING_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo + 0x200,
+    hi: 0x0000_0000,
+};
 
-pub const SOC_LOAD_OFFSET: usize = 0x100;
+pub const SOC_LOAD_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo + 0x100,
+    hi: 0x0000_0000,
+};
 
-pub const SOC_STAGING_OFFSET: usize = 0x300;
+pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo + 0x300,
+    hi: 0x0000_0000,
+};
 
 pub const MCU_FW_SIZE: usize = 256;
 pub const SOC_FW_SIZE: usize = 256;
@@ -52,101 +61,63 @@ pub const SOC_FW_SIZE: usize = 256;
 #[derive(Debug, Clone)]
 struct Image {
     pub fw_id: u32,
-    pub staging_offset: usize,
-    pub load_offset: usize,
+    pub staging_address: Addr64,
+    pub load_address: Addr64,
     pub exec_bit: u8,
     pub contents: Vec<u8>,
 }
 
 fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
-    let staging_addr = caliptra_hw_model::new_unbooted(InitParams {
-        subsystem_mode: true,
-        ..Default::default()
-    })
-    .unwrap()
-    .staging_physical_address()
-    .unwrap();
-
     let mut image_metadata = Vec::new();
+    let mut test_sram_contents = vec![0u8; TEST_SRAM_SIZE];
     for image in images {
         let mut flags = ImageMetadataFlags(0);
         flags.set_ignore_auth_check(false);
         flags.set_image_source(ImageHashSource::StagingAddress as u32);
         flags.set_exec_bit(image.exec_bit as u32);
 
+        let load_memory_contents = image.contents.clone();
+
         let mut hasher = Sha384::new();
-        hasher.update(&image.contents);
+        hasher.update(load_memory_contents);
         let fw_digest = hasher.finalize();
-
-        let image_staging_address = Addr64 {
-            lo: staging_addr as u32 + image.staging_offset as u32,
-            hi: (staging_addr >> 32) as u32,
-        };
-
-        let image_load_address = Addr64 {
-            lo: staging_addr as u32 + image.load_offset as u32,
-            hi: (staging_addr >> 32) as u32,
-        };
 
         image_metadata.push(AuthManifestImageMetadata {
             fw_id: image.fw_id,
             flags: flags.0,
             digest: fw_digest.into(),
-            image_staging_address,
-            image_load_address,
+            image_staging_address: image.staging_address,
+            image_load_address: image.load_address,
             ..Default::default()
         });
+
+        // Load the firmware contents into the staging area in test SRAM
+        let staging_address = image.staging_address.lo as usize - TEST_SRAM_BASE.lo as usize;
+        let image_size = image.contents.len();
+        assert!(staging_address + image_size <= TEST_SRAM_SIZE);
+        test_sram_contents[staging_address..staging_address + image_size]
+            .copy_from_slice(&image.contents);
     }
 
     let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
-    let runtime_args = RuntimeTestArgs {
-        subsystem_mode: true,
-        test_image_options: Some(caliptra_builder::ImageOptions {
-            pqc_key_type: caliptra_image_types::FwVerificationPqcKeyType::LMS,
-            ..Default::default()
-        }),
-        soc_manifest: Some(auth_manifest.as_bytes()),
-        mcu_fw_image: Some(&images[0].contents),
-        ..Default::default()
-    };
-    let mut model = run_rt_test(runtime_args);
+    let mut model = set_auth_manifest_with_test_sram(
+        Some(auth_manifest),
+        &test_sram_contents,
+        &images[0].contents,
+    );
 
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read()
-            == u32::from(caliptra_runtime::RtBootStatus::RtReadyForCommands)
-    });
-
-    let mut set_auth_manifest_cmd =
-        MailboxReq::SetAuthManifest(caliptra_common::mailbox_api::SetAuthManifestReq {
-            hdr: MailboxReqHeader { chksum: 0 },
-            manifest_size: auth_manifest.as_bytes().len() as u32,
-            manifest: {
-                let mut slice =
-                    [0u8; caliptra_common::mailbox_api::SetAuthManifestReq::MAX_MAN_SIZE];
-                slice[..auth_manifest.as_bytes().len()].copy_from_slice(auth_manifest.as_bytes());
-                slice
-            },
-        });
-    set_auth_manifest_cmd.populate_chksum().unwrap();
-
-    model
-        .mailbox_execute(
-            u32::from(CommandId::SET_AUTH_MANIFEST),
-            set_auth_manifest_cmd.as_bytes().unwrap(),
-        )
-        .unwrap()
-        .expect("We should have received a response");
+    #[cfg(feature = "fpga_subsystem")]
+    {
+        crate::test_authorize_and_stash::write_mcu_mbox_sram(&mut model, &test_sram_contents);
+    }
 
     for image in images {
-        model
-            .write_payload_to_ss_staging_area(&image.contents, image.staging_offset)
-            .unwrap();
         let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
             hdr: MailboxReqHeader { chksum: 0 },
             fw_id: image.fw_id.to_le_bytes(),
             measurement: [0; 48],
             source: ImageHashSource::StagingAddress as u32,
-            flags: 1, // Skip stash
+            flags: 0, // Don't skip stash
             image_size: image.contents.len() as u32,
             ..Default::default()
         });
@@ -179,13 +150,20 @@ fn send_activate_firmware_cmd(
             activate_cmd.as_bytes().unwrap(),
         )
         .unwrap();
-    if reset_expected {
-        #[cfg(feature = "fpga_subsystem")]
-        {
+    #[cfg(feature = "fpga_subsystem")]
+    {
+        if reset_expected {
             let clear_interrupt = |model: &mut DefaultHwModel| {
                 let mut retry_count = 10;
                 loop {
-                    let intr_status = model.mci().intr_block_rf().notif0_internal_intr_r().read();
+                    let intr_status = model
+                        .mmio
+                        .mci()
+                        .unwrap()
+                        .regs()
+                        .intr_block_rf()
+                        .notif0_internal_intr_r()
+                        .read();
                     if intr_status.notif_cptra_mcu_reset_req_sts() {
                         break;
                     }
@@ -196,31 +174,33 @@ fn send_activate_firmware_cmd(
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
                 model
+                    .mmio
                     .mci()
+                    .unwrap()
+                    .regs()
                     .intr_block_rf()
                     .notif0_internal_intr_r()
                     .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
-                model.mci().reset_request().modify(|r| r.mcu_req(true));
+                model
+                    .mmio
+                    .mci()
+                    .unwrap()
+                    .regs()
+                    .reset_request()
+                    .modify(|r| r.mcu_req(true));
             };
             clear_interrupt(model);
         }
-        #[cfg(all(
-            not(feature = "verilator"),
-            not(feature = "fpga_realtime"),
-            not(feature = "fpga_subsystem")
-        ))]
-        {
-            model.step_until(|m| {
-                let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
-                intr_status.notif_cptra_mcu_reset_req_sts()
-            });
-            model
-                .mci()
-                .intr_block_rf()
-                .notif0_internal_intr_r()
-                .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
-            model.mci().reset_request().modify(|r| r.mcu_req(true));
-        }
+    }
+    #[cfg(all(
+        not(feature = "verilator"),
+        not(feature = "fpga_realtime"),
+        not(feature = "fpga_subsystem")
+    ))]
+    {
+        let _ = reset_expected;
+        // In emulator mode, since FW_EXEC_CTRL bit is already cleared,
+        // the MCU will be already in reset state
     }
     model.finish_mailbox_execute()
 }
@@ -230,8 +210,8 @@ fn send_activate_firmware_cmd(
 fn test_activate_mcu_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -248,7 +228,6 @@ fn test_activate_mcu_fw_success() {
             arr[0] = MCU_FW_ID_1;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
     send_activate_firmware_cmd(&mut model, activate_cmd, true)
@@ -261,16 +240,16 @@ fn test_activate_mcu_fw_success() {
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -288,7 +267,6 @@ fn test_activate_mcu_soc_fw_success() {
             arr[1] = SOC_FW_ID_1;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -302,16 +280,16 @@ fn test_activate_mcu_soc_fw_success() {
 fn test_activate_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -328,7 +306,6 @@ fn test_activate_soc_fw_success() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -342,16 +319,16 @@ fn test_activate_soc_fw_success() {
 fn test_activate_invalid_fw_id() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -368,7 +345,6 @@ fn test_activate_invalid_fw_id() {
             arr[0] = INVALID_FW_ID;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -380,16 +356,16 @@ fn test_activate_invalid_fw_id() {
 fn test_activate_fw_id_not_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -406,7 +382,6 @@ fn test_activate_fw_id_not_in_manifest() {
             arr[0] = INVALID_FW_ID;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -418,16 +393,16 @@ fn test_activate_fw_id_not_in_manifest() {
 fn test_invalid_exec_bit_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
+        staging_address: MCU_STAGING_ADDRESS,
+        load_address: MCU_LOAD_ADDRESS,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
+        staging_address: SOC_STAGING_ADDRESS,
+        load_address: SOC_LOAD_ADDRESS,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 0,
     };
@@ -444,267 +419,8 @@ fn test_invalid_exec_bit_in_manifest() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
-        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
     assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
-}
-
-/// Backward-compat: clients that pre-date the `flags` field send a request
-/// truncated to `size_of::<ActivateFirmwareReq>() - 4` bytes (no `flags`
-/// trailer). The runtime must treat the missing field as zero and proceed
-/// with the hitless-update path that those clients expect.
-#[cfg_attr(feature = "fpga_realtime", ignore)]
-#[test]
-fn test_activate_firmware_old_format_no_flags() {
-    let mcu_image = Image {
-        fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
-        exec_bit: 2,
-    };
-
-    let mut model = load_and_authorize_fw(&[mcu_image]);
-
-    // Build the request via the current `ActivateFirmwareReq` struct (which
-    // includes `flags`), then truncate the trailing `flags` u32 off the wire
-    // bytes so the runtime parser sees exactly what an old client would have
-    // sent. Compute the checksum over the truncated bytes (excluding the
-    // 4-byte `chksum` field).
-    let req = ActivateFirmwareReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        fw_id_count: 1,
-        mcu_fw_image_size: MCU_FW_SIZE as u32,
-        fw_ids: {
-            let mut arr = [0u32; 128];
-            arr[0] = MCU_FW_ID_1;
-            arr
-        },
-        flags: 0,
-    };
-    let full_bytes = req.as_bytes();
-    let old_len = full_bytes.len() - core::mem::size_of::<u32>();
-    let mut truncated = full_bytes[..old_len].to_vec();
-
-    // Patch the checksum so it covers exactly the truncated payload.
-    let chksum = calc_checksum(
-        u32::from(CommandId::ACTIVATE_FIRMWARE),
-        &truncated[core::mem::size_of::<u32>()..],
-    );
-    truncated[..core::mem::size_of::<u32>()].copy_from_slice(&chksum.to_le_bytes());
-
-    // Send the truncated buffer directly. Mirrors the
-    // `send_activate_firmware_cmd` helper but bypasses MailboxReq so we
-    // control the exact wire length.
-    model
-        .start_mailbox_execute(u32::from(CommandId::ACTIVATE_FIRMWARE), &truncated)
-        .unwrap();
-    #[cfg(feature = "fpga_subsystem")]
-    {
-        // The MCU image is included, so simulate the MCU-reset ack handshake
-        // (same as send_activate_firmware_cmd with reset_expected=true).
-        let mut retry_count = 10;
-        loop {
-            let intr_status = model
-                .mmio
-                .mci()
-                .unwrap()
-                .regs()
-                .intr_block_rf()
-                .notif0_internal_intr_r()
-                .read();
-            if intr_status.notif_cptra_mcu_reset_req_sts() {
-                break;
-            }
-            retry_count -= 1;
-            if retry_count == 0 {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
-        model
-            .mmio
-            .mci()
-            .unwrap()
-            .regs()
-            .intr_block_rf()
-            .notif0_internal_intr_r()
-            .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
-        model
-            .mmio
-            .mci()
-            .unwrap()
-            .regs()
-            .reset_request()
-            .modify(|r| r.mcu_req(true));
-    }
-    #[cfg(all(
-        not(feature = "verilator"),
-        not(feature = "fpga_realtime"),
-        not(feature = "fpga_subsystem")
-    ))]
-    {
-        model.step_until(|m| {
-            let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
-            intr_status.notif_cptra_mcu_reset_req_sts()
-        });
-        model
-            .mci()
-            .intr_block_rf()
-            .notif0_internal_intr_r()
-            .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
-        model.mci().reset_request().modify(|r| r.mcu_req(true));
-    }
-    model
-        .finish_mailbox_execute()
-        .unwrap()
-        .expect("ACTIVATE_FIRMWARE without flags trailer should succeed");
-}
-
-/// Reject unknown flag bits with `RUNTIME_MAILBOX_INVALID_PARAMS`. The
-/// reserved high bit acts as a stand-in for any future undefined flag.
-#[cfg_attr(feature = "fpga_realtime", ignore)]
-#[test]
-fn test_activate_firmware_unknown_flag_bit_rejected() {
-    let mcu_image = Image {
-        fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
-        exec_bit: 2,
-    };
-
-    let mut model = load_and_authorize_fw(&[mcu_image]);
-
-    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        fw_id_count: 1,
-        mcu_fw_image_size: MCU_FW_SIZE as u32,
-        fw_ids: {
-            let mut arr = [0u32; 128];
-            arr[0] = MCU_FW_ID_1;
-            arr
-        },
-        // A bit that is not part of `ActivateFirmwareFlags`.
-        flags: 1 << 31,
-    });
-    activate_cmd.populate_chksum().unwrap();
-
-    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
-}
-
-/// `INITIAL_ACTIVATE` is only honored when ROM set
-/// `BootMode::EncryptedFirmware`. In the normal boot flow used by this test
-/// the boot mode is `Normal`, so Caliptra must reject the request rather
-/// than skip the hitless-update steps.
-#[cfg_attr(feature = "fpga_realtime", ignore)]
-#[test]
-fn test_activate_firmware_initial_activate_wrong_boot_mode() {
-    let mcu_image = Image {
-        fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
-        exec_bit: 2,
-    };
-
-    let mut model = load_and_authorize_fw(&[mcu_image]);
-
-    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        fw_id_count: 1,
-        mcu_fw_image_size: MCU_FW_SIZE as u32,
-        fw_ids: {
-            let mut arr = [0u32; 128];
-            arr[0] = MCU_FW_ID_1;
-            arr
-        },
-        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
-    });
-    activate_cmd.populate_chksum().unwrap();
-
-    // `load_and_authorize_fw` does a normal boot, so boot_mode is Normal.
-    // The flag must be rejected.
-    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
-}
-
-/// `INITIAL_ACTIVATE` requires the MCU image bit to be in the activation
-/// bitmap. Sending it with only SoC ids must be rejected.
-#[cfg_attr(feature = "fpga_realtime", ignore)]
-#[test]
-fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
-    let mcu_image = Image {
-        fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
-        exec_bit: 2,
-    };
-
-    let soc_image = Image {
-        fw_id: SOC_FW_ID_1,
-        staging_offset: SOC_STAGING_OFFSET,
-        load_offset: SOC_LOAD_OFFSET,
-        contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
-        exec_bit: 3,
-    };
-
-    let mut model = load_and_authorize_fw(&[mcu_image, soc_image]);
-
-    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        fw_id_count: 1,
-        mcu_fw_image_size: MCU_FW_SIZE as u32,
-        fw_ids: {
-            let mut arr = [0u32; 128];
-            arr[0] = SOC_FW_ID_1;
-            arr
-        },
-        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
-    });
-    activate_cmd.populate_chksum().unwrap();
-
-    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
-}
-
-#[cfg_attr(feature = "fpga_realtime", ignore)]
-#[test]
-fn test_activate_mcu_fw_digest_mismatch() {
-    let mcu_image = Image {
-        fw_id: MCU_FW_ID_1,
-        staging_offset: MCU_STAGING_OFFSET,
-        load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
-        exec_bit: 2,
-    };
-
-    let mut model = load_and_authorize_fw(&[mcu_image]);
-
-    // Tamper with the image in the staging area so the digest won't match the manifest
-    model
-        .write_payload_to_ss_staging_area(&[0x75u8, 0x55u8, 0x55u8, 0x55u8], MCU_STAGING_OFFSET)
-        .unwrap();
-
-    // Send ActivateFirmware command
-    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        fw_id_count: 1,
-        mcu_fw_image_size: MCU_FW_SIZE as u32,
-        fw_ids: {
-            let mut arr = [0u32; 128];
-            arr[0] = MCU_FW_ID_1;
-            arr
-        },
-        flags: 0,
-    });
-    activate_cmd.populate_chksum().unwrap();
-
-    assert_eq!(
-        send_activate_firmware_cmd(&mut model, activate_cmd, true),
-        Err(ModelError::MailboxCmdFailed(
-            CaliptraError::IMAGE_VERIFIER_ACTIVATION_FAILED.into()
-        ))
-    );
 }

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -1,19 +1,22 @@
 // Licensed under the Apache-2.0 license
-use crate::test_authorize_and_stash::set_auth_manifest_with_test_sram;
+use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_api::mailbox::ActivateFirmwareReq;
+use caliptra_api::mailbox::{ActivateFirmwareFlags, ActivateFirmwareReq};
+use caliptra_api::SocManager;
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
+use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
     MailboxReqHeader,
 };
-use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, ModelError};
+use caliptra_kat::CaliptraError;
 use caliptra_runtime::IMAGE_AUTHORIZED;
 use sha2::{Digest, Sha384};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
 
-pub const TEST_SRAM_SIZE: usize = 0x1000;
+pub const TEST_SRAM_SIZE: usize = 64 * 1024; // 64 KB
 
 #[cfg(feature = "fpga_subsystem")]
 const MCI_BASE: u32 = 0xA8000000;
@@ -35,25 +38,13 @@ pub const MCU_FW_ID_1: u32 = 0x2;
 pub const SOC_FW_ID_1: u32 = 0x3;
 pub const INVALID_FW_ID: u32 = 128;
 
-pub const MCU_LOAD_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo,
-    hi: 0x0000_0000,
-};
+pub const MCU_LOAD_OFFSET: usize = 0x000;
 
-pub const MCU_STAGING_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x200,
-    hi: 0x0000_0000,
-};
+pub const MCU_STAGING_OFFSET: usize = 0x200;
 
-pub const SOC_LOAD_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x100,
-    hi: 0x0000_0000,
-};
+pub const SOC_LOAD_OFFSET: usize = 0x100;
 
-pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x300,
-    hi: 0x0000_0000,
-};
+pub const SOC_STAGING_OFFSET: usize = 0x300;
 
 pub const MCU_FW_SIZE: usize = 256;
 pub const SOC_FW_SIZE: usize = 256;
@@ -61,63 +52,101 @@ pub const SOC_FW_SIZE: usize = 256;
 #[derive(Debug, Clone)]
 struct Image {
     pub fw_id: u32,
-    pub staging_address: Addr64,
-    pub load_address: Addr64,
+    pub staging_offset: usize,
+    pub load_offset: usize,
     pub exec_bit: u8,
     pub contents: Vec<u8>,
 }
 
 fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
+    let staging_addr = caliptra_hw_model::new_unbooted(InitParams {
+        subsystem_mode: true,
+        ..Default::default()
+    })
+    .unwrap()
+    .staging_physical_address()
+    .unwrap();
+
     let mut image_metadata = Vec::new();
-    let mut test_sram_contents = vec![0u8; TEST_SRAM_SIZE];
     for image in images {
         let mut flags = ImageMetadataFlags(0);
         flags.set_ignore_auth_check(false);
         flags.set_image_source(ImageHashSource::StagingAddress as u32);
         flags.set_exec_bit(image.exec_bit as u32);
 
-        let load_memory_contents = image.contents.clone();
-
         let mut hasher = Sha384::new();
-        hasher.update(load_memory_contents);
+        hasher.update(&image.contents);
         let fw_digest = hasher.finalize();
+
+        let image_staging_address = Addr64 {
+            lo: staging_addr as u32 + image.staging_offset as u32,
+            hi: (staging_addr >> 32) as u32,
+        };
+
+        let image_load_address = Addr64 {
+            lo: staging_addr as u32 + image.load_offset as u32,
+            hi: (staging_addr >> 32) as u32,
+        };
 
         image_metadata.push(AuthManifestImageMetadata {
             fw_id: image.fw_id,
             flags: flags.0,
             digest: fw_digest.into(),
-            image_staging_address: image.staging_address,
-            image_load_address: image.load_address,
+            image_staging_address,
+            image_load_address,
             ..Default::default()
         });
-
-        // Load the firmware contents into the staging area in test SRAM
-        let staging_address = image.staging_address.lo as usize - TEST_SRAM_BASE.lo as usize;
-        let image_size = image.contents.len();
-        assert!(staging_address + image_size <= TEST_SRAM_SIZE);
-        test_sram_contents[staging_address..staging_address + image_size]
-            .copy_from_slice(&image.contents);
     }
 
     let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
-    let mut model = set_auth_manifest_with_test_sram(
-        Some(auth_manifest),
-        &test_sram_contents,
-        &images[0].contents,
-    );
+    let runtime_args = RuntimeTestArgs {
+        subsystem_mode: true,
+        test_image_options: Some(caliptra_builder::ImageOptions {
+            pqc_key_type: caliptra_image_types::FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        }),
+        soc_manifest: Some(auth_manifest.as_bytes()),
+        mcu_fw_image: Some(&images[0].contents),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(runtime_args);
 
-    #[cfg(feature = "fpga_subsystem")]
-    {
-        crate::test_authorize_and_stash::write_mcu_mbox_sram(&mut model, &test_sram_contents);
-    }
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read()
+            == u32::from(caliptra_runtime::RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut set_auth_manifest_cmd =
+        MailboxReq::SetAuthManifest(caliptra_common::mailbox_api::SetAuthManifestReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            manifest_size: auth_manifest.as_bytes().len() as u32,
+            manifest: {
+                let mut slice =
+                    [0u8; caliptra_common::mailbox_api::SetAuthManifestReq::MAX_MAN_SIZE];
+                slice[..auth_manifest.as_bytes().len()].copy_from_slice(auth_manifest.as_bytes());
+                slice
+            },
+        });
+    set_auth_manifest_cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            u32::from(CommandId::SET_AUTH_MANIFEST),
+            set_auth_manifest_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
 
     for image in images {
+        model
+            .write_payload_to_ss_staging_area(&image.contents, image.staging_offset)
+            .unwrap();
         let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
             hdr: MailboxReqHeader { chksum: 0 },
             fw_id: image.fw_id.to_le_bytes(),
             measurement: [0; 48],
             source: ImageHashSource::StagingAddress as u32,
-            flags: 0, // Don't skip stash
+            flags: 1, // Skip stash
             image_size: image.contents.len() as u32,
             ..Default::default()
         });
@@ -150,20 +179,13 @@ fn send_activate_firmware_cmd(
             activate_cmd.as_bytes().unwrap(),
         )
         .unwrap();
-    #[cfg(feature = "fpga_subsystem")]
-    {
-        if reset_expected {
+    if reset_expected {
+        #[cfg(feature = "fpga_subsystem")]
+        {
             let clear_interrupt = |model: &mut DefaultHwModel| {
                 let mut retry_count = 10;
                 loop {
-                    let intr_status = model
-                        .mmio
-                        .mci()
-                        .unwrap()
-                        .regs()
-                        .intr_block_rf()
-                        .notif0_internal_intr_r()
-                        .read();
+                    let intr_status = model.mci().intr_block_rf().notif0_internal_intr_r().read();
                     if intr_status.notif_cptra_mcu_reset_req_sts() {
                         break;
                     }
@@ -174,33 +196,31 @@ fn send_activate_firmware_cmd(
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }
                 model
-                    .mmio
                     .mci()
-                    .unwrap()
-                    .regs()
                     .intr_block_rf()
                     .notif0_internal_intr_r()
                     .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
-                model
-                    .mmio
-                    .mci()
-                    .unwrap()
-                    .regs()
-                    .reset_request()
-                    .modify(|r| r.mcu_req(true));
+                model.mci().reset_request().modify(|r| r.mcu_req(true));
             };
             clear_interrupt(model);
         }
-    }
-    #[cfg(all(
-        not(feature = "verilator"),
-        not(feature = "fpga_realtime"),
-        not(feature = "fpga_subsystem")
-    ))]
-    {
-        let _ = reset_expected;
-        // In emulator mode, since FW_EXEC_CTRL bit is already cleared,
-        // the MCU will be already in reset state
+        #[cfg(all(
+            not(feature = "verilator"),
+            not(feature = "fpga_realtime"),
+            not(feature = "fpga_subsystem")
+        ))]
+        {
+            model.step_until(|m| {
+                let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
+                intr_status.notif_cptra_mcu_reset_req_sts()
+            });
+            model
+                .mci()
+                .intr_block_rf()
+                .notif0_internal_intr_r()
+                .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
+            model.mci().reset_request().modify(|r| r.mcu_req(true));
+        }
     }
     model.finish_mailbox_execute()
 }
@@ -210,8 +230,8 @@ fn send_activate_firmware_cmd(
 fn test_activate_mcu_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
@@ -228,6 +248,7 @@ fn test_activate_mcu_fw_success() {
             arr[0] = MCU_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
     send_activate_firmware_cmd(&mut model, activate_cmd, true)
@@ -240,16 +261,16 @@ fn test_activate_mcu_fw_success() {
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -267,6 +288,7 @@ fn test_activate_mcu_soc_fw_success() {
             arr[1] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -280,16 +302,16 @@ fn test_activate_mcu_soc_fw_success() {
 fn test_activate_soc_fw_success() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -306,6 +328,7 @@ fn test_activate_soc_fw_success() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -319,16 +342,16 @@ fn test_activate_soc_fw_success() {
 fn test_activate_invalid_fw_id() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -345,6 +368,7 @@ fn test_activate_invalid_fw_id() {
             arr[0] = INVALID_FW_ID;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -356,16 +380,16 @@ fn test_activate_invalid_fw_id() {
 fn test_activate_fw_id_not_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 3,
     };
@@ -382,6 +406,7 @@ fn test_activate_fw_id_not_in_manifest() {
             arr[0] = INVALID_FW_ID;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
@@ -393,16 +418,16 @@ fn test_activate_fw_id_not_in_manifest() {
 fn test_invalid_exec_bit_in_manifest() {
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
-        staging_address: MCU_STAGING_ADDRESS,
-        load_address: MCU_LOAD_ADDRESS,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
         contents: [0x55u8; MCU_FW_SIZE].to_vec(),
         exec_bit: 2,
     };
 
     let soc_image = Image {
         fw_id: SOC_FW_ID_1,
-        staging_address: SOC_STAGING_ADDRESS,
-        load_address: SOC_LOAD_ADDRESS,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
         contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
         exec_bit: 0,
     };
@@ -419,8 +444,267 @@ fn test_invalid_exec_bit_in_manifest() {
             arr[0] = SOC_FW_ID_1;
             arr
         },
+        flags: 0,
     });
     activate_cmd.populate_chksum().unwrap();
 
     assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// Backward-compat: clients that pre-date the `flags` field send a request
+/// truncated to `size_of::<ActivateFirmwareReq>() - 4` bytes (no `flags`
+/// trailer). The runtime must treat the missing field as zero and proceed
+/// with the hitless-update path that those clients expect.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_old_format_no_flags() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    // Build the request via the current `ActivateFirmwareReq` struct (which
+    // includes `flags`), then truncate the trailing `flags` u32 off the wire
+    // bytes so the runtime parser sees exactly what an old client would have
+    // sent. Compute the checksum over the truncated bytes (excluding the
+    // 4-byte `chksum` field).
+    let req = ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: 0,
+    };
+    let full_bytes = req.as_bytes();
+    let old_len = full_bytes.len() - core::mem::size_of::<u32>();
+    let mut truncated = full_bytes[..old_len].to_vec();
+
+    // Patch the checksum so it covers exactly the truncated payload.
+    let chksum = calc_checksum(
+        u32::from(CommandId::ACTIVATE_FIRMWARE),
+        &truncated[core::mem::size_of::<u32>()..],
+    );
+    truncated[..core::mem::size_of::<u32>()].copy_from_slice(&chksum.to_le_bytes());
+
+    // Send the truncated buffer directly. Mirrors the
+    // `send_activate_firmware_cmd` helper but bypasses MailboxReq so we
+    // control the exact wire length.
+    model
+        .start_mailbox_execute(u32::from(CommandId::ACTIVATE_FIRMWARE), &truncated)
+        .unwrap();
+    #[cfg(feature = "fpga_subsystem")]
+    {
+        // The MCU image is included, so simulate the MCU-reset ack handshake
+        // (same as send_activate_firmware_cmd with reset_expected=true).
+        let mut retry_count = 10;
+        loop {
+            let intr_status = model
+                .mmio
+                .mci()
+                .unwrap()
+                .regs()
+                .intr_block_rf()
+                .notif0_internal_intr_r()
+                .read();
+            if intr_status.notif_cptra_mcu_reset_req_sts() {
+                break;
+            }
+            retry_count -= 1;
+            if retry_count == 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        model
+            .mmio
+            .mci()
+            .unwrap()
+            .regs()
+            .intr_block_rf()
+            .notif0_internal_intr_r()
+            .modify(|r| r.notif_cptra_mcu_reset_req_sts(true));
+        model
+            .mmio
+            .mci()
+            .unwrap()
+            .regs()
+            .reset_request()
+            .modify(|r| r.mcu_req(true));
+    }
+    #[cfg(all(
+        not(feature = "verilator"),
+        not(feature = "fpga_realtime"),
+        not(feature = "fpga_subsystem")
+    ))]
+    {
+        model.step_until(|m| {
+            let intr_status = m.mci().intr_block_rf().notif0_internal_intr_r().read();
+            intr_status.notif_cptra_mcu_reset_req_sts()
+        });
+        model
+            .mci()
+            .intr_block_rf()
+            .notif0_internal_intr_r()
+            .modify(|r| r.notif_cptra_mcu_reset_req_sts(false));
+        model.mci().reset_request().modify(|r| r.mcu_req(true));
+    }
+    model
+        .finish_mailbox_execute()
+        .unwrap()
+        .expect("ACTIVATE_FIRMWARE without flags trailer should succeed");
+}
+
+/// Reject unknown flag bits with `RUNTIME_MAILBOX_INVALID_PARAMS`. The
+/// reserved high bit acts as a stand-in for any future undefined flag.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_unknown_flag_bit_rejected() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        // A bit that is not part of `ActivateFirmwareFlags`.
+        flags: 1 << 31,
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// `INITIAL_ACTIVATE` is only honored when ROM set
+/// `BootMode::EncryptedFirmware`. In the normal boot flow used by this test
+/// the boot mode is `Normal`, so Caliptra must reject the request rather
+/// than skip the hitless-update steps.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_initial_activate_wrong_boot_mode() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    // `load_and_authorize_fw` does a normal boot, so boot_mode is Normal.
+    // The flag must be rejected.
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+/// `INITIAL_ACTIVATE` requires the MCU image bit to be in the activation
+/// bitmap. Sending it with only SoC ids must be rejected.
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let soc_image = Image {
+        fw_id: SOC_FW_ID_1,
+        staging_offset: SOC_STAGING_OFFSET,
+        load_offset: SOC_LOAD_OFFSET,
+        contents: [0xAAu8; SOC_FW_SIZE].to_vec(),
+        exec_bit: 3,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image, soc_image]);
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = SOC_FW_ID_1;
+            arr
+        },
+        flags: ActivateFirmwareFlags::INITIAL_ACTIVATE.bits(),
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_mcu_fw_digest_mismatch() {
+    let mcu_image = Image {
+        fw_id: MCU_FW_ID_1,
+        staging_offset: MCU_STAGING_OFFSET,
+        load_offset: MCU_LOAD_OFFSET,
+        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        exec_bit: 2,
+    };
+
+    let mut model = load_and_authorize_fw(&[mcu_image]);
+
+    // Tamper with the image in the staging area so the digest won't match the manifest
+    model
+        .write_payload_to_ss_staging_area(&[0x75u8, 0x55u8, 0x55u8, 0x55u8], MCU_STAGING_OFFSET)
+        .unwrap();
+
+    // Send ActivateFirmware command
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+        flags: 0,
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert_eq!(
+        send_activate_firmware_cmd(&mut model, activate_cmd, true),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::IMAGE_VERIFIER_ACTIVATION_FAILED.into()
+        ))
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_warm_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_warm_reset.rs
@@ -63,8 +63,9 @@ fn test_rt_journey_pcr_validation() {
     )
     .unwrap();
 
-    // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+    while !model.boot_complete() {
+        model.step();
+    }
 
     let _ = model
         .mailbox_execute(0xD000_0000, &[0u8; TCI_SIZE])
@@ -132,8 +133,9 @@ fn test_rt_current_pcr_validation() {
     )
     .unwrap();
 
-    // Wait for boot
-    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+    while !model.boot_complete() {
+        model.step();
+    }
 
     let _ = model
         .mailbox_execute(0xD000_0001, &[0u8; TCI_SIZE])
@@ -302,13 +304,7 @@ fn test_warm_reset_debug_unlocked() {
         ..Default::default()
     });
 
-    // Wait for runtime
-    while !model
-        .soc_ifc()
-        .cptra_flow_status()
-        .read()
-        .ready_for_runtime()
-    {
+    while !model.boot_complete() {
         model.step();
     }
 


### PR DESCRIPTION
These are necessary to get the nightlies to pass again in 2.0.

 506d2999 hw-model: fix UTF-8 search panic and expose setters for cold_reset state (#3711)
 7477854a hw-model: Do a full AXI reset on cold reset for subsystem (#3413)
 68e68557 test(2.0): revert test_activate_firmware refactor from #3719
 6c5aeb8a [fix] `ActivateFirmware` to call `AuthorizeAndStash` correctly (#3719)
 9b967a33 tests: Warm reset has a race condition for subsystem FPGA (#3456)