### PR TITLE
runtime: Implement MLDSA87_SIGNATURE_VERIFY mailbox command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "caliptra-image-verify",
  "caliptra-kat",
  "caliptra-lms-types",
+ "caliptra-mldsa",
  "caliptra-registers",
  "caliptra-x509",
  "caliptra_common",

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -21,6 +21,7 @@ impl CommandId {
     pub const GET_RT_ALIAS_CERT: Self = Self(0x43455252); // "CERR"
     pub const ECDSA384_VERIFY: Self = Self(0x53494756); // "SIGV"
     pub const LMS_VERIFY: Self = Self(0x4C4D5356); // "LMSV"
+    pub const MLDSA87_SIGNATURE_VERIFY: Self = Self(0x4D445356); // "MDSV"
     pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
     pub const DISABLE_ATTESTATION: Self = Self(0x4453424C); // "DSBL"
@@ -265,6 +266,7 @@ impl Default for MailboxResp {
 pub enum MailboxReq {
     EcdsaVerify(EcdsaVerifyReq),
     LmsVerify(LmsVerifyReq),
+    Mldsa87Verify(Mldsa87VerifyReq),
     GetLdevCert(GetLdevCertReq),
     StashMeasurement(StashMeasurementReq),
     InvokeDpeCommand(InvokeDpeReq),
@@ -294,6 +296,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(req) => Ok(req.as_bytes()),
             MailboxReq::LmsVerify(req) => Ok(req.as_bytes()),
+            MailboxReq::Mldsa87Verify(req) => Ok(req.as_bytes()),
             MailboxReq::StashMeasurement(req) => Ok(req.as_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial(),
             MailboxReq::FipsVersion(req) => Ok(req.as_bytes()),
@@ -323,6 +326,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(req) => Ok(req.as_mut_bytes()),
             MailboxReq::LmsVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::Mldsa87Verify(req) => Ok(req.as_mut_bytes()),
             MailboxReq::GetLdevCert(req) => Ok(req.as_mut_bytes()),
             MailboxReq::StashMeasurement(req) => Ok(req.as_mut_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial_mut(),
@@ -352,6 +356,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(_) => CommandId::ECDSA384_VERIFY,
             MailboxReq::LmsVerify(_) => CommandId::LMS_VERIFY,
+            MailboxReq::Mldsa87Verify(_) => CommandId::MLDSA87_SIGNATURE_VERIFY,
             MailboxReq::GetLdevCert(_) => CommandId::GET_LDEV_CERT,
             MailboxReq::StashMeasurement(_) => CommandId::STASH_MEASUREMENT,
             MailboxReq::InvokeDpeCommand(_) => CommandId::INVOKE_DPE,
@@ -602,6 +607,33 @@ pub struct LmsVerifyReq {
 impl Request for LmsVerifyReq {
     const ID: CommandId = CommandId::LMS_VERIFY;
     type Resp = MailboxRespHeader;
+}
+// No command-specific output args
+
+// MLDSA87_SIGNATURE_VERIFY
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct Mldsa87VerifyReq {
+    pub hdr: MailboxReqHeader,
+    pub pub_key: [u8; 2592],
+    pub signature: [u8; 4627],
+    pub _sig_pad: u8,
+    pub message: [u8; 64],
+}
+impl Request for Mldsa87VerifyReq {
+    const ID: CommandId = CommandId::MLDSA87_SIGNATURE_VERIFY;
+    type Resp = MailboxRespHeader;
+}
+impl Default for Mldsa87VerifyReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            pub_key: [0u8; 2592],
+            signature: [0u8; 4627],
+            _sig_pad: 0,
+            message: [0u8; 64],
+        }
+    }
 }
 // No command-specific output args
 

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -191,13 +191,29 @@ fn scalar_ntt(s: &mut Scalar) {
         offset >>= 1;
         let mut k = 0;
         for i in 0..step {
-            let step_root = NTT_ROOTS_MONTGOMERY[step + i];
-            for j in k..(k + offset) {
-                let even = s.c[j];
-                let odd =
-                    reduce_montgomery((step_root as u64).wrapping_mul(s.c[j + offset] as u64));
-                s.c[j] = reduce_once(odd.wrapping_add(even));
-                s.c[j + offset] = mod_sub(even, odd);
+            // `NTT_ROOTS_MONTGOMERY` has length `K_DEGREE`; `step + i` is
+            // always < `K_DEGREE` because `2 * step <= K_DEGREE`, but the
+            // compiler cannot see that across the doubling loop, so we
+            // use `.get()` (panic-free) instead of `[step + i]`.
+            let Some(&step_root) = NTT_ROOTS_MONTGOMERY.get(step + i) else {
+                return;
+            };
+            // Take a 2*offset slice and split it into the two `offset`-sized
+            // halves we operate on. Both `get_mut` and `split_at_mut_checked`
+            // return `Option`, so no panic landing pad is emitted; in
+            // practice both are always `Some` because `k + 2*offset <= K_DEGREE`.
+            let Some(sub) = s.c.get_mut(k..k + 2 * offset) else {
+                return;
+            };
+            let Some((left, right)) = sub.split_at_mut_checked(offset) else {
+                return;
+            };
+            for (even_ref, odd_ref) in left.iter_mut().zip(right.iter_mut()) {
+                let even = *even_ref;
+                let odd_src = *odd_ref;
+                let odd = reduce_montgomery((step_root as u64).wrapping_mul(odd_src as u64));
+                *even_ref = reduce_once(odd.wrapping_add(even));
+                *odd_ref = mod_sub(even, odd);
             }
             k += 2 * offset;
         }
@@ -212,12 +228,22 @@ fn scalar_inverse_ntt(s: &mut Scalar) {
         step >>= 1;
         let mut k = 0;
         for i in 0..step {
-            let step_root = K_PRIME.wrapping_sub(NTT_ROOTS_MONTGOMERY[step + (step - 1 - i)]);
-            for j in k..(k + offset) {
-                let even = s.c[j];
-                let odd = s.c[j + offset];
-                s.c[j] = reduce_once(odd.wrapping_add(even));
-                s.c[j + offset] = reduce_montgomery(
+            // See `scalar_ntt` for why we use `.get()` / `split_at_mut_checked`.
+            let Some(&root) = NTT_ROOTS_MONTGOMERY.get(step + (step - 1 - i)) else {
+                return;
+            };
+            let step_root = K_PRIME.wrapping_sub(root);
+            let Some(sub) = s.c.get_mut(k..k + 2 * offset) else {
+                return;
+            };
+            let Some((left, right)) = sub.split_at_mut_checked(offset) else {
+                return;
+            };
+            for (even_ref, odd_ref) in left.iter_mut().zip(right.iter_mut()) {
+                let even = *even_ref;
+                let odd = *odd_ref;
+                *even_ref = reduce_once(odd.wrapping_add(even));
+                *odd_ref = reduce_montgomery(
                     (step_root as u64)
                         .wrapping_mul((K_PRIME.wrapping_add(even).wrapping_sub(odd)) as u64),
                 );
@@ -435,16 +461,13 @@ fn vector8_count_ones(a: &Vector8) -> usize {
     count
 }
 
-fn vector8_use_hint(out: &mut Vector8, h: &Vector8, r: &Vector8) {
-    for i in 0..8 {
-        scalar_use_hint(&mut out.v[i], &h.v[i], &r.v[i]);
-    }
-}
-
 /* Bit packing. */
 
-fn scalar_encode_4(out: &mut [u8], s: &Scalar) {
-    for (i, out_byte) in out.iter_mut().enumerate().take(K_DEGREE / 2) {
+fn scalar_encode_4(out: &mut [u8; 4 * K_DEGREE / 8], s: &Scalar) {
+    // `iter_mut().enumerate()` is panic-free; `i` is statically bounded by
+    // `out.len() = 4 * K_DEGREE / 8 = K_DEGREE / 2 = 128`, so the
+    // `s.c[2 * i + 1]` index (max 255) stays inside `K_DEGREE = 256`.
+    for (i, out_byte) in out.iter_mut().enumerate() {
         let a = s.c[2 * i];
         let b = s.c[2 * i + 1];
         *out_byte = (a | (b << 4)) as u8;
@@ -484,9 +507,24 @@ fn scalar_encode_signed_20_19(out: &mut [u8], s: &Scalar) {
     }
 }
 
-fn scalar_decode_10(out: &mut Scalar, in_val: &[u8]) {
+// `scalar_decode_10` and `scalar_decode_signed_20_19` take fixed-size byte
+// array references rather than runtime-sized `&[u8]`. With statically known
+// input length and a compile-time loop bound, every byte and coefficient
+// index below is provably in range, so LLVM (with `panic = "abort"` + LTO)
+// removes the bounds-check panic landing pads. Keeping the verify path
+// panic-free is required by the runtime's `panic_is_possible` invariant
+// (see `runtime/src/main.rs`).
+
+fn scalar_decode_10(out: &mut Scalar, in_val: &[u8; 5 * K_DEGREE / 4]) {
     for i in 0..(K_DEGREE / 4) {
-        let v = u32::from_le_bytes(in_val[5 * i..5 * i + 4].try_into().unwrap());
+        // 5*i + 4 <= 5*63 + 4 = 319 < 320 = in_val.len()
+        let v = u32::from_le_bytes([
+            in_val[5 * i],
+            in_val[5 * i + 1],
+            in_val[5 * i + 2],
+            in_val[5 * i + 3],
+        ]);
+        // 4*i + 3 <= 4*63 + 3 = 255 < 256 = K_DEGREE = out.c.len()
         out.c[4 * i] = v & 0x3FF;
         out.c[4 * i + 1] = (v >> 10) & 0x3FF;
         out.c[4 * i + 2] = (v >> 20) & 0x3FF;
@@ -494,14 +532,25 @@ fn scalar_decode_10(out: &mut Scalar, in_val: &[u8]) {
     }
 }
 
-fn scalar_decode_signed_20_19(out: &mut Scalar, in_val: &[u8]) {
+fn scalar_decode_signed_20_19(out: &mut Scalar, in_val: &[u8; 10 * K_DEGREE / 4]) {
     let k_max = 1u32 << 19;
     let k20_bits = (1u32 << 20) - 1;
 
     for i in 0..(K_DEGREE / 4) {
-        let a = u32::from_le_bytes(in_val[10 * i..10 * i + 4].try_into().unwrap());
-        let b = u32::from_le_bytes(in_val[10 * i + 4..10 * i + 8].try_into().unwrap());
-        let c = u16::from_le_bytes(in_val[10 * i + 8..10 * i + 10].try_into().unwrap());
+        // 10*i + 9 <= 10*63 + 9 = 639 < 640 = in_val.len()
+        let a = u32::from_le_bytes([
+            in_val[10 * i],
+            in_val[10 * i + 1],
+            in_val[10 * i + 2],
+            in_val[10 * i + 3],
+        ]);
+        let b = u32::from_le_bytes([
+            in_val[10 * i + 4],
+            in_val[10 * i + 5],
+            in_val[10 * i + 6],
+            in_val[10 * i + 7],
+        ]);
+        let c = u16::from_le_bytes([in_val[10 * i + 8], in_val[10 * i + 9]]);
 
         out.c[i * 4] = mod_sub(k_max, a & k20_bits);
         out.c[i * 4 + 1] = mod_sub(k_max, (a >> 20) | ((b & 0xFF) << 12));
@@ -580,14 +629,18 @@ fn scalar_sample_mask(out: &mut Scalar, derived_seed: &[u8]) {
     scalar_decode_signed_20_19(out, &buf);
 }
 
-fn scalar_sample_in_ball_vartime(out: &mut Scalar, seed: &[u8], len: usize) {
+fn scalar_sample_in_ball_vartime(out: &mut Scalar, seed: &[u8; 2 * LAMBDA_BYTES]) {
     let mut shake256 = Shake256::new();
-    shake256.absorb(&seed[..len]);
+    shake256.absorb(seed);
 
     let mut block = [0u8; 136];
     shake256.squeeze(&mut block);
 
-    let mut signs = u64::from_le_bytes(block[0..8].try_into().unwrap());
+    // Read the first eight bytes via direct array indexing so the compiler
+    // does not have to keep a `try_into().unwrap()` panic landing pad alive.
+    let mut signs = u64::from_le_bytes([
+        block[0], block[1], block[2], block[3], block[4], block[5], block[6], block[7],
+    ]);
     let mut offset = 8;
 
     *out = Scalar::default();
@@ -599,13 +652,25 @@ fn scalar_sample_in_ball_vartime(out: &mut Scalar, seed: &[u8], len: usize) {
                 offset = 0;
             }
 
-            byte = block[offset] as usize;
+            // `block.get(offset)` removes the bounds-check panic landing
+            // pad that `block[offset]` would emit. `offset` is < 136 here
+            // (the if-branch above resets it to 0 whenever it hits 136),
+            // but LLVM cannot prove that invariant across the loop body,
+            // so we use the panic-free accessor.
+            let Some(&block_byte) = block.get(offset) else {
+                return;
+            };
+            byte = block_byte as usize;
             offset += 1;
             if byte <= i {
                 break;
             }
         }
 
+        // `byte <= i < K_DEGREE` and `i < K_DEGREE` so `out.c[i]` and
+        // `out.c[byte]` are statically in bounds; LLVM proves this on its
+        // own from the `for i in (K_DEGREE - TAU)..K_DEGREE` bound and the
+        // `byte <= i` break condition.
         out.c[i] = out.c[byte];
         out.c[byte] = mod_sub(1, (2u32).wrapping_mul((signs & 1) as u32));
         signs >>= 1;
@@ -656,9 +721,11 @@ fn vector7_expand_mask(out: &mut Vector7, seed: &[u8; K_RHO_PRIME_BYTES], kappa:
 
 /* Encoding. */
 
-fn vector8_encode_4(out: &mut [u8], a: &Vector8) {
-    for i in 0..8 {
-        scalar_encode_4(&mut out[i * 4 * K_DEGREE / 8..], &a.v[i]);
+fn vector8_encode_4(out: &mut [u8; 8 * 4 * K_DEGREE / 8], a: &Vector8) {
+    const SCALAR_BYTES: usize = 4 * K_DEGREE / 8;
+    let (chunks, _rem) = out.as_chunks_mut::<SCALAR_BYTES>();
+    for (out_chunk, scalar) in chunks.iter_mut().zip(a.v.iter()) {
+        scalar_encode_4(out_chunk, scalar);
     }
 }
 
@@ -668,9 +735,13 @@ fn vector8_encode_10(out: &mut [u8], a: &Vector8) {
     }
 }
 
-fn vector8_decode_10(out: &mut Vector8, in_val: &[u8]) {
-    for i in 0..8 {
-        scalar_decode_10(&mut out.v[i], &in_val[i * 10 * K_DEGREE / 8..]);
+fn vector8_decode_10(out: &mut Vector8, in_val: &[u8; 8 * 5 * K_DEGREE / 4]) {
+    // `as_chunks` is panic-free; with `in_val.len() == 8 * SCALAR_BYTES` the
+    // remainder is empty and `chunks` has exactly 8 entries, matching `out.v`.
+    const SCALAR_BYTES: usize = 5 * K_DEGREE / 4;
+    let (chunks, _rem) = in_val.as_chunks::<SCALAR_BYTES>();
+    for (out_scalar, in_chunk) in out.v.iter_mut().zip(chunks.iter()) {
+        scalar_decode_10(out_scalar, in_chunk);
     }
 }
 
@@ -680,9 +751,11 @@ fn vector7_encode_signed_20_19(out: &mut [u8], a: &Vector7) {
     }
 }
 
-fn vector7_decode_signed_20_19(out: &mut Vector7, in_val: &[u8]) {
-    for i in 0..7 {
-        scalar_decode_signed_20_19(&mut out.v[i], &in_val[i * 20 * K_DEGREE / 8..]);
+fn vector7_decode_signed_20_19(out: &mut Vector7, in_val: &[u8; 7 * 10 * K_DEGREE / 4]) {
+    const SCALAR_BYTES: usize = 10 * K_DEGREE / 4;
+    let (chunks, _rem) = in_val.as_chunks::<SCALAR_BYTES>();
+    for (out_scalar, in_chunk) in out.v.iter_mut().zip(chunks.iter()) {
+        scalar_decode_signed_20_19(out_scalar, in_chunk);
     }
 }
 
@@ -708,19 +781,38 @@ fn hint_bit_unpack(h: &mut Vector8, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
     vector8_zero(h);
     let mut index = 0;
     for i in 0..8 {
-        let limit = in_val[OMEGA + i] as usize;
+        // `in_val[OMEGA + i]` is in bounds (i < 8, len = OMEGA + 8), but
+        // `.get()` is panic-free so we use it unconditionally.
+        let Some(&limit_byte) = in_val.get(OMEGA + i) else {
+            return Mldsa87Result::SigVerifyFailed;
+        };
+        let limit = limit_byte as usize;
         if limit < index || limit > OMEGA {
             return Mldsa87Result::SigVerifyFailed;
         }
         let mut last: i32 = -1;
+        // `h.v.get_mut(i)` is statically Some (i < 8).
+        let Some(scalar) = h.v.get_mut(i) else {
+            return Mldsa87Result::SigVerifyFailed;
+        };
         while index < limit {
-            let byte = in_val[index] as usize;
+            // `in_val.get(index)` removes the bounds-check panic landing pad
+            // that `in_val[index]` would emit (LLVM can't propagate
+            // `index < limit && limit <= OMEGA && OMEGA < OMEGA + 8`).
+            let Some(&byte_val) = in_val.get(index) else {
+                return Mldsa87Result::SigVerifyFailed;
+            };
+            let byte = byte_val as usize;
             index += 1;
             if last >= 0 && byte <= last as usize {
                 return Mldsa87Result::SigVerifyFailed;
             }
             last = byte as i32;
-            h.v[i].c[byte] = 1;
+            // `byte: usize` derived from a `u8` so `byte < 256 = K_DEGREE`,
+            // but `.get_mut()` is panic-free regardless.
+            if let Some(c) = scalar.c.get_mut(byte) {
+                *c = 1;
+            }
         }
     }
     for val in in_val.iter().take(OMEGA).skip(index) {
@@ -737,8 +829,16 @@ fn encode_public_key(out: &mut [u8; MLDSA87_PUBLIC_KEY_BYTES], pub_key: &PublicK
 }
 
 fn decode_public_key(pub_key: &mut PublicKey, in_val: &[u8; MLDSA87_PUBLIC_KEY_BYTES]) {
-    pub_key.rho.copy_from_slice(&in_val[..K_RHO_BYTES]);
-    vector8_decode_10(&mut pub_key.t1, &in_val[K_RHO_BYTES..]);
+    // The two `if let Some(...)` branches are statically always taken because
+    // the fixed-size input is exactly K_RHO_BYTES + 8 * (5 * K_DEGREE / 4)
+    // bytes long. Using `split_first_chunk` / `first_chunk` instead of
+    // `try_into().unwrap()` keeps the verify path panic-free.
+    if let Some((rho_arr, rest)) = in_val.split_first_chunk::<K_RHO_BYTES>() {
+        pub_key.rho = *rho_arr;
+        if let Some(t1_bytes) = rest.first_chunk::<{ 8 * 5 * K_DEGREE / 4 }>() {
+            vector8_decode_10(&mut pub_key.t1, t1_bytes);
+        }
+    }
 
     let mut shake256 = Shake256::new();
     shake256.absorb(in_val);
@@ -757,13 +857,26 @@ fn encode_signature(out: &mut [u8; MLDSA87_SIGNATURE_BYTES], sign: &Signature) {
 }
 
 fn decode_signature(sign: &mut Signature, in_val: &[u8; MLDSA87_SIGNATURE_BYTES]) -> Mldsa87Result {
-    sign.c_tilde.copy_from_slice(&in_val[..2 * LAMBDA_BYTES]);
-    vector7_decode_signed_20_19(&mut sign.z, &in_val[2 * LAMBDA_BYTES..]);
+    // Statically the input is laid out as:
+    //   c_tilde       : 2 * LAMBDA_BYTES
+    //   z (Vector7)   : 7 * 10 * K_DEGREE / 4
+    //   h hint        : OMEGA + 8
+    // Each `split_first_chunk` / `first_chunk` is statically Some; the early
+    // returns are unreachable in practice but keep the function panic-free
+    // (no `try_into().unwrap()` landing pads) so it is acceptable on the
+    // runtime no-panic path.
+    let Some((c_tilde_arr, rest)) = in_val.split_first_chunk::<{ 2 * LAMBDA_BYTES }>() else {
+        return Mldsa87Result::SigVerifyFailed;
+    };
+    let Some((z_bytes, rest)) = rest.split_first_chunk::<{ 7 * 10 * K_DEGREE / 4 }>() else {
+        return Mldsa87Result::SigVerifyFailed;
+    };
+    let Some(hint_in) = rest.first_chunk::<{ OMEGA + 8 }>() else {
+        return Mldsa87Result::SigVerifyFailed;
+    };
 
-    let hint_in: &[u8; OMEGA + 8] = (&in_val
-        [2 * LAMBDA_BYTES + 640 * 7..2 * LAMBDA_BYTES + 640 * 7 + OMEGA + 8])
-        .try_into()
-        .unwrap();
+    sign.c_tilde = *c_tilde_arr;
+    vector7_decode_signed_20_19(&mut sign.z, z_bytes);
     hint_bit_unpack(&mut sign.h, hint_in)
 }
 
@@ -892,7 +1005,7 @@ fn sign_internal(
         shake256.squeeze(&mut sign.c_tilde);
 
         let mut c_ntt = Scalar::default();
-        scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde, sign.c_tilde.len());
+        scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde);
         scalar_ntt(&mut c_ntt);
 
         vector7_mul_scalar(cs1, &priv_key.s1_ntt, &c_ntt);
@@ -993,7 +1106,7 @@ fn verify_internal(
     shake256.squeeze(&mut mu);
 
     let mut c_ntt = Scalar::default();
-    scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde, sign.c_tilde.len());
+    scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde);
     scalar_ntt(&mut c_ntt);
 
     let mut az_ntt = Vector8::default();
@@ -1002,15 +1115,27 @@ fn verify_internal(
     let mut ct1_ntt = Vector8::default();
     vector8_scale_power2_round(&mut ct1_ntt, &pub_key.t1);
     vector8_ntt(&mut ct1_ntt);
-    let ct1_ntt_copy = ct1_ntt;
-    vector8_mul_scalar(&mut ct1_ntt, &ct1_ntt_copy, &c_ntt);
+    // Multiply each Scalar by c_ntt in place. We deliberately do NOT call
+    // vector8_mul_scalar(&mut ct1_ntt, &ct1_ntt_copy, &c_ntt), because that
+    // requires keeping an extra full Vector8 alive on the stack (8 KiB). On
+    // stack-constrained targets (e.g. the Caliptra runtime's 85 KiB stack)
+    // that 8 KiB pushes verify over budget. Doing it per-Scalar keeps the
+    // live extra copy down to 1 KiB.
+    for i in 0..8 {
+        let lhs = ct1_ntt.v[i];
+        scalar_mul(&mut ct1_ntt.v[i], &lhs, &c_ntt);
+    }
 
     let mut w1 = Vector8::default();
     vector8_sub(&mut w1, &az_ntt, &ct1_ntt);
     vector8_inverse_ntt(&mut w1);
 
-    let w1_copy = w1;
-    vector8_use_hint(&mut w1, &sign.h, &w1_copy);
+    // Apply the verifier hint in place, per-Scalar, for the same
+    // stack-budget reason as above (avoids an 8 KiB Vector8 copy).
+    for i in 0..8 {
+        let r = w1.v[i];
+        scalar_use_hint(&mut w1.v[i], &sign.h.v[i], &r);
+    }
     let mut w1_encoded = [0u8; 128 * 8];
     w1_encode(&mut w1_encoded, &w1);
 

--- a/common/crypto/shake/src/shake_impl.rs
+++ b/common/crypto/shake/src/shake_impl.rs
@@ -141,13 +141,24 @@ impl KeccakSt {
 
     pub fn absorb(&mut self, mut in_slice: &[u8]) {
         let in_len = in_slice.len();
+        let rate_bytes = self.rate_bytes;
 
         // Absorb partial block.
         if self.absorb_offset != 0 {
-            let first_block_len = self.rate_bytes - self.absorb_offset;
+            let first_block_len = rate_bytes - self.absorb_offset;
             let todo = core::cmp::min(first_block_len, in_len);
-            for (i, in_byte) in in_slice.iter().enumerate().take(todo) {
-                self.state.as_mut_bytes()[self.absorb_offset + i] ^= in_byte;
+            let absorb_offset = self.absorb_offset;
+            // Skip+take iterator avoids the bounds-check panic that
+            // `state.as_mut_bytes()[absorb_offset + i]` would emit.
+            for (dst, in_byte) in self
+                .state
+                .as_mut_bytes()
+                .iter_mut()
+                .skip(absorb_offset)
+                .take(todo)
+                .zip(in_slice.iter())
+            {
+                *dst ^= *in_byte;
             }
 
             // This input didn't fill the block.
@@ -157,21 +168,34 @@ impl KeccakSt {
             }
 
             keccak_f(&mut self.state);
-            in_slice = &in_slice[first_block_len..];
+            // Statically Some: we just consumed `first_block_len` bytes that
+            // were guaranteed to be present (else-branch above).
+            in_slice = match in_slice.get(first_block_len..) {
+                Some(rest) => rest,
+                None => return,
+            };
         }
 
-        // Absorb full blocks.
-        let rate_words = self.rate_bytes / 8;
-        while in_slice.len() >= self.rate_bytes {
-            for i in 0..rate_words {
-                let word = u64::from_le_bytes(in_slice[8 * i..8 * i + 8].try_into().unwrap());
-                self.state[i] ^= word;
+        // Absorb full blocks. Use `split_at_checked` (stable 1.80) and
+        // `as_chunks::<8>()` (stable 1.88) instead of slice ranges with
+        // `try_into().unwrap()` so no panic landing pads are emitted.
+        let rate_words = rate_bytes / 8;
+        while in_slice.len() >= rate_bytes {
+            let (block, rest) = match in_slice.split_at_checked(rate_bytes) {
+                Some(p) => p,
+                None => return,
+            };
+            let (words, _rem) = block.as_chunks::<8>();
+            for (i, word_bytes) in words.iter().enumerate().take(rate_words) {
+                if let Some(slot) = self.state.get_mut(i) {
+                    *slot ^= u64::from_le_bytes(*word_bytes);
+                }
             }
             keccak_f(&mut self.state);
-            in_slice = &in_slice[self.rate_bytes..];
+            in_slice = rest;
         }
 
-        // Absorb partial block.
+        // Absorb partial trailer.
         for (s, in_byte) in self.state.as_mut_bytes().iter_mut().zip(in_slice) {
             *s ^= *in_byte;
         }
@@ -181,10 +205,18 @@ impl KeccakSt {
     fn finalize(&mut self) {
         let terminator = 0x1fu8;
 
-        // XOR the terminator.
+        // Bounds-checked XORs of the two terminator bytes; both indices are
+        // statically valid (`absorb_offset < rate_bytes <= 168 < 200` and
+        // `rate_bytes - 1 < 200`), so the `if let Some` arms always run.
         let state_bytes = self.state.as_mut_bytes();
-        state_bytes[self.absorb_offset] ^= terminator;
-        state_bytes[self.rate_bytes - 1] ^= 0x80;
+        if let Some(b) = state_bytes.get_mut(self.absorb_offset) {
+            *b ^= terminator;
+        }
+        if self.rate_bytes > 0 {
+            if let Some(b) = state_bytes.get_mut(self.rate_bytes - 1) {
+                *b ^= 0x80;
+            }
+        }
 
         keccak_f(&mut self.state);
     }
@@ -203,11 +235,25 @@ impl KeccakSt {
 
             let remaining = self.rate_bytes - self.squeeze_offset;
             let todo = core::cmp::min(out_slice.len(), remaining);
-            out_slice[..todo].copy_from_slice(
-                &self.state.as_bytes()[self.squeeze_offset..self.squeeze_offset + todo],
-            );
 
-            let (_, rest) = out_slice.split_at_mut(todo);
+            // `split_at_mut_checked` / `get` avoid the panic landing pads
+            // that `out_slice[..todo]` and `state[squeeze_offset..+todo]`
+            // would otherwise leave behind. Both are always `Some` here.
+            let (dst, rest) = match out_slice.split_at_mut_checked(todo) {
+                Some(p) => p,
+                None => return,
+            };
+            let state_bytes = self.state.as_bytes();
+            let src = match state_bytes.get(self.squeeze_offset..self.squeeze_offset + todo) {
+                Some(s) => s,
+                None => return,
+            };
+            // Iterator copy: avoids `copy_from_slice`'s length-mismatch
+            // panic landing pad. Both slices have the same length (`todo`).
+            for (d, s) in dst.iter_mut().zip(src.iter()) {
+                *d = *s;
+            }
+
             out_slice = rest;
             self.squeeze_offset += todo;
         }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1258,6 +1258,16 @@ impl CaliptraError {
             0x000E0061,
             "Runtime Error: Multiple CCIV contexts found"
         ),
+        (
+            RUNTIME_MLDSA87_VERIFY_FAILED,
+            0x000E0062,
+            "Runtime Error: ML-DSA-87 signature verification failed"
+        ),
+        (
+            RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
+            0x000E0063,
+            "Runtime Error: ML-DSA-87 verify request reserved padding byte is non-zero"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -663,6 +663,27 @@ int rt_test_all_commands(const test_info* info)
         printf("LMS Verify: OK\n");
     }
 
+    // MLDSA87_SIGNATURE_VERIFY
+    struct caliptra_mldsa87_signature_verify_req mldsa_req = {};
+
+    status = caliptra_mldsa87_signature_verify(&mldsa_req, false);
+
+    // Not testing for full success.
+    // An all-zero public key + signature is well-formed wire-wise (chksum is
+    // populated by the SDK and `_sig_pad` defaults to zero) but is rejected
+    // by the verify algorithm. Seeing RUNTIME_MLDSA87_VERIFY_FAILED here
+    // proves the FW recognized the new MDSV command and routed it to the
+    // ML-DSA-87 verify code path.
+    uint32_t RUNTIME_MLDSA87_VERIFY_FAILED = 0xE0062;
+    non_fatal_error = caliptra_read_fw_non_fatal_error();
+    if (status != MBX_STATUS_FAILED || non_fatal_error != RUNTIME_MLDSA87_VERIFY_FAILED) {
+        printf("MLDSA87 Signature Verify unexpected result/failure: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        failure = 1;
+    } else {
+        printf("MLDSA87 Signature Verify: OK\n");
+    }
+
     // STASH_MEASUREMENT
     struct caliptra_stash_measurement_req stash_req = {};
     struct caliptra_stash_measurement_resp stash_resp;

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -179,6 +179,9 @@ int caliptra_ecdsa384_verify(struct caliptra_ecdsa_verify_req *req, bool async);
 // LMS Verify
 int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async);
 
+// ML-DSA-87 Signature Verify (RFC #3700)
+int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async);
+
 // Stash measurement
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async);
 

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -131,6 +131,21 @@ struct caliptra_lms_verify_req
     uint8_t signature_tree_path[360];
 };
 
+// MLDSA87_SIGNATURE_VERIFY (RFC #3700).
+//
+// `_sig_pad` is reserved and must be zero; it aligns `message` on an
+// 8-byte boundary inside the wire-format request. `message` is intended
+// to carry a fixed-size digest (e.g. SHA-256/384/512) computed by the
+// caller, since the runtime command does not pre-hash large payloads.
+struct caliptra_mldsa87_signature_verify_req
+{
+    struct caliptra_req_header hdr;
+    uint8_t pub_key[2592];
+    uint8_t signature[4627];
+    uint8_t _sig_pad;
+    uint8_t message[64];
+};
+
 struct caliptra_stash_measurement_req
 {
     struct caliptra_req_header hdr;

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1058,6 +1058,21 @@ int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async)
     return pack_and_execute_command(&p, async);
 }
 
+// ML-DSA-87 Signature Verify (RFC #3700)
+int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async)
+{
+    if (!req)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_resp_header resp_hdr = {};
+
+    CREATE_PARCEL(p, OP_MLDSA87_SIGNATURE_VERIFY, req, &resp_hdr);
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Stash measurement
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -35,6 +35,7 @@ enum mailbox_command {
     OP_GET_RT_ALIAS_CERT             = 0x43455252, // "CERR"
     OP_ECDSA384_VERIFY               = 0x53494756, // "SIGV"
     OP_LMS_VERIFY                    = 0x4C4D5356, // "LMSV"
+    OP_MLDSA87_SIGNATURE_VERIFY      = 0x4D445356, // "MDSV"
     OP_STASH_MEASUREMENT             = 0x4D454153, // "MEAS"
     OP_INVOKE_DPE_COMMAND            = 0x44504543, // "DPEC"
     OP_DISABLE_ATTESTATION           = 0x4453424C, // "DSBL"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ caliptra-cfi-lib = { workspace = true, default-features = false, features = ["cf
 caliptra-cfi-derive.workspace = true
 caliptra_common = { workspace = true, default-features = false, features = ["runtime"] }
 caliptra-cpu.workspace = true
-caliptra-drivers = { workspace = true, features = ["runtime"] }
+caliptra-drivers = { workspace = true, features = ["runtime", "mldsa_attestation"] }
 caliptra-error = { workspace = true, default-features = false }
 caliptra-image-types = { workspace = true, default-features = false }
 caliptra-auth-man-types = { workspace = true, default-features = false }
@@ -47,6 +47,7 @@ caliptra-image-crypto.workspace = true
 caliptra-auth-man-gen.workspace = true
 caliptra-image-serde.workspace = true
 caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
+caliptra-mldsa.workspace = true
 openssl.workspace = true
 sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
 cms.workspace = true

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -418,6 +418,40 @@ Command Code: `0x4C4D_5356` ("LMSV")
 | chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
 | fips\_status | u32      | Indicates if the command is FIPS approved or an error.
 
+### MLDSA87\_SIGNATURE\_VERIFY
+
+Verifies an ML-DSA-87 (FIPS 204) signature. Unlike the ECDSA and LMS verify
+commands, the message is supplied directly in the request rather than read
+from the SHA accelerator. Callers are expected to pre-hash large payloads
+(SHA-256 / SHA-384 / SHA-512) and pass the digest in the fixed 64-byte
+`message` field.
+
+ML-DSA-87 is stateless and does not have the per-key signature budget that
+LMS does, which is the primary motivation for adding this command alongside
+the existing `LMS_SIGNATURE_VERIFY`.
+
+In the event of an invalid signature, the mailbox command will report
+`CMD_FAILURE` and the cause will be logged as a non-fatal error.
+
+Command Code: `0x4D44_5356` ("MDSV")
+
+*Table: `MLDSA87_SIGNATURE_VERIFY` input arguments*
+
+| **Name**     | **Type**  | **Description**
+| --------     | --------- | ---------------
+| chksum       | u32       | Checksum over other input arguments, computed by the caller. Little endian.
+| pub\_key     | u8[2592]  | Encoded ML-DSA-87 public key (FIPS 204).
+| signature    | u8[4627]  | Encoded ML-DSA-87 signature (FIPS 204).
+| \_sig\_pad   | u8        | Reserved. Must be zero. Aligns `message` on an 8-byte boundary.
+| message      | u8[64]    | Message to verify. Intended for SHA-256/384/512 digests or other fixed-size messages.
+
+*Table: `MLDSA87_SIGNATURE_VERIFY` output arguments*
+
+| **Name**    | **Type** | **Description**
+| --------    | -------- | ---------------
+| chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
+| fips\_status | u32      | Indicates if the command is FIPS approved or an error.
+
 ### STASH\_MEASUREMENT
 
 Makes a measurement into the DPE default context. This command is intended for

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -61,6 +61,14 @@ Checks that the lms_signature_verify mailbox command correctly returns an error 
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the signature to the lms_signature_verify mailbox command | **test_lms_verify_invalid_sig_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the public key to the lms_signature_verify mailbox command | **test_lms_verify_invalid_key_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS OTS algorithm type is provided to the lms_signature_verify mailbox command | **test_lms_verify_invalid_lmots_type** | RUNTIME_LMS_VERIFY_INVALID_LMOTS_ALGORITHM
+Round-trips deterministically generated ML-DSA-87 keypairs / signatures through the mldsa87_signature_verify mailbox command for two seeds and two messages | **test_mldsa87_verify_cmd** | N/A
+Checks that the mldsa87_signature_verify mailbox command rejects a single-bit-flipped signature | **test_mldsa87_verify_failure_tampered_signature** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a different message | **test_mldsa87_verify_failure_wrong_message** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a public key from a different seed | **test_mldsa87_verify_failure_wrong_pub_key** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects an all-zero public key and signature | **test_mldsa87_verify_failure_all_zero** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a request with a stale (zero) checksum | **test_mldsa87_verify_bad_chksum** | RUNTIME_INVALID_CHECKSUM
+Checks that the mldsa87_signature_verify mailbox command rejects a request whose reserved `_sig_pad` byte is nonzero | **test_mldsa87_verify_invalid_padding** | RUNTIME_MLDSA87_VERIFY_INVALID_PADDING
+Checks that the mldsa87_signature_verify mailbox command rejects a request that is shorter than the request struct | **test_mldsa87_verify_truncated_request** | RUNTIME_INSUFFICIENT_MEMORY
 
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub use pcr::{GetPcrLogCmd, IncrementPcrResetCounterCmd};
 pub use reallocate_dpe_context_limits::ReallocateDpeContextLimitsCmd;
 pub use set_auth_manifest::SetAuthManifestCmd;
 pub use stash_measurement::StashMeasurementCmd;
-pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd};
+pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd, Mldsa87VerifyCmd};
 pub mod packet;
 use caliptra_common::mailbox_api::{CommandId, MailboxResp};
 use packet::Packet;
@@ -201,6 +201,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers, cmd_bytes),
         CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers, cmd_bytes),
         CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
+        CommandId::MLDSA87_SIGNATURE_VERIFY => Mldsa87VerifyCmd::execute(drivers, cmd_bytes),
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers, cmd_bytes),
         CommandId::DISABLE_ATTESTATION => DisableAttestationCmd::execute(drivers),

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -14,10 +14,10 @@ Abstract:
 
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxResp};
+use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxResp, Mldsa87VerifyReq};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
-    Ecc384Signature, LmsResult,
+    Ecc384Signature, LmsResult, Mldsa87, Mldsa87Result,
 };
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
@@ -125,6 +125,28 @@ impl LmsVerifyCmd {
         )?;
         if success != LmsResult::Success {
             return Err(CaliptraError::RUNTIME_LMS_VERIFY_FAILED);
+        }
+
+        Ok(MailboxResp::default())
+    }
+}
+
+pub struct Mldsa87VerifyCmd;
+impl Mldsa87VerifyCmd {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(_drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        let cmd = Mldsa87VerifyReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        // Reserved padding byte must be zero per RFC #3700.
+        if cmd._sig_pad != 0 {
+            return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING);
+        }
+
+        let result = Mldsa87::verify(&cmd.pub_key, &cmd.signature, &cmd.message)?;
+        if result != Mldsa87Result::Success {
+            return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED);
         }
 
         Ok(MailboxResp::default())

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -14,6 +14,7 @@ mod test_info;
 mod test_invoke_dpe;
 mod test_lms;
 mod test_mailbox;
+mod test_mldsa_verify;
 mod test_panic_missing;
 mod test_pauser_privilege_levels;
 mod test_pcr;

--- a/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
@@ -1,0 +1,336 @@
+// Licensed under the Apache-2.0 license.
+
+//! Integration tests for the `MLDSA87_SIGNATURE_VERIFY` runtime mailbox
+//! command (RFC #3700).
+//!
+//! The command is a thin wrapper around the pure-software ML-DSA-87 verify
+//! implementation in `caliptra-mldsa`, so these tests:
+//!
+//! * derive a deterministic ML-DSA-87 keypair on the host from a seed,
+//! * deterministically sign a 64-byte message with that key,
+//! * round-trip the resulting `(pub_key, signature, message)` triple through
+//!   the runtime mailbox, and
+//! * verify both the happy path and a comprehensive set of negative /
+//!   malformed inputs.
+//!
+//! Because the SoC firmware is expected to pre-hash large payloads (see
+//! `runtime/README.md`), the `message` field is always 64 bytes and we treat
+//! it as opaque — no SHA accelerator interaction is required, unlike the
+//! ECDSA / LMS verify mailbox commands.
+
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
+use caliptra_common::checksum::calc_checksum;
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, Mldsa87VerifyReq,
+};
+use caliptra_hw_model::HwModel;
+use caliptra_mldsa::{
+    Mldsa87, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
+};
+use caliptra_runtime::RtBootStatus;
+use zerocopy::FromBytes;
+
+const MSG_BYTES: usize = 64;
+
+/// Two distinct seeds let us exercise distinct keypairs and confirm that the
+/// command rejects cross-key verification.
+const SEED_A: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0x42; MLDSA87_PRIVATE_SEED_BYTES];
+const SEED_B: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0xa5; MLDSA87_PRIVATE_SEED_BYTES];
+
+/// Two distinct 64-byte "digests" used as the verified message. The actual
+/// content is irrelevant — these stand in for, e.g., SHA-512 outputs.
+const MSG_1: [u8; MSG_BYTES] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+];
+const MSG_2: [u8; MSG_BYTES] = [
+    0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xfe, 0xed, 0xfa, 0xce, 0xba, 0xad, 0xf0, 0x0d,
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+    0x55, 0x55, 0x55, 0x55, 0xaa, 0xaa, 0xaa, 0xaa, 0x5a, 0x5a, 0x5a, 0x5a, 0xa5, 0xa5, 0xa5, 0xa5,
+];
+
+/// Helper: derive (pub_key, signature) for `seed` over `msg`.
+///
+/// The boxed return values keep the ~7 KB of crypto material off the test
+/// stack frame.
+fn keygen_and_sign(
+    seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
+    msg: &[u8; MSG_BYTES],
+) -> (
+    Box<[u8; MLDSA87_PUBLIC_KEY_BYTES]>,
+    Box<[u8; MLDSA87_SIGNATURE_BYTES]>,
+) {
+    let mut pk = Box::new([0u8; MLDSA87_PUBLIC_KEY_BYTES]);
+    let mut sig = Box::new([0u8; MLDSA87_SIGNATURE_BYTES]);
+    Mldsa87::pub_from_seed(seed, &mut pk);
+    Mldsa87::sign_deterministic(seed, msg, &mut sig);
+    (pk, sig)
+}
+
+/// Helper: build a fully-populated `MailboxReq::Mldsa87Verify` and stamp a
+/// valid checksum.
+fn build_verify_req(
+    pub_key: &[u8; MLDSA87_PUBLIC_KEY_BYTES],
+    signature: &[u8; MLDSA87_SIGNATURE_BYTES],
+    message: &[u8; MSG_BYTES],
+) -> MailboxReq {
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pub_key;
+    req.signature = *signature;
+    req._sig_pad = 0;
+    req.message = *message;
+    let mut cmd = MailboxReq::Mldsa87Verify(*req);
+    cmd.populate_chksum().unwrap();
+    cmd
+}
+
+/// Helper: send an already-populated request and assert the response header
+/// looks like a successful FIPS-approved verify.
+fn execute_ok<T: HwModel>(model: &mut T, cmd: &MailboxReq) {
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("mailbox should have returned a response");
+
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+    // Checksum field is just 0 because FIPS_STATUS_APPROVED == 0.
+    assert_eq!(resp_hdr.chksum, 0);
+    assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0);
+}
+
+/// Wait until the runtime image is ready to take mailbox commands.
+fn boot_ready<T: HwModel>(model: &mut T) {
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+}
+
+// -------------------------------------------------------------------------
+// Positive tests
+// -------------------------------------------------------------------------
+
+/// End-to-end happy path: two distinct seeds × two distinct messages.
+/// Exercises the full request-parse -> verify -> response path.
+#[test]
+fn test_mldsa87_verify_cmd() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    for seed in [&SEED_A, &SEED_B] {
+        for msg in [&MSG_1, &MSG_2] {
+            let (pk, sig) = keygen_and_sign(seed, msg);
+            let cmd = build_verify_req(&pk, &sig, msg);
+            execute_ok(&mut model, &cmd);
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Negative tests (well-formed request, signature does not verify)
+// -------------------------------------------------------------------------
+
+/// Flipping a single bit in the signature must cause verification to fail
+/// with `RUNTIME_MLDSA87_VERIFY_FAILED` rather than crash or pass.
+#[test]
+fn test_mldsa87_verify_failure_tampered_signature() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, mut sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    sig[0] ^= 0xff;
+
+    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// Verifying a signature against a different message must fail.
+#[test]
+fn test_mldsa87_verify_failure_wrong_message() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let cmd = build_verify_req(&pk, &sig, &MSG_2);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// Verifying a signature against a public key from a different seed must
+/// fail.
+#[test]
+fn test_mldsa87_verify_failure_wrong_pub_key() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (_, sig_a) = keygen_and_sign(&SEED_A, &MSG_1);
+    let (pk_b, _) = keygen_and_sign(&SEED_B, &MSG_1);
+
+    let cmd = build_verify_req(&pk_b, &sig_a, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// All-zero public key + signature is a degenerate input that the verify
+/// algorithm must reject. This exercises the "structurally valid but
+/// cryptographically meaningless" path.
+#[test]
+fn test_mldsa87_verify_failure_all_zero() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+    let sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+// -------------------------------------------------------------------------
+// Malformed-request tests (request shape is wrong; handler must reject)
+// -------------------------------------------------------------------------
+
+/// Sending the request with `chksum = 0` exercises the dispatcher's
+/// pre-handler checksum gate. A real client would call `populate_chksum`
+/// first; skipping that step must surface as `RUNTIME_INVALID_CHECKSUM`.
+#[test]
+fn test_mldsa87_verify_bad_chksum() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pk;
+    req.signature = *sig;
+    req.message = MSG_1;
+    // Note: NOT calling populate_chksum, so hdr.chksum stays at 0.
+    let cmd = MailboxReq::Mldsa87Verify(*req);
+
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_INVALID_CHECKSUM,
+        err,
+    );
+}
+
+/// The `_sig_pad` byte exists solely to align `message` on an 8-byte
+/// boundary inside the request struct; RFC #3700 mandates that it be zero.
+/// Setting it to a nonzero value must be rejected explicitly with
+/// `RUNTIME_MLDSA87_VERIFY_INVALID_PADDING` (i.e., before any verify work
+/// is done).
+#[test]
+fn test_mldsa87_verify_invalid_padding() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pk;
+    req.signature = *sig;
+    req._sig_pad = 1; // RFC #3700 violation
+    req.message = MSG_1;
+    let mut cmd = MailboxReq::Mldsa87Verify(*req);
+    // Recompute checksum so we exercise the padding check, not the chksum check.
+    cmd.populate_chksum().unwrap();
+
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
+        err,
+    );
+}
+
+/// Sending a payload that's shorter than `Mldsa87VerifyReq` (but with a
+/// valid checksum over the truncated bytes, so the dispatcher's chksum
+/// gate passes) must be rejected by the handler's `ref_from_bytes` parse
+/// with `RUNTIME_INSUFFICIENT_MEMORY`.
+#[test]
+fn test_mldsa87_verify_truncated_request() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    // Build a payload that contains the mailbox header plus a few extra
+    // bytes — well short of the full request size.
+    let mut payload = vec![0u8; core::mem::size_of::<MailboxReqHeader>() + 32];
+    // Compute a valid checksum over everything after the chksum field.
+    let chksum_size = core::mem::size_of::<u32>();
+    let chksum = calc_checksum(
+        u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+        &payload[chksum_size..],
+    );
+    payload[..chksum_size].copy_from_slice(&chksum.to_le_bytes());
+
+    let err = model
+        .mailbox_execute(u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY), &payload)
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_INSUFFICIENT_MEMORY,
+        err,
+    );
+}


### PR DESCRIPTION
Implements the runtime mailbox command proposed in RFC #3700 on top of the ML-DSA-87 driver from PR #3805. Adds the request/response wire format (cmd id 0x4D44_5356, "MDSV"), the runtime dispatch and handler, new error codes, libcaliptra C API exposure, integration tests, and documentation.
Linking caliptra-mldsa into the runtime for the first time exposed two issues that are also fixed here:
* Stack overflow in verify_internal: the ct1*c and use_hint steps were done with whole-Vector8 copies (~8 KiB each), pushing verify ~12 KiB past the 85 KiB runtime stack budget. Reworked both to operate per-Scalar in place, freeing ~14 KiB of stack.
* test_panic_missing failure: caliptra-mldsa and caliptra-shake brought in panic-emitting code (try_into().unwrap, dynamic slice indexing, copy_from_slice on unequal slices) that LTO could no longer DCE. Refactored hot paths in common/crypto/mldsa/src/mldsa87.rs and common/crypto/shake/src/shake_impl.rs to use fixed-size array refs, Option-returning accessors (.get / .get_mut / split_first_chunk / split_at_checked / as_chunks), and explicit byte-array construction so the runtime ELF is panic-free again. Tests:
- New runtime/tests/runtime_integration_tests/test_mldsa_verify.rs with positive, negative, and malformed-request coverage.
- test_panic_missing passes with mldsa_attestation enabled.