### PR TITLE
runtime: add MLDSA87_SIGNATURE_VERIFY mailbox command (RFC #3700)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "caliptra-image-verify",
  "caliptra-kat",
  "caliptra-lms-types",
+ "caliptra-mldsa",
  "caliptra-registers",
  "caliptra-x509",
  "caliptra_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "caliptra-emu-types",
  "caliptra-error",
  "caliptra-image-types",
+ "caliptra-mldsa",
  "caliptra-registers",
  "ureg",
  "zerocopy",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 [dependencies]
 bitflags.workspace = true
 caliptra-error.workspace = true
+caliptra-mldsa.workspace = true
 zerocopy.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-registers.workspace = true

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -21,6 +21,7 @@ impl CommandId {
     pub const GET_RT_ALIAS_CERT: Self = Self(0x43455252); // "CERR"
     pub const ECDSA384_VERIFY: Self = Self(0x53494756); // "SIGV"
     pub const LMS_VERIFY: Self = Self(0x4C4D5356); // "LMSV"
+    pub const MLDSA87_SIGNATURE_VERIFY: Self = Self(0x4D445356); // "MDSV"
     pub const STASH_MEASUREMENT: Self = Self(0x4D454153); // "MEAS"
     pub const INVOKE_DPE: Self = Self(0x44504543); // "DPEC"
     pub const DISABLE_ATTESTATION: Self = Self(0x4453424C); // "DSBL"
@@ -265,6 +266,7 @@ impl Default for MailboxResp {
 pub enum MailboxReq {
     EcdsaVerify(EcdsaVerifyReq),
     LmsVerify(LmsVerifyReq),
+    Mldsa87Verify(Mldsa87VerifyReq),
     GetLdevCert(GetLdevCertReq),
     StashMeasurement(StashMeasurementReq),
     InvokeDpeCommand(InvokeDpeReq),
@@ -294,6 +296,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(req) => Ok(req.as_bytes()),
             MailboxReq::LmsVerify(req) => Ok(req.as_bytes()),
+            MailboxReq::Mldsa87Verify(req) => Ok(req.as_bytes()),
             MailboxReq::StashMeasurement(req) => Ok(req.as_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial(),
             MailboxReq::FipsVersion(req) => Ok(req.as_bytes()),
@@ -323,6 +326,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(req) => Ok(req.as_mut_bytes()),
             MailboxReq::LmsVerify(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::Mldsa87Verify(req) => Ok(req.as_mut_bytes()),
             MailboxReq::GetLdevCert(req) => Ok(req.as_mut_bytes()),
             MailboxReq::StashMeasurement(req) => Ok(req.as_mut_bytes()),
             MailboxReq::InvokeDpeCommand(req) => req.as_bytes_partial_mut(),
@@ -352,6 +356,7 @@ impl MailboxReq {
         match self {
             MailboxReq::EcdsaVerify(_) => CommandId::ECDSA384_VERIFY,
             MailboxReq::LmsVerify(_) => CommandId::LMS_VERIFY,
+            MailboxReq::Mldsa87Verify(_) => CommandId::MLDSA87_SIGNATURE_VERIFY,
             MailboxReq::GetLdevCert(_) => CommandId::GET_LDEV_CERT,
             MailboxReq::StashMeasurement(_) => CommandId::STASH_MEASUREMENT,
             MailboxReq::InvokeDpeCommand(_) => CommandId::INVOKE_DPE,
@@ -602,6 +607,33 @@ pub struct LmsVerifyReq {
 impl Request for LmsVerifyReq {
     const ID: CommandId = CommandId::LMS_VERIFY;
     type Resp = MailboxRespHeader;
+}
+// No command-specific output args
+
+// MLDSA87_SIGNATURE_VERIFY
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct Mldsa87VerifyReq {
+    pub hdr: MailboxReqHeader,
+    pub pub_key: [u8; 2592],
+    pub signature: [u8; 4627],
+    pub _sig_pad: u8,
+    pub message: [u8; 64],
+}
+impl Request for Mldsa87VerifyReq {
+    const ID: CommandId = CommandId::MLDSA87_SIGNATURE_VERIFY;
+    type Resp = MailboxRespHeader;
+}
+impl Default for Mldsa87VerifyReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            pub_key: [0u8; 2592],
+            signature: [0u8; 4627],
+            _sig_pad: 0,
+            message: [0u8; 64],
+        }
+    }
 }
 // No command-specific output args
 

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -2,6 +2,7 @@
 
 use bitflags::bitflags;
 use caliptra_error::{CaliptraError, CaliptraResult};
+use caliptra_mldsa::{MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES};
 use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -621,8 +622,8 @@ impl Request for LmsVerifyReq {
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct Mldsa87VerifyReq {
     pub hdr: MailboxReqHeader,
-    pub pub_key: [u8; 2592],
-    pub signature: [u8; 4627],
+    pub pub_key: [u8; MLDSA87_PUBLIC_KEY_BYTES],
+    pub signature: [u8; MLDSA87_SIGNATURE_BYTES],
     pub _pad: u8,
 }
 impl Request for Mldsa87VerifyReq {
@@ -633,8 +634,8 @@ impl Default for Mldsa87VerifyReq {
     fn default() -> Self {
         Self {
             hdr: MailboxReqHeader::default(),
-            pub_key: [0u8; 2592],
-            signature: [0u8; 4627],
+            pub_key: [0u8; MLDSA87_PUBLIC_KEY_BYTES],
+            signature: [0u8; MLDSA87_SIGNATURE_BYTES],
             _pad: 0,
         }
     }

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -611,14 +611,19 @@ impl Request for LmsVerifyReq {
 // No command-specific output args
 
 // MLDSA87_SIGNATURE_VERIFY
+//
+// The message digest to verify against is taken from Caliptra's SHA
+// accelerator (matching ECDSA384_VERIFY and LMS_VERIFY). Callers must
+// stream the message through the SHA accelerator before issuing this
+// command. Carrying the raw message in-band would put hashing outside
+// the FIPS module boundary and is therefore disallowed.
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct Mldsa87VerifyReq {
     pub hdr: MailboxReqHeader,
     pub pub_key: [u8; 2592],
     pub signature: [u8; 4627],
-    pub _sig_pad: u8,
-    pub message: [u8; 64],
+    pub _pad: u8,
 }
 impl Request for Mldsa87VerifyReq {
     const ID: CommandId = CommandId::MLDSA87_SIGNATURE_VERIFY;
@@ -630,8 +635,7 @@ impl Default for Mldsa87VerifyReq {
             hdr: MailboxReqHeader::default(),
             pub_key: [0u8; 2592],
             signature: [0u8; 4627],
-            _sig_pad: 0,
-            message: [0u8; 64],
+            _pad: 0,
         }
     }
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1263,11 +1263,6 @@ impl CaliptraError {
             0x000E0062,
             "Runtime Error: ML-DSA-87 signature verification failed"
         ),
-        (
-            RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
-            0x000E0063,
-            "Runtime Error: ML-DSA-87 verify request reserved padding byte is non-zero"
-        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1258,6 +1258,16 @@ impl CaliptraError {
             0x000E0061,
             "Runtime Error: Multiple CCIV contexts found"
         ),
+        (
+            RUNTIME_MLDSA87_VERIFY_FAILED,
+            0x000E0062,
+            "Runtime Error: ML-DSA-87 signature verification failed"
+        ),
+        (
+            RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
+            0x000E0063,
+            "Runtime Error: ML-DSA-87 verify request reserved padding byte is non-zero"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/kat/src/mldsa87_kat.rs
+++ b/kat/src/mldsa87_kat.rs
@@ -132,7 +132,6 @@ impl Mldsa87Kat {
         if Mldsa87::verify(public_key, signature, &MESSAGE)? != Mldsa87Result::Success {
             Err(CaliptraError::KAT_MLDSA87_SIGNATURE_VERIFY_FAILURE)?;
         }
-
         Ok(())
     }
 }

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -663,6 +663,27 @@ int rt_test_all_commands(const test_info* info)
         printf("LMS Verify: OK\n");
     }
 
+    // MLDSA87_SIGNATURE_VERIFY
+    struct caliptra_mldsa87_signature_verify_req mldsa_req = {};
+
+    status = caliptra_mldsa87_signature_verify(&mldsa_req, false);
+
+    // Not testing for full success.
+    // An all-zero public key + signature is well-formed wire-wise (chksum is
+    // populated by the SDK and `_sig_pad` defaults to zero) but is rejected
+    // by the verify algorithm. Seeing RUNTIME_MLDSA87_VERIFY_FAILED here
+    // proves the FW recognized the new MDSV command and routed it to the
+    // ML-DSA-87 verify code path.
+    uint32_t RUNTIME_MLDSA87_VERIFY_FAILED = 0xE0062;
+    non_fatal_error = caliptra_read_fw_non_fatal_error();
+    if (status != MBX_STATUS_FAILED || non_fatal_error != RUNTIME_MLDSA87_VERIFY_FAILED) {
+        printf("MLDSA87 Signature Verify unexpected result/failure: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        failure = 1;
+    } else {
+        printf("MLDSA87 Signature Verify: OK\n");
+    }
+
     // STASH_MEASUREMENT
     struct caliptra_stash_measurement_req stash_req = {};
     struct caliptra_stash_measurement_resp stash_resp;

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -682,10 +682,9 @@ int rt_test_all_commands(const test_info* info)
 
     // Not testing for full success.
     // An all-zero public key + signature is well-formed wire-wise (chksum is
-    // populated by the SDK and `_sig_pad` defaults to zero) but is rejected
-    // by the verify algorithm. Seeing RUNTIME_MLDSA87_VERIFY_FAILED here
-    // proves the FW recognized the new MDSV command and routed it to the
-    // ML-DSA-87 verify code path.
+    // populated by the SDK) but is rejected by the verify algorithm. Seeing
+    // RUNTIME_MLDSA87_VERIFY_FAILED here proves the FW recognized the new
+    // MDSV command and routed it to the ML-DSA-87 verify code path.
     uint32_t RUNTIME_MLDSA87_VERIFY_FAILED = 0xE0062;
     non_fatal_error = caliptra_read_fw_non_fatal_error();
     if (status != MBX_STATUS_FAILED || non_fatal_error != RUNTIME_MLDSA87_VERIFY_FAILED) {

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -664,6 +664,18 @@ int rt_test_all_commands(const test_info* info)
     }
 
     // MLDSA87_SIGNATURE_VERIFY
+    //
+    // TODO(https://github.com/chipsalliance/caliptra-sw/issues/3835): re-enable once both
+    //   1. caliptra-mldsa::verify_internal stack-budget reduction (per-Scalar
+    //      rewrite so verify fits the runtime's ~85 KiB stack), and
+    //   2. caliptra-mldsa / caliptra-shake panic-freedom audit (so
+    //      test_panic_missing keeps passing once mldsa_attestation is
+    //      enabled in APP_WITH_UART)
+    // both land in caliptra-1.x. Until then, MDSV is not compiled into the
+    // upstream firmware image used by this hwmodel test (the mldsa_attestation
+    // cargo feature on caliptra-runtime is off by default), so calling MDSV
+    // here would return RUNTIME_UNIMPLEMENTED_COMMAND (0xE0002).
+#if 0
     struct caliptra_mldsa87_signature_verify_req mldsa_req = {};
 
     status = caliptra_mldsa87_signature_verify(&mldsa_req, false);
@@ -683,6 +695,7 @@ int rt_test_all_commands(const test_info* info)
     } else {
         printf("MLDSA87 Signature Verify: OK\n");
     }
+#endif
 
     // STASH_MEASUREMENT
     struct caliptra_stash_measurement_req stash_req = {};

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -179,6 +179,9 @@ int caliptra_ecdsa384_verify(struct caliptra_ecdsa_verify_req *req, bool async);
 // LMS Verify
 int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async);
 
+// ML-DSA-87 Signature Verify (RFC #3700)
+int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async);
+
 // Stash measurement
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async);
 

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -179,7 +179,7 @@ int caliptra_ecdsa384_verify(struct caliptra_ecdsa_verify_req *req, bool async);
 // LMS Verify
 int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async);
 
-// ML-DSA-87 Signature Verify (RFC #3700)
+// ML-DSA-87 Signature Verify
 int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async);
 
 // Stash measurement

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -131,7 +131,7 @@ struct caliptra_lms_verify_req
     uint8_t signature_tree_path[360];
 };
 
-// MLDSA87_SIGNATURE_VERIFY (RFC #3700).
+// MLDSA87_SIGNATURE_VERIFY.
 // The message digest to verify against is taken from Caliptra's SHA
 // accelerator (matching ECDSA384_VERIFY and LMS_VERIFY). The caller
 // must stream the message through the SHA accelerator before issuing

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -131,6 +131,21 @@ struct caliptra_lms_verify_req
     uint8_t signature_tree_path[360];
 };
 
+// MLDSA87_SIGNATURE_VERIFY (RFC #3700).
+//
+// `_sig_pad` is reserved and must be zero; it aligns `message` on an
+// 8-byte boundary inside the wire-format request. `message` is intended
+// to carry a fixed-size digest (e.g. SHA-256/384/512) computed by the
+// caller, since the runtime command does not pre-hash large payloads.
+struct caliptra_mldsa87_signature_verify_req
+{
+    struct caliptra_req_header hdr;
+    uint8_t pub_key[2592];
+    uint8_t signature[4627];
+    uint8_t _sig_pad;
+    uint8_t message[64];
+};
+
 struct caliptra_stash_measurement_req
 {
     struct caliptra_req_header hdr;

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -132,18 +132,17 @@ struct caliptra_lms_verify_req
 };
 
 // MLDSA87_SIGNATURE_VERIFY (RFC #3700).
-//
-// `_sig_pad` is reserved and must be zero; it aligns `message` on an
-// 8-byte boundary inside the wire-format request. `message` is intended
-// to carry a fixed-size digest (e.g. SHA-256/384/512) computed by the
-// caller, since the runtime command does not pre-hash large payloads.
+// The message digest to verify against is taken from Caliptra's SHA
+// accelerator (matching ECDSA384_VERIFY and LMS_VERIFY). The caller
+// must stream the message through the SHA accelerator before issuing
+// this command. Carrying the raw message in-band would put hashing
+// outside the FIPS module boundary and is therefore disallowed.
 struct caliptra_mldsa87_signature_verify_req
 {
     struct caliptra_req_header hdr;
     uint8_t pub_key[2592];
     uint8_t signature[4627];
-    uint8_t _sig_pad;
-    uint8_t message[64];
+    uint8_t _pad;
 };
 
 struct caliptra_stash_measurement_req

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1058,7 +1058,7 @@ int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async)
     return pack_and_execute_command(&p, async);
 }
 
-// ML-DSA-87 Signature Verify (RFC #3700)
+// ML-DSA-87 Signature Verify
 int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async)
 {
     if (!req)

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1058,6 +1058,21 @@ int caliptra_lms_verify(struct caliptra_lms_verify_req *req, bool async)
     return pack_and_execute_command(&p, async);
 }
 
