### PR TITLE
Adding hashing step to ECDSA KAT

### DIFF
--- a/drivers/src/ecc384.rs
+++ b/drivers/src/ecc384.rs
@@ -253,7 +253,7 @@ impl Ecc384 {
         trng: &mut Trng,
         priv_key: Ecc384PrivKeyOut,
     ) -> CaliptraResult<Ecc384PubKey> {
-        self.key_pair_base(seed, nonce, trng, priv_key, None)
+        self.key_pair_base(seed, nonce, trng, priv_key, None, None)
     }
 
     /// Generate ECC-384 Key Pair for FIPS KAT testing
@@ -264,6 +264,7 @@ impl Ecc384 {
     /// * `trng` - TRNG driver instance
     /// * `priv_key` - Generate ECC-384 Private key
     /// * `pct_sig` - Ecc 384 signature to return signature generated during the pairwise consistency test
+    /// * `pct_digest` - Digest to use for the pairwise consistency test signature
     ///
     /// # Returns
     ///
@@ -274,6 +275,7 @@ impl Ecc384 {
         trng: &mut Trng,
         priv_key: Ecc384PrivKeyOut,
         pct_sig: &mut Ecc384Signature,
+        pct_digest: &Array4x12,
     ) -> CaliptraResult<Ecc384PubKey> {
         let seed = Array4x12::new([0u32; 12]);
         let nonce = Array4x12::new([0u32; 12]);
@@ -283,6 +285,7 @@ impl Ecc384 {
             trng,
             priv_key,
             Some(pct_sig),
+            Some(pct_digest),
         )
     }
 
@@ -312,6 +315,7 @@ impl Ecc384 {
             trng,
             Ecc384PrivKeyOut::Array4x12(priv_key),
             None,
+            None,
         )?;
         self.ecdh_pct(Ecc384PrivKeyIn::Array4x12(priv_key), &pub_key, trng)?;
         Ok(pub_key)
@@ -319,6 +323,7 @@ impl Ecc384 {
 
     /// Private base function to generate ECC-384 Key Pair
     /// pct_sig should only be provided in the KAT use case
+    /// pct_digest is the digest to use for the pairwise consistency test sign operation
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn key_pair_base(
@@ -328,6 +333,7 @@ impl Ecc384 {
         trng: &mut Trng,
         priv_key: Ecc384PrivKeyOut,
         pct_sig: Option<&mut Ecc384Signature>,
+        pct_digest: Option<&Array4x12>,
     ) -> CaliptraResult<Ecc384PubKey> {
         #[cfg(feature = "fips-test-hooks")]
         unsafe {
@@ -396,8 +402,6 @@ impl Ecc384 {
         };
 
         // Pairwise consistency check.
-        let digest = Array4x12::new([0u32; 12]);
-
         #[cfg(feature = "fips-test-hooks")]
         let pub_key = unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
@@ -406,7 +410,9 @@ impl Ecc384 {
             )
         };
 
-        match self.sign(priv_key.into(), &pub_key, &digest, trng) {
+        let zero_digest = Array4x12::new([0u32; 12]);
+        let digest = pct_digest.unwrap_or(&zero_digest);
+        match self.sign(priv_key.into(), &pub_key, digest, trng) {
             Ok(mut sig) => {
                 // Return the signature from this test if requested (only used for KAT)
                 if let Some(output_sig) = pct_sig {

--- a/drivers/test-fw/src/bin/ecc384_tests.rs
+++ b/drivers/test-fw/src/bin/ecc384_tests.rs
@@ -18,13 +18,15 @@ Abstract:
 use caliptra_cfi_lib::CfiCounter;
 use caliptra_drivers::{
     Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PrivKeyOut, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
-    Ecc384Seed, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, PersistentDataAccessor, Trng,
+    Ecc384Seed, KeyId, KeyReadArgs, KeyUsage, KeyWriteArgs, PersistentDataAccessor, Sha2_512_384,
+    Trng,
 };
 use caliptra_error::CaliptraError;
 use caliptra_kat::{Ecc384Kat, EcdhKat};
 use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::ecc::EccReg;
 use caliptra_registers::entropy_src::EntropySrcReg;
+use caliptra_registers::sha512::Sha512Reg;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use caliptra_registers::soc_ifc_trng::SocIfcTrngReg;
 use caliptra_test_harness::test_suite;
@@ -490,6 +492,7 @@ fn test_no_private_key_usage() {
 
 fn test_kat() {
     let mut ecc = unsafe { Ecc384::new(EccReg::new()) };
+    let mut sha = unsafe { Sha2_512_384::new(Sha512Reg::new()) };
     let mut trng = unsafe {
         Trng::new(
             CsrngReg::new(),
@@ -509,7 +512,9 @@ fn test_kat() {
     CfiCounter::reset(&mut entropy_gen);
 
     assert_eq!(
-        Ecc384Kat::default().execute(&mut ecc, &mut trng).is_ok(),
+        Ecc384Kat::default()
+            .execute(&mut ecc, &mut sha, &mut trng)
+            .is_ok(),
         true
     );
     assert_eq!(

--- a/kat/src/ecc384_kat.rs
+++ b/kat/src/ecc384_kat.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use caliptra_drivers::{
     Array4x12, Array4xN, CaliptraError, CaliptraResult, Ecc384, Ecc384PrivKeyOut, Ecc384PubKey,
-    Ecc384Signature, Trng,
+    Ecc384Signature, Sha2_512_384, Trng,
 };
 
 const KEY_GEN_PRIV_KEY: Array4x12 = Array4x12::new([
@@ -35,12 +35,12 @@ const KEY_GEN_PUB_KEY: Ecc384PubKey = Ecc384PubKey {
 
 const SIGNATURE: Ecc384Signature = Ecc384Signature {
     r: Array4xN([
-        0x93799D55, 0x12263628, 0x34F60F7B, 0x945290B7, 0xCCE6E996, 0x01FB7EBD, 0x026C2E3C,
-        0x445D3CD9, 0xB65068DA, 0xC0A848BE, 0x9F0560AA, 0x758FDA27,
+        0x78c52a07, 0xa1fcdcae, 0x52fb32e1, 0x4734bf3f, 0x014aa242, 0x778df0f2, 0xbfc09ca1,
+        0x45cceab6, 0x25a7fd5f, 0x6634c02c, 0x80f98919, 0xce53ed47,
     ]),
     s: Array4xN([
-        0xE548E535, 0xA1CC600E, 0x133B5591, 0xAEBAAD78, 0x054006D7, 0x52D0E1DF, 0x94FBFA95,
-        0xD78F0B3F, 0x8E81B911, 0x9C2BE008, 0xBF6D6F4E, 0x4185F87D,
+        0x47226c6b, 0x29719f52, 0xd11bb477, 0x9994b15b, 0xdf594ef8, 0xa686ccfd, 0x78659ffa,
+        0x96787f80, 0x2a63300d, 0xc3f78cb8, 0xa55f13b1, 0xb48aa603,
     ]),
 };
 
@@ -51,7 +51,8 @@ impl Ecc384Kat {
     /// This function executes the Known Answer Tests (aka KAT) for ECC384.
     ///
     /// Test vector source:
-    /// Zeroed inputs, outputs verified against python cryptography lib built on OpenSSL
+    /// Zeroed seed/nonce; key pair derived via test\src\crypto.rs
+    /// Signature verified using python cryptography lib (built on OpenSSL)
     ///
     /// # Arguments
     ///
@@ -60,13 +61,19 @@ impl Ecc384Kat {
     /// # Returns
     ///
     /// * `CaliptraResult` - Result denoting the KAT outcome.
-    pub fn execute(&self, ecc: &mut Ecc384, trng: &mut Trng) -> CaliptraResult<()> {
-        self.kat_key_pair_gen_sign_and_verify(ecc, trng)
+    pub fn execute(
+        &self,
+        ecc: &mut Ecc384,
+        sha: &mut Sha2_512_384,
+        trng: &mut Trng,
+    ) -> CaliptraResult<()> {
+        self.kat_key_pair_gen_sign_and_verify(ecc, sha, trng)
     }
 
     fn kat_key_pair_gen_sign_and_verify(
         &self,
         ecc: &mut Ecc384,
+        sha: &mut Sha2_512_384,
         trng: &mut Trng,
     ) -> CaliptraResult<()> {
         let mut priv_key = Array4x12::new([0u32; 12]);
@@ -75,8 +82,17 @@ impl Ecc384Kat {
             s: Array4x12::new([0u32; 12]),
         };
 
+        let msg_digest = sha
+            .sha384_digest(&[])
+            .map_err(|_| CaliptraError::KAT_ECC384_KEY_PAIR_GENERATE_FAILURE)?;
+
         let pub_key = ecc
-            .key_pair_for_fips_kat(trng, Ecc384PrivKeyOut::from(&mut priv_key), &mut pct_sig)
+            .key_pair_for_fips_kat(
+                trng,
+                Ecc384PrivKeyOut::from(&mut priv_key),
+                &mut pct_sig,
+                &msg_digest,
+            )
             .map_err(|_| CaliptraError::KAT_ECC384_KEY_PAIR_GENERATE_FAILURE)?;
 
         // NOTE: Signature verify step is performed in ECC driver sign function

--- a/kat/src/lib.rs
+++ b/kat/src/lib.rs
@@ -75,7 +75,7 @@ pub fn execute_kat(env: &mut KatsEnv<'_, '_>) -> CaliptraResult<InitializedDrive
     Shake256Kat::default().execute(env.sha3)?;
 
     cprintln!("[kat] ECC-384");
-    Ecc384Kat::default().execute(env.ecc384, env.trng)?;
+    Ecc384Kat::default().execute(env.ecc384, env.sha2_512_384, env.trng)?;
 
     cprintln!("[kat] ECDH");
     EcdhKat::default().execute(env.ecc384, env.trng)?;

--- a/test/src/crypto.rs
+++ b/test/src/crypto.rs
@@ -713,3 +713,24 @@ fn test_preconditioned_aes() {
     );
     assert_eq!(decrypted, plaintext.to_vec());
 }
+
+/// Prints ECC-384 KAT key pair constants derived from zeroed inputs
+///
+/// Run with: cargo test -p caliptra-test gen_ecc384_kat_vectors -- --include-ignored --nocapture
+#[test]
+#[ignore = "vector generation helper; not part of normal CI"]
+fn gen_ecc384_kat_vectors() {
+    // Key pair from zeroed seed/nonce
+    let (priv_key, pub_x, pub_y) = derive_ecdsa_keypair(&[0u8; 48]);
+
+    let hex = |b: &[u8]| {
+        b.iter().fold(String::new(), |mut s, x| {
+            use std::fmt::Write;
+            write!(s, "{x:02x}").unwrap();
+            s
+        })
+    };
+    println!("priv_key: {}", hex(&priv_key));
+    println!("pub_x:    {}", hex(&pub_x));
+    println!("pub_y:    {}", hex(&pub_y));
+}


### PR DESCRIPTION
- KAT flow performs SHA384 operation and provides digest to key gen PCT
- Added generation function in test/src/crypto.rs to output expected KAT key pair