### PR TITLE
[runtime] Reduce redundant logging

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -1005,10 +1005,7 @@ impl<'a> DmaRecovery<'a> {
         // Lock the SHA accelerator to ensure that the AXI user is set to the DMA user.
         self.with_sha_acc(|dma_sha| {
             if dma_sha.lock().read().lock() {
-                cprintln!(
-                    "[dma-image] SHA accelerator lock not acquired by DMA, cannot start operation"
-                );
-                return Err(CaliptraError::RUNTIME_INTERNAL);
+                return Err(CaliptraError::DRIVER_DMA_SHA_ACCELERATOR_NOT_LOCKED);
             }
 
             // we only use the raw SHA accelerator driver to get the digest at the end.
@@ -1073,9 +1070,6 @@ impl<'a> DmaRecovery<'a> {
         // Lock the SHA accelerator to ensure that the AXI user is set to the DMA user.
         self.with_sha_acc(|dma_sha| {
             if dma_sha.lock().read().lock() {
-                cprintln!(
-                    "[dma-image] SHA accelerator lock not acquired by DMA, cannot start operation"
-                );
                 return Err(CaliptraError::DRIVER_DMA_SHA_ACCELERATOR_NOT_LOCKED);
             }
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1853,6 +1853,31 @@ impl CaliptraError {
             0x000E0094,
             "Runtime Error: Multiple CCIV contexts found"
         ),
+        (
+            RUNTIME_DISABLE_ATTESTATION_FAILED_WARM_RESET,
+            0x000E0097,
+            "Runtime Error: Disable attestation failed during warm reset"
+        ),
+        (
+            RUNTIME_DISABLE_ATTESTATION_FAILED_RESET_FLOW,
+            0x000E0098,
+            "Runtime Error: Disable attestation failed during reset flow"
+        ),
+        (
+            RUNTIME_DISABLE_ATTESTATION_FAILED_DPE_VALIDATION,
+            0x000E0099,
+            "Runtime Error: Disable attestation failed during DPE validation"
+        ),
+        (
+            RUNTIME_DISABLE_ATTESTATION_FAILED_DPE_LIMITS,
+            0x000E009A,
+            "Runtime Error: Disable attestation failed during DPE limits check"
+        ),
+        (
+            RUNTIME_DISABLE_ATTESTATION_FAILED_PCR_VALIDATION,
+            0x000E009B,
+            "Runtime Error: Disable attestation failed during PCR validation"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/debug_unlock.rs
+++ b/runtime/src/debug_unlock.rs
@@ -14,12 +14,9 @@ Abstract:
 
 use crate::mutrefbytes;
 use caliptra_cfi_lib::CfiCounter;
-use caliptra_common::{
-    cprintln,
-    mailbox_api::{
-        ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
-        ProductionAuthDebugUnlockToken,
-    },
+use caliptra_common::mailbox_api::{
+    ProductionAuthDebugUnlockChallenge, ProductionAuthDebugUnlockReq,
+    ProductionAuthDebugUnlockToken,
 };
 use caliptra_drivers::{CaliptraResult, Lifecycle};
 use caliptra_error::CaliptraError;
@@ -65,11 +62,8 @@ impl ProductionDebugUnlock {
         let req = ProductionAuthDebugUnlockReq::read_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE)?;
 
-        cprintln!("[rt] Starting production debug unlock request");
-
         // Check if the device is in Production lifecycle
         if soc_ifc.lifecycle() != Lifecycle::Production {
-            cprintln!("[rt] Debug unlock request failed: Not in Production lifecycle");
             return Err(CaliptraError::RUNTIME_DEBUG_UNLOCK_INVALID_LIFECYCLE);
         }
 
@@ -86,8 +80,6 @@ impl ProductionDebugUnlock {
             let stored_challenge = challenge.clone();
             self.last_challenge = Some(stored_challenge);
             self.last_request = Some(req);
-
-            cprintln!("[rt] Production debug unlock challenge generated");
 
             let resp = mutrefbytes::<ProductionAuthDebugUnlockChallenge>(resp)?;
             *resp = challenge;
@@ -116,14 +108,11 @@ impl ProductionDebugUnlock {
         let token = ProductionAuthDebugUnlockToken::read_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE)?;
 
-        cprintln!("[rt] Starting production debug unlock token validation");
-
         // Random delay for CFI glitch protection.
         CfiCounter::delay();
 
         // Check if the device is in Production lifecycle
         if soc_ifc.lifecycle() != Lifecycle::Production {
-            cprintln!("[rt] Debug unlock token validation failed: Not in Production lifecycle");
             return Err(CaliptraError::RUNTIME_DEBUG_UNLOCK_INVALID_LIFECYCLE);
         }
 
@@ -153,12 +142,10 @@ impl ProductionDebugUnlock {
         let ret = match result {
             Ok(()) => {
                 soc_ifc.set_ss_dbg_unlock_level(request.unlock_level);
-                cprintln!("[rt] Debug unlock successful");
                 soc_ifc.set_ss_dbg_unlock_result(true);
                 Ok(0)
             }
             Err(e) => {
-                cprintln!("[rt] Debug unlock failed: {}", e.0);
                 soc_ifc.set_ss_dbg_unlock_result(false);
                 Err(e)
             }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -54,7 +54,6 @@ use caliptra_dpe_crypto::ecdsa::curve_384::EcdsaPub384;
 use caliptra_dpe_crypto::ecdsa::EcdsaPubKey;
 use caliptra_dpe_crypto::{Digest, PubKey};
 use caliptra_drivers::{
-    cprintln,
     hand_off::DataStore,
     pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
@@ -242,7 +241,7 @@ impl Drivers {
             .init(&self.persistent_data, &mut self.trng)?;
         if self.persistent_data.get().fw.dpe.attestation_disabled.get() {
             DisableAttestationCmd::execute(self)
-                .map_err(|_| CaliptraError::RUNTIME_GLOBAL_EXCEPTION)?;
+                .map_err(|_| CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED_RESET_FLOW)?;
         }
 
         let reset_reason = self.soc_ifc.reset_reason();
@@ -384,9 +383,8 @@ impl Drivers {
                         CaliptraError::RUNTIME_DPE_VALIDATION_FAILED.into(),
                     );
                 }
-                Err(e) => {
-                    cprintln!("{}", e.0);
-                    return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+                Err(_) => {
+                    return Err(CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED_DPE_VALIDATION);
                 }
             }
         } else {
@@ -408,9 +406,8 @@ impl Drivers {
                     Ok(_) => {
                         caliptra_drivers::report_fw_error_non_fatal(e.into());
                     }
-                    Err(e) => {
-                        cprintln!("{}", e.0);
-                        return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+                    Err(_) => {
+                        return Err(CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED_DPE_LIMITS);
                     }
                 }
             }
@@ -489,21 +486,10 @@ impl Drivers {
 
     /// Release MCU SRAM if MCU FW was previously loaded correctly
     fn release_mcu_sram(drivers: &mut Drivers) -> CaliptraResult<()> {
-        // Check if MCU previous Cold-Reset was successful.
+        // Check if MCU previous Cold-Reset or Update-Reset was successful.
         let mcu_firmware_loaded = drivers.persistent_data.get().fw.mcu_firmware_loaded;
-        if mcu_firmware_loaded == McuFwStatus::NotLoaded.into() {
-            cprintln!("[rt-warm-reset] Warning: Prev Cold Reset failed, not releasing MCU SRAM");
-        }
-
-        // Check if MCU previous Update-Reset, if any, was successful.
-        if mcu_firmware_loaded == McuFwStatus::HitlessUpdateStarted.into() {
-            cprintln!(
-                "[rt-warm-reset] Warning: Prev Hitless Update Reset failed, not releasing MCU SRAM"
-            );
-        }
 
         cfi_assert_eq(mcu_firmware_loaded, McuFwStatus::Loaded.into());
-        cprintln!("[rt-warm-reset] MCU FW is loaded in SRAM");
         Self::request_mcu_reset(drivers, McuResetReason::FwBoot);
 
         Ok(())
@@ -533,9 +519,8 @@ impl Drivers {
 
                     caliptra_drivers::report_fw_error_non_fatal(error.into());
                 }
-                Err(e) => {
-                    cprintln!("{}", e.0);
-                    return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+                Err(_) => {
+                    return Err(CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED_PCR_VALIDATION);
                 }
             }
         } else {

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -12,7 +12,6 @@ Abstract:
 
 --*/
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
-use caliptra_common::cprintln;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Ecc384;
@@ -126,14 +125,12 @@ pub mod fips_self_test_cmd {
                 ResetReason::UpdateReset,
             )
         })?;
-        cprintln!("[rt] Verify complete");
         Ok(())
     }
 
     #[cfg_attr(feature = "cfi", cfi_mod_fn)]
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<()> {
         caliptra_drivers::report_boot_status(RtFipSelfTestStarted.into());
-        cprintln!("[rt] FIPS self test");
         execute_kats(env)?;
         rom_integrity_test(env)?;
         copy_and_verify_image(env)?;
@@ -211,7 +208,6 @@ pub mod fips_self_test_cmd {
         let mut digest = unsafe { env.sha256.digest_blocks_raw(rom_start, n_blocks)? };
         if digest.0 != rom_info.sha256_digest {
             digest.zeroize();
-            cprintln!("ROM integrity test failed");
             return Err(CaliptraError::ROM_INTEGRITY_FAILURE);
         } else {
             cfi_assert_eq_8_words(&digest.0, &rom_info.sha256_digest);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -651,13 +651,6 @@ fn handle_external_mailbox_cmd(
         return Err(CaliptraError::RUNTIME_INVALID_CHECKSUM);
     }
 
-    cprintln!(
-        "[rt] Received external command=0x{:x} ({}), len={}",
-        cmd_id,
-        human_readable_command(&cmd_id.to_be_bytes()),
-        cmd_bytes.len()
-    );
-
     execute_command(drivers, cmd_id, cmd_bytes)
 }
 
@@ -697,14 +690,12 @@ pub fn handle_mailbox_commands(drivers: &mut Drivers) -> CaliptraResult<()> {
             cfi_check!(result);
             match result {
                 Ok(_) => {
-                    cprintln!("Disabled attestation due to cmd busy during warm reset");
                     caliptra_drivers::report_fw_error_non_fatal(
                         CaliptraError::RUNTIME_CMD_BUSY_DURING_WARM_RESET.into(),
                     );
                 }
-                Err(e) => {
-                    cprintln!("{}", e.0);
-                    return Err(CaliptraError::RUNTIME_GLOBAL_EXCEPTION);
+                Err(_) => {
+                    return Err(CaliptraError::RUNTIME_DISABLE_ATTESTATION_FAILED_WARM_RESET);
                 }
             }
         }

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -51,12 +51,10 @@ pub extern "C" fn entry_point() -> ! {
 
     let mut drivers = unsafe { Drivers::new_from_registers() };
     let drivers = okmutref(&mut drivers).unwrap_or_else(|e| {
-        cprintln!("[rt] RT can't load drivers");
         handle_fatal_error(e.into());
     });
 
     if cfg!(feature = "cfi") {
-        cprintln!("[state] CFI Enabled");
         let mut entropy_gen = || {
             drivers
                 .trng
@@ -99,12 +97,10 @@ pub extern "C" fn entry_point() -> ! {
     }
 
     drivers.run_reset_flow().unwrap_or_else(|e| {
-        cprintln!("[rt] RT failed reset flow");
         handle_fatal_error(e.into());
     });
 
     if !drivers.persistent_data.get().rom.fht.is_valid() {
-        cprintln!("[rt] RT can't load FHT");
         handle_fatal_error(caliptra_drivers::CaliptraError::RUNTIME_HANDOFF_FHT_NOT_LOADED.into());
     }
     cprintln!("[rt] RT listening for mailbox commands...");
@@ -158,7 +154,6 @@ extern "C" fn nmi_handler(trap_record: &TrapRecord) {
 
     let wdt_status = soc_ifc.regs().cptra_wdt_status().read();
     let error = if wdt_status.t1_timeout() || wdt_status.t2_timeout() {
-        cprintln!("[rt] WDT Expired");
         CaliptraError::RUNTIME_GLOBAL_WDT_EXPIRED
     } else {
         CaliptraError::RUNTIME_GLOBAL_NMI

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -90,10 +90,8 @@ impl RecoveryFlow {
             )?;
             dma_recovery.wait_for_payload_not_available();
 
-            cprintln!("[rt] Uploading MCU firmware");
             let mcu_size_bytes =
                 dma_recovery.download_image_to_mcu(MCU_FIRMWARE_INDEX, AesDmaMode::None)?;
-            cprintln!("[rt] Calculating MCU digest");
             let digest = dma_recovery.sha384_mcu_sram(
                 &mut drivers.sha2_512_384_acc,
                 0,
@@ -153,8 +151,6 @@ impl RecoveryFlow {
             // for Caliptra to publish FW_EXEC_CTRL[MCU].
             let boot_mode = drivers.persistent_data.get().rom.boot_mode;
             if boot_mode == BootMode::EncryptedFirmware {
-                cprintln!("[rt] Encrypted firmware boot mode - skipping MCU activation");
-
                 // The image in MCU SRAM is ciphertext || 16-byte GCM tag.
                 // CM_AES_GCM_DECRYPT_DMA expects the tag as a separate field
                 // and verifies the SHA-384 against only the ciphertext portion,
@@ -171,10 +167,6 @@ impl RecoveryFlow {
                 )?;
                 drivers.mcu_fw_info.size = ciphertext_size;
                 drivers.mcu_fw_info.sha384 = ciphertext_digest.into();
-                cprintln!(
-                    "[rt] Stored MCU ciphertext size {} for GET_MCU_FW_SIZE",
-                    ciphertext_size
-                );
 
                 // we're done with recovery, but MCU will handle its own boot after decryption
                 dma_recovery.set_recovery_status(DmaRecovery::RECOVERY_STATUS_SUCCESSFUL, 0)?;
@@ -190,16 +182,8 @@ impl RecoveryFlow {
                 )
             };
 
-            cprintln!("[rt] Setting MCU firmware ready");
             // notify MCU that it can boot its firmware
             drivers.soc_ifc.set_mcu_firmware_ready();
-            cprintln!(
-                "[rt] Setting MCU firmware ready: {:08x}{:08x}{:08x}{:08x}",
-                drivers.soc_ifc.fw_ctrl(0),
-                drivers.soc_ifc.fw_ctrl(1),
-                drivers.soc_ifc.fw_ctrl(2),
-                drivers.soc_ifc.fw_ctrl(3)
-            );
 
             // leave recovery status open in case MCU wants to load additional images
         }


### PR DESCRIPTION
This removes some unnecessary logging to reduce runtime codespace. It adds a few new error codes to handle conditions where duplicate error codes were used but distinguished using print statements. This also removes some print statements that simply stated the error code description.