+// ML-DSA-87 Signature Verify (RFC #3700)
+int caliptra_mldsa87_signature_verify(struct caliptra_mldsa87_signature_verify_req *req, bool async)
+{
+    if (!req)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_resp_header resp_hdr = {};
+
+    CREATE_PARCEL(p, OP_MLDSA87_SIGNATURE_VERIFY, req, &resp_hdr);
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Stash measurement
 int caliptra_stash_measurement(struct caliptra_stash_measurement_req *req, struct caliptra_stash_measurement_resp *resp, bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -35,6 +35,7 @@ enum mailbox_command {
     OP_GET_RT_ALIAS_CERT             = 0x43455252, // "CERR"
     OP_ECDSA384_VERIFY               = 0x53494756, // "SIGV"
     OP_LMS_VERIFY                    = 0x4C4D5356, // "LMSV"
+    OP_MLDSA87_SIGNATURE_VERIFY      = 0x4D445356, // "MDSV"
     OP_STASH_MEASUREMENT             = 0x4D454153, // "MEAS"
     OP_INVOKE_DPE_COMMAND            = 0x44504543, // "DPEC"
     OP_DISABLE_ATTESTATION           = 0x4453424C, // "DSBL"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -47,6 +47,7 @@ caliptra-image-crypto.workspace = true
 caliptra-auth-man-gen.workspace = true
 caliptra-image-serde.workspace = true
 caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
+caliptra-mldsa.workspace = true
 openssl.workspace = true
 sha2 = { version = "0.10.2", default-features = false, features = ["compress"] }
 cms.workspace = true
@@ -67,3 +68,4 @@ cfi = ["caliptra-image-verify/cfi", "caliptra-image-types/cfi", "caliptra-driver
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
 "hw-1.0" = ["caliptra-builder/hw-1.0", "caliptra-drivers/hw-1.0", "caliptra-kat/hw-1.0","caliptra-cpu/hw-1.0", "caliptra-hw-model/hw-1.0"]
 fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]
+mldsa_attestation = ["caliptra-drivers/mldsa_attestation"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,4 +68,3 @@ cfi = ["caliptra-image-verify/cfi", "caliptra-image-types/cfi", "caliptra-driver
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
 "hw-1.0" = ["caliptra-builder/hw-1.0", "caliptra-drivers/hw-1.0", "caliptra-kat/hw-1.0","caliptra-cpu/hw-1.0", "caliptra-hw-model/hw-1.0"]
 fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]
-mldsa_attestation = ["caliptra-drivers/mldsa_attestation"]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -418,6 +418,40 @@ Command Code: `0x4C4D_5356` ("LMSV")
 | chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
 | fips\_status | u32      | Indicates if the command is FIPS approved or an error.
 
+### MLDSA87\_SIGNATURE\_VERIFY
+
+Verifies an ML-DSA-87 (FIPS 204) signature. Unlike the ECDSA and LMS verify
+commands, the message is supplied directly in the request rather than read
+from the SHA accelerator. Callers are expected to pre-hash large payloads
+(SHA-256 / SHA-384 / SHA-512) and pass the digest in the fixed 64-byte
+`message` field.
+
+ML-DSA-87 is stateless and does not have the per-key signature budget that
+LMS does, which is the primary motivation for adding this command alongside
+the existing `LMS_SIGNATURE_VERIFY`.
+
+In the event of an invalid signature, the mailbox command will report
+`CMD_FAILURE` and the cause will be logged as a non-fatal error.
+
+Command Code: `0x4D44_5356` ("MDSV")
+
+*Table: `MLDSA87_SIGNATURE_VERIFY` input arguments*
+
+| **Name**     | **Type**  | **Description**
+| --------     | --------- | ---------------
+| chksum       | u32       | Checksum over other input arguments, computed by the caller. Little endian.
+| pub\_key     | u8[2592]  | Encoded ML-DSA-87 public key (FIPS 204).
+| signature    | u8[4627]  | Encoded ML-DSA-87 signature (FIPS 204).
+| \_sig\_pad   | u8        | Reserved. Must be zero. Aligns `message` on an 8-byte boundary.
+| message      | u8[64]    | Message to verify. Intended for SHA-256/384/512 digests or other fixed-size messages.
+
+*Table: `MLDSA87_SIGNATURE_VERIFY` output arguments*
+
+| **Name**    | **Type** | **Description**
+| --------    | -------- | ---------------
+| chksum      | u32      | Checksum over other output arguments, computed by Caliptra. Little endian.
+| fips\_status | u32      | Indicates if the command is FIPS approved or an error.
+
 ### STASH\_MEASUREMENT
 
 Makes a measurement into the DPE default context. This command is intended for

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -420,11 +420,12 @@ Command Code: `0x4C4D_5356` ("LMSV")
 
 ### MLDSA87\_SIGNATURE\_VERIFY
 
-Verifies an ML-DSA-87 (FIPS 204) signature. Unlike the ECDSA and LMS verify
-commands, the message is supplied directly in the request rather than read
-from the SHA accelerator. Callers are expected to pre-hash large payloads
-(SHA-256 / SHA-384 / SHA-512) and pass the digest in the fixed 64-byte
-`message` field.
+Verifies an ML-DSA-87 (FIPS 204) signature. As with the ECDSA and LMS
+verify commands, the message digest to be verified is taken from
+Caliptra's SHA384 accelerator peripheral. Callers must stream the
+message through the SHA accelerator before issuing this command;
+carrying the raw message in-band would put hashing outside the FIPS
+module boundary and is therefore disallowed.
 
 ML-DSA-87 is stateless and does not have the per-key signature budget that
 LMS does, which is the primary motivation for adding this command alongside
@@ -442,8 +443,6 @@ Command Code: `0x4D44_5356` ("MDSV")
 | chksum       | u32       | Checksum over other input arguments, computed by the caller. Little endian.
 | pub\_key     | u8[2592]  | Encoded ML-DSA-87 public key (FIPS 204).
 | signature    | u8[4627]  | Encoded ML-DSA-87 signature (FIPS 204).
-| \_sig\_pad   | u8        | Reserved. Must be zero. Aligns `message` on an 8-byte boundary.
-| message      | u8[64]    | Message to verify. Intended for SHA-256/384/512 digests or other fixed-size messages.
 
 *Table: `MLDSA87_SIGNATURE_VERIFY` output arguments*
 

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -61,6 +61,14 @@ Checks that the lms_signature_verify mailbox command correctly returns an error 
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the signature to the lms_signature_verify mailbox command | **test_lms_verify_invalid_sig_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the public key to the lms_signature_verify mailbox command | **test_lms_verify_invalid_key_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS OTS algorithm type is provided to the lms_signature_verify mailbox command | **test_lms_verify_invalid_lmots_type** | RUNTIME_LMS_VERIFY_INVALID_LMOTS_ALGORITHM
+Round-trips deterministically generated ML-DSA-87 keypairs / signatures through the mldsa87_signature_verify mailbox command for two seeds and two messages | **test_mldsa87_verify_cmd** | N/A
+Checks that the mldsa87_signature_verify mailbox command rejects a single-bit-flipped signature | **test_mldsa87_verify_failure_tampered_signature** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a different message | **test_mldsa87_verify_failure_wrong_message** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a public key from a different seed | **test_mldsa87_verify_failure_wrong_pub_key** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects an all-zero public key and signature | **test_mldsa87_verify_failure_all_zero** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a request with a stale (zero) checksum | **test_mldsa87_verify_bad_chksum** | RUNTIME_INVALID_CHECKSUM
+Checks that the mldsa87_signature_verify mailbox command rejects a request whose reserved `_sig_pad` byte is nonzero | **test_mldsa87_verify_invalid_padding** | RUNTIME_MLDSA87_VERIFY_INVALID_PADDING
+Checks that the mldsa87_signature_verify mailbox command rejects a request that is shorter than the request struct | **test_mldsa87_verify_truncated_request** | RUNTIME_INSUFFICIENT_MEMORY
 
 
 

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -61,13 +61,12 @@ Checks that the lms_signature_verify mailbox command correctly returns an error 
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the signature to the lms_signature_verify mailbox command | **test_lms_verify_invalid_sig_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS algorithm type is provided in the public key to the lms_signature_verify mailbox command | **test_lms_verify_invalid_key_lms_type** | RUNTIME_LMS_VERIFY_INVALID_LMS_ALGORITHM
 Checks that the correct error is returned when an unsupported LMS OTS algorithm type is provided to the lms_signature_verify mailbox command | **test_lms_verify_invalid_lmots_type** | RUNTIME_LMS_VERIFY_INVALID_LMOTS_ALGORITHM
-Round-trips deterministically generated ML-DSA-87 keypairs / signatures through the mldsa87_signature_verify mailbox command for two seeds and two messages | **test_mldsa87_verify_cmd** | N/A
+Streams 2 different test messages to the SHA accelerator and round-trips deterministically generated ML-DSA-87 keypairs / signatures through the mldsa87_signature_verify mailbox command for two seeds and two messages | **test_mldsa87_verify_cmd** | N/A
 Checks that the mldsa87_signature_verify mailbox command rejects a single-bit-flipped signature | **test_mldsa87_verify_failure_tampered_signature** | RUNTIME_MLDSA87_VERIFY_FAILED
-Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a different message | **test_mldsa87_verify_failure_wrong_message** | RUNTIME_MLDSA87_VERIFY_FAILED
+Checks that the mldsa87_signature_verify mailbox command rejects a signature when a different message digest is primed in the SHA accelerator | **test_mldsa87_verify_failure_wrong_message** | RUNTIME_MLDSA87_VERIFY_FAILED
 Checks that the mldsa87_signature_verify mailbox command rejects a signature presented with a public key from a different seed | **test_mldsa87_verify_failure_wrong_pub_key** | RUNTIME_MLDSA87_VERIFY_FAILED
 Checks that the mldsa87_signature_verify mailbox command rejects an all-zero public key and signature | **test_mldsa87_verify_failure_all_zero** | RUNTIME_MLDSA87_VERIFY_FAILED
 Checks that the mldsa87_signature_verify mailbox command rejects a request with a stale (zero) checksum | **test_mldsa87_verify_bad_chksum** | RUNTIME_INVALID_CHECKSUM
-Checks that the mldsa87_signature_verify mailbox command rejects a request whose reserved `_sig_pad` byte is nonzero | **test_mldsa87_verify_invalid_padding** | RUNTIME_MLDSA87_VERIFY_INVALID_PADDING
 Checks that the mldsa87_signature_verify mailbox command rejects a request that is shorter than the request struct | **test_mldsa87_verify_truncated_request** | RUNTIME_INSUFFICIENT_MEMORY
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -199,7 +199,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers),
         CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
-        CommandId::MLDSA87_SIGNATURE_VERIFY => Mldsa87VerifyCmd::execute(drivers, cmd_bytes),
+        CommandId::MLDSA87_SIGNATURE_VERIFY => Mldsa87VerifyCmd::execute(drivers),
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers),
         CommandId::DISABLE_ATTESTATION => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -81,6 +81,8 @@ pub use pcr::{GetPcrLogCmd, IncrementPcrResetCounterCmd};
 pub use reallocate_dpe_context_limits::ReallocateDpeContextLimitsCmd;
 pub use set_auth_manifest::SetAuthManifestCmd;
 pub use stash_measurement::StashMeasurementCmd;
+#[cfg(feature = "mldsa_attestation")]
+pub use verify::Mldsa87VerifyCmd;
 pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd};
 pub mod packet;
 use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxResp};
