### PR TITLE
Backport SPDM/DPE certificate retrieval and AES-GCM fixes to `caliptra-2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "aes-gcm",
+ "anyhow",
  "arrayvec",
  "asn1",
  "bitfield",

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -90,6 +90,7 @@ impl CommandId {
     pub const CERTIFY_KEY_EXTENDED: Self = Self(0x434B4558); // "CKEX"
     pub const CERTIFY_KEY_EXTENDED_ECC384: Self = Self(0x434B4558); // "CKEX"
     pub const CERTIFY_KEY_EXTENDED_MLDSA87: Self = Self(0x434B584D); // "CKXM"
+    pub const CERTIFY_KEY_CHUNKS: Self = Self(0x434B4348); // "CKCH"
 
     /// FIPS module commands.
     /// The status command.
@@ -337,6 +338,7 @@ pub enum MailboxResp {
     ProductionAuthDebugUnlockChallenge(ProductionAuthDebugUnlockChallenge),
     GetPcrLog(GetPcrLogResp),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsResp),
+    CertifyKeyChunks(CertifyKeyChunksResp),
 }
 
 pub const MAX_RESP_SIZE: usize = size_of::<MailboxResp>();
@@ -401,6 +403,7 @@ impl MailboxResp {
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_bytes()),
         }
     }
 
@@ -463,6 +466,7 @@ impl MailboxResp {
             MailboxResp::ProductionAuthDebugUnlockChallenge(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_mut_bytes()),
         }
     }
 
@@ -574,6 +578,7 @@ pub enum MailboxReq {
     GetPcrLog(MailboxReqHeader),
     FeProg(FeProgReq),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsReq),
+    CertifyKeyChunks(CertifyKeyChunksReq),
 }
 
 pub const MAX_REQ_SIZE: usize = size_of::<MailboxReq>();
@@ -654,6 +659,7 @@ impl MailboxReq {
             MailboxReq::GetPcrLog(req) => Ok(req.as_bytes()),
             MailboxReq::FeProg(req) => Ok(req.as_bytes()),
             MailboxReq::ReallocateDpeContextLimits(req) => Ok(req.as_bytes()),
+            MailboxReq::CertifyKeyChunks(req) => Ok(req.as_bytes()),
         }
     }
 
@@ -732,6 +738,7 @@ impl MailboxReq {
             MailboxReq::GetPcrLog(req) => Ok(req.as_mut_bytes()),
             MailboxReq::FeProg(req) => Ok(req.as_mut_bytes()),
             MailboxReq::ReallocateDpeContextLimits(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CertifyKeyChunks(req) => Ok(req.as_mut_bytes()),
         }
     }
 
@@ -814,6 +821,7 @@ impl MailboxReq {
                 CommandId::PRODUCTION_AUTH_DEBUG_UNLOCK_TOKEN
             }
             MailboxReq::ReallocateDpeContextLimits(_) => CommandId::REALLOCATE_DPE_CONTEXT_LIMITS,
+            MailboxReq::CertifyKeyChunks(_) => CommandId::CERTIFY_KEY_CHUNKS,
         }
     }
 
@@ -1362,6 +1370,76 @@ impl CertifyKeyExtendedResp {
         }
         let unused_byte_count = Self::CERTIFY_KEY_RESP_SIZE - self.size as usize;
         Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+
+// CERTIFY_KEY_CHUNKS
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksReq {
+    pub hdr: MailboxReqHeader,
+    pub flags: CertifyKeyChunksFlags,
+    pub reserved: u32,
+    pub max_size: u32,
+    pub offset: u32,
+    pub certify_key_req: [u8; Self::CERTIFY_KEY_REQ_SIZE],
+}
+
+impl CertifyKeyChunksReq {
+    pub const CERTIFY_KEY_REQ_SIZE: usize = 72;
+}
+
+impl Request for CertifyKeyChunksReq {
+    const ID: CommandId = CommandId::CERTIFY_KEY_CHUNKS;
+    type Resp = CertifyKeyChunksResp;
+}
+
+#[repr(C)]
+#[derive(
+    Debug, PartialEq, Eq, FromBytes, Immutable, KnownLayout, IntoBytes, Default, Copy, Clone,
+)]
+pub struct CertifyKeyChunksFlags(pub u32);
+
+bitflags! {
+    impl CertifyKeyChunksFlags: u32 {
+        const USE_MLDSA = 1u32 << 31;
+    }
+}
+
+impl CertifyKeyChunksFlags {
+    pub fn use_mldsa(&self) -> bool {
+        self.contains(CertifyKeyChunksFlags::USE_MLDSA)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksRespInfo {
+    pub hdr: MailboxRespHeader,
+    pub context_handle: [u8; 16],
+    pub chunk_len: u32,
+    pub remaining: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyChunksResp {
+    pub info: CertifyKeyChunksRespInfo,
+    pub certify_key_resp: [u8; Self::MAX_CHUNK_SIZE],
+}
+
+impl CertifyKeyChunksResp {
+    pub const MAX_CHUNK_SIZE: usize = 15 * 1024;
+}
+
+impl Response for CertifyKeyChunksResp {}
+
+impl Default for CertifyKeyChunksResp {
+    fn default() -> Self {
+        Self {
+            info: Default::default(),
+            certify_key_resp: [0u8; Self::MAX_CHUNK_SIZE],
+        }
     }
 }
 

--- a/drivers/src/aes.rs
+++ b/drivers/src/aes.rs
@@ -384,13 +384,10 @@ impl Aes {
         let mut buffer = [0u8; AES_BLOCK_SIZE_BYTES];
         buffer[..input.len()].copy_from_slice(input);
 
-        let ghash_state = if context.aad_len == 0 && context.buffer_len == 0 {
-            // Edge case where we have not actually done any AES operations,
-            // so the GHASH state should not be saved.
-            [0; 16]
-        } else {
-            self.save()?
-        };
+        // We've processed at least one block. The GHASH accumulator in
+        // the hardware reflects that work and must be saved so a subsequent
+        // update/final restores it.
+        let ghash_state = self.save()?;
         self.zeroize_internal();
         Ok((
             written,
@@ -600,10 +597,10 @@ impl Aes {
 
             wait_for_idle(&aes);
 
-            // if we haven't actually written any AAD or input, then
-            // we can skip the restore operation.
-            // This avoids some edge cases in the hardware.
-            if aad_len == 0 && len == 0 {
+            // Nothing to restore until either AAD or a full block of text has
+            // been processed by the hardware. Issuing GcmPhase::Restore with a
+            // zero GHASH state corrupts subsequent tag computation.
+            if aad_len == 0 && (len as usize) < AES_BLOCK_SIZE_BYTES {
                 return Ok(());
             }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -46,6 +46,7 @@ caliptra-gen-linker-scripts.workspace = true
 cfg-if.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 aes.workspace = true
 aes-gcm.workspace = true
 caliptra-api.workspace = true

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1164,6 +1164,34 @@ Command Code: `0x434B_4558` ("CKEX")
 | fips\_status       | u32      | Indicates if the command is FIPS approved or an error.                     |
 | certify\_key\_resp | u8[2176] | Certify Key Response.                                                      |
 
+### CERTIFY\_KEY\_CHUNKS
+
+Invokes a DPE `CertifyKey` command (ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+
+Command Code: `0x434B_4348` ("CKCH")
+
+*Table: `CERTIFY_KEY_CHUNKS` input arguments*
+
+| **Name**          | **Type** | **Description**                                                                       |
+| ----------------- | -------- | ------------------------------------------------------------------------------------- |
+| chksum            | u32      | Checksum over other input arguments, computed by the caller. Little endian.           |
+| flags             | u32      | Flags (reserved).                                                                     |
+| reserved          | u32      | Reserved.                                                                             |
+| max\_size         | u32      | The maximum length of the chunk the caller wants to receive. If 0, defaults to 15360. |
+| offset            | u32      | Offset into the full CertifyKey response to read from.                                |
+| certify\_key\_req | u8[72]   | The serialized DPE `CertifyKey` command.                                              |
+
+*Table: `CERTIFY_KEY_CHUNKS` output arguments*
+
+| **Name**           | **Type**  | **Description**                                                            |
+| ------------------ | --------- | -------------------------------------------------------------------------- |
+| chksum             | u32       | Checksum over other output arguments, computed by Caliptra. Little endian. |
+| fips\_status       | u32       | Indicates if the command is FIPS approved or an error.                     |
+| context\_handle    | u8[16]    | The new DPE context handle returned by the `CertifyKey` command.           |
+| chunk\_len         | u32       | The length of the chunk returned in `certify_key_resp`.                    |
+| remaining          | u32       | The number of bytes remaining in the full response after this chunk.       |
+| certify\_key\_resp | u8[15360] | The chunk of the DPE `CertifyKey` response.                                |
+
 ### SET_AUTH_MANIFEST
 
 The SoC uses this command and `SET_IMAGE_METADTA` to program an image manifest for Manifest-Based Image Authorization to Caliptra. In response to these commands, the Caliptra Runtime will verify the manifest by authenticating the public keys and in turn using them to authenticate the IMC. On successful verification, the Runtime will store the IMEs into DCCM for future use.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1166,7 +1166,9 @@ Command Code: `0x434B_4558` ("CKEX")
 
 ### CERTIFY\_KEY\_CHUNKS
 
-Invokes a DPE `CertifyKey` command (ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+Invokes a DPE `CertifyKey` command (ECC-P384 or ML-DSA-87) and returns the response in chunks. This is useful when the DPE response (which contains a certificate or CSR) is larger than the mailbox size or larger than the caller can easily consume.
+
+The handler re-executes the full DPE `CertifyKey` operation on every call and then returns the requested `[offset, offset+max_size)` window of the freshly generated response. Each call rotates the context handle, if needed. The new handle is returned in the per-chunk response header and must be used for the next call.
 
 Command Code: `0x434B_4348` ("CKCH")
 
@@ -1175,11 +1177,19 @@ Command Code: `0x434B_4348` ("CKCH")
 | **Name**          | **Type** | **Description**                                                                       |
 | ----------------- | -------- | ------------------------------------------------------------------------------------- |
 | chksum            | u32      | Checksum over other input arguments, computed by the caller. Little endian.           |
-| flags             | u32      | Flags (reserved).                                                                     |
+| flags             | u32      | Flags.                                                                                |
 | reserved          | u32      | Reserved.                                                                             |
 | max\_size         | u32      | The maximum length of the chunk the caller wants to receive. If 0, defaults to 15360. |
 | offset            | u32      | Offset into the full CertifyKey response to read from.                                |
 | certify\_key\_req | u8[72]   | The serialized DPE `CertifyKey` command.                                              |
+
+*Table: `CERTIFY_KEY_CHUNKS` input flags*
+
+| **Name**  | **Offset** |
+| --------- | ---------- |
+| USE_MLDSA | 1 << 31    |
+
+When `USE_MLDSA` is set, the command operates on the ML-DSA-87 DPE profile; otherwise, it operates on the ECC-P384 profile.
 
 *Table: `CERTIFY_KEY_CHUNKS` output arguments*
 

--- a/runtime/src/certify_key_chunks.rs
+++ b/runtime/src/certify_key_chunks.rs
@@ -12,11 +12,12 @@ Abstract:
 
 --*/
 
+use crate::PauserPrivileges;
 use crate::{invoke_dpe::invoke_dpe_cmd, CaliptraDpeProfile, Drivers};
 use caliptra_api::mailbox::CertifyKeyChunksRespInfo;
 use caliptra_common::mailbox_api::{CertifyKeyChunksReq, CertifyKeyChunksResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use dpe::commands::{CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
+use dpe::commands::{CertifyKeyCommand, CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
 use dpe::response::{CertifyKeyMldsa87Resp, CertifyKeyP384Resp};
 use memoffset::span_of;
 use zerocopy::FromBytes;
@@ -39,17 +40,26 @@ impl CertifyKeyChunksCmd {
         };
 
         let certify_key_cmd = match profile {
-            CaliptraDpeProfile::Ecc384 => Command::from(
+            CaliptraDpeProfile::Ecc384 => CertifyKeyCommand::from(
                 CertifyKeyP384Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
                     CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
                 ))?,
             ),
-            CaliptraDpeProfile::Mldsa87 => Command::from(
+            CaliptraDpeProfile::Mldsa87 => CertifyKeyCommand::from(
                 CertifyKeyMldsa87Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
                     CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
                 ))?,
             ),
         };
+
+        // Check if command can be executed
+        // PL1 cannot request X509
+        let caller_privilege_level = drivers.caller_privilege_level();
+        if certify_key_cmd.format() == CertifyKeyCommand::FORMAT_X509
+            && caller_privilege_level != PauserPrivileges::PL0
+        {
+            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+        }
 
         let (resp_info, certify_key_resp_bytes) =
             CertifyKeyChunksRespInfo::mut_from_prefix(mbox_resp)
@@ -71,11 +81,10 @@ impl CertifyKeyChunksCmd {
         }
 
         // Get the full CertifyKey response
-        let cmd = &certify_key_cmd;
         let dpe_resp_len = invoke_dpe_cmd(
             profile,
             drivers,
-            cmd,
+            &Command::from(&certify_key_cmd),
             None,
             None,
             None,

--- a/runtime/src/certify_key_chunks.rs
+++ b/runtime/src/certify_key_chunks.rs
@@ -1,0 +1,146 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    certify_key_chunks.rs
+
+Abstract:
+
+    File contains CertifyKeyChunks mailbox command.
+
+--*/
+
+use crate::{invoke_dpe::invoke_dpe_cmd, CaliptraDpeProfile, Drivers};
+use caliptra_api::mailbox::CertifyKeyChunksRespInfo;
+use caliptra_common::mailbox_api::{CertifyKeyChunksReq, CertifyKeyChunksResp};
+use caliptra_error::{CaliptraError, CaliptraResult};
+use dpe::commands::{CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command};
+use dpe::response::{CertifyKeyMldsa87Resp, CertifyKeyP384Resp};
+use memoffset::span_of;
+use zerocopy::FromBytes;
+
+pub struct CertifyKeyChunksCmd;
+impl CertifyKeyChunksCmd {
+    #[inline(never)]
+    pub(crate) fn execute(
+        drivers: &mut Drivers,
+        cmd_args: &[u8],
+        mbox_resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        let chunk_cmd = CertifyKeyChunksReq::ref_from_bytes(cmd_args)
+            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        let profile = if chunk_cmd.flags.use_mldsa() {
+            CaliptraDpeProfile::Mldsa87
+        } else {
+            CaliptraDpeProfile::Ecc384
+        };
+
+        let certify_key_cmd = match profile {
+            CaliptraDpeProfile::Ecc384 => Command::from(
+                CertifyKeyP384Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+            CaliptraDpeProfile::Mldsa87 => Command::from(
+                CertifyKeyMldsa87Cmd::ref_from_bytes(&chunk_cmd.certify_key_req[..]).or(Err(
+                    CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+                ))?,
+            ),
+        };
+
+        let (resp_info, certify_key_resp_bytes) =
+            CertifyKeyChunksRespInfo::mut_from_prefix(mbox_resp)
+                .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+        let (min_resp_size, handle_range) = match profile {
+            CaliptraDpeProfile::Ecc384 => (
+                size_of::<CertifyKeyP384Resp>(),
+                span_of!(CertifyKeyP384Resp, new_context_handle..derived_pubkey_x),
+            ),
+            CaliptraDpeProfile::Mldsa87 => (
+                size_of::<CertifyKeyMldsa87Resp>(),
+                span_of!(CertifyKeyMldsa87Resp, new_context_handle..pubkey),
+            ),
+        };
+
+        if certify_key_resp_bytes.len() < min_resp_size {
+            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+        }
+
+        // Get the full CertifyKey response
+        let cmd = &certify_key_cmd;
+        let dpe_resp_len = invoke_dpe_cmd(
+            profile,
+            drivers,
+            cmd,
+            None,
+            None,
+            None,
+            certify_key_resp_bytes,
+        )
+        .map_err(|e| {
+            // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+            if let Some(ext_err) = e.get_error_detail() {
+                drivers.soc_ifc.set_fw_extended_error(ext_err);
+            }
+            CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
+        })?;
+
+        // If the offset is past the end of the response this will make it have nothing in the
+        // chunk, but the caller will still get the handle back
+        let offset = usize::min(chunk_cmd.offset as usize, dpe_resp_len);
+
+        // Copy the new handle to the response header
+        resp_info.context_handle = certify_key_resp_bytes[handle_range].try_into().unwrap();
+
+        // Copy the chunk of the response to the beginning of the response buffer
+        let max_chunk_size = CertifyKeyChunksResp::MAX_CHUNK_SIZE;
+        let max_chunk_size = if chunk_cmd.max_size > 0 {
+            usize::min(max_chunk_size, chunk_cmd.max_size as usize)
+        } else {
+            max_chunk_size
+        };
+        let total_remaining = dpe_resp_len.saturating_sub(offset);
+        let chunk_len = core::cmp::min(total_remaining, max_chunk_size);
+        copy_to_start(certify_key_resp_bytes, offset, chunk_len)?;
+
+        // Fill in the rest of the response info
+        resp_info.chunk_len = chunk_len as u32;
+        resp_info.remaining = dpe_resp_len
+            .saturating_sub(offset)
+            .saturating_sub(chunk_len) as u32;
+
+        Ok(core::mem::size_of::<CertifyKeyChunksRespInfo>() + chunk_len)
+    }
+}
+
+fn copy_to_start(slice: &mut [u8], src_offset: usize, len: usize) -> CaliptraResult<()> {
+    let slice_len = slice.len();
+
+    if src_offset > slice_len || len > slice_len {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    }
+
+    let src_end = src_offset
+        .checked_add(len)
+        .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    if src_end > slice_len {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    }
+
+    // Copy forwards (left to right) is always safe when copying to the start (dest = 0)
+    for i in 0..len {
+        let src_idx = src_offset + i;
+        let val = *slice
+            .get(src_idx)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+        *slice
+            .get_mut(i)
+            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)? = val;
+    }
+
+    Ok(())
+}

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -1081,6 +1081,72 @@ impl Commands {
         resp.partial_len()
     }
 
+    /// Common GCM init logic for encrypt and decrypt.
+    /// When `cmd_iv` is `None`, generates a random IV and increments the usage counter (encrypt).
+    /// When `cmd_iv` is `Some`, uses the provided IV (decrypt).
+    #[inline(never)]
+    fn gcm_init_common(
+        drivers: &mut Drivers,
+        cmk_bytes: &[u8],
+        flags: u32,
+        aad: &[u8],
+        cmd_iv: Option<&[u8; 12]>,
+    ) -> CaliptraResult<AesGcmContext> {
+        let encrypted_cmk = EncryptedCmk::ref_from_bytes(cmk_bytes)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
+            &mut drivers.aes,
+            &mut drivers.trng,
+            encrypted_cmk,
+        )?;
+
+        if cmk.length as usize > cmk.key_material.len() {
+            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+        }
+
+        let iv_arr;
+        let key_usage: CmKeyUsage = CmKeyUsage::from(cmk.key_usage as u32);
+
+        let (key, iv) = if flags != 0 {
+            if !matches!(key_usage, CmKeyUsage::Hmac) {
+                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+            }
+            let spdm_version: SpdmVersion = (flags as u8).try_into()?;
+            let (key, iv) = Self::spdm_derive_key_and_iv(
+                drivers,
+                &cmk.key_material[..cmk.length as usize],
+                spdm_version,
+            )?;
+            iv_arr = iv;
+            (key, AesGcmIv::Array(&iv_arr))
+        } else if let Some(ref provided_iv) = cmd_iv {
+            // Decrypt: use provided IV
+            if !matches!(key_usage, CmKeyUsage::Aes) {
+                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+            }
+            let key: [u8; 32] = cmk.key_material[..32].try_into().unwrap();
+            (key, (*provided_iv).into())
+        } else {
+            // Encrypt: increment and check usage, random IV
+            if !matches!(key_usage, CmKeyUsage::Aes) {
+                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+            }
+            let counter = drivers.cryptographic_mailbox.increment_counter(&cmk)?;
+            if counter > GCM_MAX_KEY_USES {
+                Err(CaliptraError::RUNTIME_GCM_KEY_USAGE_LIMIT_REACHED)?;
+            }
+            let key: [u8; 32] = cmk.key_material[..32].try_into().unwrap();
+            (key, AesGcmIv::Random)
+        };
+
+        let unencrypted_context = drivers
+            .aes
+            .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
+
+        Ok(unencrypted_context)
+    }
+
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub(crate) fn aes_256_gcm_encrypt_init(
         drivers: &mut Drivers,
@@ -1098,51 +1164,7 @@ impl Commands {
         }
         let aad = &cmd.aad[..cmd.aad_size as usize];
 
-        let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmd.cmk.0[..])
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
-
-        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
-            &mut drivers.aes,
-            &mut drivers.trng,
-            encrypted_cmk,
-        )?;
-
-        if cmk.length as usize > cmk.key_material.len() {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-
-        let iv_arr;
-        let key_usage: CmKeyUsage = CmKeyUsage::from(cmk.key_usage as u32);
-
-        let (key, iv) = if cmd.flags != 0 {
-            if !matches!(key_usage, CmKeyUsage::Hmac) {
-                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-            }
-            let spdm_version: SpdmVersion = (cmd.flags as u8).try_into()?;
-            let (key, iv) = Self::spdm_derive_key_and_iv(
-                drivers,
-                &cmk.key_material[..cmk.length as usize],
-                spdm_version,
-            )?;
-            iv_arr = iv;
-            (key, AesGcmIv::Array(&iv_arr))
-        } else {
-            // increment and check usage
-            if !matches!(key_usage, CmKeyUsage::Aes) {
-                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-            }
-            let counter = drivers.cryptographic_mailbox.increment_counter(&cmk)?;
-            if counter > GCM_MAX_KEY_USES {
-                Err(CaliptraError::RUNTIME_GCM_KEY_USAGE_LIMIT_REACHED)?;
-            }
-            let key: [u8; 32] = cmk.key_material[..32].try_into().unwrap();
-            (key, AesGcmIv::Random)
-        };
-
-        let unencrypted_context =
-            drivers
-                .aes
-                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
+        let unencrypted_context = Self::gcm_init_common(drivers, &cmd.cmk.0[..], 0, aad, None)?;
         let encrypted_context = drivers.cryptographic_mailbox.encrypt_aes_gcm_context(
             &mut drivers.aes,
             &mut drivers.trng,
@@ -1171,6 +1193,51 @@ impl Commands {
         result
     }
 
+    /// Common SPDM GCM init logic for encrypt and decrypt.
+    #[inline(never)]
+    fn spdm_gcm_init_common(
+        drivers: &mut Drivers,
+        cmk_bytes: &[u8],
+        spdm_flags: u32,
+        spdm_counter: &[u8; 8],
+        aad: &[u8],
+    ) -> CaliptraResult<AesGcmContext> {
+        let encrypted_cmk = EncryptedCmk::ref_from_bytes(cmk_bytes)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
+            &mut drivers.aes,
+            &mut drivers.trng,
+            encrypted_cmk,
+        )?;
+
+        if cmk.length as usize > cmk.key_material.len() {
+            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+        }
+
+        let key_usage: CmKeyUsage = CmKeyUsage::from(cmk.key_usage as u32);
+
+        if !matches!(key_usage, CmKeyUsage::Hmac) {
+            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
+        }
+
+        let flags = SpdmFlags(spdm_flags);
+        let spdm_version: SpdmVersion = (flags.version() as u8).try_into()?;
+        let (key, iv) = Self::spdm_derive_key_and_iv(
+            drivers,
+            &cmk.key_material[..cmk.length as usize],
+            spdm_version,
+        )?;
+        let iv = Self::xor_iv(&iv, spdm_counter, flags.counter_big_endian() == 1);
+        let iv = AesGcmIv::Array(&iv);
+
+        let unencrypted_context = drivers
+            .aes
+            .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
+
+        Ok(unencrypted_context)
+    }
+
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     pub(crate) fn aes_256_gcm_spdm_encrypt_init(
         drivers: &mut Drivers,
@@ -1188,38 +1255,13 @@ impl Commands {
         }
         let aad = &cmd.aad[..cmd.aad_size as usize];
 
-        let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmd.cmk.0[..])
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
-
-        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
-            &mut drivers.aes,
-            &mut drivers.trng,
-            encrypted_cmk,
-        )?;
-
-        if cmk.length as usize > cmk.key_material.len() {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-
-        let key_usage = CmKeyUsage::from(cmk.key_usage as u32);
-
-        if !matches!(key_usage, CmKeyUsage::Hmac) {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-        let spdm_flags = SpdmFlags(cmd.spdm_flags);
-        let spdm_version: SpdmVersion = (spdm_flags.version() as u8).try_into()?;
-        let (key, iv) = Self::spdm_derive_key_and_iv(
+        let unencrypted_context = Self::spdm_gcm_init_common(
             drivers,
-            &cmk.key_material[..cmk.length as usize],
-            spdm_version,
+            &cmd.cmk.0[..],
+            cmd.spdm_flags,
+            &cmd.spdm_counter,
+            aad,
         )?;
-        let iv = Self::xor_iv(&iv, &cmd.spdm_counter, spdm_flags.counter_big_endian() == 1);
-        let iv = AesGcmIv::Array(&iv);
-
-        let unencrypted_context =
-            drivers
-                .aes
-                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
         let encrypted_context = drivers.cryptographic_mailbox.encrypt_aes_gcm_context(
             &mut drivers.aes,
             &mut drivers.trng,
@@ -1337,47 +1379,8 @@ impl Commands {
         }
         let aad = &cmd.aad[..cmd.aad_size as usize];
 
-        let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmd.cmk.0[..])
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
-        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
-            &mut drivers.aes,
-            &mut drivers.trng,
-            encrypted_cmk,
-        )?;
-
-        if cmk.length as usize > cmk.key_material.len() {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-
-        let iv_arr;
-        let key_usage: CmKeyUsage = CmKeyUsage::from(cmk.key_usage as u32);
-
-        let (key, iv) = if cmd.flags != 0 {
-            if !matches!(key_usage, CmKeyUsage::Hmac) {
-                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-            }
-            let spdm_version: SpdmVersion = (cmd.flags as u8).try_into()?;
-            let (key, iv) = Self::spdm_derive_key_and_iv(
-                drivers,
-                &cmk.key_material[..cmk.length as usize],
-                spdm_version,
-            )?;
-            iv_arr = iv;
-            (key, AesGcmIv::Array(&iv_arr))
-        } else {
-            // check usage
-            if !matches!(key_usage, CmKeyUsage::Aes) {
-                Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-            }
-            let key: [u8; 32] = cmk.key_material[..32].try_into().unwrap();
-            (key, AesGcmIv::Array(&cmd.iv))
-        };
-
         let unencrypted_context =
-            drivers
-                .aes
-                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
-
+            Self::gcm_init_common(drivers, &cmd.cmk.0[..], 0, aad, Some(&cmd.iv))?;
         let encrypted_context = drivers.cryptographic_mailbox.encrypt_aes_gcm_context(
             &mut drivers.aes,
             &mut drivers.trng,
@@ -1411,37 +1414,13 @@ impl Commands {
         }
         let aad = &cmd.aad[..cmd.aad_size as usize];
 
-        let encrypted_cmk = EncryptedCmk::ref_from_bytes(&cmd.cmk.0[..])
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
-        let cmk = drivers.cryptographic_mailbox.decrypt_cmk(
-            &mut drivers.aes,
-            &mut drivers.trng,
-            encrypted_cmk,
-        )?;
-
-        if cmk.length as usize > cmk.key_material.len() {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-
-        let key_usage: CmKeyUsage = CmKeyUsage::from(cmk.key_usage as u32);
-
-        if !matches!(key_usage, CmKeyUsage::Hmac) {
-            Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
-        }
-        let spdm_version: SpdmVersion = (cmd.spdm_flags as u8).try_into()?;
-        let (key, iv) = Self::spdm_derive_key_and_iv(
+        let unencrypted_context = Self::spdm_gcm_init_common(
             drivers,
-            &cmk.key_material[..cmk.length as usize],
-            spdm_version,
+            &cmd.cmk.0[..],
+            cmd.spdm_flags,
+            &cmd.spdm_counter,
+            aad,
         )?;
-        let iv = Self::xor_iv(&iv, &cmd.spdm_counter, (cmd.spdm_flags >> 8) & 1 == 1);
-        let iv = AesGcmIv::Array(&iv);
-
-        let unencrypted_context =
-            drivers
-                .aes
-                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
-
         let encrypted_context = drivers.cryptographic_mailbox.encrypt_aes_gcm_context(
             &mut drivers.aes,
             &mut drivers.trng,

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -1120,13 +1120,13 @@ impl Commands {
             )?;
             iv_arr = iv;
             (key, AesGcmIv::Array(&iv_arr))
-        } else if let Some(ref provided_iv) = cmd_iv {
+        } else if let Some(provided_iv) = cmd_iv {
             // Decrypt: use provided IV
             if !matches!(key_usage, CmKeyUsage::Aes) {
                 Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?;
             }
             let key: [u8; 32] = cmk.key_material[..32].try_into().unwrap();
-            (key, (*provided_iv).into())
+            (key, provided_iv.into())
         } else {
             // Encrypt: increment and check usage, random IV
             if !matches!(key_usage, CmKeyUsage::Aes) {
@@ -1140,9 +1140,10 @@ impl Commands {
             (key, AesGcmIv::Random)
         };
 
-        let unencrypted_context = drivers
-            .aes
-            .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
+        let unencrypted_context =
+            drivers
+                .aes
+                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
 
         Ok(unencrypted_context)
     }
@@ -1231,9 +1232,10 @@ impl Commands {
         let iv = Self::xor_iv(&iv, spdm_counter, flags.counter_big_endian() == 1);
         let iv = AesGcmIv::Array(&iv);
 
-        let unencrypted_context = drivers
-            .aes
-            .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
+        let unencrypted_context =
+            drivers
+                .aes
+                .aes_256_gcm_init(&mut drivers.trng, &key, iv, aad, cmk.fips_valid())?;
 
         Ok(unencrypted_context)
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -17,6 +17,7 @@ mod activate_firmware;
 mod attested_csr;
 mod authorize_and_stash;
 mod capabilities;
+mod certify_key_chunks;
 mod certify_key_extended;
 mod cryptographic_mailbox;
 mod debug_unlock;
@@ -350,6 +351,7 @@ fn execute_command(
         }
         CommandId::INVOKE_DPE_ECC384 => execute_invoke_dpe_ecc384(drivers, cmd_bytes),
         CommandId::INVOKE_DPE_MLDSA87 => execute_invoke_dpe_mldsa87(drivers, cmd_bytes),
+        CommandId::CERTIFY_KEY_CHUNKS => execute_certify_key_chunks(drivers, cmd_bytes),
         CommandId::GET_ATTESTED_ECC384_CSR => {
             attested_csr::AttestedEccCsrCmd::execute(drivers, cmd_bytes)
         }
@@ -441,7 +443,7 @@ fn execute_command_with_common_resp(
             GetRtAliasCertCmd::execute(drivers, AlgorithmType::Mldsa87, resp)
         }
         CommandId::ADD_SUBJECT_ALT_NAME => AddSubjectAltNameCmd::execute(drivers, cmd_bytes),
-        // CERTIFY_KEY_EXTENDED_{ECC384,MLDSA87} are dispatched earlier.
+        // CERTIFY_KEY_EXTENDED_{ECC384,MLDSA87} and CERTIFY_KEY_CHUNKS are dispatched earlier.
         CommandId::INCREMENT_PCR_RESET_COUNTER => {
             IncrementPcrResetCounterCmd::execute(drivers, cmd_bytes)
         }
@@ -664,6 +666,19 @@ fn execute_invoke_dpe_mldsa87(
 ) -> CaliptraResult<MboxStatusE> {
     let resp = &mut [0u8; DPE_RESP_BUF_SIZE][..];
     let len = InvokeDpeCmd::execute_mldsa87(drivers, cmd_bytes, resp)?;
+    finalize_response(drivers, resp, len)
+}
+
+#[inline(never)]
+fn execute_certify_key_chunks(
+    drivers: &mut Drivers,
+    cmd_bytes: &[u8],
+) -> CaliptraResult<MboxStatusE> {
+    // Buffer must hold CertifyKeyChunksRespInfo header + full DPE CertifyKey response.
+    const BUF_SIZE: usize =
+        DPE_RESP_BUF_SIZE + size_of::<caliptra_api::mailbox::CertifyKeyChunksRespInfo>();
+    let resp = &mut [0u8; BUF_SIZE][..];
+    let len = certify_key_chunks::CertifyKeyChunksCmd::execute(drivers, cmd_bytes, resp)?;
     finalize_response(drivers, resp, len)
 }
 

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+use anyhow::Context;
 use caliptra_api::{
     mailbox::{GetFmcAliasMlDsa87CertResp, Request},
     SocManager,
@@ -14,8 +15,10 @@ use caliptra_builder::{
 };
 use caliptra_common::{
     mailbox_api::{
-        CommandId, GetFmcAliasEcc384CertResp, GetLdevCertResp, GetRtAliasCertResp, InvokeDpeReq,
-        InvokeDpeResp, MailboxReq, MailboxReqHeader,
+        AxiResponseInfo, CertifyKeyChunksFlags, CertifyKeyChunksReq, CertifyKeyChunksResp,
+        CommandId, GetFmcAliasEcc384CertResp, GetLdevCertResp, GetRtAliasCertResp,
+        InvokeDpeMldsa87Flags, InvokeDpeMldsa87Req, InvokeDpeReq, InvokeDpeResp, MailboxReq,
+        MailboxReqHeader, MailboxRespHeader,
     },
     memory_layout::{ROM_ORG, ROM_SIZE, ROM_STACK_ORG, ROM_STACK_SIZE, STACK_ORG, STACK_SIZE},
     FMC_ORG, FMC_SIZE, RUNTIME_ORG, RUNTIME_SIZE,
@@ -29,16 +32,25 @@ use caliptra_hw_model::{
 use caliptra_image_crypto::OsslCrypto as Crypto;
 use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
+use caliptra_runtime::CaliptraDpeProfile;
 use caliptra_test::image_pk_desc_hash;
+use crypto::{Digest, Mu, PrecomputedSignData, Sha384};
 use dpe::{
-    commands::{Command, CommandHdr},
-    response::{DpeErrorCode, Response, ResponseHdr},
+    commands::{
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyMldsa87Cmd, CertifyKeyP384Cmd, Command,
+        CommandHdr, SignFlags, SignMldsa87Cmd, SignP384Cmd,
+    },
+    context::ContextHandle,
+    response::{CertifyKeyResp, DpeErrorCode, Response, ResponseHdr, SignResp},
     DpeProfile,
 };
 use openssl::{
     asn1::{Asn1Integer, Asn1Time},
     bn::BigNum,
+    ec::{EcGroup, EcKey},
+    ecdsa::EcdsaSig,
     hash::MessageDigest,
+    nid::Nid,
     pkey::{PKey, Private},
     x509::{X509Builder, X509},
     x509::{X509Name, X509NameBuilder},
@@ -55,6 +67,14 @@ pub const TEST_DIGEST: [u8; 48] = [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
 ];
+pub const TEST_MU: [u8; 64] = [
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+    51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+];
+pub const TEST_SD_SHA384: PrecomputedSignData =
+    PrecomputedSignData::Digest(Digest::Sha384(Sha384(TEST_DIGEST)));
+pub const TEST_SD_MU: PrecomputedSignData = PrecomputedSignData::Mu(Mu(TEST_MU));
 
 pub const DEFAULT_FMC_VERSION: u16 = 0xaaaa;
 pub const DEFAULT_APP_VERSION: u32 = 0xbbbbbbbb;
@@ -342,7 +362,7 @@ pub fn generate_test_x509_cert(private_key: &PKey<Private>) -> X509 {
     cert_builder.build()
 }
 
-fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
+pub fn check_dpe_status(resp_bytes: &[u8], expected_status: DpeErrorCode) {
     if let Ok(&ResponseHdr { status, .. }) =
         ResponseHdr::try_ref_from_bytes(&resp_bytes[..core::mem::size_of::<ResponseHdr>()])
     {
@@ -406,6 +426,328 @@ pub fn execute_dpe_cmd(
         DpeResult::DpeCmdFailure => Response::Error(ResponseHdr::try_read_from_bytes(resp_bytes).unwrap()),
         DpeResult::MboxCmdFailure(_) => unreachable!("If MboxCmdFailure is the expected DPE result, the function would have returned None earlier."),
     })
+}
+
+pub fn check_header_checksum(resp: &[u8]) -> anyhow::Result<()> {
+    let resp_hdr =
+        MailboxReqHeader::try_read_from_bytes(&resp[..core::mem::size_of::<MailboxReqHeader>()])
+            .map_err(|e| anyhow::anyhow!("Failed to get the header from the response: {e}"))?;
+    if !caliptra_common::checksum::verify_checksum(
+        resp_hdr.chksum,
+        0x0,
+        &resp[core::mem::size_of_val(&resp_hdr.chksum)..],
+    ) {
+        anyhow::bail!("Invalid checksum in response header");
+    }
+    Ok(())
+}
+
+/// Response from `execute_dpe_cmd_raw` that can hold responses larger than
+/// `InvokeDpeResp::DATA_MAX_SIZE` (needed for MLDSA87 certify-key responses).
+pub struct DpeRawResp {
+    pub data_size: u32,
+    pub data: Vec<u8>,
+}
+
+pub fn execute_dpe_cmd_raw(
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+    dpe_cmd: &mut Command,
+) -> Result<DpeRawResp, ModelError> {
+    // Fill the request buffer with the correct info
+    let mut cmd_data: [u8; 512] = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
+    let cmd_hdr = CommandHdr::new(profile.into(), dpe_cmd.id());
+    let cmd_hdr_buf = cmd_hdr.as_bytes();
+    cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
+    let dpe_cmd_buf = dpe_cmd.as_bytes();
+    cmd_data[cmd_hdr_buf.len()..cmd_hdr_buf.len() + dpe_cmd_buf.len()].copy_from_slice(dpe_cmd_buf);
+
+    let data_size = (cmd_hdr_buf.len() + dpe_cmd_buf.len()) as u32;
+
+    // Get the profile specific mailbox command
+    let resp = match profile {
+        CaliptraDpeProfile::Ecc384 => {
+            let mut mbox_cmd = MailboxReq::InvokeDpeEcc384Command(InvokeDpeReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                data: cmd_data,
+                data_size,
+            });
+            mbox_cmd.populate_chksum().unwrap();
+            model.mailbox_execute(
+                u32::from(CommandId::INVOKE_DPE_ECC384),
+                mbox_cmd.as_bytes().unwrap(),
+            )?
+        }
+        CaliptraDpeProfile::Mldsa87 => {
+            let mut mbox_cmd = MailboxReq::InvokeDpeMldsa87Command(InvokeDpeMldsa87Req {
+                hdr: MailboxReqHeader { chksum: 0 },
+                flags: InvokeDpeMldsa87Flags::empty(),
+                axi_response: AxiResponseInfo::default(),
+                data: cmd_data,
+                data_size,
+            });
+            mbox_cmd.populate_chksum().unwrap();
+            model.mailbox_execute(
+                u32::from(CommandId::INVOKE_DPE_MLDSA87),
+                mbox_cmd.as_bytes().unwrap(),
+            )?
+        }
+    };
+
+    let resp = resp.expect("We should have received a response");
+    check_header_checksum(&resp).unwrap();
+
+    // Parse data_size and data from raw response bytes
+    // Layout: MailboxRespHeader (8 bytes) | data_size (4 bytes) | data (variable)
+    let hdr_size = core::mem::size_of::<MailboxRespHeader>();
+    let data_size_offset = hdr_size;
+    let data_offset = data_size_offset + core::mem::size_of::<u32>();
+    let data_size = u32::from_le_bytes(
+        resp[data_size_offset..data_offset]
+            .try_into()
+            .expect("data_size field"),
+    );
+    let data = resp[data_offset..].to_vec();
+
+    Ok(DpeRawResp { data_size, data })
+}
+
+pub fn certify_key(
+    model: &mut DefaultHwModel,
+    cmd: &mut CertifyKeyCommandNoRef,
+) -> anyhow::Result<CertifyKeyResp> {
+    if model.subsystem_mode() {
+        certify_key_chunks(model, cmd, None)
+    } else {
+        let resp = match cmd {
+            CertifyKeyCommandNoRef::P384(ref cmd) => {
+                let resp = execute_dpe_cmd_raw(
+                    model,
+                    CaliptraDpeProfile::Ecc384,
+                    &mut Command::from(cmd),
+                )?;
+                let resp = resp.data[..resp.data_size as usize].to_vec();
+                check_dpe_status(&resp, DpeErrorCode::NoError);
+                resp
+            }
+            CertifyKeyCommandNoRef::Mldsa(ref cmd) => {
+                let resp = execute_dpe_cmd_raw(
+                    model,
+                    CaliptraDpeProfile::Mldsa87,
+                    &mut Command::from(cmd),
+                )?;
+                let resp = resp.data[..resp.data_size as usize].to_vec();
+                check_dpe_status(&resp, DpeErrorCode::NoError);
+                resp
+            }
+        };
+        let resp = Response::try_read_from_bytes(&Command::from(&*cmd), &resp).map_err(|e| {
+            anyhow::anyhow!("Failed to convert response into DPE response. {:?}", e)
+        })?;
+        let Response::CertifyKey(resp) = resp else {
+            anyhow::bail!("Unexpected response type for CertifyKey command");
+        };
+        Ok(resp)
+    }
+}
+
+pub fn certify_key_chunks(
+    model: &mut DefaultHwModel,
+    cmd: &mut CertifyKeyCommandNoRef,
+    max_chunk_size: Option<usize>,
+) -> anyhow::Result<CertifyKeyResp> {
+    let mut full_resp = Vec::<u8>::new();
+    let mut offset = 0;
+
+    let use_mldsa = match cmd {
+        CertifyKeyCommandNoRef::P384(_) => false,
+        CertifyKeyCommandNoRef::Mldsa(_) => true,
+    };
+
+    let cmd_bytes = match cmd {
+        CertifyKeyCommandNoRef::P384(ref c) => c.as_bytes().to_vec(),
+        CertifyKeyCommandNoRef::Mldsa(ref c) => c.as_bytes().to_vec(),
+    };
+
+    let flags = if use_mldsa {
+        CertifyKeyChunksFlags::USE_MLDSA
+    } else {
+        CertifyKeyChunksFlags(0)
+    };
+
+    loop {
+        let mut certify_key_req = [0u8; 72];
+        certify_key_req[..cmd_bytes.len()].copy_from_slice(&cmd_bytes);
+        let req = CertifyKeyChunksReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            flags,
+            reserved: 0,
+            max_size: max_chunk_size.unwrap_or(0) as u32,
+            offset: offset as u32,
+            certify_key_req,
+        };
+        let mut mbox_cmd = MailboxReq::CertifyKeyChunks(req);
+        mbox_cmd.populate_chksum().unwrap();
+
+        let resp_data = model
+            .mailbox_execute(
+                u32::from(CommandId::CERTIFY_KEY_CHUNKS),
+                mbox_cmd.as_bytes().unwrap(),
+            )
+            .context("Failed to get chunked certify key response")?;
+        let resp_data = resp_data.expect("We should have received a response");
+        check_header_checksum(&resp_data).unwrap();
+
+        let mut resp = CertifyKeyChunksResp::default();
+        assert!(resp_data.len() <= size_of::<CertifyKeyChunksResp>());
+        resp.as_mut_bytes()[..resp_data.len()].copy_from_slice(&resp_data);
+
+        let chunk_len = resp.info.chunk_len as usize;
+        let remaining = resp.info.remaining as usize;
+
+        full_resp.extend_from_slice(&resp.certify_key_resp[..chunk_len]);
+
+        match cmd {
+            CertifyKeyCommandNoRef::P384(ref mut c) => c.handle.0 = resp.info.context_handle,
+            CertifyKeyCommandNoRef::Mldsa(ref mut c) => c.handle.0 = resp.info.context_handle,
+        }
+
+        if remaining == 0 {
+            break;
+        }
+        offset += chunk_len;
+    }
+
+    let resp = Response::try_read_from_bytes(&Command::from(&*cmd), &full_resp)
+        .map_err(|e| anyhow::anyhow!("Failed to convert response into DPE response. {:?}", e))?;
+    let Response::CertifyKey(resp) = resp else {
+        anyhow::bail!("Unexpected response type for CertifyKey command");
+    };
+    Ok(resp)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CertifyKeyCommandNoRef {
+    P384(CertifyKeyP384Cmd),
+    Mldsa(CertifyKeyMldsa87Cmd),
+}
+
+impl CertifyKeyCommandNoRef {
+    pub fn new(args: CreateCertifyKeyCmdArgs) -> Self {
+        match args.profile {
+            CaliptraDpeProfile::Ecc384 => CertifyKeyCommandNoRef::P384(CertifyKeyP384Cmd {
+                handle: args.handle,
+                label: args.label,
+                flags: args.flags,
+                format: args.format,
+            }),
+            CaliptraDpeProfile::Mldsa87 => CertifyKeyCommandNoRef::Mldsa(CertifyKeyMldsa87Cmd {
+                handle: args.handle,
+                label: args.label,
+                flags: args.flags,
+                format: args.format,
+            }),
+        }
+    }
+}
+
+impl CertifyKeyCommandNoRef {
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            CertifyKeyCommandNoRef::P384(cmd) => cmd.as_bytes(),
+            CertifyKeyCommandNoRef::Mldsa(cmd) => cmd.as_bytes(),
+        }
+    }
+}
+
+impl<'a> From<&'a CertifyKeyCommandNoRef> for Command<'a> {
+    fn from(cmd: &'a CertifyKeyCommandNoRef) -> Command<'a> {
+        match cmd {
+            CertifyKeyCommandNoRef::P384(cmd) => cmd.into(),
+            CertifyKeyCommandNoRef::Mldsa(cmd) => cmd.into(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignCommandNoRef {
+    P384(SignP384Cmd),
+    Mldsa(SignMldsa87Cmd),
+}
+
+impl SignCommandNoRef {
+    pub fn new(args: CreateSignCmdArgs) -> Self {
+        let CreateSignCmdArgs { profile, data, .. } = args;
+        match (profile, data) {
+            (CaliptraDpeProfile::Ecc384, PrecomputedSignData::Digest(Digest::Sha384(digest))) => {
+                Self::P384(SignP384Cmd {
+                    handle: args.handle,
+                    label: args.label,
+                    flags: args.flags,
+                    digest: digest.0,
+                })
+            }
+            (CaliptraDpeProfile::Mldsa87, PrecomputedSignData::Mu(mu)) => {
+                Self::Mldsa(SignMldsa87Cmd {
+                    handle: args.handle,
+                    label: args.label,
+                    flags: args.flags,
+                    digest: mu.0,
+                })
+            }
+            _ => panic!("Invalid combination of profile and precomputed sign data"),
+        }
+    }
+}
+
+impl<'a> From<&'a SignCommandNoRef> for Command<'a> {
+    fn from(cmd: &'a SignCommandNoRef) -> Command<'a> {
+        match cmd {
+            SignCommandNoRef::P384(cmd) => cmd.into(),
+            SignCommandNoRef::Mldsa(cmd) => cmd.into(),
+        }
+    }
+}
+
+pub struct CreateSignCmdArgs {
+    pub profile: CaliptraDpeProfile,
+    pub handle: ContextHandle,
+    pub label: [u8; 48],
+    pub flags: SignFlags,
+    pub data: PrecomputedSignData,
+}
+
+impl Default for CreateSignCmdArgs {
+    fn default() -> Self {
+        Self {
+            profile: CaliptraDpeProfile::Ecc384,
+            handle: ContextHandle::default(),
+            label: TEST_LABEL,
+            flags: SignFlags::empty(),
+            data: PrecomputedSignData::Digest([0u8; 48].into()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CreateCertifyKeyCmdArgs {
+    pub profile: CaliptraDpeProfile,
+    pub handle: ContextHandle,
+    pub label: [u8; 48],
+    pub flags: CertifyKeyFlags,
+    pub format: u32,
+}
+
+impl Default for CreateCertifyKeyCmdArgs {
+    fn default() -> Self {
+        Self {
+            profile: CaliptraDpeProfile::Ecc384,
+            handle: ContextHandle::default(),
+            label: TEST_LABEL,
+            flags: CertifyKeyFlags::empty(),
+            format: CertifyKeyCommand::FORMAT_X509,
+        }
+    }
 }
 
 pub fn assert_error(
@@ -558,4 +900,61 @@ pub fn calculate_cptra_config_init_vals_hash<T: HwModel>(
     hasher.update(manifest.runtime.entry_point.as_bytes());
 
     hasher.finalize().into()
+}
+
+pub fn verify_sign_and_certify_key(
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+    sign_resp: &Response,
+    certify_key_resp: &CertifyKeyResp,
+    data: &[u8],
+) {
+    match (profile, sign_resp, certify_key_resp) {
+        (
+            CaliptraDpeProfile::Ecc384,
+            Response::Sign(SignResp::P384(sign_resp)),
+            CertifyKeyResp::P384(certify_key_resp),
+        ) => {
+            let sig = EcdsaSig::from_private_components(
+                BigNum::from_slice(&sign_resp.sig_r).unwrap(),
+                BigNum::from_slice(&sign_resp.sig_s).unwrap(),
+            )
+            .unwrap();
+
+            let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
+                &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
+            )
+            .unwrap();
+            assert!(sig.verify(data, &ecc_pub_key).unwrap());
+
+            // Verify the certificate
+            let alias_cert_resp = get_rt_alias_ecc384_cert(model);
+            let alias_cert_bytes = alias_cert_resp.data().unwrap();
+            let alias_x509 = X509::from_der(alias_cert_bytes).unwrap();
+            let alias_pubkey = alias_x509.public_key().unwrap();
+
+            let leaf_cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+            let leaf_x509 = X509::from_der(leaf_cert_bytes).unwrap();
+            assert!(leaf_x509.verify(&alias_pubkey).unwrap());
+        }
+        (
+            CaliptraDpeProfile::Mldsa87,
+            Response::Sign(SignResp::MlDsa(_sign_resp)),
+            CertifyKeyResp::Mldsa87(certify_key_resp),
+        ) => {
+            // Skip raw MLDSA signature verification (ml-dsa v0.1.0-rc.0 has upstream compile issues)
+            // Verify the certificate instead
+            let alias_cert_resp = get_rt_alias_mldsa87_cert(model);
+            let alias_cert_bytes = alias_cert_resp.data().unwrap();
+            let alias_x509 = X509::from_der(alias_cert_bytes).unwrap();
+            let alias_pubkey = alias_x509.public_key().unwrap();
+
+            let leaf_cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+            let leaf_x509 = X509::from_der(leaf_cert_bytes).unwrap();
+            assert!(leaf_x509.verify(&alias_pubkey).unwrap());
+        }
+        _ => panic!("Wrong response type!"),
+    }
 }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -5,6 +5,7 @@ mod test_activate_firmware;
 mod test_attested_csr;
 mod test_authorize_and_stash;
 mod test_boot;
+mod test_certify_key_chunks;
 mod test_certify_key_extended;
 mod test_certs;
 mod test_cryptographic_mailbox;

--- a/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
+++ b/runtime/tests/runtime_integration_tests/test_attested_csr/test_rt_alias.rs
@@ -2,33 +2,49 @@
 
 use caliptra_hw_model::DefaultHwModel;
 use dpe::{
-    commands::{CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command},
+    commands::{CertifyKeyCommand, CertifyKeyFlags},
     context::ContextHandle,
-    response::{CertifyKeyResp, Response},
+    response::CertifyKeyResp,
 };
 use openssl::x509::X509;
 
 use super::*;
-use crate::common::{execute_dpe_cmd, run_rt_test, DpeResult, RuntimeTestArgs, TEST_LABEL};
+use crate::common::{
+    certify_key, run_rt_test, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, RuntimeTestArgs,
+    TEST_LABEL,
+};
+use caliptra_runtime::CaliptraDpeProfile;
 
-/// Generate a DPE leaf cert using CertifyKey and return it as X509.
-fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        flags: CertifyKeyFlags::empty(),
-        label: TEST_LABEL,
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+/// Generate an ECC384 DPE leaf cert using CertifyKey and return it as X509.
+fn get_ecc_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile: CaliptraDpeProfile::Ecc384,
+        ..Default::default()
+    });
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
-        .expect("Failed to parse DPE leaf cert")
+        .expect("Failed to parse ECC DPE leaf cert")
+}
+
+/// Generate an MLDSA87 DPE leaf cert using CertifyKey and return it as X509.
+#[allow(dead_code)]
+fn get_mldsa_dpe_leaf_cert(model: &mut DefaultHwModel) -> X509 {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile: CaliptraDpeProfile::Mldsa87,
+        handle: ContextHandle::default(),
+        label: TEST_LABEL,
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+    });
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::Mldsa87(certify_key_resp) = resp else {
+        panic!("Wrong response type!");
+    };
+    X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
+        .expect("Failed to parse MLDSA DPE leaf cert")
 }
 
 #[test]
@@ -48,7 +64,7 @@ fn test_get_attested_rt_alias_ecc_csr() {
     );
 
     // Generate a DPE leaf cert and verify it is signed by the RT Alias key
-    let dpe_leaf_cert = get_dpe_leaf_cert(&mut model);
+    let dpe_leaf_cert = get_ecc_dpe_leaf_cert(&mut model);
     assert!(
         dpe_leaf_cert.verify(&pubkey).unwrap(),
         "DPE leaf cert should be signed by RT Alias ECC key"

--- a/runtime/tests/runtime_integration_tests/test_certify_key_chunks.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_chunks.rs
@@ -1,0 +1,81 @@
+// Licensed under the Apache-2.0 license
+
+use crate::common::{
+    check_dpe_status, execute_dpe_cmd_raw, run_rt_test, verify_sign_and_certify_key,
+    CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, CreateSignCmdArgs, RuntimeTestArgs,
+    SignCommandNoRef, TEST_SD_MU, TEST_SD_SHA384,
+};
+use caliptra_api::SocManager;
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
+use dpe::commands::{CertifyKeyCommand, Command};
+use dpe::response::{DpeErrorCode, Response};
+
+fn test_certify_chunks_helper(profile: CaliptraDpeProfile, max_chunk_size: Option<usize>) {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let data = match profile {
+        CaliptraDpeProfile::Ecc384 => TEST_SD_SHA384,
+        CaliptraDpeProfile::Mldsa87 => TEST_SD_MU,
+    };
+
+    // MLDSA87 Sign is not implemented on caliptra-2.0 (CryptoError::NotImplemented),
+    // so only do sign+verify for ECC384. For MLDSA87, just test certify_key_chunks.
+    let sign_resp = if profile == CaliptraDpeProfile::Ecc384 {
+        let sign_cmd = SignCommandNoRef::new(CreateSignCmdArgs {
+            profile,
+            data: data.clone(),
+            ..Default::default()
+        });
+
+        let mut cmd = Command::from(&sign_cmd);
+        let resp = execute_dpe_cmd_raw(&mut model, profile, &mut cmd).unwrap();
+        let resp_data = resp.data[..resp.data_size as usize].to_vec();
+        check_dpe_status(&resp_data, DpeErrorCode::NoError);
+        Some(Response::try_read_from_bytes(&cmd, &resp_data).unwrap())
+    } else {
+        None
+    };
+
+    let mut certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile,
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+
+    let certify_key_resp =
+        crate::common::certify_key_chunks(&mut model, &mut certify_key_cmd, max_chunk_size)
+            .unwrap();
+
+    if let Some(sign_resp) = &sign_resp {
+        verify_sign_and_certify_key(
+            &mut model,
+            profile,
+            sign_resp,
+            &certify_key_resp,
+            data.as_slice(),
+        );
+    }
+}
+
+#[test]
+fn test_certify_key_chunks_ecdsa_helper_subsystem() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Ecc384, None);
+}
+
+#[test]
+fn test_certify_key_chunks_ecdsa_helper_subsystem_max_chunk_size() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Ecc384, Some(512));
+}
+
+#[test]
+fn test_certify_key_chunks_mldsa_helper_subsystem_max_chunk_size() {
+    test_certify_chunks_helper(CaliptraDpeProfile::Mldsa87, Some(512));
+}

--- a/runtime/tests/runtime_integration_tests/test_certs.rs
+++ b/runtime/tests/runtime_integration_tests/test_certs.rs
@@ -1,10 +1,10 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::PQC_KEY_TYPE;
+use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE};
 use crate::common::{
     execute_dpe_cmd, generate_test_x509_cert, get_ecc_fmc_alias_cert, get_mldsa_fmc_alias_cert,
     get_rt_alias_ecc384_cert, get_rt_alias_mldsa87_cert, run_rt_test, run_rt_test_pqc, DpeResult,
-    RuntimeTestArgs, TEST_LABEL,
+    RuntimeTestArgs,
 };
 use caliptra_api::SocManager;
 use caliptra_builder::firmware::{APP_WITH_UART, APP_WITH_UART_FPGA, FMC_WITH_UART};
@@ -19,10 +19,7 @@ use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, DefaultHwModel, Fuses, HwModel, InitParams};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::{
-    commands::{
-        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command,
-        DeriveContextCmd, DeriveContextFlags,
-    },
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
     response::{CertifyKeyP384Resp, CertifyKeyResp, Response},
     tci::TciMeasurement,
@@ -441,18 +438,9 @@ fn test_dpe_leaf_cert() {
     let rt_resp = get_rt_alias_ecc384_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     let dpe_leaf_cert: X509 =
@@ -540,18 +528,9 @@ fn test_full_cert_chain_mldsa87() {
 }
 
 fn get_dpe_leaf_cert(model: &mut DefaultHwModel) -> CertifyKeyP384Resp {
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
     certify_key_resp
@@ -728,8 +707,8 @@ pub fn test_all_measurement_apis() {
         // Certs should be exactly the same regardless of method
         //
         if hw.subsystem_mode() {
-            // Subsystem will measure & store MCU FW _after_ booting into runtime.
-            // This means the certificate won't match the cert produced with the ROM stashed measurement because the ROM measurement is _before_ the MCU FW measurement.
+            // Subsystem measures and stores MCU FW after booting into runtime.
+            // The ROM-stashed measurement is from before the MCU FW measurement.
             assert_eq!(derive_context_dpe_cert, rt_stash_dpe_cert);
         } else {
             assert_eq!(rom_stash_dpe_cert, rt_stash_dpe_cert);

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -3462,9 +3462,7 @@ fn test_kek_iv_initialized() {
 fn test_gcm_streaming_ghash_tamper_undetected_mailbox() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+    model.step_until_ready_for_runtime();
 
     let key = [0x42u8; 32];
     let cmk = import_key(&mut model, &key, CmKeyUsage::Aes);
@@ -3525,9 +3523,7 @@ fn test_gcm_streaming_ghash_tamper_undetected_mailbox() {
 fn test_aes_gcm_empty_aad_small_chunks() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+    model.step_until_ready_for_runtime();
 
     let key = [0x5au8; 32];
     let cmk = import_key(&mut model, &key, CmKeyUsage::Aes);

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -3455,3 +3455,160 @@ fn test_kek_iv_initialized() {
         "kek_next_iv was not initialized - IV should be random, not zero"
     );
 }
+
+/// Check that GHASH state is preserved when AAD is empty and first
+/// block is 32 bytes long.
+#[test]
+fn test_gcm_streaming_ghash_tamper_undetected_mailbox() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let key = [0x42u8; 32];
+    let cmk = import_key(&mut model, &key, CmKeyUsage::Aes);
+
+    // 48 bytes = 3 AES blocks
+    let plaintext = [0xABu8; 48];
+
+    // Streaming encrypt with empty AAD.
+    // split=32 means: first update gets 32 bytes (aad_len==0 && buffer_len==0),
+    // then final gets the remaining 16 bytes.
+    let (iv, tag, ciphertext) = mailbox_gcm_encrypt(
+        &mut model,
+        &cmk,
+        &[],
+        &plaintext,
+        32,
+        MailboxRespHeader::FIPS_STATUS_APPROVED,
+    );
+
+    assert_eq!(ciphertext.len(), plaintext.len());
+
+    // Compute the correct GCM ciphertext + tag.
+    let (expected_tag, expected_ct) = rustcrypto_gcm_encrypt(&key, &iv, &[], &plaintext);
+    assert_eq!(
+        ciphertext, expected_ct,
+        "Device ciphertext must match a known-good GCM implementation",
+    );
+    assert_eq!(tag, expected_tag);
+
+    // Tamper: flip every bit in the first block of ciphertext
+    let mut tampered_ct = ciphertext.clone();
+    for byte in tampered_ct[..AES_BLOCK_SIZE_BYTES].iter_mut() {
+        *byte ^= 0xFF;
+    }
+    assert_ne!(
+        &tampered_ct[..AES_BLOCK_SIZE_BYTES],
+        &ciphertext[..AES_BLOCK_SIZE_BYTES],
+    );
+
+    // Streaming decrypt the tampered ciphertext with the original tag.
+    let (tag_verified, decrypted) = mailbox_gcm_decrypt(
+        &mut model,
+        &cmk,
+        &iv,
+        &[],
+        &tampered_ct,
+        &tag,
+        32,
+        MailboxRespHeader::FIPS_STATUS_APPROVED,
+    );
+    assert_ne!(plaintext[..48], decrypted[..48]);
+    assert!(!tag_verified);
+}
+
+/// Exercise streaming AES-GCM with **empty AAD** across a sweep of
+/// plaintext sizes and chunk split sizes, including 1-byte-at-a-time.
+#[test]
+fn test_aes_gcm_empty_aad_small_chunks() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let key = [0x5au8; 32];
+    let cmk = import_key(&mut model, &key, CmKeyUsage::Aes);
+
+    // Cover: zero-length, sub-block, exactly one block, one-plus-partial,
+    // multi-block-with-partial, and a mid-sized payload.
+    let plaintext_lens: &[usize] = &[0, 1, 7, 15, 16, 17, 31, 32, 33, 48, 100];
+    // Cover: byte-at-a-time, odd sub-block, block-aligned, block-plus-one,
+    // and a generous split.
+    let splits: &[usize] = &[1, 7, 15, 16, 17, 32];
+
+    for &pt_len in plaintext_lens {
+        // Deterministic but non-trivial plaintext so different lengths
+        // produce different tags.
+        let plaintext: Vec<u8> = (0..pt_len)
+            .map(|i| (i as u8).wrapping_mul(31) ^ 0xA5)
+            .collect();
+
+        for &split in splits {
+            let (iv, tag, ciphertext) = mailbox_gcm_encrypt(
+                &mut model,
+                &cmk,
+                &[],
+                &plaintext,
+                split,
+                MailboxRespHeader::FIPS_STATUS_APPROVED,
+            );
+            let (ref_tag, ref_ct) = rustcrypto_gcm_encrypt(&key, &iv, &[], &plaintext);
+            assert_eq!(
+                ciphertext, ref_ct,
+                "ciphertext mismatch (pt_len={pt_len}, split={split})",
+            );
+            assert_eq!(
+                tag, ref_tag,
+                "tag mismatch (pt_len={pt_len}, split={split}) -- \
+                 likely a GHASH save/restore bug at an update boundary",
+            );
+
+            // Roundtrip: correct ciphertext/tag must verify.
+            let (ok, decrypted) = mailbox_gcm_decrypt(
+                &mut model,
+                &cmk,
+                &iv,
+                &[],
+                &ciphertext,
+                &tag,
+                split,
+                MailboxRespHeader::FIPS_STATUS_APPROVED,
+            );
+            assert!(
+                ok,
+                "tag should verify on roundtrip (pt_len={pt_len}, split={split})",
+            );
+            assert_eq!(
+                decrypted, plaintext,
+                "roundtrip plaintext mismatch (pt_len={pt_len}, split={split})",
+            );
+
+            // Tampering in the first block of ciphertext (or in the only
+            // partial block when pt_len < 16) must be rejected.
+            if pt_len > 0 {
+                let mut tampered = ciphertext.clone();
+                let flip = core::cmp::min(AES_BLOCK_SIZE_BYTES, tampered.len());
+                for b in &mut tampered[..flip] {
+                    *b ^= 0xFF;
+                }
+                let (ok, _) = mailbox_gcm_decrypt(
+                    &mut model,
+                    &cmk,
+                    &iv,
+                    &[],
+                    &tampered,
+                    &tag,
+                    split,
+                    MailboxRespHeader::FIPS_STATUS_APPROVED,
+                );
+                assert!(
+                    !ok,
+                    "tag must reject tampered first block (pt_len={pt_len}, split={split})",
+                );
+            }
+        }
+    }
+}

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -8,10 +8,7 @@ use caliptra_common::mailbox_api::{CommandId, FwInfoResp, MailboxReqHeader, Mail
 use caliptra_hw_model::HwModel;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use dpe::{
-    commands::{
-        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command, SignFlags,
-        SignP384Cmd as SignCmd,
-    },
+    commands::{Command, SignFlags, SignP384Cmd as SignCmd},
     context::ContextHandle,
     response::{CertifyKeyResp, Response, SignResp},
 };
@@ -25,8 +22,8 @@ use openssl::{
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_ecc384_cert, run_rt_test, DpeResult, RuntimeTestArgs,
-    TEST_DIGEST, TEST_LABEL,
+    certify_key, execute_dpe_cmd, get_rt_alias_ecc384_cert, run_rt_test, CertifyKeyCommandNoRef,
+    CreateCertifyKeyCmdArgs, DpeResult, RuntimeTestArgs, TEST_DIGEST, TEST_LABEL,
 };
 
 #[test]
@@ -69,18 +66,9 @@ fn test_disable_attestation_cmd() {
     );
 
     // get pub key
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let CertifyKeyResp::P384(certify_key_resp) = resp else {
         panic!("Wrong response type!");
     };
 
@@ -153,22 +141,9 @@ fn test_attestation_disabled_flag_after_update_reset() {
     let rt_resp = get_rt_alias_ecc384_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
-        panic!("Wrong response type!");
-    };
-    let dpe_leaf_cert: X509 =
-        X509::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize]).unwrap();
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+    let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let dpe_leaf_cert: X509 = X509::from_der(resp.cert().unwrap()).unwrap();
 
     assert!(!dpe_leaf_cert
         .verify(&rt_cert.public_key().unwrap())

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -1,17 +1,18 @@
 // Licensed under the Apache-2.0 license.
 
 use crate::common::{
-    execute_dpe_cmd, get_rt_alias_ecc384_cert, run_rt_test, DpeResult, RuntimeTestArgs,
-    TEST_DIGEST, TEST_LABEL,
+    certify_key, check_dpe_status, execute_dpe_cmd, execute_dpe_cmd_raw, get_rt_alias_ecc384_cert,
+    run_rt_test, verify_sign_and_certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs,
+    CreateSignCmdArgs, DpeResult, RuntimeTestArgs, SignCommandNoRef, TEST_DIGEST, TEST_LABEL,
+    TEST_SD_SHA384,
 };
 use caliptra_api::SocManager;
 use caliptra_common::mailbox_api::{
     CommandId, FwInfoResp, InvokeDpeReq, MailboxReq, MailboxReqHeader,
 };
 use caliptra_drivers::CaliptraError;
-use caliptra_hw_model::{HwModel, SecurityState};
-use caliptra_runtime::RtBootStatus;
-use caliptra_runtime::{DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
+use caliptra_hw_model::{DefaultHwModel, HwModel, SecurityState};
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus, DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
 use cms::{
     cert::x509::der::{Decode, Encode},
     content_info::{CmsVersion, ContentInfo},
@@ -19,21 +20,14 @@ use cms::{
 };
 use dpe::{
     commands::{
-        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd as CertifyKeyCmd, Command,
-        DeriveContextCmd, DeriveContextFlags, GetCertificateChainCmd, GetProfileCmd, InitCtxCmd,
-        RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd as SignCmd,
+        CertifyKeyCommand, Command, DeriveContextCmd, DeriveContextFlags, GetCertificateChainCmd,
+        GetProfileCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd as SignCmd,
     },
     context::ContextHandle,
-    response::{CertifyKeyResp, DpeErrorCode, Response, SignResp},
+    response::{DpeErrorCode, Response, SignResp},
     DpeProfile,
 };
-use openssl::{
-    bn::BigNum,
-    ec::{EcGroup, EcKey},
-    ecdsa::EcdsaSig,
-    nid::Nid,
-    x509::X509,
-};
+use openssl::{ecdsa::EcdsaSig, x509::X509};
 use sha2::{Digest, Sha384};
 use x509_parser::{nom::Parser, prelude::*};
 use zerocopy::{FromBytes, IntoBytes};
@@ -140,53 +134,61 @@ fn test_invoke_dpe_get_certificate_chain_cmd() {
     assert_ne!([0u8; 2048], cert_chain.certificate_chain);
 }
 
+fn sign_and_certify_key_test_helper(model: &mut DefaultHwModel) {
+    // MLDSA87 Sign is not implemented on caliptra-2.0 (CryptoError::NotImplemented),
+    // so only test sign+certify+verify with ECC384.
+    let profile = CaliptraDpeProfile::Ecc384;
+    let data = TEST_SD_SHA384;
+    let sign_cmd = SignCommandNoRef::new(CreateSignCmdArgs {
+        profile,
+        data: data.clone(),
+        ..Default::default()
+    });
+    let mut cmd = Command::from(&sign_cmd);
+    let resp = execute_dpe_cmd_raw(model, profile, &mut cmd).unwrap();
+    let resp_data = resp.data[..resp.data_size as usize].to_vec();
+    check_dpe_status(&resp_data, DpeErrorCode::NoError);
+    let sign_resp = Response::try_read_from_bytes(&cmd, &resp_data).unwrap();
+
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile,
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+
+    let certify_key_resp = certify_key(model, certify_key_cmd).unwrap();
+
+    verify_sign_and_certify_key(
+        model,
+        profile,
+        &sign_resp,
+        &certify_key_resp,
+        data.as_slice(),
+    );
+}
+
 #[test]
 fn test_invoke_dpe_sign_and_certify_key_cmds() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    let sign_cmd = SignCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: SignFlags::empty(),
-        digest: TEST_DIGEST,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&sign_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::Sign(SignResp::P384(sign_resp))) = resp else {
-        panic!("Wrong response type!");
-    };
+    sign_and_certify_key_test_helper(&mut model);
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
-        panic!("Wrong response type!");
-    };
+    // Make sure both profiles can get certificates and CSRs
+    for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
+        let formats = [
+            CertifyKeyCommand::FORMAT_X509,
+            CertifyKeyCommand::FORMAT_CSR,
+        ];
+        for format in formats {
+            let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+                profile,
+                format,
+                ..Default::default()
+            });
 
-    let sig = EcdsaSig::from_private_components(
-        BigNum::from_slice(&sign_resp.sig_r).unwrap(),
-        BigNum::from_slice(&sign_resp.sig_s).unwrap(),
-    )
-    .unwrap();
-
-    let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
-        &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
-        &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
-        &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
-    )
-    .unwrap();
-    assert!(sig.verify(&TEST_DIGEST, &ecc_pub_key).unwrap());
+            let _ = certify_key(&mut model, certify_key_cmd).unwrap();
+        }
+    }
 }
 
 #[test]
@@ -242,28 +244,29 @@ fn test_invoke_dpe_certify_key_csr() {
 
     model.step_until_ready_for_runtime();
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
+    for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+            profile,
+            format: CertifyKeyCommand::FORMAT_CSR,
+            ..Default::default()
+        });
+        let _ = certify_key(&mut model, certify_key_cmd).unwrap();
+    }
+
+    // Detailed CSR parsing for ECC384
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        profile: CaliptraDpeProfile::Ecc384,
         format: CertifyKeyCommand::FORMAT_CSR,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp))) = resp else {
-        panic!("Wrong response type!");
-    };
+        ..Default::default()
+    });
+    let certify_key_resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let cert_bytes = certify_key_resp.cert().unwrap();
 
     let rt_resp = get_rt_alias_ecc384_cert(&mut model);
     let rt_cert: X509 = X509::from_der(&rt_resp.data[..rt_resp.data_size as usize]).unwrap();
 
     // parse CMS ContentInfo
-    let content_info =
-        ContentInfo::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
-            .unwrap();
+    let content_info = ContentInfo::from_der(cert_bytes).unwrap();
     // parse SignedData
     let mut signed_data = SignedData::from_der(&content_info.content.to_der().unwrap()).unwrap();
     assert_eq!(signed_data.version, CmsVersion::V3);
@@ -358,21 +361,16 @@ fn check_dice_extension_criticality(cert: &[u8], expected_criticality: bool) {
 fn test_invoke_dpe_certify_key_with_non_critical_dice_extensions() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
-        format: CertifyKeyCommand::FORMAT_X509,
-    };
-    let resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::CertifyKey(CertifyKeyResp::P384(resp))) = resp else {
-        panic!("Wrong response type!");
-    };
-    check_dice_extension_criticality(&resp.cert[..resp.cert_size as usize], false);
+    for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
+        let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+            profile,
+            format: CertifyKeyCommand::FORMAT_X509,
+            ..Default::default()
+        });
+
+        let resp = certify_key(&mut model, certify_key_cmd).unwrap();
+        check_dice_extension_criticality(resp.cert().unwrap(), false);
+    }
 }
 
 #[test]
@@ -500,25 +498,12 @@ fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    let certify_key_cmd = CertifyKeyCmd {
-        handle: ContextHandle::default(),
-        label: TEST_LABEL,
-        flags: CertifyKeyFlags::empty(),
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
         format: CertifyKeyCommand::FORMAT_X509,
-    };
-
-    let certify_key_resp = execute_dpe_cmd(
-        &mut model,
-        &mut Command::from(&certify_key_cmd),
-        DpeResult::Success,
-    )
-    .unwrap();
-
-    let Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)) = certify_key_resp else {
-        panic!("Wrong response type!");
-    };
-
-    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+        ..Default::default()
+    });
+    let certify_key_resp = certify_key(&mut model, certify_key_cmd).unwrap();
+    let cert_bytes = certify_key_resp.cert().unwrap();
 
     let (_, cert) = X509CertificateParser::new()
         .with_deep_parse_extensions(true)

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -24,7 +24,7 @@ use caliptra_image_elf::ElfExecutable;
 use caliptra_image_gen::{ImageGenerator, ImageGeneratorConfig};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageSignData};
 use caliptra_runtime::{
-    RtBootStatus, PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
+    CaliptraDpeProfile, RtBootStatus, PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
     PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -1,8 +1,11 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::PQC_KEY_TYPE;
+use crate::common::{CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE};
 use caliptra_api::{
-    mailbox::{RevokeExportedCdiHandleReq, SignWithExportedEcdsaReq},
+    mailbox::{
+        CertifyKeyChunksFlags, CertifyKeyChunksReq, RevokeExportedCdiHandleReq,
+        SignWithExportedEcdsaReq,
+    },
     SocManager,
 };
 use caliptra_builder::{
@@ -550,6 +553,66 @@ fn test_certify_key_extended_cannot_be_called_from_pl1() {
             CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
             resp,
         );
+    }
+}
+
+#[test]
+fn test_certify_key_chunks_cannot_be_called_from_pl1() {
+    for pqc_key_type in PQC_KEY_TYPE.iter() {
+        let mut image_opts = ImageOptions {
+            pqc_key_type: *pqc_key_type,
+            ..Default::default()
+        };
+        image_opts.vendor_config.pl0_pauser = None;
+
+        let args = RuntimeTestArgs {
+            test_image_options: Some(image_opts),
+            ..Default::default()
+        };
+
+        let mut model = run_rt_test_pqc(args, *pqc_key_type);
+
+        model.step_until(|m| {
+            m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+        });
+
+        for profile in [CaliptraDpeProfile::Ecc384, CaliptraDpeProfile::Mldsa87] {
+            let flags = match profile {
+                CaliptraDpeProfile::Ecc384 => CertifyKeyChunksFlags(0),
+                CaliptraDpeProfile::Mldsa87 => CertifyKeyChunksFlags::USE_MLDSA,
+            };
+
+            let cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+                profile,
+                flags: CertifyKeyFlags::empty(),
+                format: CertifyKeyCommand::FORMAT_X509,
+                ..Default::default()
+            });
+            let mut certify_key_req = [0u8; CertifyKeyChunksReq::CERTIFY_KEY_REQ_SIZE];
+            certify_key_req[..cmd.as_bytes().len()].copy_from_slice(cmd.as_bytes());
+
+            let mut certify_key_chunks_cmd = MailboxReq::CertifyKeyChunks(CertifyKeyChunksReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                flags,
+                reserved: 0,
+                max_size: 0,
+                offset: 0,
+                certify_key_req,
+            });
+            certify_key_chunks_cmd.populate_chksum().unwrap();
+
+            let resp = model
+                .mailbox_execute(
+                    u32::from(CommandId::CERTIFY_KEY_CHUNKS),
+                    certify_key_chunks_cmd.as_bytes().unwrap(),
+                )
+                .unwrap_err();
+            assert_error(
+                &mut model,
+                CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+                resp,
+            );
+        }
     }
 }
 

--- a/sw-emulator/lib/periph/src/aes.rs
+++ b/sw-emulator/lib/periph/src/aes.rs
@@ -384,6 +384,13 @@ impl Aes {
                 state[4..8].copy_from_slice(&self.data_in[1].to_le_bytes());
                 state[8..12].copy_from_slice(&self.data_in[2].to_le_bytes());
                 state[12..16].copy_from_slice(&self.data_in[3].to_le_bytes());
+                // Model the hardware behaviour where issuing GcmPhase::Restore
+                // with a zero GHASH state (i.e., before any AAD or full text
+                // block has been processed) corrupts subsequent tag
+                // computation. Drivers must avoid Restore in this case.
+                if state == [0u8; AES_256_BLOCK_SIZE] {
+                    state = 0xfeed_face_dead_beef_0bad_c0de_cafe_babe_u128.to_be_bytes();
+                }
                 self.ghash.restore(state);
             }
             GcmCtrl::PHASE::Value::TEXT => {


### PR DESCRIPTION
 ## Summary
 
 Backport SPDM/DPE certificate retrieval and AES-GCM fixes to `caliptra-2.0`.
 
 This includes:
 - Add `CERTIFY_KEY_CHUNKS` for chunked DPE certificate retrieval.
 - Add PL0-only enforcement for X.509 requests through `CERTIFY_KEY_CHUNKS`.
 - Backport AES-GCM/SPDM mailbox cleanup.
 - Fix AES-GCM streaming GHASH save/restore handling.
 