### PR TITLE
Disable entropy_src repcnts health test in ROM

### DIFF
--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -303,7 +303,7 @@ fn check_for_alert_state(
             ALERT_HANG => {
                 let alert_counts = entropy_src.alert_fail_counts().read();
 
-                if alert_counts.repcnt_fail_count() > 0 || alert_counts.repcnts_fail_count() > 0 {
+                if alert_counts.repcnt_fail_count() > 0 {
                     return Err(CaliptraError::DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED);
                 }
 
@@ -594,9 +594,6 @@ fn set_health_check_thresholds(
         .write(|w| w.fips_window(entropy_cfg.health_test_window));
 
     e.repcnt_thresholds()
-        .write(|w| w.fips_thresh(entropy_cfg.repcnt_threshold));
-
-    e.repcnts_thresholds()
         .write(|w| w.fips_thresh(entropy_cfg.repcnt_threshold));
 
     e.adaptp_hi_thresholds()

--- a/drivers/test-fw/src/bin/csrng_fail_repcnts_tests.rs
+++ b/drivers/test-fw/src/bin/csrng_fail_repcnts_tests.rs
@@ -12,10 +12,11 @@ Abstract:
     File contains test cases for CSRNG API when the physical entropy source
     produces repeated 4-bit symbols (nibbles).
 
-    Unlike the per-wire repcnt test which checks each RNG wire independently,
-    the repcnts test fails when the entire 4-bit symbol repeats consecutively.
-
-    We expect the Repetition Count Symbol health check to fail for these tests.
+    The Repetition Count Symbol (repcnts) health test is intentionally disabled
+    in the driver. A repeating 4-bit symbol means every individual RNG wire is
+    also constant, so the per-wire repetition count (repcnt) test still fails
+    for these streams. We therefore expect CSRNG construction to fail with
+    DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED.
 --*/
 #![no_std]
 #![no_main]
@@ -36,10 +37,10 @@ fn test_boot_fail_repcnts_check() {
         assert_eq!(
             e,
             CaliptraError::DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED,
-            "error code should indicate the repetition count (symbol) test failed"
+            "error code should indicate the per-wire repetition count test failed (repcnts is disabled)"
         )
     } else {
-        panic!("failing repetition count symbol test should prevent CSRNG from being constructed");
+        panic!("constant nibble stream should fail the repcnt test and prevent CSRNG from being constructed");
     }
 }
 

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -1112,8 +1112,10 @@ fn test_csrng_adaptive_proportion() {
     test_with_soc_threshold(FAIL, include_bytes!("test_data/csrng/2449_ones_1647_zeros"));
 }
 
-/// Test the Repetition Count Symbol (repcnts) health check.
-/// Unlike the per-wire repcnt test, repcnts checks if the entire 4-bit symbol repeats.
+/// Test that a repeating 4-bit symbol stream is rejected at boot.
+/// The Repetition Count Symbol (repcnts) health test is intentionally disabled
+/// in the driver, but a constant nibble also makes every individual wire
+/// constant, so the per-wire repcnt test still catches these streams.
 #[test]
 #[cfg_attr(
     all(
@@ -1127,15 +1129,15 @@ fn test_csrng_adaptive_proportion() {
     ignore
 )]
 fn test_csrng_repcnts() {
-    // Test that repeating nibble symbols fail the repcnts health check.
-    // A stream of alternating 0x5 and 0xA nibbles passes (nibbles don't repeat),
-    // but a stream of constant nibbles fails because the symbol repeats.
+    // The repcnts (symbol) health test is disabled in the driver. A stream of
+    // constant nibbles still fails because every individual RNG wire is
+    // constant, which trips the per-wire repcnt test.
 
     const FAIL: &FwId = &firmware::driver_tests::CSRNG_FAIL_REPCNTS_TESTS;
 
     // Constant nibble stream: 0x7, 0x7, 0x7, ...
-    // This will fail both repcnt (individual wires repeat) and repcnts (symbol repeats).
-    // The driver returns DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED for both.
+    // Each wire repeats its bit, so the per-wire repcnt test fails and the
+    // driver returns DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED.
     test_csrng_with_nibbles(FAIL, Box::new(iter::repeat(0b0111)));
 
     // Different constant value to verify it's not value-specific


### PR DESCRIPTION
The Repetition Count Symbol (repcnts) health test is recommended to be disabled for FIPS, so stop programming its threshold and leave it at the reset default, which disables it. A repeating 4-bit symbol also makes every individual RNG wire
constant, so the per-wire repcnt test still catches these streams.