@@ -196,6 +198,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers),
         CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers),
         CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::MLDSA87_SIGNATURE_VERIFY => Mldsa87VerifyCmd::execute(drivers, cmd_bytes),
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers),
         CommandId::DISABLE_ATTESTATION => {

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -144,16 +144,25 @@ pub struct Mldsa87VerifyCmd;
 impl Mldsa87VerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(_drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
         let cmd = Mldsa87VerifyReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
-        // Reserved padding byte must be zero per RFC #3700.
-        if cmd._sig_pad != 0 {
-            return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING);
+        // Pull the SHA-384 digest from the SHA accelerator (same pattern as
+        // ECDSA384_VERIFY and LMS_VERIFY). The caller is expected to have
+        // streamed the message through the accelerator before dispatching
+        // this command. Keeping the hashing inside the SHA accelerator
+        // preserves the FIPS module boundary for this verify operation.
+        let msg_digest_be = drivers.sha_acc.regs().digest().truncate::<12>().read();
+        // The accelerator exposes the digest as big-endian u32 words; flip
+        // them back to a raw byte stream so ML-DSA verifies against the
+        // canonical SHA-384 byte ordering.
+        let mut msg_digest = [0u8; 48];
+        for (i, src_word) in msg_digest_be.iter().enumerate() {
+            msg_digest[i * 4..][..4].copy_from_slice(&src_word.to_be_bytes());
         }
 
-        let result = Mldsa87::verify(&cmd.pub_key, &cmd.signature, &cmd.message)?;
+        let result = Mldsa87::verify(&cmd.pub_key, &cmd.signature, &msg_digest)?;
         if result != Mldsa87Result::Success {
             return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED);
         }

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -15,11 +15,15 @@ Abstract:
 use crate::packet::copy_from_mbox;
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
+#[cfg(feature = "mldsa_attestation")]
+use caliptra_common::mailbox_api::Mldsa87VerifyReq;
 use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxResp};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Signature, LmsResult,
 };
