### PR TITLE
[fix] Report firmware verification recovery reason

### DIFF
--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -513,7 +513,19 @@ impl<'a> DmaRecovery<'a> {
     const PROT_CAP2_FLASHLESS_BOOT_VALUE: u32 = 0x800; // Bit 11 in agent_caps
     const PROT_CAP2_FIFO_CMS_SUPPORT: u32 = 0x1000; // Bit 12 in agent_caps
 
-    const FLASHLESS_STREAMING_BOOT_VALUE: u32 = 0x12;
+    pub const RECOVERY_REASON_CORRUPTED_CRITICAL_DATA: u32 = 0x4;
+    pub const RECOVERY_REASON_ANTI_ROLLBACK_FAILURE: u32 = 0xA;
+    pub const RECOVERY_REASON_FLASHLESS_STREAMING_BOOT: u32 = 0x12;
+    // DEVICE_STATUS_0.REC_REASON_CODE reserves 0x80..=0xFF for vendor-unique boot failure codes.
+    pub const RECOVERY_REASON_VENDOR_KEY_INVALID: u32 = 0x80;
+    pub const RECOVERY_REASON_VENDOR_KEY_REVOKED: u32 = 0x81;
+    pub const RECOVERY_REASON_VENDOR_SIGNATURE_INVALID: u32 = 0x82;
+    pub const RECOVERY_REASON_OWNER_KEY_INVALID: u32 = 0x83;
+    pub const RECOVERY_REASON_OWNER_SIGNATURE_INVALID: u32 = 0x84;
+    pub const RECOVERY_REASON_FIRMWARE_IMAGE_DIGEST_MISMATCH: u32 = 0x85;
+    pub const RECOVERY_REASON_FIRMWARE_IMAGE_LAYOUT_INVALID: u32 = 0x86;
+    pub const RECOVERY_REASON_PQC_CONFIGURATION_INVALID: u32 = 0x87;
+    pub const RECOVERY_REASON_FIRMWARE_VERSION_INVALID: u32 = 0x88;
 
     pub const RECOVERY_STATUS_AWAITING_RECOVERY_IMAGE: u32 = 0x1;
     const RECOVERY_STATUS_BOOTING_RECOVERY_IMAGE: u32 = 0x2;
@@ -523,6 +535,7 @@ impl<'a> DmaRecovery<'a> {
     pub const DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE: u32 = 0x3;
     const DEVICE_STATUS_PENDING: u32 = 0x4;
     pub const DEVICE_STATUS_RUNNING_RECOVERY_IMAGE: u32 = 0x5;
+    pub const DEVICE_STATUS_BOOT_FAILURE: u32 = 0xE;
     pub const DEVICE_STATUS_FATAL_ERROR: u32 = 0xF;
 
     const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
@@ -794,7 +807,7 @@ impl<'a> DmaRecovery<'a> {
                 Self::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE
             );
             recovery.device_status_0().modify(|val| {
-                val.rec_reason_code(Self::FLASHLESS_STREAMING_BOOT_VALUE)
+                val.rec_reason_code(Self::RECOVERY_REASON_FLASHLESS_STREAMING_BOOT)
                     .dev_status(Self::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE)
             });
 
@@ -843,6 +856,28 @@ impl<'a> DmaRecovery<'a> {
                 .device_status_0()
                 .modify(|device_status_val| device_status_val.dev_status(status));
         })
+    }
+
+    pub fn set_device_status_with_recovery_reason(
+        &self,
+        status: u32,
+        recovery_reason: u32,
+    ) -> CaliptraResult<()> {
+        self.with_regs_mut(|regs_mut| {
+            let recovery = regs_mut.sec_fw_recovery_if();
+            recovery.device_status_0().modify(|device_status_val| {
+                device_status_val
+                    .dev_status(status)
+                    .rec_reason_code(recovery_reason)
+            });
+        })
+    }
+
+    pub fn set_boot_failure_reason(&self, recovery_reason: u32) -> CaliptraResult<()> {
+        self.set_device_status_with_recovery_reason(
+            Self::DEVICE_STATUS_BOOT_FAILURE,
+            recovery_reason,
+        )
     }
 
     pub fn reset_indirect_fifo_ctrl(&self) -> CaliptraResult<()> {

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -103,6 +103,122 @@ pub struct FwProcInfo {
 pub struct FirmwareProcessor {}
 
 impl FirmwareProcessor {
+    fn recovery_reason_from_verification_error(err: CaliptraError) -> u32 {
+        let err = u32::from(err);
+
+        macro_rules! err_is {
+            ($($candidate:expr),+ $(,)?) => {
+                $(err == u32::from($candidate))||+
+            };
+        }
+
+        if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PUB_KEY_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_ECC_KEY_DESCRIPTOR_VERSION_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_ECC_KEY_DESCRIPTOR_INVALID_HASH_COUNT,
+            CaliptraError::IMAGE_VERIFIER_ERR_ECC_KEY_DESCRIPTOR_HASH_COUNT_GT_MAX,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_OUT_OF_BOUNDS,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INDEX_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_INDEX_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_INDEX_OUT_OF_BOUNDS,
+            CaliptraError::IMAGE_VERIFIER_ERR_LMS_VENDOR_PUB_KEY_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_VENDOR_PUB_KEY_READ_FAILED,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_DIGEST_MISMATCH,
+        ) {
+            DmaRecovery::RECOVERY_REASON_VENDOR_KEY_INVALID
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_REVOKED,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_PQC_PUB_KEY_REVOKED,
+        ) {
+            DmaRecovery::RECOVERY_REASON_VENDOR_KEY_REVOKED
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_PUB_KEY_INVALID_ARG,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_ECC_SIGNATURE_INVALID_ARG,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_LMS_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_LMS_SIGNATURE_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_LMS_VENDOR_SIG_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_VENDOR_SIG_READ_FAILED,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_MLDSA_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_VENDOR_MLDSA_SIGNATURE_INVALID,
+        ) {
+            DmaRecovery::RECOVERY_REASON_VENDOR_SIGNATURE_INVALID
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_ECC_PUB_KEY_INVALID_ARG,
+            CaliptraError::IMAGE_VERIFIER_ERR_LMS_OWNER_PUB_KEY_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_OWNER_PUB_KEY_READ_FAILED,
+            CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH,
+        ) {
+            DmaRecovery::RECOVERY_REASON_OWNER_KEY_INVALID
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_ECC_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_ECC_SIGNATURE_INVALID_ARG,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_LMS_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_LMS_SIGNATURE_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_LMS_OWNER_SIG_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_MLDSA_OWNER_SIG_READ_FAILED,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_MLDSA_VERIFY_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_MLDSA_SIGNATURE_INVALID,
+        ) {
+            DmaRecovery::RECOVERY_REASON_OWNER_SIGNATURE_INVALID
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_DIGEST_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_TOC_DIGEST_FAILURE,
+            CaliptraError::IMAGE_VERIFIER_ERR_TOC_DIGEST_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_HEADER_DIGEST_FAILURE,
+        ) {
+            DmaRecovery::RECOVERY_REASON_FIRMWARE_IMAGE_DIGEST_MISMATCH
+        } else if err_is!(CaliptraError::IMAGE_VERIFIER_ERR_FIRMWARE_SVN_GREATER_THAN_MAX_SUPPORTED,)
+        {
+            DmaRecovery::RECOVERY_REASON_FIRMWARE_VERSION_INVALID
+        } else if err_is!(CaliptraError::IMAGE_VERIFIER_ERR_FIRMWARE_SVN_LESS_THAN_FUSE,) {
+            DmaRecovery::RECOVERY_REASON_ANTI_ROLLBACK_FAILURE
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_INVALID_PQC_KEY_TYPE_IN_FUSE,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_TYPE_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_TYPE_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_DESCRIPTOR_VERSION_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_DESCRIPTOR_TYPE_MISMATCH,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_DESCRIPTOR_INVALID_HASH_COUNT,
+            CaliptraError::IMAGE_VERIFIER_ERR_PQC_KEY_DESCRIPTOR_HASH_COUNT_GT_MAX,
+        ) {
+            DmaRecovery::RECOVERY_REASON_PQC_CONFIGURATION_INVALID
+        } else if err_is!(
+            CaliptraError::IMAGE_VERIFIER_ERR_TOC_ENTRY_COUNT_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_RUNTIME_OVERLAP,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_RUNTIME_INCORRECT_ORDER,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_LOAD_ADDR_UNALIGNED,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_ENTRY_POINT_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_ENTRY_POINT_UNALIGNED,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDR_UNALIGNED,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_ENTRY_POINT_INVALID,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_ENTRY_POINT_UNALIGNED,
+            CaliptraError::IMAGE_VERIFIER_ERR_IMAGE_LEN_MORE_THAN_BUNDLE_SIZE,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_RUNTIME_LOAD_ADDR_OVERLAP,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_SIZE_ZERO,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_SIZE_ZERO,
+            CaliptraError::IMAGE_VERIFIER_ERR_FMC_LOAD_ADDRESS_IMAGE_SIZE_ARITHMETIC_OVERFLOW,
+            CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_LOAD_ADDRESS_IMAGE_SIZE_ARITHMETIC_OVERFLOW,
+            CaliptraError::IMAGE_VERIFIER_ERR_TOC_ENTRY_RANGE_ARITHMETIC_OVERFLOW,
+        ) {
+            DmaRecovery::RECOVERY_REASON_FIRMWARE_IMAGE_LAYOUT_INVALID
+        } else {
+            DmaRecovery::RECOVERY_REASON_CORRUPTED_CRITICAL_DATA
+        }
+    }
+
     pub fn process(env: &mut RomEnv) -> CaliptraResult<FwProcInfo> {
         // Process mailbox commands.
         let (mut txn, image_size_bytes) = env.abr.with_mldsa87(|mut mldsa87| {
@@ -699,32 +815,35 @@ impl FirmwareProcessor {
             // Reset the Indirect FIFO control so that payload_available is reset.
             dma_recovery.reset_indirect_fifo_ctrl()?;
 
-            let (recovery_status, next_image_idx, device_status) = if info.is_err() {
-                (
+            if let Some(err) = info.as_ref().err().copied() {
+                let recovery_reason = Self::recovery_reason_from_verification_error(err);
+                cprintln!(
+                    "[fwproc] Setting device recovery status to 0x{:x}, image index 0x0, device status 0x{:x}, recovery reason 0x{:x}",
+                    DmaRecovery::RECOVERY_STATUS_IMAGE_AUTHENTICATION_ERROR,
+                    DmaRecovery::DEVICE_STATUS_BOOT_FAILURE,
+                    recovery_reason
+                );
+                dma_recovery.set_recovery_status(
                     DmaRecovery::RECOVERY_STATUS_IMAGE_AUTHENTICATION_ERROR,
                     0,
-                    DmaRecovery::DEVICE_STATUS_FATAL_ERROR,
-                )
+                )?;
+                dma_recovery.set_boot_failure_reason(recovery_reason)?;
             } else {
                 // we still have to do the SoC and MCU images
                 // we pre-emptively set the next image index to 1 so that the recovery interface
                 // will receive the right index so that no matter what order the recovery registers
                 // are read, we will send the right image next
-                (
+                cprintln!(
+                    "[fwproc] Setting device recovery status to 0x{:x}, image index 0x1, device status 0x{:x}",
                     DmaRecovery::RECOVERY_STATUS_AWAITING_RECOVERY_IMAGE,
-                    1,
+                    DmaRecovery::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE
+                );
+                dma_recovery
+                    .set_recovery_status(DmaRecovery::RECOVERY_STATUS_AWAITING_RECOVERY_IMAGE, 1)?;
+                dma_recovery.set_device_status(
                     DmaRecovery::DEVICE_STATUS_READY_TO_ACCEPT_RECOVERY_IMAGE_VALUE,
-                )
-            };
-
-            cprintln!(
-                "[fwproc] Setting device recovery status to 0x{:x}, image index 0x{:x}, device status 0x{:x}",
-                recovery_status,
-                next_image_idx,
-                device_status
-            );
-            dma_recovery.set_recovery_status(recovery_status, next_image_idx)?;
-            dma_recovery.set_device_status(device_status)?;
+                )?;
+            }
         }
 
         let info = match info {


### PR DESCRIPTION
Set DEVICE_STATUS_0 to Boot Failure instead of Fatal Error when ROM firmware verification fails in subsystem recovery flow. Populate REC_REASON_CODE with a coarse verification failure reason so the recovery agent can distinguish key, signature, digest, layout, rollback, and PQC configuration failures.