### PR TITLE
[runtime] Add privilege check for the X509 flag in `CertifyKeyChunksReq`

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1355,7 +1355,9 @@ Command Code: `0x434B_584D` ("CKXM")
 
 ### CERTIFY\_KEY\_CHUNKS
 
-Invokes a DPE `CertifyKey` command (ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+Invokes a DPE `CertifyKey` command (ECC-P384 or ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+
+The handler re-executes the full DPE `CertifyKey` operation on every call and then returns the requested `[offset, offset+max_size)` window of the freshly generated response. Each call rotates the context handle, if needed. The new handle is returned in the per-chunk response header and must be used for the next call.
 
 Command Code: `0x434B_4348` ("CKCH")
 
@@ -1364,11 +1366,19 @@ Command Code: `0x434B_4348` ("CKCH")
 | **Name**          | **Type** | **Description**                                                                       |
 | ----------------- | -------- | ------------------------------------------------------------------------------------- |
 | chksum            | u32      | Checksum over other input arguments, computed by the caller. Little endian.           |
-| flags             | u32      | Flags (reserved).                                                                     |
+| flags             | u32      | Flags.                                                                                |
 | reserved          | u32      | Reserved.                                                                             |
 | max\_size         | u32      | The maximum length of the chunk the caller wants to receive. If 0, defaults to 15360. |
 | offset            | u32      | Offset into the full CertifyKey response to read from.                                |
 | certify\_key\_req | u8[72]   | The serialized DPE `CertifyKey` command.                                              |
+
+*Table: `CERTIFY_KEY_CHUNKS` input flags*
+
+| **Name**  | **Offset** |
+| --------- | ---------- |
+| USE_MLDSA | 1 << 31    |
+
+When `USE_MLDSA` is set, the command operates on the ML-DSA-87 DPE profile; otherwise, it operates on the ECC-P384 profile.
 
 *Table: `CERTIFY_KEY_CHUNKS` output arguments*
 

--- a/runtime/src/certify_key_chunks.rs
+++ b/runtime/src/certify_key_chunks.rs
@@ -12,10 +12,11 @@ Abstract:
 
 --*/
 
+use crate::PauserPrivileges;
 use crate::{invoke_dpe::invoke_dpe_cmd, CaliptraDpeProfile, Drivers};
 use caliptra_api::mailbox::CertifyKeyChunksRespInfo;
 use caliptra_common::mailbox_api::{CertifyKeyChunksReq, CertifyKeyChunksResp};
-use caliptra_dpe::commands::{CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
+use caliptra_dpe::commands::{CertifyKeyCommand, CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
 use caliptra_dpe::response::{CertifyKeyMldsa87Resp, CertifyKeyP384Resp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use memoffset::span_of;
@@ -39,17 +40,26 @@ impl CertifyKeyChunksCmd {
         };
 
         let certify_key_cmd = match profile {
-            CaliptraDpeProfile::Ecc384 => Command::from(
+            CaliptraDpeProfile::Ecc384 => CertifyKeyCommand::from(
                 CertifyKeyP384Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
                     CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
                 ))?,
             ),
-            CaliptraDpeProfile::Mldsa87 => Command::from(
+            CaliptraDpeProfile::Mldsa87 => CertifyKeyCommand::from(
                 CertifyKeyMldsa87Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
                     CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
                 ))?,
             ),
         };
+
+        // Check if command can be executed
+        // PL1 cannot request X509
+        let caller_privilege_level = drivers.caller_privilege_level();
+        if certify_key_cmd.format() == CertifyKeyCommand::FORMAT_X509
+            && caller_privilege_level != PauserPrivileges::PL0
+        {
+            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+        }
 
         let (resp_info, certify_key_resp_bytes) =
             CertifyKeyChunksRespInfo::mut_from_prefix(mbox_resp)
@@ -71,11 +81,10 @@ impl CertifyKeyChunksCmd {
         }
 
         // Get the full CertifyKey response
-        let cmd = &certify_key_cmd;
         let dpe_resp_len = invoke_dpe_cmd(
             profile,
             drivers,
-            cmd,
+            &Command::from(&certify_key_cmd),
             None,
             None,
             None,

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -1,10 +1,10 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::PQC_KEY_TYPE;
+use crate::common::{CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE};
 use caliptra_api::{
     mailbox::{
-        AxiResponseInfo, CertifyKeyExtendedMldsa87Req, RevokeExportedCdiHandleReq,
-        SignWithExportedEcdsaReq,
+        AxiResponseInfo, CertifyKeyChunksFlags, CertifyKeyChunksReq, CertifyKeyExtendedMldsa87Req,
+        RevokeExportedCdiHandleReq, SignWithExportedEcdsaReq,
     },
     SocManager,
 };
@@ -612,6 +612,66 @@ fn test_certify_key_extended_cannot_be_called_from_pl1() {
                 .mailbox_execute(
                     u32::from(cmd_id),
                     certify_key_extended_cmd.as_bytes().unwrap(),
+                )
+                .unwrap_err();
+            assert_error(
+                &mut model,
+                CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+                resp,
+            );
+        }
+    }
+}
+
+#[test]
+fn test_certify_key_chunks_cannot_be_called_from_pl1() {
+    for pqc_key_type in PQC_KEY_TYPE.iter() {
+        let mut image_opts = ImageOptions {
+            pqc_key_type: *pqc_key_type,
+            ..Default::default()
+        };
+        image_opts.vendor_config.pl0_pauser = None;
+
+        let args = RuntimeTestArgs {
+            test_image_options: Some(image_opts),
+            ..Default::default()
+        };
+
+        let mut model = run_rt_test_pqc(args, *pqc_key_type);
+
+        model.step_until(|m| {
+            m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+        });
+
+        for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
+            let flags = match profile {
+                CaliptraDpeProfile::Ecc384 => CertifyKeyChunksFlags(0),
+                CaliptraDpeProfile::Mldsa87 => CertifyKeyChunksFlags::USE_MLDSA,
+            };
+
+            let cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+                profile,
+                flags: CertifyKeyFlags::empty(),
+                format: CertifyKeyCommand::FORMAT_X509,
+                ..Default::default()
+            });
+            let mut certify_key_req = [0u8; CertifyKeyChunksReq::CERTIFY_KEY_REQ_SIZE];
+            certify_key_req[..cmd.as_bytes().len()].copy_from_slice(cmd.as_bytes());
+
+            let mut certify_key_chunks_cmd = MailboxReq::CertifyKeyChunks(CertifyKeyChunksReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                flags,
+                reserved: 0,
+                max_size: 0,
+                offset: 0,
+                certify_key_req,
+            });
+            certify_key_chunks_cmd.populate_chksum().unwrap();
+
+            let resp = model
+                .mailbox_execute(
+                    u32::from(CommandId::CERTIFY_KEY_CHUNKS),
+                    certify_key_chunks_cmd.as_bytes().unwrap(),
                 )
                 .unwrap_err();
             assert_error(


### PR DESCRIPTION
This is blocked by `InvokeDpe`, but was missed while creating this command. This adds the check here as well. It also adds a test to make sure it is blocked from PL1 correctly.