+#[cfg(feature = "mldsa_attestation")]
+use caliptra_drivers::{Mldsa87, Mldsa87Result};
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
 };
@@ -128,6 +132,30 @@ impl LmsVerifyCmd {
         )?;
         if success != LmsResult::Success {
             return Err(CaliptraError::RUNTIME_LMS_VERIFY_FAILED);
+        }
+
+        Ok(MailboxResp::default())
+    }
+}
+
+#[cfg(feature = "mldsa_attestation")]
+pub struct Mldsa87VerifyCmd;
+#[cfg(feature = "mldsa_attestation")]
+impl Mldsa87VerifyCmd {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(_drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+        let cmd = Mldsa87VerifyReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        // Reserved padding byte must be zero per RFC #3700.
+        if cmd._sig_pad != 0 {
+            return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING);
+        }
+
+        let result = Mldsa87::verify(&cmd.pub_key, &cmd.signature, &cmd.message)?;
+        if result != Mldsa87Result::Success {
+            return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED);
         }
 
         Ok(MailboxResp::default())

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -144,9 +144,9 @@ pub struct Mldsa87VerifyCmd;
 impl Mldsa87VerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = Mldsa87VerifyReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = Mldsa87VerifyReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         // Pull the SHA-384 digest from the SHA accelerator (same pattern as
         // ECDSA384_VERIFY and LMS_VERIFY). The caller is expected to have

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -14,6 +14,8 @@ mod test_info;
 mod test_invoke_dpe;
 mod test_lms;
 mod test_mailbox;
