### PR TITLE
[x509]: Use LZSS to compress and decompress x509 templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
 name = "caliptra-x509"
 version = "0.1.0"
 dependencies = [
+ "caliptra-error",
  "hex",
  "openssl",
  "rand 0.8.5",
@@ -1315,6 +1316,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitfield",
+ "caliptra-x509",
  "const-oid 0.9.6",
  "convert_case",
  "der 0.7.10",

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2794,6 +2794,11 @@ impl CaliptraError {
             0xa006_0005,
             "UDS FE Zeroization Failed"
         ),
+        (
+            X509_TEMPLATE_DECOMPRESSION_FAILED,
+            0xa007_0001,
+            "X509 template decompression failed"
+        ),
     ];
 }
 

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -111,7 +111,7 @@ fn make_ecc_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     };
 
     // Generate the `To Be Signed` portion of the CSR
-    let tbs = FmcAliasCsrTbsEcc384::new(&params);
+    let tbs = FmcAliasCsrTbsEcc384::new(&params)?;
 
     // Sign the `To Be Signed` portion
     let mut sig = Crypto::ecdsa384_sign_and_verify(
@@ -168,7 +168,7 @@ fn make_mldsa_csr(env: &mut FmcEnv, output: &DiceOutput) -> CaliptraResult<()> {
     };
 
     // Generate the `To Be Signed` portion of the CSR
-    let tbs = FmcAliasTbsMlDsa87::new(&params);
+    let tbs = FmcAliasTbsMlDsa87::new(&params)?;
 
     // Sign the `To Be Signed` portion
     let mut sig = env.abr.with_mldsa87(|mut mldsa87| {

--- a/fmc/src/flow/rt_alias.rs
+++ b/fmc/src/flow/rt_alias.rs
@@ -410,7 +410,7 @@ impl RtAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = RtAliasCertTbsEcc384::new(&params);
+        let tbs = RtAliasCertTbsEcc384::new(&params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(
@@ -505,7 +505,7 @@ impl RtAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = RtAliasCertTbsMlDsa87::new(&params);
+        let tbs = RtAliasCertTbsMlDsa87::new(&params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -209,7 +209,7 @@ impl FmcAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = FmcAliasCertTbsEcc384::new(&params);
+        let tbs = FmcAliasCertTbsEcc384::new(&params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(
@@ -290,7 +290,7 @@ impl FmcAliasLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = FmcAliasCertTbsMlDsa87::new(&params);
+        let tbs = FmcAliasCertTbsMlDsa87::new(&params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -453,7 +453,7 @@ impl InitDevIdLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = InitDevIdCsrTbsEcc384::new(&params);
+        let tbs = InitDevIdCsrTbsEcc384::new(&params)?;
 
         cprintln!(
             "[idev] Sign CSR {} SUBJECT.KEYID = {}",
@@ -512,7 +512,7 @@ impl InitDevIdLayer {
         };
 
         // Generate the `To Be Signed` portion of the CSR
-        let tbs = InitDevIdCsrTbsMlDsa87::new(&params);
+        let tbs = InitDevIdCsrTbsMlDsa87::new(&params)?;
 
         cprintln!(
             "[idev] Sign CSR {} SUBJECT.KEYID = {}",

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -281,7 +281,7 @@ impl LocalDevIdLayer {
         };
 
         // Generate the ECC `To Be Signed` portion of the CSR
-        let ecc_tbs = LocalDevIdCertTbsEcc384::new(&ecc_tbs_params);
+        let ecc_tbs = LocalDevIdCertTbsEcc384::new(&ecc_tbs_params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(
@@ -353,7 +353,7 @@ impl LocalDevIdLayer {
         };
 
         // Generate the ECC `To Be Signed` portion of the CSR
-        let mldsa_tbs = LocalDevIdCertTbsMlDsa87::new(&mldsa_tbs_params);
+        let mldsa_tbs = LocalDevIdCertTbsMlDsa87::new(&mldsa_tbs_params)?;
 
         // Sign the `To Be Signed` portion
         cprintln!(

--- a/runtime/src/attested_csr/ldevid.rs
+++ b/runtime/src/attested_csr/ldevid.rs
@@ -33,7 +33,7 @@ pub fn generate_ldevid_ecc_csr(
         ueid: &ueid,
     };
 
-    let csr_tbs = LocalDevIdCsrTbsEcc384::new(&params);
+    let csr_tbs = LocalDevIdCsrTbsEcc384::new(&params)?;
     let null_sig = Ecdsa384Signature::default();
     let csr_builder = Ecdsa384CsrBuilder::new(csr_tbs.tbs(), &null_sig)
         .ok_or(CaliptraError::RUNTIME_ATTESTED_CSR_EAT_ENCODING_ERROR)?;
@@ -64,7 +64,7 @@ pub fn generate_ldevid_mldsa_csr(
         ueid: &ueid,
     };
 
-    let csr_tbs = LocalDevIdCsrTbsMlDsa87::new(&params);
+    let csr_tbs = LocalDevIdCsrTbsMlDsa87::new(&params)?;
     let null_sig = MlDsa87Signature::default();
     let csr_builder = MlDsa87CsrBuilder::new(csr_tbs.tbs(), &null_sig)
         .ok_or(CaliptraError::RUNTIME_ATTESTED_CSR_EAT_ENCODING_ERROR)?;

--- a/runtime/src/attested_csr/rt_alias.rs
+++ b/runtime/src/attested_csr/rt_alias.rs
@@ -33,7 +33,7 @@ pub fn generate_rt_alias_ecc_csr(
         tcb_info_fw_svn: &fw_svn.to_be_bytes(),
     };
 
-    let tbs = RtAliasCsrTbsEcc384::new(&params);
+    let tbs = RtAliasCsrTbsEcc384::new(&params)?;
 
     // Sign the TBS with RT Alias ECC private key
     let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;
@@ -80,7 +80,7 @@ pub fn generate_rt_alias_mldsa_csr(
         tcb_info_fw_svn: &fw_svn.to_be_bytes(),
     };
 
-    let tbs = RtAliasCsrTbsMlDsa87::new(&params);
+    let tbs = RtAliasCsrTbsMlDsa87::new(&params)?;
 
     // Sign the TBS with RT Alias ML-DSA private key
     // ML-DSA handles its own internal hashing, so pass raw TBS data

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 zeroize.workspace = true
+caliptra-error.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/x509/build/fmc_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_cert_tbs_ecc_384.rs
@@ -69,72 +69,105 @@ impl FmcAliasCertTbsEcc384 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 918usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 3u8, 146u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 112u8,
-        49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8,
-        112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8,
-        52u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
-        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
-        115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8,
-        105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
-        56u8, 52u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8,
-        48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8,
-        16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8,
-        34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 157usize] = [
+        255u8, 48u8, 130u8, 3u8, 146u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 255u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8,
+        67u8, 255u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 255u8, 50u8, 46u8, 49u8,
+        32u8, 69u8, 99u8, 99u8, 51u8, 255u8, 56u8, 52u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8,
+        223u8, 68u8, 49u8, 73u8, 48u8, 71u8, 2u8, 81u8, 5u8, 19u8, 225u8, 64u8, 5u8, 47u8, 6u8,
+        79u8, 7u8, 111u8, 7u8, 232u8, 34u8, 24u8, 15u8, 252u8, 9u8, 108u8, 1u8, 30u8, 48u8, 115u8,
+        49u8, 38u8, 48u8, 36u8, 250u8, 9u8, 99u8, 29u8, 9u8, 111u8, 52u8, 32u8, 70u8, 77u8, 67u8,
+        63u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 9u8, 159u8, 15u8, 47u8, 248u8, 16u8, 79u8,
+        17u8, 111u8, 17u8, 113u8, 118u8, 48u8, 16u8, 6u8, 7u8, 254u8, 17u8, 146u8, 2u8, 1u8, 6u8,
+        5u8, 43u8, 129u8, 4u8, 31u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 237usize] = [
+        255u8, 163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 255u8, 48u8, 18u8, 6u8, 3u8,
+        85u8, 29u8, 19u8, 1u8, 191u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 175u8, 1u8,
+        5u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 255u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8,
+        6u8, 6u8, 255u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 223u8, 48u8, 19u8, 4u8, 17u8,
+        95u8, 0u8, 29u8, 48u8, 27u8, 174u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 7u8, 2u8,
+        162u8, 100u8, 213u8, 12u8, 0u8, 149u8, 9u8, 6u8, 96u8, 58u8, 4u8, 4u8, 5u8, 4u8, 247u8,
+        130u8, 1u8, 46u8, 7u8, 96u8, 42u8, 48u8, 95u8, 166u8, 255u8, 63u8, 48u8, 61u8, 6u8, 9u8,
+        96u8, 134u8, 72u8, 15u8, 1u8, 101u8, 3u8, 4u8, 6u8, 65u8, 5u8, 94u8, 1u8, 31u8, 7u8, 138u8,
+        255u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 255u8, 82u8, 65u8, 95u8, 50u8,
+        95u8, 88u8, 95u8, 70u8, 255u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8, 69u8, 255u8, 82u8,
+        95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 208u8, 6u8, 31u8, 6u8, 47u8, 7u8, 79u8, 6u8,
+        25u8, 29u8, 6u8, 31u8, 86u8, 69u8, 247u8, 78u8, 68u8, 79u8, 6u8, 36u8, 101u8, 131u8, 2u8,
+        1u8, 208u8, 12u8, 127u8, 12u8, 127u8, 13u8, 159u8, 12u8, 122u8, 30u8, 12u8, 123u8, 77u8,
+        67u8, 255u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 245u8, 69u8, 12u8, 147u8,
+        29u8, 26u8, 1u8, 14u8, 4u8, 22u8, 4u8, 233u8, 20u8, 18u8, 47u8, 23u8, 160u8, 31u8, 27u8,
+        241u8, 35u8, 4u8, 24u8, 7u8, 48u8, 22u8, 128u8, 2u8, 31u8, 26u8, 144u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
-        1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8,
-        85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8,
-        6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8,
-        100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 9u8, 48u8, 130u8, 1u8, 58u8,
-        6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8, 46u8, 48u8, 130u8, 1u8, 42u8,
-        48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8,
-        2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
-        82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8,
-        69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
-        96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8,
-        67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8,
-        83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8,
-        101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8,
-        80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8, 73u8,
-        82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 3u8, 146u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
+            56u8, 52u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8,
+            3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8,
+            3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8,
+            32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 70u8, 77u8,
+            67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
+            4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8,
+            16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8,
+            0u8, 34u8, 3u8, 98u8, 0u8,
+        ];
+        let after = [
+            163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
+            19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8,
+            6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8,
+            6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
+            9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8,
+            1u8, 46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8,
+            134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8,
+            88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8,
+            78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+            1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8,
+            29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8,
+            70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8,
+            70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
+            96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8,
+            95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8,
+            69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8,
+            4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8,
+            4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -147,14 +180,21 @@ impl FmcAliasCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &FmcAliasCertTbsEcc384Params) -> Self {
+    pub fn new(params: &FmcAliasCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -221,6 +261,32 @@ impl FmcAliasCertTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; FmcAliasCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            FmcAliasCertTbsEcc384::TBS_TEMPLATE[..FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            FmcAliasCertTbsEcc384::TBS_TEMPLATE[FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + FmcAliasCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/fmc_alias_cert_tbs_ml_dsa_87.rs
@@ -69,72 +69,105 @@ impl FmcAliasCertTbsMlDsa87 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3415usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 13u8, 83u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
-        113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8,
-        105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8,
-        97u8, 56u8, 55u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8,
-        3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8,
-        15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 30u8, 67u8,
-        97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
-        68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8,
-        115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8,
-        4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 149usize] = [
+        255u8, 48u8, 130u8, 13u8, 83u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 113u8, 49u8, 36u8, 48u8, 255u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+        27u8, 255u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 255u8, 32u8, 50u8, 46u8,
+        49u8, 32u8, 77u8, 108u8, 68u8, 255u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8, 101u8,
+        127u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 2u8, 97u8, 135u8, 5u8, 19u8, 64u8, 5u8,
+        79u8, 6u8, 111u8, 7u8, 143u8, 8u8, 8u8, 34u8, 243u8, 24u8, 15u8, 9u8, 140u8, 1u8, 30u8,
+        48u8, 116u8, 49u8, 39u8, 203u8, 48u8, 37u8, 9u8, 115u8, 30u8, 9u8, 127u8, 9u8, 112u8, 70u8,
+        77u8, 127u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 9u8, 175u8, 112u8, 15u8, 95u8,
+        16u8, 127u8, 17u8, 159u8, 17u8, 161u8, 130u8, 10u8, 50u8, 17u8, 234u8, 31u8, 3u8, 130u8,
+        10u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 237usize] = [
+        255u8, 163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 255u8, 48u8, 18u8, 6u8, 3u8,
+        85u8, 29u8, 19u8, 1u8, 191u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 175u8, 1u8,
+        5u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 255u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8,
+        6u8, 6u8, 255u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 223u8, 48u8, 19u8, 4u8, 17u8,
+        95u8, 0u8, 29u8, 48u8, 27u8, 174u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 7u8, 2u8,
+        162u8, 100u8, 213u8, 12u8, 0u8, 149u8, 9u8, 6u8, 96u8, 58u8, 4u8, 4u8, 5u8, 4u8, 247u8,
+        130u8, 1u8, 46u8, 7u8, 96u8, 42u8, 48u8, 95u8, 166u8, 255u8, 63u8, 48u8, 61u8, 6u8, 9u8,
+        96u8, 134u8, 72u8, 15u8, 1u8, 101u8, 3u8, 4u8, 6u8, 65u8, 5u8, 94u8, 1u8, 31u8, 7u8, 138u8,
+        255u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 255u8, 82u8, 65u8, 95u8, 50u8,
+        95u8, 88u8, 95u8, 70u8, 255u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8, 69u8, 255u8, 82u8,
+        95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 208u8, 6u8, 31u8, 6u8, 47u8, 7u8, 79u8, 6u8,
+        25u8, 29u8, 6u8, 31u8, 86u8, 69u8, 247u8, 78u8, 68u8, 79u8, 6u8, 36u8, 101u8, 131u8, 2u8,
+        1u8, 208u8, 12u8, 127u8, 12u8, 127u8, 13u8, 159u8, 12u8, 122u8, 30u8, 12u8, 123u8, 77u8,
+        67u8, 255u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 245u8, 69u8, 12u8, 147u8,
+        29u8, 26u8, 1u8, 14u8, 4u8, 22u8, 4u8, 233u8, 20u8, 18u8, 47u8, 23u8, 160u8, 31u8, 27u8,
+        241u8, 35u8, 4u8, 24u8, 7u8, 48u8, 22u8, 128u8, 2u8, 31u8, 26u8, 144u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
-        1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8,
-        85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8,
-        6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8,
-        100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 9u8, 48u8, 130u8, 1u8, 58u8,
-        6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8, 46u8, 48u8, 130u8, 1u8, 42u8,
-        48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8,
-        2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
-        82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8,
-        69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
-        96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8,
-        67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8,
-        83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8,
-        101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8,
-        80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8, 73u8,
-        82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 13u8, 83u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8,
+            108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
+            68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8,
+            48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 116u8, 49u8, 39u8,
+            48u8, 37u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+            116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+            55u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
+            71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8,
+            3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+        ];
+        let after = [
+            163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
+            19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8,
+            6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8,
+            6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
+            9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8,
+            1u8, 46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8,
+            134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8,
+            88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8,
+            78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+            1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8,
+            29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8,
+            70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8,
+            70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
+            96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8,
+            95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8,
+            69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8,
+            4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8,
+            4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -147,14 +180,21 @@ impl FmcAliasCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &FmcAliasCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &FmcAliasCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -221,6 +261,32 @@ impl FmcAliasCertTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; FmcAliasCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            FmcAliasCertTbsMlDsa87::TBS_TEMPLATE[..FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            FmcAliasCertTbsMlDsa87::TBS_TEMPLATE[FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + FmcAliasCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_csr_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_csr_tbs_ecc_384.rs
@@ -45,56 +45,85 @@ impl FmcAliasCsrTbsEcc384 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 687usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 2u8, 171u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 70u8, 77u8, 67u8, 32u8,
-        65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
-        64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8,
-        61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 101usize] = [
+        255u8, 48u8, 130u8, 2u8, 171u8, 2u8, 1u8, 0u8, 48u8, 255u8, 115u8, 49u8, 38u8, 48u8, 36u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
+        255u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 223u8, 115u8, 49u8, 73u8, 48u8,
+        71u8, 2u8, 129u8, 5u8, 19u8, 195u8, 64u8, 95u8, 0u8, 31u8, 1u8, 63u8, 2u8, 95u8, 3u8,
+        118u8, 48u8, 118u8, 255u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 255u8, 61u8,
+        2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 31u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 230usize] = [
+        255u8, 160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 255u8, 6u8, 9u8, 42u8, 134u8,
+        72u8, 134u8, 247u8, 13u8, 127u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 1u8, 48u8, 255u8,
+        160u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 127u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8,
+        0u8, 112u8, 95u8, 2u8, 1u8, 5u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 255u8, 4u8, 3u8,
+        2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 255u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 191u8,
+        21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 0u8, 29u8, 48u8, 93u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8,
+        4u8, 224u8, 7u8, 2u8, 162u8, 171u8, 100u8, 12u8, 0u8, 149u8, 9u8, 7u8, 144u8, 58u8, 4u8,
+        4u8, 5u8, 239u8, 4u8, 130u8, 1u8, 46u8, 8u8, 144u8, 42u8, 48u8, 95u8, 255u8, 166u8, 63u8,
+        48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 31u8, 72u8, 1u8, 101u8, 3u8, 4u8, 6u8, 65u8, 5u8, 94u8,
+        1u8, 31u8, 254u8, 7u8, 138u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 255u8, 84u8, 82u8,
+        65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 255u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8,
+        255u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 161u8, 96u8, 6u8, 31u8, 6u8, 47u8,
+        7u8, 79u8, 6u8, 25u8, 29u8, 6u8, 31u8, 86u8, 239u8, 69u8, 78u8, 68u8, 79u8, 6u8, 36u8,
+        101u8, 131u8, 2u8, 161u8, 1u8, 12u8, 127u8, 12u8, 127u8, 13u8, 159u8, 12u8, 122u8, 30u8,
+        12u8, 123u8, 77u8, 255u8, 67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 3u8, 82u8, 69u8,
+        12u8, 146u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
-        247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8, 18u8,
-        6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8,
-        1u8, 5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8,
-        4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8,
-        17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
-        9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8,
-        46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8,
-        72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8,
-        76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8,
-        95u8, 79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8,
-        48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8,
-        88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8,
-        78u8, 70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
-        96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8,
-        67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8,
-        67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 2u8, 171u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 70u8, 77u8, 67u8,
+            32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8,
+            5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8,
+            16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8,
+            0u8, 34u8, 3u8, 98u8, 0u8,
+        ];
+        let after = [
+            160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
+            247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8,
+            18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8,
+            255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8,
+            4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8,
+            21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8,
+            4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8, 46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8,
+            166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8,
+            4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8,
+            80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8,
+            79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8,
+            48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
+            82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8,
+            78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8,
+            95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8,
+            2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8,
+            80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8,
+            73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -107,14 +136,21 @@ impl FmcAliasCsrTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &FmcAliasCsrTbsEcc384Params) -> Self {
+    pub fn new(params: &FmcAliasCsrTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -157,6 +193,32 @@ impl FmcAliasCsrTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; FmcAliasCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            FmcAliasCsrTbsEcc384::TBS_TEMPLATE[..FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            FmcAliasCsrTbsEcc384::TBS_TEMPLATE
+                [FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET + FmcAliasCsrTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_tbs_ml_dsa_87.rs
+++ b/x509/build/fmc_alias_tbs_ml_dsa_87.rs
@@ -45,56 +45,85 @@ impl FmcAliasTbsMlDsa87 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3182usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 12u8, 106u8, 2u8, 1u8, 0u8, 48u8, 116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8,
-        32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
-        19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8,
-        134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 101usize] = [
+        255u8, 48u8, 130u8, 12u8, 106u8, 2u8, 1u8, 0u8, 48u8, 255u8, 116u8, 49u8, 39u8, 48u8, 37u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+        55u8, 255u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 191u8, 97u8, 115u8, 49u8,
+        73u8, 48u8, 71u8, 2u8, 145u8, 5u8, 135u8, 19u8, 64u8, 95u8, 0u8, 31u8, 1u8, 63u8, 2u8,
+        95u8, 3u8, 118u8, 48u8, 255u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 255u8, 134u8,
+        72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 31u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 230usize] = [
+        255u8, 160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 255u8, 6u8, 9u8, 42u8, 134u8,
+        72u8, 134u8, 247u8, 13u8, 127u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 1u8, 48u8, 255u8,
+        160u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 127u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8,
+        0u8, 112u8, 95u8, 2u8, 1u8, 5u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 255u8, 4u8, 3u8,
+        2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 255u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 191u8,
+        21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 0u8, 29u8, 48u8, 93u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8,
+        4u8, 224u8, 7u8, 2u8, 162u8, 171u8, 100u8, 12u8, 0u8, 149u8, 9u8, 7u8, 144u8, 58u8, 4u8,
+        4u8, 5u8, 239u8, 4u8, 130u8, 1u8, 46u8, 8u8, 144u8, 42u8, 48u8, 95u8, 255u8, 166u8, 63u8,
+        48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 31u8, 72u8, 1u8, 101u8, 3u8, 4u8, 6u8, 65u8, 5u8, 94u8,
+        1u8, 31u8, 254u8, 7u8, 138u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8, 80u8, 255u8, 84u8, 82u8,
+        65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 255u8, 70u8, 85u8, 83u8, 69u8, 95u8, 79u8, 87u8, 78u8,
+        255u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 161u8, 96u8, 6u8, 31u8, 6u8, 47u8,
+        7u8, 79u8, 6u8, 25u8, 29u8, 6u8, 31u8, 86u8, 239u8, 69u8, 78u8, 68u8, 79u8, 6u8, 36u8,
+        101u8, 131u8, 2u8, 161u8, 1u8, 12u8, 127u8, 12u8, 127u8, 13u8, 159u8, 12u8, 122u8, 30u8,
+        12u8, 123u8, 77u8, 255u8, 67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 3u8, 82u8, 69u8,
+        12u8, 146u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
-        247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8, 18u8,
-        6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8,
-        1u8, 5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8,
-        4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8,
-        17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
-        9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8,
-        46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8,
-        72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8,
-        76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8,
-        95u8, 79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8,
-        48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8,
-        88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8, 78u8, 68u8, 79u8, 82u8, 95u8, 73u8,
-        78u8, 70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8,
-        96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8,
-        67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8,
-        67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 12u8, 106u8, 2u8, 1u8, 0u8, 48u8, 116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8,
+            67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
+            4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8,
+            50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8,
+            130u8, 10u8, 33u8, 0u8,
+        ];
+        let after = [
+            160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
+            247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8,
+            18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8,
+            255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8,
+            4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8,
+            21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8,
+            4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 6u8, 7u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 9u8, 48u8, 130u8, 1u8, 58u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 5u8, 4u8, 130u8, 1u8, 46u8, 48u8, 130u8, 1u8, 42u8, 48u8, 95u8,
+            166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8,
+            4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 28u8, 67u8, 65u8, 76u8, 73u8,
+            80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8,
+            79u8, 87u8, 78u8, 69u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 96u8, 166u8, 63u8,
+            48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
+            82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 85u8, 83u8, 69u8, 95u8, 86u8, 69u8,
+            78u8, 68u8, 79u8, 82u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 101u8, 131u8, 2u8, 1u8,
+            95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8,
+            2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 30u8, 67u8, 65u8, 76u8, 73u8,
+            80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 70u8, 77u8, 67u8, 95u8, 70u8,
+            73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -107,14 +136,21 @@ impl FmcAliasTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &FmcAliasTbsMlDsa87Params) -> Self {
+    pub fn new(params: &FmcAliasTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -157,6 +193,32 @@ impl FmcAliasTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; FmcAliasTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            FmcAliasTbsMlDsa87::TBS_TEMPLATE[..FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &FmcAliasTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            FmcAliasTbsMlDsa87::TBS_TEMPLATE
+                [FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET + FmcAliasTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/init_dev_id_csr_tbs_ecc_384.rs
+++ b/x509/build/init_dev_id_csr_tbs_ecc_384.rs
@@ -29,35 +29,53 @@ impl InitDevIdCsrTbsEcc384 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 358usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8,
-        4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8,
-        46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8,
-        68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8,
-        43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 98usize] = [
+        255u8, 48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 255u8, 112u8, 49u8, 35u8, 48u8, 33u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
+        255u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 123u8, 48u8, 71u8, 2u8, 81u8, 5u8,
+        19u8, 64u8, 95u8, 0u8, 31u8, 248u8, 1u8, 63u8, 2u8, 95u8, 3u8, 118u8, 48u8, 118u8, 48u8,
+        16u8, 6u8, 255u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 255u8, 6u8, 5u8, 43u8,
+        129u8, 4u8, 0u8, 34u8, 3u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 96usize] = [
+        255u8, 160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 255u8, 72u8, 134u8, 247u8, 13u8,
+        1u8, 9u8, 14u8, 49u8, 255u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 255u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 125u8, 6u8, 0u8, 112u8, 2u8, 1u8, 7u8, 48u8, 14u8,
+        1u8, 65u8, 253u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 255u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 5u8, 4u8, 255u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 118u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 45u8, 7u8, 2u8, 162u8,
+        100u8, 6u8, 0u8, 149u8, 12u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
-        49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
-        48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
-        1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8,
-        4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8,
-        37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 6u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 73u8, 68u8, 101u8,
+            118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
+            134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8,
+            0u8,
+        ];
+        let after = [
+            160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8,
+            14u8, 49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+            15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8,
+            5u8, 4u8, 100u8, 6u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -70,14 +88,21 @@ impl InitDevIdCsrTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &InitDevIdCsrTbsEcc384Params) -> Self {
+    pub fn new(params: &InitDevIdCsrTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -105,5 +130,31 @@ impl InitDevIdCsrTbsEcc384 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; InitDevIdCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &InitDevIdCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            InitDevIdCsrTbsEcc384::TBS_TEMPLATE[..InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; InitDevIdCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &InitDevIdCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            InitDevIdCsrTbsEcc384::TBS_TEMPLATE[InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                + InitDevIdCsrTbsEcc384::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
@@ -29,35 +29,53 @@ impl InitDevIdCsrTbsMlDsa87 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 2853usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8,
-        101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8,
-        1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 98usize] = [
+        255u8, 48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 255u8, 113u8, 49u8, 36u8, 48u8, 34u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+        55u8, 255u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 247u8, 73u8, 48u8, 71u8,
+        2u8, 97u8, 5u8, 19u8, 64u8, 95u8, 240u8, 0u8, 31u8, 1u8, 63u8, 2u8, 95u8, 3u8, 118u8, 48u8,
+        130u8, 10u8, 50u8, 255u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 255u8, 101u8, 3u8,
+        4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 3u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 96usize] = [
+        255u8, 160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 255u8, 72u8, 134u8, 247u8, 13u8,
+        1u8, 9u8, 14u8, 49u8, 255u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 255u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 125u8, 6u8, 0u8, 112u8, 2u8, 1u8, 7u8, 48u8, 14u8,
+        1u8, 65u8, 253u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 255u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 5u8, 4u8, 255u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 118u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 45u8, 7u8, 2u8, 162u8,
+        100u8, 6u8, 0u8, 149u8, 12u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
-        49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
-        48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
-        1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8,
-        4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8,
-        37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 6u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8,
+            101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8,
+            6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8,
+            0u8,
+        ];
+        let after = [
+            160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8,
+            14u8, 49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+            15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8,
+            5u8, 4u8, 100u8, 6u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -70,14 +88,21 @@ impl InitDevIdCsrTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &InitDevIdCsrTbsMlDsa87Params) -> Self {
+    pub fn new(params: &InitDevIdCsrTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -105,5 +130,31 @@ impl InitDevIdCsrTbsMlDsa87 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &InitDevIdCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE[..InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &InitDevIdCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE[InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/local_dev_id_cert_tbs_ecc_384.rs
+++ b/x509/build/local_dev_id_cert_tbs_ecc_384.rs
@@ -53,50 +53,74 @@ impl LocalDevIdCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 595usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 2u8, 79u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 112u8, 49u8,
-        35u8, 48u8, 33u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8,
-        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
-        73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
-        19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 112u8, 49u8,
-        35u8, 48u8, 33u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8,
-        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
-        76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
-        19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8,
-        206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 138usize] = [
+        255u8, 48u8, 130u8, 2u8, 79u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 255u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8,
+        67u8, 255u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 255u8, 50u8, 46u8, 49u8,
+        32u8, 69u8, 99u8, 99u8, 51u8, 255u8, 56u8, 52u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8,
+        223u8, 68u8, 49u8, 73u8, 48u8, 71u8, 2u8, 81u8, 5u8, 19u8, 225u8, 64u8, 5u8, 47u8, 6u8,
+        79u8, 7u8, 111u8, 7u8, 232u8, 34u8, 24u8, 15u8, 16u8, 9u8, 108u8, 1u8, 30u8, 9u8, 111u8,
+        9u8, 108u8, 76u8, 9u8, 111u8, 14u8, 175u8, 15u8, 207u8, 124u8, 16u8, 239u8, 17u8, 70u8,
+        118u8, 48u8, 16u8, 6u8, 7u8, 17u8, 98u8, 255u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8,
+        15u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 110usize] = [
+        255u8, 163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 255u8, 6u8, 3u8, 85u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 239u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 1u8, 6u8, 235u8, 48u8,
+        14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 255u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 255u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 183u8, 4u8, 17u8, 95u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 107u8, 4u8, 20u8, 4u8, 224u8, 7u8, 2u8, 162u8,
+        100u8, 7u8, 0u8, 149u8, 247u8, 12u8, 48u8, 29u8, 6u8, 33u8, 14u8, 4u8, 22u8, 4u8, 233u8,
+        20u8, 3u8, 158u8, 3u8, 193u8, 31u8, 8u8, 17u8, 35u8, 4u8, 24u8, 7u8, 48u8, 22u8, 128u8,
+        2u8, 31u8, 6u8, 176u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8,
-        255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8,
-        29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
-        129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8,
-        3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
-        7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8,
-        14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8,
-        29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 2u8, 79u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
+            56u8, 52u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8,
+            3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8,
+            3u8, 85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8,
+            32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 76u8, 68u8,
+            101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8,
+            42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8,
+            98u8, 0u8,
+        ];
+        let after = [
+            163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8,
+            1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8,
+            85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8,
+            5u8, 5u8, 4u8, 100u8, 7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -109,14 +133,21 @@ impl LocalDevIdCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &LocalDevIdCertTbsEcc384Params) -> Self {
+    pub fn new(params: &LocalDevIdCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -167,6 +198,32 @@ impl LocalDevIdCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; LocalDevIdCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            LocalDevIdCertTbsEcc384::TBS_TEMPLATE[..LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            LocalDevIdCertTbsEcc384::TBS_TEMPLATE[LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + LocalDevIdCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/local_dev_id_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/local_dev_id_cert_tbs_ml_dsa_87.rs
@@ -53,51 +53,73 @@ impl LocalDevIdCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 3092usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 12u8, 16u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
-        113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8,
-        105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8,
-        97u8, 56u8, 55u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8,
-        3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8,
-        15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8,
-        97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
-        68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8,
-        48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8,
-        50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8,
-        10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 130usize] = [
+        255u8, 48u8, 130u8, 12u8, 16u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 113u8, 49u8, 36u8, 48u8, 255u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+        27u8, 255u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 255u8, 32u8, 50u8, 46u8,
+        49u8, 32u8, 77u8, 108u8, 68u8, 255u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8, 101u8,
+        127u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 2u8, 97u8, 135u8, 5u8, 19u8, 64u8, 5u8,
+        79u8, 6u8, 111u8, 7u8, 143u8, 8u8, 8u8, 34u8, 67u8, 24u8, 15u8, 9u8, 140u8, 1u8, 30u8, 9u8,
+        127u8, 9u8, 125u8, 76u8, 9u8, 127u8, 112u8, 14u8, 223u8, 15u8, 255u8, 17u8, 31u8, 17u8,
+        118u8, 130u8, 10u8, 50u8, 17u8, 186u8, 31u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 110usize] = [
+        255u8, 163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 255u8, 6u8, 3u8, 85u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 239u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 1u8, 6u8, 235u8, 48u8,
+        14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 255u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 255u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 183u8, 4u8, 17u8, 95u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 107u8, 4u8, 20u8, 4u8, 224u8, 7u8, 2u8, 162u8,
+        100u8, 7u8, 0u8, 149u8, 247u8, 12u8, 48u8, 29u8, 6u8, 33u8, 14u8, 4u8, 22u8, 4u8, 233u8,
+        20u8, 3u8, 158u8, 3u8, 193u8, 31u8, 8u8, 17u8, 35u8, 4u8, 24u8, 7u8, 48u8, 22u8, 128u8,
+        2u8, 31u8, 6u8, 176u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8,
-        255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8,
-        29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
-        129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8,
-        3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8,
-        7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8,
-        14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8,
-        29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 12u8, 16u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8,
+            108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
+            68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8,
+            48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 113u8, 49u8, 36u8,
+            48u8, 34u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+            116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+            55u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8,
+            85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8,
+            10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            3u8, 130u8, 10u8, 33u8, 0u8,
+        ];
+        let after = [
+            163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8,
+            1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8,
+            85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
+            103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            48u8, 27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8,
+            5u8, 5u8, 4u8, 100u8, 7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -110,14 +132,21 @@ impl LocalDevIdCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &LocalDevIdCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &LocalDevIdCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -168,6 +197,32 @@ impl LocalDevIdCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE[..LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE[LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/local_dev_id_csr_tbs_ecc_384.rs
+++ b/x509/build/local_dev_id_csr_tbs_ecc_384.rs
@@ -29,35 +29,53 @@ impl LocalDevIdCsrTbsEcc384 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 358usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8,
-        4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8,
-        46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8,
-        68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8,
-        43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 98usize] = [
+        255u8, 48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 255u8, 112u8, 49u8, 35u8, 48u8, 33u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
+        255u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 123u8, 48u8, 71u8, 2u8, 81u8, 5u8,
+        19u8, 64u8, 95u8, 0u8, 31u8, 248u8, 1u8, 63u8, 2u8, 95u8, 3u8, 118u8, 48u8, 118u8, 48u8,
+        16u8, 6u8, 255u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 255u8, 6u8, 5u8, 43u8,
+        129u8, 4u8, 0u8, 34u8, 3u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 96usize] = [
+        255u8, 160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 255u8, 72u8, 134u8, 247u8, 13u8,
+        1u8, 9u8, 14u8, 49u8, 255u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 255u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 125u8, 6u8, 0u8, 112u8, 2u8, 1u8, 6u8, 48u8, 14u8,
+        1u8, 65u8, 253u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 255u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 5u8, 4u8, 255u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 118u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 45u8, 7u8, 2u8, 162u8,
+        100u8, 7u8, 0u8, 149u8, 12u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
-        49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
-        48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
-        1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8,
-        4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8,
-        37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 7u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 76u8, 68u8, 101u8,
+            118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
+            134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8,
+            0u8,
+        ];
+        let after = [
+            160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8,
+            14u8, 49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+            15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8,
+            5u8, 4u8, 100u8, 7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -70,14 +88,21 @@ impl LocalDevIdCsrTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &LocalDevIdCsrTbsEcc384Params) -> Self {
+    pub fn new(params: &LocalDevIdCsrTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -105,5 +130,31 @@ impl LocalDevIdCsrTbsEcc384 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; LocalDevIdCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            LocalDevIdCsrTbsEcc384::TBS_TEMPLATE[..LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            LocalDevIdCsrTbsEcc384::TBS_TEMPLATE[LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                + LocalDevIdCsrTbsEcc384::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/local_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/local_dev_id_csr_tbs_ml_dsa_87.rs
@@ -29,35 +29,53 @@ impl LocalDevIdCsrTbsMlDsa87 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 2853usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8,
-        101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8,
-        1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 98usize] = [
+        255u8, 48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 255u8, 113u8, 49u8, 36u8, 48u8, 34u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+        55u8, 255u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8, 68u8, 49u8, 247u8, 73u8, 48u8, 71u8,
+        2u8, 97u8, 5u8, 19u8, 64u8, 95u8, 240u8, 0u8, 31u8, 1u8, 63u8, 2u8, 95u8, 3u8, 118u8, 48u8,
+        130u8, 10u8, 50u8, 255u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 255u8, 101u8, 3u8,
+        4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 3u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 96usize] = [
+        255u8, 160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 255u8, 72u8, 134u8, 247u8, 13u8,
+        1u8, 9u8, 14u8, 49u8, 255u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 255u8, 29u8,
+        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 125u8, 6u8, 0u8, 112u8, 2u8, 1u8, 6u8, 48u8, 14u8,
+        1u8, 65u8, 253u8, 15u8, 1u8, 65u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 255u8, 31u8, 6u8, 6u8,
+        103u8, 129u8, 5u8, 5u8, 4u8, 255u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 118u8,
+        0u8, 29u8, 48u8, 27u8, 4u8, 81u8, 37u8, 4u8, 20u8, 4u8, 224u8, 45u8, 7u8, 2u8, 162u8,
+        100u8, 7u8, 0u8, 149u8, 12u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
-        49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
-        48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
-        1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8,
-        4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 27u8, 6u8, 3u8, 85u8, 29u8,
-        37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 7u8, 6u8, 7u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8,
+            101u8, 118u8, 73u8, 68u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8,
+            6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8,
+            0u8,
+        ];
+        let after = [
+            160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8,
+            14u8, 49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8,
+            15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            27u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 20u8, 48u8, 18u8, 6u8, 7u8, 103u8, 129u8, 5u8,
+            5u8, 4u8, 100u8, 7u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -70,14 +88,21 @@ impl LocalDevIdCsrTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &LocalDevIdCsrTbsMlDsa87Params) -> Self {
+    pub fn new(params: &LocalDevIdCsrTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -105,5 +130,31 @@ impl LocalDevIdCsrTbsMlDsa87 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE[..LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &LocalDevIdCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE[LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
@@ -49,48 +49,73 @@ impl OcpLockEcdh384CertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 563usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 2u8, 47u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
-        37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8,
-        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
-        82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
-        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
-        122u8, 49u8, 45u8, 48u8, 43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8, 79u8, 67u8, 80u8,
-        32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
-        111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8, 68u8, 72u8, 32u8,
-        80u8, 45u8, 51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8,
-        2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 184usize] = [
+        255u8, 48u8, 130u8, 2u8, 47u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 255u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8,
+        67u8, 255u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 255u8, 50u8, 46u8, 49u8,
+        32u8, 69u8, 99u8, 99u8, 51u8, 255u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8,
+        127u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 2u8, 113u8, 135u8, 5u8, 19u8, 64u8, 5u8,
+        79u8, 6u8, 111u8, 7u8, 143u8, 8u8, 8u8, 34u8, 243u8, 24u8, 15u8, 9u8, 140u8, 1u8, 30u8,
+        48u8, 122u8, 49u8, 45u8, 251u8, 48u8, 43u8, 9u8, 131u8, 36u8, 79u8, 67u8, 80u8, 32u8,
+        255u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 255u8, 69u8, 32u8, 69u8, 110u8,
+        100u8, 111u8, 114u8, 115u8, 255u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8,
+        31u8, 68u8, 72u8, 32u8, 80u8, 45u8, 10u8, 144u8, 10u8, 15u8, 15u8, 191u8, 248u8, 16u8,
+        223u8, 17u8, 255u8, 18u8, 1u8, 118u8, 48u8, 16u8, 6u8, 7u8, 254u8, 18u8, 34u8, 2u8, 1u8,
+        6u8, 5u8, 43u8, 129u8, 4u8, 31u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 2u8, 47u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
+            56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
+            71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 122u8, 49u8, 45u8, 48u8,
+            43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8,
+            75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8, 111u8, 114u8, 115u8,
+            101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8, 68u8, 72u8, 32u8, 80u8, 45u8,
+            51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
+            134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8,
+            0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -103,14 +128,21 @@ impl OcpLockEcdh384CertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &OcpLockEcdh384CertTbsEcc384Params) -> Self {
+    pub fn new(params: &OcpLockEcdh384CertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -160,6 +192,33 @@ impl OcpLockEcdh384CertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockEcdh384CertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockEcdh384CertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE[OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
@@ -49,48 +49,73 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 565usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 2u8, 49u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
-        49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8,
-        112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8,
-        56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
-        71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 48u8, 122u8, 49u8, 45u8, 48u8, 43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8,
-        79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
-        110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8,
-        68u8, 72u8, 32u8, 80u8, 45u8, 51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
-        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
-        134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 191usize] = [
+        255u8, 48u8, 130u8, 2u8, 49u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 115u8, 49u8, 38u8, 48u8, 255u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+        29u8, 255u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 255u8, 32u8, 50u8, 46u8,
+        49u8, 32u8, 77u8, 108u8, 68u8, 255u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8,
+        255u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 29u8, 71u8, 2u8, 129u8, 5u8,
+        19u8, 64u8, 5u8, 111u8, 6u8, 143u8, 7u8, 175u8, 206u8, 8u8, 40u8, 34u8, 24u8, 15u8, 9u8,
+        172u8, 1u8, 30u8, 48u8, 122u8, 239u8, 49u8, 45u8, 48u8, 43u8, 9u8, 147u8, 36u8, 79u8, 67u8,
+        255u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 255u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+        110u8, 100u8, 111u8, 255u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 255u8,
+        69u8, 67u8, 68u8, 72u8, 32u8, 80u8, 45u8, 51u8, 131u8, 56u8, 52u8, 10u8, 15u8, 15u8, 223u8,
+        16u8, 255u8, 18u8, 31u8, 18u8, 33u8, 118u8, 255u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8,
+        206u8, 255u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 31u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 2u8, 49u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8,
+            108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
+            68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8,
+            115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            122u8, 49u8, 45u8, 48u8, 43u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 36u8, 79u8, 67u8, 80u8,
+            32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
+            111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 69u8, 67u8, 68u8, 72u8,
+            32u8, 80u8, 45u8, 51u8, 56u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
+            19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8,
+            6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8,
+            34u8, 3u8, 98u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 17u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -103,14 +128,23 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &OcpLockEcdh384CertTbsMlDsa87Params) -> Self {
+    pub fn new(
+        params: &OcpLockEcdh384CertTbsMlDsa87Params,
+    ) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -160,6 +194,34 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockEcdh384CertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockEcdh384CertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE
+                [OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                    + OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_hybrid_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_hybrid_cert_tbs_ecc_384.rs
@@ -49,49 +49,74 @@ impl OcpLockHybridCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2141usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
-        73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 37u8,
-        48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8,
-        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8,
-        116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
-        129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8, 79u8, 67u8, 80u8,
-        32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
-        111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8, 69u8,
-        77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8, 80u8, 51u8, 56u8,
-        52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8,
-        63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 198usize] = [
+        255u8, 48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 114u8, 49u8, 73u8, 48u8, 71u8, 127u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 2u8,
+        223u8, 120u8, 3u8, 255u8, 5u8, 31u8, 6u8, 55u8, 49u8, 37u8, 48u8, 35u8, 4u8, 177u8, 255u8,
+        3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 255u8, 116u8, 114u8, 97u8, 32u8, 50u8,
+        46u8, 49u8, 32u8, 255u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 255u8, 116u8,
+        32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 231u8, 34u8, 24u8, 15u8, 9u8, 140u8, 1u8,
+        30u8, 48u8, 129u8, 133u8, 224u8, 9u8, 159u8, 12u8, 223u8, 13u8, 255u8, 15u8, 31u8, 9u8,
+        145u8, 56u8, 48u8, 54u8, 254u8, 9u8, 147u8, 47u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8,
+        255u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 255u8, 69u8, 110u8, 100u8, 111u8,
+        114u8, 115u8, 101u8, 109u8, 255u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8,
+        255u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 191u8, 69u8, 67u8, 68u8, 72u8, 45u8,
+        80u8, 11u8, 80u8, 48u8, 247u8, 130u8, 6u8, 146u8, 19u8, 1u8, 43u8, 6u8, 1u8, 5u8, 255u8,
+        5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 1u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            114u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+            28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8,
+            32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8,
+            97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 129u8, 133u8, 49u8,
+            73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8, 79u8,
+            67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+            110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+            45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8,
+            45u8, 80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8,
+            1u8, 5u8, 5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -104,14 +129,21 @@ impl OcpLockHybridCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &OcpLockHybridCertTbsEcc384Params) -> Self {
+    pub fn new(params: &OcpLockHybridCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -161,6 +193,33 @@ impl OcpLockHybridCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE[OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
@@ -49,49 +49,74 @@ impl OcpLockHybridCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2143usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
-        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8,
-        38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8,
-        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
-        55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 48u8, 129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
-        64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8,
-        79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
-        110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
-        45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8,
-        80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8,
-        5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 203usize] = [
+        255u8, 48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 115u8, 49u8, 73u8, 48u8, 255u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
+        64u8, 240u8, 2u8, 239u8, 4u8, 15u8, 5u8, 47u8, 6u8, 71u8, 49u8, 38u8, 48u8, 36u8, 254u8,
+        4u8, 177u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8, 114u8, 97u8,
+        32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 255u8,
+        32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 159u8, 115u8, 48u8, 34u8, 24u8, 15u8,
+        9u8, 172u8, 1u8, 30u8, 48u8, 131u8, 129u8, 133u8, 9u8, 175u8, 12u8, 255u8, 14u8, 31u8,
+        15u8, 63u8, 9u8, 161u8, 56u8, 251u8, 48u8, 54u8, 9u8, 163u8, 47u8, 79u8, 67u8, 80u8, 32u8,
+        255u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 255u8, 69u8, 32u8, 69u8, 110u8,
+        100u8, 111u8, 114u8, 115u8, 255u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+        255u8, 45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 255u8, 52u8, 45u8, 69u8, 67u8, 68u8,
+        72u8, 45u8, 80u8, 255u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 255u8, 10u8, 6u8,
+        8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 255u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8,
+            12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8,
+            49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8,
+            108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 129u8,
+            133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+            47u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8,
+            32u8, 69u8, 110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8,
+            77u8, 76u8, 45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8,
+            68u8, 72u8, 45u8, 80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8,
+            8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -104,14 +129,21 @@ impl OcpLockHybridCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &OcpLockHybridCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &OcpLockHybridCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -161,6 +193,33 @@ impl OcpLockHybridCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE[OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
@@ -49,48 +49,73 @@ impl OcpLockMlKemCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2034usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 7u8, 238u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8,
-        49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8,
-        112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8,
-        52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8,
-        6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8,
-        15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 123u8, 49u8, 46u8, 48u8, 44u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 37u8, 79u8,
-        67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8,
-        100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8,
-        75u8, 69u8, 77u8, 32u8, 49u8, 48u8, 50u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8,
-        4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 6u8, 50u8, 48u8, 11u8, 6u8,
-        9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8, 130u8, 6u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 188usize] = [
+        255u8, 48u8, 130u8, 7u8, 238u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 255u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8,
+        67u8, 255u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 255u8, 50u8, 46u8, 49u8,
+        32u8, 69u8, 99u8, 99u8, 51u8, 255u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8,
+        127u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 2u8, 113u8, 135u8, 5u8, 19u8, 64u8, 5u8,
+        79u8, 6u8, 111u8, 7u8, 143u8, 8u8, 8u8, 34u8, 243u8, 24u8, 15u8, 9u8, 140u8, 1u8, 30u8,
+        48u8, 123u8, 49u8, 46u8, 251u8, 48u8, 44u8, 9u8, 131u8, 37u8, 79u8, 67u8, 80u8, 32u8,
+        255u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 255u8, 69u8, 32u8, 69u8, 110u8,
+        100u8, 111u8, 114u8, 115u8, 255u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+        255u8, 45u8, 75u8, 69u8, 77u8, 32u8, 49u8, 48u8, 50u8, 193u8, 52u8, 10u8, 31u8, 15u8,
+        207u8, 16u8, 239u8, 18u8, 15u8, 18u8, 17u8, 130u8, 6u8, 255u8, 50u8, 48u8, 11u8, 6u8, 9u8,
+        96u8, 134u8, 72u8, 239u8, 1u8, 101u8, 3u8, 4u8, 18u8, 112u8, 130u8, 6u8, 33u8, 1u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 7u8, 238u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
+            56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
+            71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 123u8, 49u8, 46u8, 48u8,
+            44u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 37u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8,
+            75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8, 111u8, 114u8, 115u8,
+            101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8, 69u8, 77u8, 32u8,
+            49u8, 48u8, 50u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 6u8, 50u8, 48u8, 11u8,
+            6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8, 130u8, 6u8, 33u8,
+            0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -103,14 +128,21 @@ impl OcpLockMlKemCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &OcpLockMlKemCertTbsEcc384Params) -> Self {
+    pub fn new(params: &OcpLockMlKemCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -160,6 +192,32 @@ impl OcpLockMlKemCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockMlKemCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE[..OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockMlKemCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE[OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
@@ -49,49 +49,73 @@ impl OcpLockMlKemCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2036usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 7u8, 240u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
-        115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8,
-        105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8,
-        97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8,
-        48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8,
-        15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 48u8, 123u8, 49u8, 46u8, 48u8, 44u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
-        37u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8,
-        69u8, 110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8,
-        76u8, 45u8, 75u8, 69u8, 77u8, 32u8, 49u8, 48u8, 50u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8,
-        3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 6u8, 50u8, 48u8,
-        11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8, 130u8, 6u8, 33u8,
-        0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 181usize] = [
+        255u8, 48u8, 130u8, 7u8, 240u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 115u8, 49u8, 38u8, 48u8, 255u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+        29u8, 255u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 255u8, 32u8, 50u8, 46u8,
+        49u8, 32u8, 77u8, 108u8, 68u8, 255u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8,
+        255u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 29u8, 71u8, 2u8, 129u8, 5u8,
+        19u8, 64u8, 5u8, 111u8, 6u8, 143u8, 7u8, 175u8, 206u8, 8u8, 40u8, 34u8, 24u8, 15u8, 9u8,
+        172u8, 1u8, 30u8, 48u8, 123u8, 239u8, 49u8, 46u8, 48u8, 44u8, 9u8, 147u8, 37u8, 79u8, 67u8,
+        255u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 255u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+        110u8, 100u8, 111u8, 255u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 255u8,
+        77u8, 76u8, 45u8, 75u8, 69u8, 77u8, 32u8, 49u8, 7u8, 48u8, 50u8, 52u8, 10u8, 31u8, 15u8,
+        239u8, 17u8, 15u8, 18u8, 47u8, 18u8, 49u8, 247u8, 130u8, 6u8, 50u8, 18u8, 120u8, 4u8, 3u8,
+        3u8, 130u8, 7u8, 6u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 7u8, 240u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8,
+            108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
+            68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8,
+            115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            123u8, 49u8, 46u8, 48u8, 44u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 37u8, 79u8, 67u8, 80u8,
+            32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
+            111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8,
+            69u8, 77u8, 32u8, 49u8, 48u8, 50u8, 52u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8,
+            5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 6u8,
+            50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8,
+            130u8, 6u8, 33u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 66u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -104,14 +128,21 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &OcpLockMlKemCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &OcpLockMlKemCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -161,6 +192,33 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockMlKemCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockMlKemCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE[OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/rt_alias_cert_tbs_ecc_384.rs
@@ -61,58 +61,86 @@ impl RtAliasCertTbsEcc384 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 707usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 2u8, 191u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 115u8,
-        49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8,
-        112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8,
-        52u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8,
-        71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8,
-        67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8,
-        99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8,
-        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
-        118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8,
-        129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 153usize] = [
+        255u8, 48u8, 130u8, 2u8, 191u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 255u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8,
+        67u8, 255u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 255u8, 50u8, 46u8, 49u8,
+        32u8, 69u8, 99u8, 99u8, 51u8, 255u8, 56u8, 52u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 255u8,
+        108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 14u8, 2u8, 129u8, 5u8, 19u8, 64u8, 5u8,
+        95u8, 6u8, 127u8, 7u8, 159u8, 8u8, 24u8, 231u8, 34u8, 24u8, 15u8, 9u8, 156u8, 1u8, 30u8,
+        48u8, 114u8, 49u8, 215u8, 37u8, 48u8, 35u8, 9u8, 147u8, 28u8, 9u8, 159u8, 52u8, 32u8,
+        131u8, 82u8, 116u8, 9u8, 143u8, 14u8, 239u8, 16u8, 15u8, 17u8, 47u8, 17u8, 151u8, 118u8,
+        239u8, 48u8, 16u8, 6u8, 7u8, 17u8, 178u8, 2u8, 1u8, 6u8, 255u8, 5u8, 43u8, 129u8, 4u8, 0u8,
+        34u8, 3u8, 98u8, 1u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 183usize] = [
+        255u8, 163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 255u8, 48u8, 18u8, 6u8, 3u8, 85u8,
+        29u8, 19u8, 1u8, 191u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 175u8, 1u8, 4u8,
+        48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 255u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8,
+        6u8, 255u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 159u8, 48u8, 19u8, 4u8, 17u8,
+        95u8, 0u8, 29u8, 4u8, 83u8, 37u8, 191u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 2u8, 162u8, 100u8,
+        247u8, 12u8, 48u8, 112u8, 3u8, 84u8, 1u8, 4u8, 102u8, 48u8, 255u8, 100u8, 131u8, 2u8, 1u8,
+        95u8, 166u8, 63u8, 48u8, 255u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 63u8, 3u8,
+        4u8, 2u8, 2u8, 4u8, 48u8, 4u8, 142u8, 1u8, 31u8, 254u8, 6u8, 186u8, 137u8, 29u8, 67u8,
+        65u8, 76u8, 73u8, 80u8, 255u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 255u8, 82u8,
+        84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 255u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8,
+        79u8, 251u8, 48u8, 29u8, 12u8, 177u8, 14u8, 4u8, 22u8, 4u8, 20u8, 244u8, 5u8, 175u8, 10u8,
+        80u8, 31u8, 14u8, 161u8, 35u8, 4u8, 24u8, 48u8, 3u8, 22u8, 128u8, 2u8, 31u8, 13u8, 64u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
-        1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8, 6u8, 3u8,
-        85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8, 6u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 18u8,
-        6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8,
-        100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8,
-        100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8,
-        80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8,
-        77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8,
-        29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8,
-        85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 2u8, 191u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8,
+            56u8, 52u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8,
+            48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 114u8, 49u8, 37u8,
+            48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8,
+            116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8,
+            32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8,
+            3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8,
+            129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+        ];
+        let after = [
+            163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
+            19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
+            6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8,
+            31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8,
+            7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8,
+            5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8,
+            61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8,
+            65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8,
+            65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8,
+            4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8,
+            35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -125,14 +153,21 @@ impl RtAliasCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &RtAliasCertTbsEcc384Params) -> Self {
+    pub fn new(params: &RtAliasCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -191,6 +226,32 @@ impl RtAliasCertTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; RtAliasCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            RtAliasCertTbsEcc384::TBS_TEMPLATE[..RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            RtAliasCertTbsEcc384::TBS_TEMPLATE
+                [RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET + RtAliasCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/rt_alias_cert_tbs_ml_dsa_87.rs
@@ -61,58 +61,85 @@ impl RtAliasCertTbsMlDsa87 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3204usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 12u8, 128u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
-        116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8,
-        105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8,
-        97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8,
-        73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8,
-        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8,
-        12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8,
-        32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8,
-        105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 145usize] = [
+        255u8, 48u8, 130u8, 12u8, 128u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 116u8, 49u8, 39u8, 48u8, 255u8, 37u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+        30u8, 255u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 255u8, 32u8, 50u8, 46u8,
+        49u8, 32u8, 77u8, 108u8, 68u8, 255u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8,
+        255u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 59u8, 48u8, 71u8, 2u8, 145u8,
+        5u8, 19u8, 64u8, 5u8, 127u8, 6u8, 159u8, 156u8, 7u8, 191u8, 8u8, 56u8, 34u8, 24u8, 15u8,
+        9u8, 188u8, 1u8, 30u8, 48u8, 95u8, 115u8, 49u8, 38u8, 48u8, 36u8, 9u8, 163u8, 29u8, 9u8,
+        175u8, 6u8, 9u8, 160u8, 82u8, 116u8, 9u8, 159u8, 15u8, 31u8, 16u8, 63u8, 17u8, 95u8, 17u8,
+        199u8, 247u8, 130u8, 10u8, 50u8, 18u8, 10u8, 3u8, 130u8, 10u8, 33u8, 1u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 183usize] = [
+        255u8, 163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 255u8, 48u8, 18u8, 6u8, 3u8, 85u8,
+        29u8, 19u8, 1u8, 191u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8, 2u8, 175u8, 1u8, 4u8,
+        48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 255u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8,
+        6u8, 255u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 159u8, 48u8, 19u8, 4u8, 17u8,
+        95u8, 0u8, 29u8, 4u8, 83u8, 37u8, 191u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 2u8, 162u8, 100u8,
+        247u8, 12u8, 48u8, 112u8, 3u8, 84u8, 1u8, 4u8, 102u8, 48u8, 255u8, 100u8, 131u8, 2u8, 1u8,
+        95u8, 166u8, 63u8, 48u8, 255u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 63u8, 3u8,
+        4u8, 2u8, 2u8, 4u8, 48u8, 4u8, 142u8, 1u8, 31u8, 254u8, 6u8, 186u8, 137u8, 29u8, 67u8,
+        65u8, 76u8, 73u8, 80u8, 255u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 255u8, 82u8,
+        84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 255u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8,
+        79u8, 251u8, 48u8, 29u8, 12u8, 177u8, 14u8, 4u8, 22u8, 4u8, 20u8, 244u8, 5u8, 175u8, 10u8,
+        80u8, 31u8, 14u8, 161u8, 35u8, 4u8, 24u8, 48u8, 3u8, 22u8, 128u8, 2u8, 31u8, 13u8, 64u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
-        1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8, 6u8, 3u8,
-        85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8, 6u8,
-        103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 18u8,
-        6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8,
-        100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8,
-        100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
-        101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8,
-        80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8,
-        77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8,
-        29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8,
-        85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 12u8, 128u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8,
+            108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8,
+            68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8, 32u8, 65u8, 108u8, 105u8, 97u8,
+            115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
+            115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8,
+            105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8,
+            115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8,
+            49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8,
+            72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+        ];
+        let after = [
+            163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
+            19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
+            6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8,
+            31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8,
+            7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8,
+            5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8,
+            61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 82u8,
+            65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8,
+            65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8, 48u8, 29u8, 6u8, 3u8, 85u8, 29u8, 14u8,
+            4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8,
+            35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -125,14 +152,21 @@ impl RtAliasCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &RtAliasCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &RtAliasCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -191,6 +225,32 @@ impl RtAliasCertTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; RtAliasCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            RtAliasCertTbsMlDsa87::TBS_TEMPLATE[..RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            RtAliasCertTbsMlDsa87::TBS_TEMPLATE[RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + RtAliasCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_csr_tbs_ecc_384.rs
+++ b/x509/build/rt_alias_csr_tbs_ecc_384.rs
@@ -37,42 +37,66 @@ impl RtAliasCsrTbsEcc384 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 469usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 1u8, 209u8, 2u8, 1u8, 0u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8,
-        108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8,
-        2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 100usize] = [
+        255u8, 48u8, 130u8, 1u8, 209u8, 2u8, 1u8, 0u8, 48u8, 255u8, 114u8, 49u8, 37u8, 48u8, 35u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8,
+        255u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 239u8, 49u8, 73u8, 48u8, 71u8,
+        2u8, 113u8, 5u8, 19u8, 64u8, 225u8, 95u8, 0u8, 31u8, 1u8, 63u8, 2u8, 95u8, 3u8, 118u8,
+        48u8, 118u8, 48u8, 255u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 255u8, 2u8, 1u8,
+        6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 15u8, 34u8, 3u8, 98u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 171usize] = [
+        255u8, 160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 255u8, 42u8, 134u8, 72u8, 134u8,
+        247u8, 13u8, 1u8, 9u8, 255u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 255u8,
+        18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 223u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8,
+        2u8, 1u8, 215u8, 4u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 3u8, 255u8, 2u8, 2u8,
+        132u8, 48u8, 31u8, 6u8, 6u8, 103u8, 255u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8,
+        207u8, 19u8, 4u8, 17u8, 95u8, 0u8, 29u8, 4u8, 83u8, 37u8, 4u8, 223u8, 11u8, 48u8, 9u8, 6u8,
+        7u8, 2u8, 162u8, 100u8, 12u8, 251u8, 48u8, 112u8, 3u8, 84u8, 1u8, 4u8, 102u8, 48u8, 100u8,
+        255u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+        1u8, 101u8, 3u8, 31u8, 4u8, 2u8, 2u8, 4u8, 48u8, 4u8, 142u8, 1u8, 31u8, 6u8, 186u8, 255u8,
+        137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 255u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8,
+        95u8, 82u8, 255u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 127u8, 82u8, 69u8, 95u8,
+        73u8, 78u8, 70u8, 79u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8,
-        1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
-        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
-        6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8,
-        6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 103u8, 129u8, 5u8,
-        5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8,
-        48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8,
-        1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8,
-        73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8,
-        82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 1u8, 209u8, 2u8, 1u8, 0u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8,
+            65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
+            19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8,
+            6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8,
+            34u8, 3u8, 98u8, 0u8,
+        ];
+        let after = [
+            160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8,
+            13u8, 1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8,
+            85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8,
+            48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8,
+            132u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8,
+            4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8,
+            9u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8,
+            48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
+            82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8,
+            87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -85,14 +109,21 @@ impl RtAliasCsrTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &RtAliasCsrTbsEcc384Params) -> Self {
+    pub fn new(params: &RtAliasCsrTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -127,6 +158,32 @@ impl RtAliasCsrTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; RtAliasCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            RtAliasCsrTbsEcc384::TBS_TEMPLATE[..RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCsrTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            RtAliasCsrTbsEcc384::TBS_TEMPLATE
+                [RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET + RtAliasCsrTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/rt_alias_csr_tbs_ml_dsa_87.rs
@@ -37,42 +37,66 @@ impl RtAliasCsrTbsMlDsa87 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 2964usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 11u8, 144u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
-        85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
-        50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8,
-        32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8,
-        19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8,
-        134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 100usize] = [
+        255u8, 48u8, 130u8, 11u8, 144u8, 2u8, 1u8, 0u8, 48u8, 255u8, 115u8, 49u8, 38u8, 48u8, 36u8,
+        6u8, 3u8, 85u8, 255u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8,
+        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
+        55u8, 255u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 223u8, 115u8, 49u8, 73u8,
+        48u8, 71u8, 2u8, 129u8, 5u8, 19u8, 195u8, 64u8, 95u8, 0u8, 31u8, 1u8, 63u8, 2u8, 95u8, 3u8,
+        118u8, 48u8, 130u8, 255u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 255u8, 72u8, 1u8,
+        101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 15u8, 130u8, 10u8, 33u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 171usize] = [
+        255u8, 160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 255u8, 42u8, 134u8, 72u8, 134u8,
+        247u8, 13u8, 1u8, 9u8, 255u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 255u8,
+        18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 223u8, 255u8, 4u8, 8u8, 48u8, 6u8, 0u8, 112u8,
+        2u8, 1u8, 215u8, 4u8, 48u8, 14u8, 1u8, 65u8, 15u8, 1u8, 65u8, 4u8, 3u8, 255u8, 2u8, 2u8,
+        132u8, 48u8, 31u8, 6u8, 6u8, 103u8, 255u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8,
+        207u8, 19u8, 4u8, 17u8, 95u8, 0u8, 29u8, 4u8, 83u8, 37u8, 4u8, 223u8, 11u8, 48u8, 9u8, 6u8,
+        7u8, 2u8, 162u8, 100u8, 12u8, 251u8, 48u8, 112u8, 3u8, 84u8, 1u8, 4u8, 102u8, 48u8, 100u8,
+        255u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8,
+        1u8, 101u8, 3u8, 31u8, 4u8, 2u8, 2u8, 4u8, 48u8, 4u8, 142u8, 1u8, 31u8, 6u8, 186u8, 255u8,
+        137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8, 255u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8,
+        95u8, 82u8, 255u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 127u8, 82u8, 69u8, 95u8,
+        73u8, 78u8, 70u8, 79u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8,
-        1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
-        19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
-        6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8,
-        6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8, 4u8, 17u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8, 9u8, 6u8, 7u8, 103u8, 129u8, 5u8,
-        5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8,
-        48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8, 48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8,
-        1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8,
-        73u8, 80u8, 84u8, 82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8,
-        82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 11u8, 144u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
+            85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
+            50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8,
+            32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8,
+            5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8,
+            50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8,
+            130u8, 10u8, 33u8, 0u8,
+        ];
+        let after = [
+            160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8,
+            13u8, 1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8,
+            85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8,
+            48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8,
+            132u8, 48u8, 31u8, 6u8, 6u8, 103u8, 129u8, 5u8, 5u8, 4u8, 4u8, 4u8, 21u8, 48u8, 19u8,
+            4u8, 17u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 37u8, 4u8, 11u8, 48u8,
+            9u8, 6u8, 7u8, 103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8, 48u8, 112u8, 6u8, 6u8, 103u8,
+            129u8, 5u8, 5u8, 4u8, 1u8, 4u8, 102u8, 48u8, 100u8, 131u8, 2u8, 1u8, 95u8, 166u8, 63u8,
+            48u8, 61u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 2u8, 2u8, 4u8, 48u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 137u8, 29u8, 67u8, 65u8, 76u8, 73u8, 80u8, 84u8,
+            82u8, 65u8, 95u8, 50u8, 95u8, 88u8, 95u8, 82u8, 84u8, 95u8, 70u8, 73u8, 82u8, 77u8,
+            87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -85,14 +109,21 @@ impl RtAliasCsrTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &RtAliasCsrTbsMlDsa87Params) -> Self {
+    pub fn new(params: &RtAliasCsrTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -127,6 +158,32 @@ impl RtAliasCsrTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; RtAliasCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            RtAliasCsrTbsMlDsa87::TBS_TEMPLATE[..RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &RtAliasCsrTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            RtAliasCsrTbsMlDsa87::TBS_TEMPLATE
+                [RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET + RtAliasCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/gen/Cargo.toml
+++ b/x509/gen/Cargo.toml
@@ -21,3 +21,4 @@ rand.workspace = true
 syn.workspace = true
 x509-cert.workspace = true
 const-oid.workspace = true
+caliptra-x509 = { workspace = true, features = ["std"] }

--- a/x509/gen/src/code_gen.rs
+++ b/x509/gen/src/code_gen.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 use crate::tbs::TbsTemplate;
+use caliptra_x509::lzss;
 use convert_case::{Case, Casing};
 use quote::{__private::TokenStream, format_ident, quote};
 use std::{path::Path, process::Command};
@@ -85,20 +86,44 @@ impl CodeGen {
             pub const TBS_TEMPLATE_LEN: usize = #tbs_len;
         );
 
-        // Generate chunked template constants and new() body
-        let (template_consts, new_body) = if let (Some(before_key), Some(after_key)) =
+        // Generate chunked template constants, new() body, and verification tests
+        let (template_consts, new_body, verification_test) = if let (
+            Some(before_key),
+            Some(after_key),
+        ) =
             (template.tbs_before_key(), template.tbs_after_key())
         {
+            let compressed_before = lzss::compress(before_key);
+            let compressed_after = lzss::compress(after_key);
+
+            // Build-time verification
+            {
+                let mut decompressed_before = vec![0u8; before_key.len()];
+                assert!(lzss::decompress(
+                    &compressed_before,
+                    &mut decompressed_before
+                ));
+                assert_eq!(before_key, decompressed_before);
+
+                let mut decompressed_after = vec![0u8; after_key.len()];
+                assert!(lzss::decompress(&compressed_after, &mut decompressed_after));
+                assert_eq!(after_key, decompressed_after);
+            }
+
+            let compressed_before_len = compressed_before.len();
+            let compressed_after_len = compressed_after.len();
+
             let template_consts = quote!(
-                const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [#(#before_key,)*];
+                const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; #compressed_before_len] = [#(#compressed_before,)*];
+                const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; #compressed_after_len] = [#(#compressed_after,)*];
+                const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
                 const TBS_TEMPLATE_AFTER_KEY_LEN: usize = Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-                const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [#(#after_key,)*];
 
                 #[cfg(test)]
                 const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
                     let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-                    let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-                    let after = Self::TBS_TEMPLATE_AFTER_KEY;
+                    let before = [#(#before_key,)*];
+                    let after = [#(#after_key,)*];
                     let mut i = 0;
                     while i < before.len() {
                         result[i] = before[i];
@@ -114,34 +139,90 @@ impl CodeGen {
             );
 
             let new_body = quote!(
-                pub fn new(params: &#param_name) -> Self {
+                pub fn new(params: &#param_name) -> caliptra_error::CaliptraResult<Self> {
                     let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-                    tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-                    tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+
+                    let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+                    if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+                        return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+                    }
+                    tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+
+                    let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+                    if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+                        return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+                    }
+                    tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
+
                     let mut template = Self { tbs };
                     template.apply(params);
-                    template
+                    Ok(template)
                 }
             );
 
-            (template_consts, new_body)
+            let verification_test = quote!(
+                #[cfg(test)]
+                mod lzss_tests {
+                    use super::*;
+                    #[test]
+                    fn test_template_decompression() {
+                        let mut before_key = [0u8; #type_name::TBS_TEMPLATE_BEFORE_KEY_LEN];
+                        assert!(crate::lzss::decompress(&#type_name::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key));
+                        assert_eq!(before_key, #type_name::TBS_TEMPLATE[..#type_name::PUBLIC_KEY_OFFSET]);
+
+                        let mut after_key = [0u8; #type_name::TBS_TEMPLATE_AFTER_KEY_LEN];
+                        assert!(crate::lzss::decompress(&#type_name::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key));
+                        assert_eq!(after_key, #type_name::TBS_TEMPLATE[#type_name::PUBLIC_KEY_OFFSET + #type_name::PUBLIC_KEY_LEN..]);
+                    }
+                }
+            );
+
+            (template_consts, new_body, verification_test)
         } else {
             let tbs = template.tbs();
+            let compressed_tbs = lzss::compress(tbs);
+            let compressed_tbs_len = compressed_tbs.len();
+
+            // Build-time verification
+            {
+                let mut decompressed_tbs = vec![0u8; tbs.len()];
+                assert!(lzss::decompress(&compressed_tbs, &mut decompressed_tbs));
+                assert_eq!(tbs, decompressed_tbs);
+            }
+
             let template_consts = quote!(
+                const COMPRESSED_TBS_TEMPLATE: [u8; #compressed_tbs_len] = [#(#compressed_tbs,)*];
+
+                #[cfg(test)]
                 const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [#(#tbs,)*];
             );
 
             let new_body = quote!(
-                pub fn new(params: &#param_name) -> Self {
-                    let mut template = Self {
-                        tbs: Self::TBS_TEMPLATE,
-                    };
+                pub fn new(params: &#param_name) -> caliptra_error::CaliptraResult<Self> {
+                    let mut tbs = [0u8; Self::TBS_TEMPLATE_LEN];
+                    if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE, &mut tbs) {
+                        return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+                    }
+                    let mut template = Self { tbs };
                     template.apply(params);
-                    template
+                    Ok(template)
                 }
             );
 
-            (template_consts, new_body)
+            let verification_test = quote!(
+                #[cfg(test)]
+                mod lzss_tests {
+                    use super::*;
+                    #[test]
+                    fn test_template_decompression() {
+                        let mut tbs = [0u8; #type_name::TBS_TEMPLATE_LEN];
+                        assert!(crate::lzss::decompress(&#type_name::COMPRESSED_TBS_TEMPLATE, &mut tbs));
+                        assert_eq!(tbs, #type_name::TBS_TEMPLATE);
+                    }
+                }
+            );
+
+            (template_consts, new_body, verification_test)
         };
 
         quote!(
@@ -195,6 +276,8 @@ Abstract:
                     #(#apply_calls)*
                 }
             }
+
+            #verification_test
         )
         .to_string()
     }

--- a/x509/src/fmc_alias_cert_ecc_384.rs
+++ b/x509/src/fmc_alias_cert_ecc_384.rs
@@ -69,7 +69,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        FmcAliasCertTbsEcc384::new(&params)
+        FmcAliasCertTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/fmc_alias_cert_mldsa_87.rs
+++ b/x509/src/fmc_alias_cert_mldsa_87.rs
@@ -70,7 +70,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        FmcAliasCertTbsMlDsa87::new(&params)
+        FmcAliasCertTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/fmc_alias_csr_ecc_384.rs
+++ b/x509/src/fmc_alias_csr_ecc_384.rs
@@ -48,7 +48,7 @@ mod tests {
             tcb_info_fw_svn: &TEST_TCB_INFO_FW_SVN.try_into().unwrap(),
         };
 
-        FmcAliasCsrTbsEcc384::new(&params)
+        FmcAliasCsrTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/fmc_alias_csr_mldsa_87.rs
+++ b/x509/src/fmc_alias_csr_mldsa_87.rs
@@ -54,7 +54,7 @@ mod tests {
             tcb_info_fw_svn: &TEST_TCB_INFO_FW_SVN.try_into().unwrap(),
         };
 
-        FmcAliasTbsMlDsa87::new(&params)
+        FmcAliasTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/idevid_csr_ecc_384.rs
+++ b/x509/src/idevid_csr_ecc_384.rs
@@ -38,7 +38,7 @@ mod tests {
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        InitDevIdCsrTbsEcc384::new(&params)
+        InitDevIdCsrTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/idevid_csr_mldsa_87.rs
+++ b/x509/src/idevid_csr_mldsa_87.rs
@@ -38,7 +38,7 @@ mod tests {
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        InitDevIdCsrTbsMlDsa87::new(&params)
+        InitDevIdCsrTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/ldevid_cert_ecc_384.rs
+++ b/x509/src/ldevid_cert_ecc_384.rs
@@ -54,7 +54,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        LocalDevIdCertTbsEcc384::new(&params)
+        LocalDevIdCertTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/ldevid_cert_mldsa_87.rs
+++ b/x509/src/ldevid_cert_mldsa_87.rs
@@ -55,7 +55,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        LocalDevIdCertTbsMlDsa87::new(&params)
+        LocalDevIdCertTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/ldevid_csr_ecc_384.rs
+++ b/x509/src/ldevid_csr_ecc_384.rs
@@ -38,7 +38,7 @@ mod tests {
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        LocalDevIdCsrTbsEcc384::new(&params)
+        LocalDevIdCsrTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/ldevid_csr_mldsa_87.rs
+++ b/x509/src/ldevid_csr_mldsa_87.rs
@@ -39,7 +39,7 @@ mod tests {
             ueid: &TEST_UEID.try_into().unwrap(),
         };
 
-        LocalDevIdCsrTbsMlDsa87::new(&params)
+        LocalDevIdCsrTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -26,6 +26,7 @@ mod ldevid_cert_ecc_384;
 mod ldevid_cert_mldsa_87;
 mod ldevid_csr_ecc_384;
 mod ldevid_csr_mldsa_87;
+pub mod lzss;
 mod ocp_lock_hpke_certs;
 mod rt_alias_cert_ecc_384;
 mod rt_alias_cert_mldsa_87;

--- a/x509/src/lzss.rs
+++ b/x509/src/lzss.rs
@@ -1,0 +1,241 @@
+// Licensed under the Apache-2.0 license.
+
+//! Lightweight LZSS compression and decompression implementation.
+//!
+//! # LZSS Algorithm Overview
+//!
+//! LZSS (Lempel-Ziv-Storer-Szymanski) is a lossless data compression algorithm.
+//! It replaces repeated substrings with references to a sliding window of history.
+//!
+//! ## Format Specification
+//!
+//! The compressed stream consists of blocks. Each block starts with a 1-byte
+//! `control` header, followed by up to 8 tokens (literals or references).
+//!
+//! The 8 bits of the `control` byte (from LSB to MSB) correspond to the 8 tokens:
+//! - **Bit = 1 (Literal):** The token is a single raw byte.
+//! - **Bit = 0 (Reference):** The token is a 2-byte reference to previously
+//!   decompressed data.
+//!
+//! ### Reference Encoding
+//! A reference is encoded as two bytes `(b1, b2)` representing an `offset` and `length`:
+//! - **Offset (12 bits):** How far back in the decompressed buffer to start copying.
+//!   Reconstructed as `(b1 << 4) | (b2 >> 4)`. Maximum offset is 4095.
+//! - **Length (4 bits):** How many bytes to copy.
+//!   Reconstructed as `(b2 & 0x0F) + 3`. Range is 3 to 18 bytes.
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+/// Decompresses a single literal byte.
+///
+/// Reads the next byte from `src` and writes it to `dst` at `dst_idx`.
+/// Advances both `src_idx` and `dst_idx` by 1.
+#[inline(always)]
+fn decompress_literal(
+    src: &[u8],
+    src_idx: &mut usize,
+    dst: &mut [u8],
+    dst_idx: &mut usize,
+) -> bool {
+    let val = match src.get(*src_idx) {
+        Some(&v) => v,
+        None => return false,
+    };
+    if let Some(d) = dst.get_mut(*dst_idx) {
+        *d = val;
+    } else {
+        return false;
+    }
+    *dst_idx += 1;
+    *src_idx += 1;
+    true
+}
+
+/// Decompresses a reference to previous data.
+///
+/// Reads a 2-byte reference from `src`, decodes the offset and length,
+/// and copies `length` bytes from `dst` history (at `dst_idx - offset`) to `dst_idx`.
+/// Advances `src_idx` by 2 and `dst_idx` by `length`.
+#[inline(always)]
+fn decompress_reference(
+    src: &[u8],
+    src_idx: &mut usize,
+    dst: &mut [u8],
+    dst_idx: &mut usize,
+) -> bool {
+    let b1 = match src.get(*src_idx) {
+        Some(&b) => b as usize,
+        None => return false,
+    };
+    let b2 = match src.get(*src_idx + 1) {
+        Some(&b) => b as usize,
+        None => return false,
+    };
+    *src_idx += 2;
+
+    let offset = (b1 << 4) | (b2 >> 4);
+    let length = (b2 & 0x0F) + 3;
+
+    if offset == 0 || *dst_idx < offset {
+        return false;
+    }
+
+    for _ in 0..length {
+        if *dst_idx >= dst.len() {
+            return false;
+        }
+        let src_val = match dst.get(*dst_idx - offset) {
+            Some(&val) => val,
+            None => return false,
+        };
+        if let Some(d) = dst.get_mut(*dst_idx) {
+            *d = src_val;
+        } else {
+            return false;
+        }
+        *dst_idx += 1;
+    }
+    true
+}
+
+/// Decompress LZSS compressed data.
+///
+/// Iterates through the compressed data, reading a control byte for every 8 tokens.
+/// The control byte indicates whether each of the next 8 tokens is a literal (bit = 1)
+/// or a reference (bit = 0).
+///
+/// Returns true on success, false if the data is corrupt or dst is too small.
+pub fn decompress(src: &[u8], dst: &mut [u8]) -> bool {
+    let mut src_idx = 0;
+    let mut dst_idx = 0;
+    while dst_idx < dst.len() {
+        let control = match src.get(src_idx) {
+            Some(&c) => c,
+            None => return false,
+        };
+        src_idx += 1;
+        for bit in 0..8 {
+            if dst_idx >= dst.len() {
+                break;
+            }
+            if (control & (1 << bit)) != 0 {
+                if !decompress_literal(src, &mut src_idx, dst, &mut dst_idx) {
+                    return false;
+                }
+            } else {
+                if !decompress_reference(src, &mut src_idx, dst, &mut dst_idx) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+#[cfg(feature = "std")]
+fn find_longest_match(src: &[u8], src_idx: usize) -> (usize, usize) {
+    let mut best_offset = 0;
+    let mut best_len = 0;
+
+    let start = if src_idx > 4095 { src_idx - 4095 } else { 0 };
+
+    for i in start..src_idx {
+        let mut len = 0;
+        while src_idx + len < src.len() && src[i + len] == src[src_idx + len] && len < 18 {
+            len += 1;
+        }
+        if len > best_len {
+            best_len = len;
+            best_offset = src_idx - i;
+        }
+    }
+    (best_offset, best_len)
+}
+
+/// Compress data using LZSS.
+///
+/// Iterates through the input data, searching for matches in the sliding window
+/// (up to 4095 bytes back). If a match of length >= 3 is found, it writes a reference token.
+/// Otherwise, it writes a literal token. Every 8 tokens are prefixed with a control byte.
+#[cfg(feature = "std")]
+pub fn compress(src: &[u8]) -> Vec<u8> {
+    let mut dst = Vec::new();
+    let mut src_idx = 0;
+
+    while src_idx < src.len() {
+        let mut control = 0u8;
+        let mut token_bytes = Vec::new();
+
+        for bit in 0..8 {
+            if src_idx >= src.len() {
+                break;
+            }
+
+            let (match_offset, match_len) = find_longest_match(src, src_idx);
+
+            if match_len >= 3 {
+                // Reference
+                let offset = match_offset;
+                let length = match_len;
+
+                let b1 = (offset >> 4) as u8;
+                let b2 = (((offset & 0x0F) << 4) | ((length - 3) & 0x0F)) as u8;
+                token_bytes.push(b1);
+                token_bytes.push(b2);
+
+                src_idx += match_len;
+            } else {
+                // Literal
+                control |= 1 << bit;
+                token_bytes.push(src[src_idx]);
+                src_idx += 1;
+            }
+        }
+
+        dst.push(control);
+        dst.extend(token_bytes);
+    }
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let data: &[u8] = &[];
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; 0];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, decompressed);
+    }
+
+    #[test]
+    fn test_simple() {
+        let data = b"Hello World! Hello World! Hello World!";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+
+    #[test]
+    fn test_repeating() {
+        let data = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+
+    #[test]
+    fn test_random() {
+        let data = b"abcdefghijklmnopqrstuvwxyz1234567890";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+}

--- a/x509/src/ocp_lock_hpke_certs.rs
+++ b/x509/src/ocp_lock_hpke_certs.rs
@@ -54,7 +54,7 @@ pub mod ml_kem_ecc_348 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockMlKemCertTbsEcc384::new(&params);
+            let cert = OcpLockMlKemCertTbsEcc384::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {
@@ -189,7 +189,7 @@ pub mod ml_kem_mldsa_87 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockMlKemCertTbsMlDsa87::new(&params);
+            let cert = OcpLockMlKemCertTbsMlDsa87::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {
@@ -324,7 +324,7 @@ pub mod ecdh_384_ecc_348 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockEcdh384CertTbsEcc384::new(&params);
+            let cert = OcpLockEcdh384CertTbsEcc384::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {
@@ -459,7 +459,7 @@ pub mod ecdh_384_mldsa_87 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockEcdh384CertTbsMlDsa87::new(&params);
+            let cert = OcpLockEcdh384CertTbsMlDsa87::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {
@@ -594,7 +594,7 @@ pub mod hybrid_ecc_384 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockHybridCertTbsEcc384::new(&params);
+            let cert = OcpLockHybridCertTbsEcc384::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {
@@ -703,7 +703,7 @@ pub mod hybrid_mldsa_87 {
                 not_after: &NotAfter::default().value,
             };
 
-            let cert = OcpLockHybridCertTbsMlDsa87::new(&params);
+            let cert = OcpLockHybridCertTbsMlDsa87::new(&params).unwrap();
 
             let sig = cert
                 .sign(|b| {

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
@@ -49,49 +49,74 @@ impl OcpLockHybridCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2141usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
-        73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 37u8,
-        48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8,
-        114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8,
-        116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8,
-        129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8, 79u8, 67u8, 80u8,
-        32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8, 110u8, 100u8,
-        111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8, 69u8,
-        77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8, 80u8, 51u8, 56u8,
-        52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8,
-        63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 198usize] = [
+        255u8, 48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 10u8, 255u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 255u8, 3u8,
+        3u8, 48u8, 114u8, 49u8, 73u8, 48u8, 71u8, 127u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 2u8,
+        223u8, 120u8, 3u8, 255u8, 5u8, 31u8, 6u8, 55u8, 49u8, 37u8, 48u8, 35u8, 4u8, 177u8, 255u8,
+        3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 255u8, 116u8, 114u8, 97u8, 32u8, 50u8,
+        46u8, 49u8, 32u8, 255u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 255u8, 116u8,
+        32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 231u8, 34u8, 24u8, 15u8, 9u8, 140u8, 1u8,
+        30u8, 48u8, 129u8, 133u8, 224u8, 9u8, 159u8, 12u8, 223u8, 13u8, 255u8, 15u8, 31u8, 9u8,
+        145u8, 56u8, 48u8, 54u8, 254u8, 9u8, 147u8, 47u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8,
+        255u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 255u8, 69u8, 110u8, 100u8, 111u8,
+        114u8, 115u8, 101u8, 109u8, 255u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8, 45u8, 75u8,
+        255u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 191u8, 69u8, 67u8, 68u8, 72u8, 45u8,
+        80u8, 11u8, 80u8, 48u8, 247u8, 130u8, 6u8, 146u8, 19u8, 1u8, 43u8, 6u8, 1u8, 5u8, 255u8,
+        5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 1u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8,
+            114u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+            28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8,
+            32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8,
+            97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 129u8, 133u8, 49u8,
+            73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8, 79u8,
+            67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
+            110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+            45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8,
+            45u8, 80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8,
+            1u8, 5u8, 5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -104,14 +129,21 @@ impl OcpLockHybridCertTbsEcc384 {
         }
         result
     };
-    pub fn new(params: &OcpLockHybridCertTbsEcc384Params) -> Self {
+    pub fn new(params: &OcpLockHybridCertTbsEcc384Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -161,6 +193,33 @@ impl OcpLockHybridCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsEcc384::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE[OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
@@ -49,49 +49,74 @@ impl OcpLockHybridCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2143usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
-        48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
-        49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8,
-        38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8,
-        116u8, 114u8, 97u8, 32u8, 50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8,
-        55u8, 32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 48u8, 129u8, 133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
-        64u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8, 47u8,
-        79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8, 32u8, 69u8,
-        110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
-        45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8, 68u8, 72u8, 45u8,
-        80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8,
-        5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+    const COMPRESSED_TBS_TEMPLATE_BEFORE_KEY: [u8; 203usize] = [
+        255u8, 48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 239u8, 2u8, 2u8, 20u8, 95u8, 0u8,
+        31u8, 95u8, 48u8, 11u8, 255u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 255u8, 4u8,
+        3u8, 19u8, 48u8, 115u8, 49u8, 73u8, 48u8, 255u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8,
+        64u8, 240u8, 2u8, 239u8, 4u8, 15u8, 5u8, 47u8, 6u8, 71u8, 49u8, 38u8, 48u8, 36u8, 254u8,
+        4u8, 177u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 255u8, 112u8, 116u8, 114u8, 97u8,
+        32u8, 50u8, 46u8, 49u8, 255u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 255u8,
+        32u8, 82u8, 116u8, 32u8, 65u8, 108u8, 105u8, 97u8, 159u8, 115u8, 48u8, 34u8, 24u8, 15u8,
+        9u8, 172u8, 1u8, 30u8, 48u8, 131u8, 129u8, 133u8, 9u8, 175u8, 12u8, 255u8, 14u8, 31u8,
+        15u8, 63u8, 9u8, 161u8, 56u8, 251u8, 48u8, 54u8, 9u8, 163u8, 47u8, 79u8, 67u8, 80u8, 32u8,
+        255u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 255u8, 69u8, 32u8, 69u8, 110u8,
+        100u8, 111u8, 114u8, 115u8, 255u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8, 77u8, 76u8,
+        255u8, 45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 255u8, 52u8, 45u8, 69u8, 67u8, 68u8,
+        72u8, 45u8, 80u8, 255u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 255u8, 10u8, 6u8,
+        8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 255u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
+    const COMPRESSED_TBS_TEMPLATE_AFTER_KEY: [u8; 92usize] = [
+        255u8, 163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 255u8, 85u8, 29u8, 19u8, 1u8, 1u8,
+        255u8, 4u8, 5u8, 127u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 1u8, 17u8, 253u8, 15u8, 1u8,
+        17u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 255u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8,
+        255u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 183u8, 2u8, 1u8, 2u8, 0u8, 48u8, 48u8,
+        29u8, 3u8, 129u8, 14u8, 223u8, 4u8, 22u8, 4u8, 20u8, 95u8, 0u8, 31u8, 95u8, 48u8, 253u8,
+        31u8, 5u8, 113u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 0u8, 2u8, 31u8, 3u8, 32u8,
+    ];
+    const TBS_TEMPLATE_BEFORE_KEY_LEN: usize = Self::PUBLIC_KEY_OFFSET;
     const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
         Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
-        163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
-        5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
-        4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
-        4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8, 29u8, 6u8, 3u8,
-        85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 31u8, 6u8,
-        3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-        95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
-    ];
     #[cfg(test)]
     const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
+        let before = [
+            48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8,
+            48u8, 115u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8, 85u8, 4u8, 3u8,
+            12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8, 46u8,
+            49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8, 32u8, 65u8,
+            108u8, 105u8, 97u8, 115u8, 48u8, 34u8, 24u8, 15u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 24u8, 15u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 129u8,
+            133u8, 49u8, 73u8, 48u8, 71u8, 6u8, 3u8, 85u8, 4u8, 5u8, 19u8, 64u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 49u8, 56u8, 48u8, 54u8, 6u8, 3u8, 85u8, 4u8, 3u8, 12u8,
+            47u8, 79u8, 67u8, 80u8, 32u8, 76u8, 79u8, 67u8, 75u8, 32u8, 72u8, 80u8, 75u8, 69u8,
+            32u8, 69u8, 110u8, 100u8, 111u8, 114u8, 115u8, 101u8, 109u8, 101u8, 110u8, 116u8, 32u8,
+            77u8, 76u8, 45u8, 75u8, 69u8, 77u8, 45u8, 49u8, 48u8, 50u8, 52u8, 45u8, 69u8, 67u8,
+            68u8, 72u8, 45u8, 80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8,
+            8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
+        ];
+        let after = [
+            163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8,
+            4u8, 5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8,
+            255u8, 4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8,
+            1u8, 1u8, 4u8, 11u8, 48u8, 9u8, 2u8, 1u8, 81u8, 2u8, 1u8, 2u8, 2u8, 1u8, 2u8, 48u8,
+            29u8, 6u8, 3u8, 85u8, 29u8, 14u8, 4u8, 22u8, 4u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 48u8, 31u8, 6u8, 3u8, 85u8, 29u8, 35u8, 4u8, 24u8, 48u8, 22u8, 128u8, 20u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
+            95u8, 95u8, 95u8, 95u8, 95u8,
+        ];
         let mut i = 0;
         while i < before.len() {
             result[i] = before[i];
@@ -104,14 +129,21 @@ impl OcpLockHybridCertTbsMlDsa87 {
         }
         result
     };
-    pub fn new(params: &OcpLockHybridCertTbsMlDsa87Params) -> Self {
+    pub fn new(params: &OcpLockHybridCertTbsMlDsa87Params) -> caliptra_error::CaliptraResult<Self> {
         let mut tbs = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&Self::TBS_TEMPLATE_BEFORE_KEY);
-        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..]
-            .copy_from_slice(&Self::TBS_TEMPLATE_AFTER_KEY);
+        let mut before_key = [0u8; Self::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY, &mut before_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[..Self::PUBLIC_KEY_OFFSET].copy_from_slice(&before_key);
+        let mut after_key = [0u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN];
+        if !crate::lzss::decompress(&Self::COMPRESSED_TBS_TEMPLATE_AFTER_KEY, &mut after_key) {
+            return Err(caliptra_error::CaliptraError::X509_TEMPLATE_DECOMPRESSION_FAILED);
+        }
+        tbs[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN..].copy_from_slice(&after_key);
         let mut template = Self { tbs };
         template.apply(params);
-        template
+        Ok(template)
     }
     pub fn sign<Sig, Error>(
         &self,
@@ -161,6 +193,33 @@ impl OcpLockHybridCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod lzss_tests {
+    use super::*;
+    #[test]
+    fn test_template_decompression() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_BEFORE_KEY,
+            &mut before_key
+        ));
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY_LEN];
+        assert!(crate::lzss::decompress(
+            &OcpLockHybridCertTbsMlDsa87::COMPRESSED_TBS_TEMPLATE_AFTER_KEY,
+            &mut after_key
+        ));
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE[OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/src/rt_alias_cert_ecc_384.rs
+++ b/x509/src/rt_alias_cert_ecc_384.rs
@@ -62,7 +62,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        let cert = RtAliasCertTbsEcc384::new(&params);
+        let cert = RtAliasCertTbsEcc384::new(&params).unwrap();
 
         let sig = cert
             .sign(|b| {

--- a/x509/src/rt_alias_cert_mldsa_87.rs
+++ b/x509/src/rt_alias_cert_mldsa_87.rs
@@ -63,7 +63,7 @@ mod tests {
             not_after: &NotAfter::default().value,
         };
 
-        let cert = RtAliasCertTbsMlDsa87::new(&params);
+        let cert = RtAliasCertTbsMlDsa87::new(&params).unwrap();
 
         let sig = cert
             .sign(|b| {

--- a/x509/src/rt_alias_csr_ecc_384.rs
+++ b/x509/src/rt_alias_csr_ecc_384.rs
@@ -42,7 +42,7 @@ mod tests {
             tcb_info_fw_svn: &TEST_FW_SVN.try_into().unwrap(),
         };
 
-        RtAliasCsrTbsEcc384::new(&params)
+        RtAliasCsrTbsEcc384::new(&params).unwrap()
     }
 
     #[test]

--- a/x509/src/rt_alias_csr_mldsa_87.rs
+++ b/x509/src/rt_alias_csr_mldsa_87.rs
@@ -44,7 +44,7 @@ mod tests {
             tcb_info_fw_svn: &TEST_FW_SVN.try_into().unwrap(),
         };
 
-        RtAliasCsrTbsMlDsa87::new(&params)
+        RtAliasCsrTbsMlDsa87::new(&params).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
This greatly reduces code size taken by the templates at the cost of a small amount of implementation complexity and latency.