### PR TITLE
runtime: small code-size reductions

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-c2c3a1c7c3488f898bcdb785d686fda401f87609b91725a1110dee04e3ea18f2597fef5037b0ae58eeae23c7474a57c8  caliptra-rom-no-log.bin
-62954d1988b66176909d090c66cb82630271af74befa5576e45acf1a737be1890f09914188be419677436255d1ddb398  caliptra-rom-with-log.bin
+5d6c3590c6d11e1bfd8b55837eca07e984d6c0d40563830852ccd3a6552b08b65c9e56532181c0e76a6e656b919e3d3a  caliptra-rom-no-log.bin
+34f8bebcbc3c14eddc75c898a7d1d38876b5055984c3847e976ec38f04f20f8f4b59d27ceaa7f459c172ea3626c221c1  caliptra-rom-with-log.bin

--- a/drivers/src/abr.rs
+++ b/drivers/src/abr.rs
@@ -75,6 +75,7 @@ impl Abr {
     ///     mldsa.key_pair(seed, trng, None)
     /// })?;
     /// ```
+    #[inline(always)]
     pub fn with_mldsa87<'s, F, R>(&'s mut self, f: F) -> R
     where
         F: FnOnce(Mldsa87<'s>) -> R,
@@ -104,6 +105,7 @@ impl Abr {
     ///     ml_kem.key_pair(seeds)
     /// })?;
     /// ```
+    #[inline(always)]
     pub fn with_ml_kem<'s, F, R>(&'s mut self, f: F) -> R
     where
         F: FnOnce(MlKem1024<'s>) -> R,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -190,12 +190,12 @@ fn enter_idle(drivers: &mut Drivers) {
     caliptra_cpu::csr::mpmc_halt_and_enable_interrupts();
 }
 
-fn human_readable_command(bytes: &[u8]) -> Option<&str> {
+fn human_readable_command(bytes: &[u8]) -> &str {
     if bytes.len() == 4 && bytes.iter().all(|c| c.is_ascii_alphanumeric()) {
         // Safety: we just checked that all bytes are ASCII.
-        Some(unsafe { core::str::from_utf8_unchecked(bytes) })
+        unsafe { core::str::from_utf8_unchecked(bytes) }
     } else {
-        None
+        "?"
     }
 }
 
@@ -245,20 +245,12 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     let cmd_bytes = req_packet.as_bytes()?;
     let cmd_id = req_packet.cmd;
 
-    if let Some(ascii) = human_readable_command(&cmd_id.to_be_bytes()) {
-        cprintln!(
-            "[rt] Received command=0x{:x} ({}), len={}",
-            req_packet.cmd,
-            ascii,
-            req_packet.payload().len()
-        );
-    } else {
-        cprintln!(
-            "[rt] Received command=0x{:x}, len={}",
-            req_packet.cmd,
-            req_packet.payload().len()
-        );
-    }
+    cprintln!(
+        "[rt] Received command=0x{:x} ({}), len={}",
+        req_packet.cmd,
+        human_readable_command(&cmd_id.to_be_bytes()),
+        req_packet.payload().len()
+    );
 
     // Check for EXTERNAL_MAILBOX_CMD and handle FIRMWARE_VERIFY specially
     if drivers.soc_ifc.subsystem_mode()
@@ -623,22 +615,13 @@ fn handle_external_mailbox_cmd(
     // FIRMWARE_VERIFY is handled earlier in handle_command() before this function is called
     cfi_assert_ne(cmd_id, CommandId::FIRMWARE_VERIFY.into());
 
-    if let Some(ascii) = human_readable_command(&cmd_id.to_be_bytes()) {
-        cprintln!(
-            "[rt] Loading external command=0x{:x} ({}), len={} from AXI address: 0x{:x}",
-            external_cmd.command_id,
-            ascii,
-            external_cmd.command_size,
-            u64::from(axi_addr),
-        );
-    } else {
-        cprintln!(
-            "[rt] Loading external command=0x{:x}, len={} from AXI address: 0x{:x}",
-            external_cmd.command_id,
-            external_cmd.command_size,
-            u64::from(axi_addr),
-        );
-    }
+    cprintln!(
+        "[rt] Loading external command=0x{:x} ({}), len={} from AXI address: 0x{:x}",
+        external_cmd.command_id,
+        human_readable_command(&cmd_id.to_be_bytes()),
+        external_cmd.command_size,
+        u64::from(axi_addr),
+    );
     // check that the command is not too large
     if external_cmd.command_size as usize > caliptra_common::mailbox_api::MAX_REQ_SIZE {
         return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
@@ -668,20 +651,12 @@ fn handle_external_mailbox_cmd(
         return Err(CaliptraError::RUNTIME_INVALID_CHECKSUM);
     }
 
-    if let Some(ascii) = human_readable_command(&cmd_id.to_be_bytes()) {
-        cprintln!(
-            "[rt] Received external command=0x{:x} ({}), len={}",
-            cmd_id,
-            ascii,
-            cmd_bytes.len()
-        );
-    } else {
-        cprintln!(
-            "[rt] Received external command=0x{:x}, len={}",
-            cmd_id,
-            cmd_bytes.len()
-        );
-    }
+    cprintln!(
+        "[rt] Received external command=0x{:x} ({}), len={}",
+        cmd_id,
+        human_readable_command(&cmd_id.to_be_bytes()),
+        cmd_bytes.len()
+    );
 
     execute_command(drivers, cmd_id, cmd_bytes)
 }


### PR DESCRIPTION
Reclaim ~550 B of runtime .text:

- abr: mark with_mldsa87/with_ml_kem #[inline(always)] so the five generic monomorphizations of the closure wrappers collapse into their call sites instead of emitting separate function bodies.
- lib: have human_readable_command return &str ("?" sentinel) instead of Option<&str>, collapsing three cprintln! if/else pairs into single calls.

No functional change.