+#[cfg(feature = "mldsa_attestation")]
+mod test_mldsa_verify;
 mod test_panic_missing;
 mod test_pauser_privilege_levels;
 mod test_pcr;

--- a/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
@@ -3,62 +3,54 @@
 //! Integration tests for the `MLDSA87_SIGNATURE_VERIFY` runtime mailbox
 //! command (RFC #3700).
 //!
-//! The command is a thin wrapper around the pure-software ML-DSA-87 verify
-//! implementation in `caliptra-mldsa`, so these tests:
+//! The command verifies an ML-DSA-87 signature over a message digest that
+//! has been streamed through Caliptra's SHA accelerator (the same pattern
+//! used by `ECDSA384_VERIFY` and `LMS_VERIFY`). Keeping the hashing inside
+//! the SHA accelerator preserves the FIPS module boundary for this verify
+//! operation.
+//!
+//! These tests:
 //!
 //! * derive a deterministic ML-DSA-87 keypair on the host from a seed,
-//! * deterministically sign a 64-byte message with that key,
-//! * round-trip the resulting `(pub_key, signature, message)` triple through
-//!   the runtime mailbox, and
+//! * deterministically sign the SHA-384 digest of a host-side message,
+//! * stream the same message into the SHA accelerator,
+//! * round-trip the resulting `(pub_key, signature)` pair through the
+//!   runtime mailbox, and
 //! * verify both the happy path and a comprehensive set of negative /
 //!   malformed inputs.
-//!
-//! Because the SoC firmware is expected to pre-hash large payloads (see
-//! `runtime/README.md`), the `message` field is always 64 bytes and we treat
-//! it as opaque — no SHA accelerator interaction is required, unlike the
-//! ECDSA / LMS verify mailbox commands.
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
     CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, Mldsa87VerifyReq,
 };
-use caliptra_hw_model::HwModel;
+use caliptra_hw_model::{HwModel, ShaAccMode};
 use caliptra_mldsa::{
     Mldsa87, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
 };
 use caliptra_runtime::RtBootStatus;
+use openssl::sha::sha384;
 use zerocopy::FromBytes;
-
-const MSG_BYTES: usize = 64;
 
 /// Two distinct seeds let us exercise distinct keypairs and confirm that the
 /// command rejects cross-key verification.
 const SEED_A: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0x42; MLDSA87_PRIVATE_SEED_BYTES];
 const SEED_B: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0xa5; MLDSA87_PRIVATE_SEED_BYTES];
 
