### PR TITLE
[x509]: Use LZSS to compress and decompress x509 templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
 name = "caliptra-x509"
 version = "0.1.0"
 dependencies = [
+ "caliptra-error",
  "hex",
  "openssl",
  "rand 0.8.5",
@@ -1315,6 +1316,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitfield",
+ "caliptra-x509",
  "const-oid 0.9.6",
  "convert_case",
  "der 0.7.10",

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -2794,6 +2794,11 @@ impl CaliptraError {
             0xa006_0005,
             "UDS FE Zeroization Failed"
         ),
+        (
+            X509_TEMPLATE_DECOMPRESSION_FAILED,
+            0xa007_0001,
+            "X509 template decompression failed"
+        ),
     ];
 }
 

--- a/x509/Cargo.toml
+++ b/x509/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 zeroize.workspace = true
+caliptra-error.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/x509/build/fmc_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_cert_tbs_ecc_384.rs
@@ -69,7 +69,7 @@ impl FmcAliasCertTbsEcc384 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 918usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 333usize] = [
         48u8, 130u8, 3u8, 146u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 112u8,
@@ -94,9 +94,7 @@ impl FmcAliasCertTbsEcc384 {
         16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8,
         34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 488usize] = [
         163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
         1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8,
         85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
@@ -131,18 +129,17 @@ impl FmcAliasCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -221,6 +218,28 @@ impl FmcAliasCertTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&FmcAliasCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            FmcAliasCertTbsEcc384::TBS_TEMPLATE[..FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCertTbsEcc384::TBS_TEMPLATE_LEN
+            - FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - FmcAliasCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&FmcAliasCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            FmcAliasCertTbsEcc384::TBS_TEMPLATE[FmcAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + FmcAliasCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/fmc_alias_cert_tbs_ml_dsa_87.rs
@@ -69,7 +69,7 @@ impl FmcAliasCertTbsMlDsa87 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3415usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 335usize] = [
         48u8, 130u8, 13u8, 83u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
@@ -94,9 +94,7 @@ impl FmcAliasCertTbsMlDsa87 {
         95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8,
         4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 488usize] = [
         163u8, 130u8, 1u8, 228u8, 48u8, 130u8, 1u8, 224u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
         1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 5u8, 48u8, 14u8, 6u8, 3u8,
         85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8,
@@ -131,18 +129,17 @@ impl FmcAliasCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -221,6 +218,28 @@ impl FmcAliasCertTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&FmcAliasCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            FmcAliasCertTbsMlDsa87::TBS_TEMPLATE[..FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - FmcAliasCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&FmcAliasCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            FmcAliasCertTbsMlDsa87::TBS_TEMPLATE[FmcAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + FmcAliasCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_csr_tbs_ecc_384.rs
+++ b/x509/build/fmc_alias_csr_tbs_ecc_384.rs
@@ -45,7 +45,7 @@ impl FmcAliasCsrTbsEcc384 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 687usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 147usize] = [
         48u8, 130u8, 2u8, 171u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 70u8, 77u8, 67u8, 32u8,
@@ -57,9 +57,7 @@ impl FmcAliasCsrTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8,
         61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 443usize] = [
         160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
         247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8, 18u8,
         6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8,
@@ -91,18 +89,17 @@ impl FmcAliasCsrTbsEcc384 {
         67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -157,6 +154,28 @@ impl FmcAliasCsrTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&FmcAliasCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            FmcAliasCsrTbsEcc384::TBS_TEMPLATE[..FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasCsrTbsEcc384::TBS_TEMPLATE_LEN
+            - FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET
+            - FmcAliasCsrTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&FmcAliasCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            FmcAliasCsrTbsEcc384::TBS_TEMPLATE
+                [FmcAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET + FmcAliasCsrTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/fmc_alias_tbs_ml_dsa_87.rs
+++ b/x509/build/fmc_alias_tbs_ml_dsa_87.rs
@@ -45,7 +45,7 @@ impl FmcAliasTbsMlDsa87 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3182usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 147usize] = [
         48u8, 130u8, 12u8, 106u8, 2u8, 1u8, 0u8, 48u8, 116u8, 49u8, 39u8, 48u8, 37u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 30u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 70u8, 77u8, 67u8,
@@ -57,9 +57,7 @@ impl FmcAliasTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8,
         134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 443usize] = [
         160u8, 130u8, 1u8, 183u8, 48u8, 130u8, 1u8, 179u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8,
         247u8, 13u8, 1u8, 9u8, 14u8, 49u8, 130u8, 1u8, 164u8, 48u8, 130u8, 1u8, 160u8, 48u8, 18u8,
         6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8,
@@ -91,18 +89,17 @@ impl FmcAliasTbsMlDsa87 {
         67u8, 95u8, 70u8, 73u8, 82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -157,6 +154,28 @@ impl FmcAliasTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&FmcAliasTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            FmcAliasTbsMlDsa87::TBS_TEMPLATE[..FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; FmcAliasTbsMlDsa87::TBS_TEMPLATE_LEN
+            - FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - FmcAliasTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&FmcAliasTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            FmcAliasTbsMlDsa87::TBS_TEMPLATE
+                [FmcAliasTbsMlDsa87::PUBLIC_KEY_OFFSET + FmcAliasTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/init_dev_id_csr_tbs_ecc_384.rs
+++ b/x509/build/init_dev_id_csr_tbs_ecc_384.rs
@@ -29,7 +29,7 @@ impl InitDevIdCsrTbsEcc384 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 358usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 144usize] = [
         48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8,
         4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8,
         46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 73u8, 68u8, 101u8, 118u8, 73u8,
@@ -41,9 +41,7 @@ impl InitDevIdCsrTbsEcc384 {
         48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8,
         43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 117usize] = [
         160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
         49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
         48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
@@ -54,18 +52,17 @@ impl InitDevIdCsrTbsEcc384 {
         103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -105,5 +102,27 @@ impl InitDevIdCsrTbsEcc384 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&InitDevIdCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            InitDevIdCsrTbsEcc384::TBS_TEMPLATE[..InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; InitDevIdCsrTbsEcc384::TBS_TEMPLATE_LEN
+            - InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+            - InitDevIdCsrTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&InitDevIdCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            InitDevIdCsrTbsEcc384::TBS_TEMPLATE[InitDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                + InitDevIdCsrTbsEcc384::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/init_dev_id_csr_tbs_ml_dsa_87.rs
@@ -29,7 +29,7 @@ impl InitDevIdCsrTbsMlDsa87 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 2853usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 144usize] = [
         48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 73u8, 68u8,
@@ -41,9 +41,7 @@ impl InitDevIdCsrTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8,
         1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 117usize] = [
         160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
         49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
         48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 7u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
@@ -54,18 +52,17 @@ impl InitDevIdCsrTbsMlDsa87 {
         103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -105,5 +102,27 @@ impl InitDevIdCsrTbsMlDsa87 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE[..InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE_LEN
+            - InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            InitDevIdCsrTbsMlDsa87::TBS_TEMPLATE[InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + InitDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/local_dev_id_cert_tbs_ecc_384.rs
+++ b/x509/build/local_dev_id_cert_tbs_ecc_384.rs
@@ -53,7 +53,7 @@ impl LocalDevIdCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 595usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 330usize] = [
         48u8, 130u8, 2u8, 79u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 112u8, 49u8,
@@ -77,9 +77,7 @@ impl LocalDevIdCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8,
         206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 168usize] = [
         163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8,
         255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8,
         29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
@@ -93,18 +91,17 @@ impl LocalDevIdCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -167,6 +164,28 @@ impl LocalDevIdCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&LocalDevIdCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            LocalDevIdCertTbsEcc384::TBS_TEMPLATE[..LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCertTbsEcc384::TBS_TEMPLATE_LEN
+            - LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - LocalDevIdCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&LocalDevIdCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            LocalDevIdCertTbsEcc384::TBS_TEMPLATE[LocalDevIdCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + LocalDevIdCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/local_dev_id_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/local_dev_id_cert_tbs_ml_dsa_87.rs
@@ -53,7 +53,7 @@ impl LocalDevIdCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 3092usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 332usize] = [
         48u8, 130u8, 12u8, 16u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
@@ -78,9 +78,7 @@ impl LocalDevIdCertTbsMlDsa87 {
         50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8,
         10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 168usize] = [
         163u8, 129u8, 165u8, 48u8, 129u8, 162u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8,
         255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8,
         29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 4u8, 48u8, 31u8, 6u8, 6u8, 103u8,
@@ -94,18 +92,17 @@ impl LocalDevIdCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -168,6 +165,28 @@ impl LocalDevIdCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE[..LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            LocalDevIdCertTbsMlDsa87::TBS_TEMPLATE[LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + LocalDevIdCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/local_dev_id_csr_tbs_ecc_384.rs
+++ b/x509/build/local_dev_id_csr_tbs_ecc_384.rs
@@ -29,7 +29,7 @@ impl LocalDevIdCsrTbsEcc384 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 358usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 144usize] = [
         48u8, 130u8, 1u8, 98u8, 2u8, 1u8, 0u8, 48u8, 112u8, 49u8, 35u8, 48u8, 33u8, 6u8, 3u8, 85u8,
         4u8, 3u8, 12u8, 26u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8, 50u8,
         46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 76u8, 68u8, 101u8, 118u8, 73u8,
@@ -41,9 +41,7 @@ impl LocalDevIdCsrTbsEcc384 {
         48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8,
         43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 117usize] = [
         160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
         49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
         48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
@@ -54,18 +52,17 @@ impl LocalDevIdCsrTbsEcc384 {
         103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -105,5 +102,27 @@ impl LocalDevIdCsrTbsEcc384 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&LocalDevIdCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            LocalDevIdCsrTbsEcc384::TBS_TEMPLATE[..LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCsrTbsEcc384::TBS_TEMPLATE_LEN
+            - LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+            - LocalDevIdCsrTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&LocalDevIdCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            LocalDevIdCsrTbsEcc384::TBS_TEMPLATE[LocalDevIdCsrTbsEcc384::PUBLIC_KEY_OFFSET
+                + LocalDevIdCsrTbsEcc384::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/local_dev_id_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/local_dev_id_csr_tbs_ml_dsa_87.rs
@@ -29,7 +29,7 @@ impl LocalDevIdCsrTbsMlDsa87 {
     const SUBJECT_SN_LEN: usize = 64usize;
     const UEID_LEN: usize = 17usize;
     pub const TBS_TEMPLATE_LEN: usize = 2853usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 144usize] = [
         48u8, 130u8, 11u8, 33u8, 2u8, 1u8, 0u8, 48u8, 113u8, 49u8, 36u8, 48u8, 34u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 27u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 76u8, 68u8,
@@ -41,9 +41,7 @@ impl LocalDevIdCsrTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8,
         1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 117usize] = [
         160u8, 115u8, 48u8, 113u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8, 1u8, 9u8, 14u8,
         49u8, 100u8, 48u8, 98u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8, 8u8,
         48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 6u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8,
@@ -54,18 +52,17 @@ impl LocalDevIdCsrTbsMlDsa87 {
         103u8, 129u8, 5u8, 5u8, 4u8, 100u8, 12u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -105,5 +102,27 @@ impl LocalDevIdCsrTbsMlDsa87 {
             params.subject_sn,
         );
         apply_slice::<{ Self::UEID_OFFSET }, { Self::UEID_LEN }>(&mut self.tbs, params.ueid);
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE[..LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE_LEN
+            - LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            LocalDevIdCsrTbsMlDsa87::TBS_TEMPLATE[LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + LocalDevIdCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
+        );
     }
 }

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ecc_384.rs
@@ -49,7 +49,7 @@ impl OcpLockEcdh384CertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 563usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 342usize] = [
         48u8, 130u8, 2u8, 47u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
@@ -74,9 +74,7 @@ impl OcpLockEcdh384CertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8,
         2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -87,18 +85,17 @@ impl OcpLockEcdh384CertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -160,6 +157,29 @@ impl OcpLockEcdh384CertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE_LEN
+            - OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET
+            - OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockEcdh384CertTbsEcc384::TBS_TEMPLATE[OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockEcdh384CertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ecdh_384_cert_tbs_ml_dsa_87.rs
@@ -49,7 +49,7 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 565usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 344usize] = [
         48u8, 130u8, 2u8, 49u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
@@ -74,9 +74,7 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8,
         134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -87,18 +85,17 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -160,6 +157,30 @@ impl OcpLockEcdh384CertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockEcdh384CertTbsMlDsa87::TBS_TEMPLATE
+                [OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                    + OcpLockEcdh384CertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_hybrid_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_hybrid_cert_tbs_ecc_384.rs
@@ -49,7 +49,7 @@ impl OcpLockHybridCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2141usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 352usize] = [
         48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
@@ -75,9 +75,7 @@ impl OcpLockHybridCertTbsEcc384 {
         52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8,
         63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -88,18 +86,17 @@ impl OcpLockHybridCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -161,6 +158,29 @@ impl OcpLockHybridCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_LEN
+            - OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE[OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
@@ -49,7 +49,7 @@ impl OcpLockHybridCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2143usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 354usize] = [
         48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
@@ -75,9 +75,7 @@ impl OcpLockHybridCertTbsMlDsa87 {
         80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8,
         5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -88,18 +86,17 @@ impl OcpLockHybridCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -161,6 +158,29 @@ impl OcpLockHybridCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE[OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ecc_384.rs
@@ -49,7 +49,7 @@ impl OcpLockMlKemCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2034usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 342usize] = [
         48u8, 130u8, 7u8, 238u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8,
@@ -74,9 +74,7 @@ impl OcpLockMlKemCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 6u8, 50u8, 48u8, 11u8, 6u8,
         9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8, 130u8, 6u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -87,18 +85,17 @@ impl OcpLockMlKemCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -160,6 +157,28 @@ impl OcpLockMlKemCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE[..OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE_LEN
+            - OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockMlKemCertTbsEcc384::TBS_TEMPLATE[OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockMlKemCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/ocp_lock_ml_kem_cert_tbs_ml_dsa_87.rs
@@ -49,7 +49,7 @@ impl OcpLockMlKemCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2036usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 344usize] = [
         48u8, 130u8, 7u8, 240u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
@@ -75,9 +75,7 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 4u8, 3u8, 3u8, 130u8, 6u8, 33u8,
         0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -88,18 +86,17 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -161,6 +158,29 @@ impl OcpLockMlKemCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockMlKemCertTbsMlDsa87::TBS_TEMPLATE[OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockMlKemCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_cert_tbs_ecc_384.rs
+++ b/x509/build/rt_alias_cert_tbs_ecc_384.rs
@@ -61,7 +61,7 @@ impl RtAliasCertTbsEcc384 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 707usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 335usize] = [
         48u8, 130u8, 2u8, 191u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 115u8,
@@ -86,9 +86,7 @@ impl RtAliasCertTbsEcc384 {
         118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8, 2u8, 1u8, 6u8, 5u8, 43u8,
         129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 275usize] = [
         163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
         1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8, 6u8, 3u8,
         85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8, 6u8,
@@ -109,18 +107,17 @@ impl RtAliasCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -191,6 +188,28 @@ impl RtAliasCertTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&RtAliasCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            RtAliasCertTbsEcc384::TBS_TEMPLATE[..RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCertTbsEcc384::TBS_TEMPLATE_LEN
+            - RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - RtAliasCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&RtAliasCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            RtAliasCertTbsEcc384::TBS_TEMPLATE
+                [RtAliasCertTbsEcc384::PUBLIC_KEY_OFFSET + RtAliasCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_cert_tbs_ml_dsa_87.rs
+++ b/x509/build/rt_alias_cert_tbs_ml_dsa_87.rs
@@ -61,7 +61,7 @@ impl RtAliasCertTbsMlDsa87 {
     const NOT_AFTER_LEN: usize = 15usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 3204usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 337usize] = [
         48u8, 130u8, 12u8, 128u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8,
@@ -86,9 +86,7 @@ impl RtAliasCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8,
         101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 275usize] = [
         163u8, 130u8, 1u8, 15u8, 48u8, 130u8, 1u8, 11u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8, 19u8,
         1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8, 6u8, 3u8,
         85u8, 29u8, 15u8, 1u8, 1u8, 255u8, 4u8, 4u8, 3u8, 2u8, 2u8, 132u8, 48u8, 31u8, 6u8, 6u8,
@@ -109,18 +107,17 @@ impl RtAliasCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -191,6 +188,28 @@ impl RtAliasCertTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&RtAliasCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            RtAliasCertTbsMlDsa87::TBS_TEMPLATE[..RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - RtAliasCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&RtAliasCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            RtAliasCertTbsMlDsa87::TBS_TEMPLATE[RtAliasCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + RtAliasCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_csr_tbs_ecc_384.rs
+++ b/x509/build/rt_alias_csr_tbs_ecc_384.rs
@@ -37,7 +37,7 @@ impl RtAliasCsrTbsEcc384 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 469usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 146usize] = [
         48u8, 130u8, 1u8, 209u8, 2u8, 1u8, 0u8, 48u8, 114u8, 49u8, 37u8, 48u8, 35u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 28u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 69u8, 99u8, 99u8, 51u8, 56u8, 52u8, 32u8, 82u8, 116u8, 32u8, 65u8,
@@ -49,9 +49,7 @@ impl RtAliasCsrTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 48u8, 118u8, 48u8, 16u8, 6u8, 7u8, 42u8, 134u8, 72u8, 206u8, 61u8,
         2u8, 1u8, 6u8, 5u8, 43u8, 129u8, 4u8, 0u8, 34u8, 3u8, 98u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 226usize] = [
         160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8,
         1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
         19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
@@ -69,18 +67,17 @@ impl RtAliasCsrTbsEcc384 {
         82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -127,6 +124,28 @@ impl RtAliasCsrTbsEcc384 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&RtAliasCsrTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            RtAliasCsrTbsEcc384::TBS_TEMPLATE[..RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCsrTbsEcc384::TBS_TEMPLATE_LEN
+            - RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET
+            - RtAliasCsrTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&RtAliasCsrTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            RtAliasCsrTbsEcc384::TBS_TEMPLATE
+                [RtAliasCsrTbsEcc384::PUBLIC_KEY_OFFSET + RtAliasCsrTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/build/rt_alias_csr_tbs_ml_dsa_87.rs
+++ b/x509/build/rt_alias_csr_tbs_ml_dsa_87.rs
@@ -37,7 +37,7 @@ impl RtAliasCsrTbsMlDsa87 {
     const UEID_LEN: usize = 17usize;
     const TCB_INFO_FW_SVN_LEN: usize = 1usize;
     pub const TBS_TEMPLATE_LEN: usize = 2964usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 146usize] = [
         48u8, 130u8, 11u8, 144u8, 2u8, 1u8, 0u8, 48u8, 115u8, 49u8, 38u8, 48u8, 36u8, 6u8, 3u8,
         85u8, 4u8, 3u8, 12u8, 29u8, 67u8, 97u8, 108u8, 105u8, 112u8, 116u8, 114u8, 97u8, 32u8,
         50u8, 46u8, 49u8, 32u8, 77u8, 108u8, 68u8, 115u8, 97u8, 56u8, 55u8, 32u8, 82u8, 116u8,
@@ -49,9 +49,7 @@ impl RtAliasCsrTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 48u8, 130u8, 10u8, 50u8, 48u8, 11u8, 6u8, 9u8, 96u8,
         134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 3u8, 130u8, 10u8, 33u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 226usize] = [
         160u8, 129u8, 223u8, 48u8, 129u8, 220u8, 6u8, 9u8, 42u8, 134u8, 72u8, 134u8, 247u8, 13u8,
         1u8, 9u8, 14u8, 49u8, 129u8, 206u8, 48u8, 129u8, 203u8, 48u8, 18u8, 6u8, 3u8, 85u8, 29u8,
         19u8, 1u8, 1u8, 255u8, 4u8, 8u8, 48u8, 6u8, 1u8, 1u8, 255u8, 2u8, 1u8, 4u8, 48u8, 14u8,
@@ -69,18 +67,17 @@ impl RtAliasCsrTbsMlDsa87 {
         82u8, 77u8, 87u8, 65u8, 82u8, 69u8, 95u8, 73u8, 78u8, 70u8, 79u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -127,6 +124,28 @@ impl RtAliasCsrTbsMlDsa87 {
         apply_slice::<{ Self::TCB_INFO_FW_SVN_OFFSET }, { Self::TCB_INFO_FW_SVN_LEN }>(
             &mut self.tbs,
             params.tcb_info_fw_svn,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&RtAliasCsrTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            RtAliasCsrTbsMlDsa87::TBS_TEMPLATE[..RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; RtAliasCsrTbsMlDsa87::TBS_TEMPLATE_LEN
+            - RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - RtAliasCsrTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&RtAliasCsrTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            RtAliasCsrTbsMlDsa87::TBS_TEMPLATE
+                [RtAliasCsrTbsMlDsa87::PUBLIC_KEY_OFFSET + RtAliasCsrTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/gen/Cargo.toml
+++ b/x509/gen/Cargo.toml
@@ -21,3 +21,4 @@ rand.workspace = true
 syn.workspace = true
 x509-cert.workspace = true
 const-oid.workspace = true
+caliptra-x509 = { workspace = true, features = ["std"] }

--- a/x509/gen/src/code_gen.rs
+++ b/x509/gen/src/code_gen.rs
@@ -85,28 +85,31 @@ impl CodeGen {
             pub const TBS_TEMPLATE_LEN: usize = #tbs_len;
         );
 
-        // Generate chunked template constants and new() body
-        let (template_consts, new_body) = if let (Some(before_key), Some(after_key)) =
+        // Generate chunked template constants, new() body, and verification tests
+        let (template_consts, new_body, verification_test) = if let (
+            Some(before_key),
+            Some(after_key),
+        ) =
             (template.tbs_before_key(), template.tbs_after_key())
         {
+            let before_len = before_key.len();
+            let after_len = after_key.len();
+
             let template_consts = quote!(
-                const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [#(#before_key,)*];
-                const TBS_TEMPLATE_AFTER_KEY_LEN: usize = Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-                const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [#(#after_key,)*];
+                const TBS_TEMPLATE_BEFORE_KEY: [u8; #before_len] = [#(#before_key,)*];
+                const TBS_TEMPLATE_AFTER_KEY: [u8; #after_len] = [#(#after_key,)*];
 
                 #[cfg(test)]
-                const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+                pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
                     let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-                    let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-                    let after = Self::TBS_TEMPLATE_AFTER_KEY;
                     let mut i = 0;
-                    while i < before.len() {
-                        result[i] = before[i];
+                    while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+                        result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
                         i += 1;
                     }
                     i = 0;
-                    while i < after.len() {
-                        result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+                    while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+                        result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = Self::TBS_TEMPLATE_AFTER_KEY[i];
                         i += 1;
                     }
                     result
@@ -124,24 +127,43 @@ impl CodeGen {
                 }
             );
 
-            (template_consts, new_body)
+            let verification_test = quote!(
+                #[cfg(test)]
+                mod template_tests {
+                    use super::*;
+                    #[test]
+                    fn test_template_construction() {
+                        let mut before_key = [0u8; #type_name::PUBLIC_KEY_OFFSET];
+                        before_key.copy_from_slice(&#type_name::TBS_TEMPLATE_BEFORE_KEY);
+                        assert_eq!(before_key, #type_name::TBS_TEMPLATE[..#type_name::PUBLIC_KEY_OFFSET]);
+
+                        let mut after_key = [0u8; #type_name::TBS_TEMPLATE_LEN - #type_name::PUBLIC_KEY_OFFSET - #type_name::PUBLIC_KEY_LEN];
+                        after_key.copy_from_slice(&#type_name::TBS_TEMPLATE_AFTER_KEY);
+                        assert_eq!(after_key, #type_name::TBS_TEMPLATE[#type_name::PUBLIC_KEY_OFFSET + #type_name::PUBLIC_KEY_LEN..]);
+                    }
+                }
+            );
+
+            (template_consts, new_body, verification_test)
         } else {
             let tbs = template.tbs();
+
             let template_consts = quote!(
-                const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [#(#tbs,)*];
+                pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = [#(#tbs,)*];
             );
 
             let new_body = quote!(
                 pub fn new(params: &#param_name) -> Self {
-                    let mut template = Self {
-                        tbs: Self::TBS_TEMPLATE,
-                    };
+                    let mut tbs = Self::TBS_TEMPLATE;
+                    let mut template = Self { tbs };
                     template.apply(params);
                     template
                 }
             );
 
-            (template_consts, new_body)
+            let verification_test = quote!();
+
+            (template_consts, new_body, verification_test)
         };
 
         quote!(
@@ -195,6 +217,8 @@ Abstract:
                     #(#apply_calls)*
                 }
             }
+
+            #verification_test
         )
         .to_string()
     }

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -26,6 +26,7 @@ mod ldevid_cert_ecc_384;
 mod ldevid_cert_mldsa_87;
 mod ldevid_csr_ecc_384;
 mod ldevid_csr_mldsa_87;
+pub mod lzss;
 mod ocp_lock_hpke_certs;
 mod rt_alias_cert_ecc_384;
 mod rt_alias_cert_mldsa_87;

--- a/x509/src/lzss.rs
+++ b/x509/src/lzss.rs
@@ -1,0 +1,241 @@
+// Licensed under the Apache-2.0 license.
+
+//! Lightweight LZSS compression and decompression implementation.
+//!
+//! # LZSS Algorithm Overview
+//!
+//! LZSS (Lempel-Ziv-Storer-Szymanski) is a lossless data compression algorithm.
+//! It replaces repeated substrings with references to a sliding window of history.
+//!
+//! ## Format Specification
+//!
+//! The compressed stream consists of blocks. Each block starts with a 1-byte
+//! `control` header, followed by up to 8 tokens (literals or references).
+//!
+//! The 8 bits of the `control` byte (from LSB to MSB) correspond to the 8 tokens:
+//! - **Bit = 1 (Literal):** The token is a single raw byte.
+//! - **Bit = 0 (Reference):** The token is a 2-byte reference to previously
+//!   decompressed data.
+//!
+//! ### Reference Encoding
+//! A reference is encoded as two bytes `(b1, b2)` representing an `offset` and `length`:
+//! - **Offset (12 bits):** How far back in the decompressed buffer to start copying.
+//!   Reconstructed as `(b1 << 4) | (b2 >> 4)`. Maximum offset is 4095.
+//! - **Length (4 bits):** How many bytes to copy.
+//!   Reconstructed as `(b2 & 0x0F) + 3`. Range is 3 to 18 bytes.
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+/// Decompresses a single literal byte.
+///
+/// Reads the next byte from `src` and writes it to `dst` at `dst_idx`.
+/// Advances both `src_idx` and `dst_idx` by 1.
+#[inline(always)]
+fn decompress_literal(
+    src: &[u8],
+    src_idx: &mut usize,
+    dst: &mut [u8],
+    dst_idx: &mut usize,
+) -> bool {
+    let val = match src.get(*src_idx) {
+        Some(&v) => v,
+        None => return false,
+    };
+    if let Some(d) = dst.get_mut(*dst_idx) {
+        *d = val;
+    } else {
+        return false;
+    }
+    *dst_idx += 1;
+    *src_idx += 1;
+    true
+}
+
+/// Decompresses a reference to previous data.
+///
+/// Reads a 2-byte reference from `src`, decodes the offset and length,
+/// and copies `length` bytes from `dst` history (at `dst_idx - offset`) to `dst_idx`.
+/// Advances `src_idx` by 2 and `dst_idx` by `length`.
+#[inline(always)]
+fn decompress_reference(
+    src: &[u8],
+    src_idx: &mut usize,
+    dst: &mut [u8],
+    dst_idx: &mut usize,
+) -> bool {
+    let b1 = match src.get(*src_idx) {
+        Some(&b) => b as usize,
+        None => return false,
+    };
+    let b2 = match src.get(*src_idx + 1) {
+        Some(&b) => b as usize,
+        None => return false,
+    };
+    *src_idx += 2;
+
+    let offset = (b1 << 4) | (b2 >> 4);
+    let length = (b2 & 0x0F) + 3;
+
+    if offset == 0 || *dst_idx < offset {
+        return false;
+    }
+
+    for _ in 0..length {
+        if *dst_idx >= dst.len() {
+            return false;
+        }
+        let src_val = match dst.get(*dst_idx - offset) {
+            Some(&val) => val,
+            None => return false,
+        };
+        if let Some(d) = dst.get_mut(*dst_idx) {
+            *d = src_val;
+        } else {
+            return false;
+        }
+        *dst_idx += 1;
+    }
+    true
+}
+
+/// Decompress LZSS compressed data.
+///
+/// Iterates through the compressed data, reading a control byte for every 8 tokens.
+/// The control byte indicates whether each of the next 8 tokens is a literal (bit = 1)
+/// or a reference (bit = 0).
+///
+/// Returns true on success, false if the data is corrupt or dst is too small.
+pub fn decompress(src: &[u8], dst: &mut [u8]) -> bool {
+    let mut src_idx = 0;
+    let mut dst_idx = 0;
+    while dst_idx < dst.len() {
+        let control = match src.get(src_idx) {
+            Some(&c) => c,
+            None => return false,
+        };
+        src_idx += 1;
+        for bit in 0..8 {
+            if dst_idx >= dst.len() {
+                break;
+            }
+            if (control & (1 << bit)) != 0 {
+                if !decompress_literal(src, &mut src_idx, dst, &mut dst_idx) {
+                    return false;
+                }
+            } else {
+                if !decompress_reference(src, &mut src_idx, dst, &mut dst_idx) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+#[cfg(feature = "std")]
+fn find_longest_match(src: &[u8], src_idx: usize) -> (usize, usize) {
+    let mut best_offset = 0;
+    let mut best_len = 0;
+
+    let start = if src_idx > 4095 { src_idx - 4095 } else { 0 };
+
+    for i in start..src_idx {
+        let mut len = 0;
+        while src_idx + len < src.len() && src[i + len] == src[src_idx + len] && len < 18 {
+            len += 1;
+        }
+        if len > best_len {
+            best_len = len;
+            best_offset = src_idx - i;
+        }
+    }
+    (best_offset, best_len)
+}
+
+/// Compress data using LZSS.
+///
+/// Iterates through the input data, searching for matches in the sliding window
+/// (up to 4095 bytes back). If a match of length >= 3 is found, it writes a reference token.
+/// Otherwise, it writes a literal token. Every 8 tokens are prefixed with a control byte.
+#[cfg(feature = "std")]
+pub fn compress(src: &[u8]) -> Vec<u8> {
+    let mut dst = Vec::new();
+    let mut src_idx = 0;
+
+    while src_idx < src.len() {
+        let mut control = 0u8;
+        let mut token_bytes = Vec::new();
+
+        for bit in 0..8 {
+            if src_idx >= src.len() {
+                break;
+            }
+
+            let (match_offset, match_len) = find_longest_match(src, src_idx);
+
+            if match_len >= 3 {
+                // Reference
+                let offset = match_offset;
+                let length = match_len;
+
+                let b1 = (offset >> 4) as u8;
+                let b2 = (((offset & 0x0F) << 4) | ((length - 3) & 0x0F)) as u8;
+                token_bytes.push(b1);
+                token_bytes.push(b2);
+
+                src_idx += match_len;
+            } else {
+                // Literal
+                control |= 1 << bit;
+                token_bytes.push(src[src_idx]);
+                src_idx += 1;
+            }
+        }
+
+        dst.push(control);
+        dst.extend(token_bytes);
+    }
+    dst
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let data: &[u8] = &[];
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; 0];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, decompressed);
+    }
+
+    #[test]
+    fn test_simple() {
+        let data = b"Hello World! Hello World! Hello World!";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+
+    #[test]
+    fn test_repeating() {
+        let data = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+
+    #[test]
+    fn test_random() {
+        let data = b"abcdefghijklmnopqrstuvwxyz1234567890";
+        let compressed = compress(data);
+        let mut decompressed = vec![0u8; data.len()];
+        assert!(decompress(&compressed, &mut decompressed));
+        assert_eq!(data, &decompressed[..]);
+    }
+}

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ecc_384.rs
@@ -49,7 +49,7 @@ impl OcpLockHybridCertTbsEcc384 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2141usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 352usize] = [
         48u8, 130u8, 8u8, 89u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 10u8, 6u8, 8u8, 42u8, 134u8, 72u8, 206u8, 61u8, 4u8, 3u8, 3u8, 48u8, 114u8, 49u8,
@@ -75,9 +75,7 @@ impl OcpLockHybridCertTbsEcc384 {
         52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8, 5u8, 7u8, 6u8,
         63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -88,18 +86,17 @@ impl OcpLockHybridCertTbsEcc384 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -161,6 +158,29 @@ impl OcpLockHybridCertTbsEcc384 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_LEN
+            - OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+            - OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockHybridCertTbsEcc384::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsEcc384::TBS_TEMPLATE[OcpLockHybridCertTbsEcc384::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsEcc384::PUBLIC_KEY_LEN..]
         );
     }
 }

--- a/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
+++ b/x509/src/ocp_lock_hybrid_cert_tbs_ml_dsa_87.rs
@@ -49,7 +49,7 @@ impl OcpLockHybridCertTbsMlDsa87 {
     const NOT_BEFORE_LEN: usize = 15usize;
     const NOT_AFTER_LEN: usize = 15usize;
     pub const TBS_TEMPLATE_LEN: usize = 2143usize;
-    const TBS_TEMPLATE_BEFORE_KEY: [u8; Self::PUBLIC_KEY_OFFSET] = [
+    const TBS_TEMPLATE_BEFORE_KEY: [u8; 354usize] = [
         48u8, 130u8, 8u8, 91u8, 160u8, 3u8, 2u8, 1u8, 2u8, 2u8, 20u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
         48u8, 11u8, 6u8, 9u8, 96u8, 134u8, 72u8, 1u8, 101u8, 3u8, 4u8, 3u8, 19u8, 48u8, 115u8,
@@ -75,9 +75,7 @@ impl OcpLockHybridCertTbsMlDsa87 {
         80u8, 51u8, 56u8, 52u8, 48u8, 130u8, 6u8, 146u8, 48u8, 10u8, 6u8, 8u8, 43u8, 6u8, 1u8, 5u8,
         5u8, 7u8, 6u8, 63u8, 3u8, 130u8, 6u8, 130u8, 0u8,
     ];
-    const TBS_TEMPLATE_AFTER_KEY_LEN: usize =
-        Self::TBS_TEMPLATE_LEN - Self::PUBLIC_KEY_OFFSET - Self::PUBLIC_KEY_LEN;
-    const TBS_TEMPLATE_AFTER_KEY: [u8; Self::TBS_TEMPLATE_AFTER_KEY_LEN] = [
+    const TBS_TEMPLATE_AFTER_KEY: [u8; 124usize] = [
         163u8, 122u8, 48u8, 120u8, 48u8, 15u8, 6u8, 3u8, 85u8, 29u8, 19u8, 1u8, 1u8, 255u8, 4u8,
         5u8, 48u8, 3u8, 2u8, 1u8, 0u8, 48u8, 14u8, 6u8, 3u8, 85u8, 29u8, 15u8, 1u8, 1u8, 255u8,
         4u8, 4u8, 3u8, 2u8, 5u8, 32u8, 48u8, 21u8, 6u8, 6u8, 103u8, 129u8, 5u8, 21u8, 1u8, 1u8,
@@ -88,18 +86,17 @@ impl OcpLockHybridCertTbsMlDsa87 {
         95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8, 95u8,
     ];
     #[cfg(test)]
-    const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
+    pub const TBS_TEMPLATE: [u8; Self::TBS_TEMPLATE_LEN] = {
         let mut result = [0x5F_u8; Self::TBS_TEMPLATE_LEN];
-        let before = Self::TBS_TEMPLATE_BEFORE_KEY;
-        let after = Self::TBS_TEMPLATE_AFTER_KEY;
         let mut i = 0;
-        while i < before.len() {
-            result[i] = before[i];
+        while i < Self::TBS_TEMPLATE_BEFORE_KEY.len() {
+            result[i] = Self::TBS_TEMPLATE_BEFORE_KEY[i];
             i += 1;
         }
         i = 0;
-        while i < after.len() {
-            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] = after[i];
+        while i < Self::TBS_TEMPLATE_AFTER_KEY.len() {
+            result[Self::PUBLIC_KEY_OFFSET + Self::PUBLIC_KEY_LEN + i] =
+                Self::TBS_TEMPLATE_AFTER_KEY[i];
             i += 1;
         }
         result
@@ -161,6 +158,29 @@ impl OcpLockHybridCertTbsMlDsa87 {
         apply_slice::<{ Self::NOT_AFTER_OFFSET }, { Self::NOT_AFTER_LEN }>(
             &mut self.tbs,
             params.not_after,
+        );
+    }
+}
+#[cfg(test)]
+mod template_tests {
+    use super::*;
+    #[test]
+    fn test_template_construction() {
+        let mut before_key = [0u8; OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET];
+        before_key.copy_from_slice(&OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_BEFORE_KEY);
+        assert_eq!(
+            before_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE
+                [..OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET]
+        );
+        let mut after_key = [0u8; OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_LEN
+            - OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+            - OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN];
+        after_key.copy_from_slice(&OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE_AFTER_KEY);
+        assert_eq!(
+            after_key,
+            OcpLockHybridCertTbsMlDsa87::TBS_TEMPLATE[OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_OFFSET
+                + OcpLockHybridCertTbsMlDsa87::PUBLIC_KEY_LEN..]
         );
     }
 }


### PR DESCRIPTION
This greatly reduces code size taken by the templates at the cost of a small amount of implementation complexity and latency.