-/// Two distinct 64-byte "digests" used as the verified message. The actual
-/// content is irrelevant — these stand in for, e.g., SHA-512 outputs.
-const MSG_1: [u8; MSG_BYTES] = [
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
-    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
-];
-const MSG_2: [u8; MSG_BYTES] = [
-    0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
-    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xfe, 0xed, 0xfa, 0xce, 0xba, 0xad, 0xf0, 0x0d,
-    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
-    0x55, 0x55, 0x55, 0x55, 0xaa, 0xaa, 0xaa, 0xaa, 0x5a, 0x5a, 0x5a, 0x5a, 0xa5, 0xa5, 0xa5, 0xa5,
-];
+/// Two distinct messages used to derive the SHA-384 digest that ML-DSA-87
+/// will be asked to verify. The contents are arbitrary — the point is that
+/// the host and the SHA accelerator agree on the resulting digest bytes.
+const MSG_1: &[u8] = b"caliptra mldsa-87 verify test message #1";
+const MSG_2: &[u8] = b"caliptra mldsa-87 verify test message #2 (distinct)";
 
-/// Helper: derive (pub_key, signature) for `seed` over `msg`.
+/// Helper: derive (pub_key, signature) for `seed` over the SHA-384 digest
+/// of `msg`.
 ///
 /// The boxed return values keep the ~7 KB of crypto material off the test
 /// stack frame.
 fn keygen_and_sign(
     seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
-    msg: &[u8; MSG_BYTES],
+    msg: &[u8],
 ) -> (
     Box<[u8; MLDSA87_PUBLIC_KEY_BYTES]>,
     Box<[u8; MLDSA87_SIGNATURE_BYTES]>,
@@ -66,25 +58,31 @@ fn keygen_and_sign(
     let mut pk = Box::new([0u8; MLDSA87_PUBLIC_KEY_BYTES]);
     let mut sig = Box::new([0u8; MLDSA87_SIGNATURE_BYTES]);
     Mldsa87::pub_from_seed(seed, &mut pk);
-    Mldsa87::sign_deterministic(seed, msg, &mut sig);
+    Mldsa87::sign_deterministic(seed, &sha384(msg), &mut sig);
     (pk, sig)
 }
 
 /// Helper: build a fully-populated `MailboxReq::Mldsa87Verify` and stamp a
-/// valid checksum.
+/// valid checksum. The message itself is not part of the request — callers
+/// must stream it through the SHA accelerator separately.
 fn build_verify_req(
     pub_key: &[u8; MLDSA87_PUBLIC_KEY_BYTES],
     signature: &[u8; MLDSA87_SIGNATURE_BYTES],
-    message: &[u8; MSG_BYTES],
 ) -> MailboxReq {
     let mut req = Box::new(Mldsa87VerifyReq::default());
     req.pub_key = *pub_key;
     req.signature = *signature;
-    req._sig_pad = 0;
-    req.message = *message;
     let mut cmd = MailboxReq::Mldsa87Verify(*req);
     cmd.populate_chksum().unwrap();
     cmd
+}
+
+/// Stream `msg` through the SHA accelerator so the runtime can pick the
+/// SHA-384 digest off the accelerator's digest register.
+fn prime_sha_acc<T: HwModel>(model: &mut T, msg: &[u8]) {
+    model
+        .compute_sha512_acc_digest(msg, ShaAccMode::Sha384Stream)
+        .unwrap();
 }
 
 /// Helper: send an already-populated request and assert the response header
@@ -120,16 +118,18 @@ fn boot_ready<T: HwModel>(model: &mut T) {
 // -------------------------------------------------------------------------
 
 /// End-to-end happy path: two distinct seeds × two distinct messages.
-/// Exercises the full request-parse -> verify -> response path.
+/// Exercises the full SHA-stream -> request-parse -> verify -> response
+/// path.
 #[test]
 fn test_mldsa87_verify_cmd() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     boot_ready(&mut model);
 
     for seed in [&SEED_A, &SEED_B] {
-        for msg in [&MSG_1, &MSG_2] {
+        for msg in [MSG_1, MSG_2] {
             let (pk, sig) = keygen_and_sign(seed, msg);
-            let cmd = build_verify_req(&pk, &sig, msg);
+            prime_sha_acc(&mut model, msg);
+            let cmd = build_verify_req(&pk, &sig);
             execute_ok(&mut model, &cmd);
         }
     }
@@ -146,10 +146,11 @@ fn test_mldsa87_verify_failure_tampered_signature() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     boot_ready(&mut model);
 
-    let (pk, mut sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let (pk, mut sig) = keygen_and_sign(&SEED_A, MSG_1);
     sig[0] ^= 0xff;
 
-    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    prime_sha_acc(&mut model, MSG_1);
+    let cmd = build_verify_req(&pk, &sig);
     let err = model
         .mailbox_execute(
             u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
@@ -164,14 +165,18 @@ fn test_mldsa87_verify_failure_tampered_signature() {
     );
 }
 
-/// Verifying a signature against a different message must fail.
+/// Verifying a signature against a different message (i.e., a different
+/// SHA-384 digest streamed into the accelerator) must fail.
 #[test]
 fn test_mldsa87_verify_failure_wrong_message() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     boot_ready(&mut model);
 
-    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
-    let cmd = build_verify_req(&pk, &sig, &MSG_2);
+    let (pk, sig) = keygen_and_sign(&SEED_A, MSG_1);
+    // Stream a *different* message so the digest in the SHA accelerator
+    // does not match what the signature was produced for.
+    prime_sha_acc(&mut model, MSG_2);
+    let cmd = build_verify_req(&pk, &sig);
     let err = model
         .mailbox_execute(
             u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
@@ -193,10 +198,11 @@ fn test_mldsa87_verify_failure_wrong_pub_key() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     boot_ready(&mut model);
 
-    let (_, sig_a) = keygen_and_sign(&SEED_A, &MSG_1);
-    let (pk_b, _) = keygen_and_sign(&SEED_B, &MSG_1);
+    let (_, sig_a) = keygen_and_sign(&SEED_A, MSG_1);
+    let (pk_b, _) = keygen_and_sign(&SEED_B, MSG_1);
 
-    let cmd = build_verify_req(&pk_b, &sig_a, &MSG_1);
+    prime_sha_acc(&mut model, MSG_1);
+    let cmd = build_verify_req(&pk_b, &sig_a);
     let err = model
         .mailbox_execute(
             u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
@@ -221,7 +227,8 @@ fn test_mldsa87_verify_failure_all_zero() {
 
     let pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
     let sig = [0u8; MLDSA87_SIGNATURE_BYTES];
-    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    prime_sha_acc(&mut model, MSG_1);
+    let cmd = build_verify_req(&pk, &sig);
     let err = model
         .mailbox_execute(
             u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
@@ -248,14 +255,14 @@ fn test_mldsa87_verify_bad_chksum() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
     boot_ready(&mut model);
 
-    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let (pk, sig) = keygen_and_sign(&SEED_A, MSG_1);
     let mut req = Box::new(Mldsa87VerifyReq::default());
     req.pub_key = *pk;
     req.signature = *sig;
-    req.message = MSG_1;
     // Note: NOT calling populate_chksum, so hdr.chksum stays at 0.
     let cmd = MailboxReq::Mldsa87Verify(*req);
 
+    prime_sha_acc(&mut model, MSG_1);
     let err = model
         .mailbox_execute(
             u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
@@ -266,40 +273,6 @@ fn test_mldsa87_verify_bad_chksum() {
     assert_error(
         &mut model,
         caliptra_drivers::CaliptraError::RUNTIME_INVALID_CHECKSUM,
-        err,
-    );
-}
-
-/// The `_sig_pad` byte exists solely to align `message` on an 8-byte
-/// boundary inside the request struct; RFC #3700 mandates that it be zero.
-/// Setting it to a nonzero value must be rejected explicitly with
-/// `RUNTIME_MLDSA87_VERIFY_INVALID_PADDING` (i.e., before any verify work
-/// is done).
-#[test]
-fn test_mldsa87_verify_invalid_padding() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
-    boot_ready(&mut model);
-
-    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
-    let mut req = Box::new(Mldsa87VerifyReq::default());
-    req.pub_key = *pk;
-    req.signature = *sig;
-    req._sig_pad = 1; // RFC #3700 violation
-    req.message = MSG_1;
-    let mut cmd = MailboxReq::Mldsa87Verify(*req);
-    // Recompute checksum so we exercise the padding check, not the chksum check.
-    cmd.populate_chksum().unwrap();
-
-    let err = model
-        .mailbox_execute(
-            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
-            cmd.as_bytes().unwrap(),
-        )
-        .unwrap_err();
-
-    assert_error(
-        &mut model,
-        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
         err,
     );
 }
@@ -324,6 +297,7 @@ fn test_mldsa87_verify_truncated_request() {
     );
     payload[..chksum_size].copy_from_slice(&chksum.to_le_bytes());
 
+    prime_sha_acc(&mut model, MSG_1);
     let err = model
         .mailbox_execute(u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY), &payload)
         .unwrap_err();

--- a/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
@@ -1,0 +1,336 @@
+// Licensed under the Apache-2.0 license.
+
+//! Integration tests for the `MLDSA87_SIGNATURE_VERIFY` runtime mailbox
+//! command (RFC #3700).
+//!
+//! The command is a thin wrapper around the pure-software ML-DSA-87 verify
+//! implementation in `caliptra-mldsa`, so these tests:
+//!
+//! * derive a deterministic ML-DSA-87 keypair on the host from a seed,
+//! * deterministically sign a 64-byte message with that key,
+//! * round-trip the resulting `(pub_key, signature, message)` triple through
+//!   the runtime mailbox, and
+//! * verify both the happy path and a comprehensive set of negative /
+//!   malformed inputs.
+//!
+//! Because the SoC firmware is expected to pre-hash large payloads (see
+//! `runtime/README.md`), the `message` field is always 64 bytes and we treat
+//! it as opaque — no SHA accelerator interaction is required, unlike the
+//! ECDSA / LMS verify mailbox commands.
+
+use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
+use caliptra_common::checksum::calc_checksum;
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, Mldsa87VerifyReq,
+};
+use caliptra_hw_model::HwModel;
+use caliptra_mldsa::{
+    Mldsa87, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
+};
+use caliptra_runtime::RtBootStatus;
+use zerocopy::FromBytes;
+
+const MSG_BYTES: usize = 64;
+
+/// Two distinct seeds let us exercise distinct keypairs and confirm that the
+/// command rejects cross-key verification.
+const SEED_A: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0x42; MLDSA87_PRIVATE_SEED_BYTES];
+const SEED_B: [u8; MLDSA87_PRIVATE_SEED_BYTES] = [0xa5; MLDSA87_PRIVATE_SEED_BYTES];
+
+/// Two distinct 64-byte "digests" used as the verified message. The actual
+/// content is irrelevant — these stand in for, e.g., SHA-512 outputs.
+const MSG_1: [u8; MSG_BYTES] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+];
+const MSG_2: [u8; MSG_BYTES] = [
+    0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+    0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xfe, 0xed, 0xfa, 0xce, 0xba, 0xad, 0xf0, 0x0d,
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+    0x55, 0x55, 0x55, 0x55, 0xaa, 0xaa, 0xaa, 0xaa, 0x5a, 0x5a, 0x5a, 0x5a, 0xa5, 0xa5, 0xa5, 0xa5,
+];
+
+/// Helper: derive (pub_key, signature) for `seed` over `msg`.
+///
+/// The boxed return values keep the ~7 KB of crypto material off the test
+/// stack frame.
+fn keygen_and_sign(
+    seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
+    msg: &[u8; MSG_BYTES],
+) -> (
+    Box<[u8; MLDSA87_PUBLIC_KEY_BYTES]>,
+    Box<[u8; MLDSA87_SIGNATURE_BYTES]>,
+) {
+    let mut pk = Box::new([0u8; MLDSA87_PUBLIC_KEY_BYTES]);
+    let mut sig = Box::new([0u8; MLDSA87_SIGNATURE_BYTES]);
+    Mldsa87::pub_from_seed(seed, &mut pk);
+    Mldsa87::sign_deterministic(seed, msg, &mut sig);
+    (pk, sig)
+}
+
+/// Helper: build a fully-populated `MailboxReq::Mldsa87Verify` and stamp a
+/// valid checksum.
+fn build_verify_req(
+    pub_key: &[u8; MLDSA87_PUBLIC_KEY_BYTES],
+    signature: &[u8; MLDSA87_SIGNATURE_BYTES],
+    message: &[u8; MSG_BYTES],
+) -> MailboxReq {
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pub_key;
+    req.signature = *signature;
+    req._sig_pad = 0;
+    req.message = *message;
+    let mut cmd = MailboxReq::Mldsa87Verify(*req);
+    cmd.populate_chksum().unwrap();
+    cmd
+}
+
+/// Helper: send an already-populated request and assert the response header
+/// looks like a successful FIPS-approved verify.
+fn execute_ok<T: HwModel>(model: &mut T, cmd: &MailboxReq) {
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("mailbox should have returned a response");
+
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+    // Checksum field is just 0 because FIPS_STATUS_APPROVED == 0.
+    assert_eq!(resp_hdr.chksum, 0);
+    assert_eq!(model.soc_ifc().cptra_fw_error_non_fatal().read(), 0);
+}
+
+/// Wait until the runtime image is ready to take mailbox commands.
+fn boot_ready<T: HwModel>(model: &mut T) {
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+}
+
+// -------------------------------------------------------------------------
+// Positive tests
+// -------------------------------------------------------------------------
+
+/// End-to-end happy path: two distinct seeds × two distinct messages.
+/// Exercises the full request-parse -> verify -> response path.
+#[test]
+fn test_mldsa87_verify_cmd() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    for seed in [&SEED_A, &SEED_B] {
+        for msg in [&MSG_1, &MSG_2] {
+            let (pk, sig) = keygen_and_sign(seed, msg);
+            let cmd = build_verify_req(&pk, &sig, msg);
+            execute_ok(&mut model, &cmd);
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Negative tests (well-formed request, signature does not verify)
+// -------------------------------------------------------------------------
+
+/// Flipping a single bit in the signature must cause verification to fail
+/// with `RUNTIME_MLDSA87_VERIFY_FAILED` rather than crash or pass.
+#[test]
+fn test_mldsa87_verify_failure_tampered_signature() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, mut sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    sig[0] ^= 0xff;
+
+    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// Verifying a signature against a different message must fail.
+#[test]
+fn test_mldsa87_verify_failure_wrong_message() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let cmd = build_verify_req(&pk, &sig, &MSG_2);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// Verifying a signature against a public key from a different seed must
+/// fail.
+#[test]
+fn test_mldsa87_verify_failure_wrong_pub_key() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (_, sig_a) = keygen_and_sign(&SEED_A, &MSG_1);
+    let (pk_b, _) = keygen_and_sign(&SEED_B, &MSG_1);
+
+    let cmd = build_verify_req(&pk_b, &sig_a, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+/// All-zero public key + signature is a degenerate input that the verify
+/// algorithm must reject. This exercises the "structurally valid but
+/// cryptographically meaningless" path.
+#[test]
+fn test_mldsa87_verify_failure_all_zero() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+    let sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+    let cmd = build_verify_req(&pk, &sig, &MSG_1);
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED,
+        err,
+    );
+}
+
+// -------------------------------------------------------------------------
+// Malformed-request tests (request shape is wrong; handler must reject)
+// -------------------------------------------------------------------------
+
+/// Sending the request with `chksum = 0` exercises the dispatcher's
+/// pre-handler checksum gate. A real client would call `populate_chksum`
+/// first; skipping that step must surface as `RUNTIME_INVALID_CHECKSUM`.
+#[test]
+fn test_mldsa87_verify_bad_chksum() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pk;
+    req.signature = *sig;
+    req.message = MSG_1;
+    // Note: NOT calling populate_chksum, so hdr.chksum stays at 0.
+    let cmd = MailboxReq::Mldsa87Verify(*req);
+
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_INVALID_CHECKSUM,
+        err,
+    );
+}
+
+/// The `_sig_pad` byte exists solely to align `message` on an 8-byte
+/// boundary inside the request struct; RFC #3700 mandates that it be zero.
+/// Setting it to a nonzero value must be rejected explicitly with
+/// `RUNTIME_MLDSA87_VERIFY_INVALID_PADDING` (i.e., before any verify work
+/// is done).
+#[test]
+fn test_mldsa87_verify_invalid_padding() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    let (pk, sig) = keygen_and_sign(&SEED_A, &MSG_1);
+    let mut req = Box::new(Mldsa87VerifyReq::default());
+    req.pub_key = *pk;
+    req.signature = *sig;
+    req._sig_pad = 1; // RFC #3700 violation
+    req.message = MSG_1;
+    let mut cmd = MailboxReq::Mldsa87Verify(*req);
+    // Recompute checksum so we exercise the padding check, not the chksum check.
+    cmd.populate_chksum().unwrap();
+
+    let err = model
+        .mailbox_execute(
+            u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_MLDSA87_VERIFY_INVALID_PADDING,
+        err,
+    );
+}
+
+/// Sending a payload that's shorter than `Mldsa87VerifyReq` (but with a
+/// valid checksum over the truncated bytes, so the dispatcher's chksum
+/// gate passes) must be rejected by the handler's `ref_from_bytes` parse
+/// with `RUNTIME_INSUFFICIENT_MEMORY`.
+#[test]
+fn test_mldsa87_verify_truncated_request() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    boot_ready(&mut model);
+
+    // Build a payload that contains the mailbox header plus a few extra
+    // bytes — well short of the full request size.
+    let mut payload = vec![0u8; core::mem::size_of::<MailboxReqHeader>() + 32];
+    // Compute a valid checksum over everything after the chksum field.
+    let chksum_size = core::mem::size_of::<u32>();
+    let chksum = calc_checksum(
+        u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),
+        &payload[chksum_size..],
+    );
+    payload[..chksum_size].copy_from_slice(&chksum.to_le_bytes());
+
+    let err = model
+        .mailbox_execute(u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY), &payload)
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_INSUFFICIENT_MEMORY,
+        err,
+    );
+}

--- a/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 
 //! Integration tests for the `MLDSA87_SIGNATURE_VERIFY` runtime mailbox
-//! command (RFC #3700).
+//! command.
 //!
 //! The command verifies an ML-DSA-87 signature over a message digest that
 //! has been streamed through Caliptra's SHA accelerator (the same pattern


### PR DESCRIPTION
Add a new runtime mailbox command that verifies an ML-DSA-87 (FIPS 204) signature over a fixed 64-byte message. Unlike the ECDSA / LMS verify commands, the message is supplied directly in the request rather than read from the SHA accelerator; callers are expected to pre-hash large payloads.
The command (and its supporting plumbing) is gated behind a new mldsa_attestation cargo feature on caliptra-runtime, which is OFF by default. With the feature off, builds and binary size are unchanged. 

Changes:
- api: new CommandId::MLDSA87_SIGNATURE_VERIFY ("MDSV") + Mldsa87VerifyReq.
- error: new RUNTIME_MLDSA87_VERIFY_FAILED (0xE0062) and RUNTIME_MLDSA87_VERIFY_INVALID_PADDING (0xE0063).
- runtime: dispatcher arm + Mldsa87VerifyCmd handler in verify.rs, feature-gated. Validates the reserved _sig_pad byte before calling caliptra-drivers Mldsa87::verify.
- runtime/tests: 8 integration tests under test_mldsa_verify.rs covering happy path (2 seeds x 2 messages), crypto-negative cases (tampered signature, wrong message, wrong pub key, all-zero), and malformed requests (bad chksum, invalid padding, truncated request).
- libcaliptra: C bindings (caliptra_mldsa87_signature_verify_req, caliptra_mldsa87_signature_verify) + smoke test in examples/generic.
- docs: README mailbox-command reference + test-coverage.md entries. Two prerequisites are tracked separately and must land before mldsa_attestation can be enabled in a shipping build: (1) panic-freedom in caliptra-mldsa / caliptra-shake (for test_panic_missing), and (2) stack-budget reduction in caliptra-mldsa::verify_internal.