### PR TITLE
CI: re-enable CSR envelope stress test and fix subsystem boot race

### DIFF
--- a/.config/nextest-fpga-slow-tests.toml
+++ b/.config/nextest-fpga-slow-tests.toml
@@ -1,0 +1,21 @@
+# Licensed under the Apache-2.0 license
+#
+# Nextest tool-config layered on top of .config/nextest.toml ONLY for nightly
+# FPGA runs that are built with the `slow_tests` feature (see the FPGA workflows).
+#
+# With `slow_tests`, test_generate_csr_envelop_stress runs many iterations and
+# legitimately needs a long timeout. PR/merge_group runs do NOT pass this file,
+# so they fall through to the short profile default in .config/nextest.toml and a
+# hang fails fast instead of stalling the pipeline for ~90 minutes. See TODO(#2369).
+#
+# Tool-config overrides take precedence over the profile default but sit below
+# .config/nextest.toml, so this file must remain the only place that sets a
+# slow-timeout for this test.
+
+[[profile.fpga-subsystem.overrides]]
+filter = 'test(test_generate_csr_envelop_stress)'
+slow-timeout = { period = "30s", terminate-after = 180 }
+
+[[profile.fpga-core.overrides]]
+filter = 'test(test_generate_csr_envelop_stress)'
+slow-timeout = { period = "30s", terminate-after = 180 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,6 @@ default-filter = """
 (package(caliptra-rom)
     - test(test_debug_unlock::)
     - test(test_fmcalias_derivation::test_zero_firmware_size)
-    - test(test_generate_csr_envelop_stress)
     - test(test_uds_fe)
     - test(test_wdt_activation_and_stoppage::)
     - test(test_warm_reset::test_warm_reset_during_update_reset)
@@ -53,10 +52,6 @@ failure-output = "immediate-final"
 fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 6 }
 retries = 3 # the fpga subsystem is a bit flaky with typically 1 test randomly failing out of 100-200
-
-[[profile.fpga-subsystem.overrides]]
-filter = 'test(test_generate_csr_envelop_stress)'
-slow-timeout = { period = "30s", terminate-after = 180 }
 
 [[profile.fpga-subsystem.overrides]]
 filter = 'test(test_binaries_are_identical)'
@@ -100,7 +95,6 @@ not (package(/caliptra-emu-.*/) |
        package(compliance-test) |
        test(test_csrng_runtime_health_failure) |
        test(test_doe_when_debug_not_locked) |
-       test(test_generate_csr_envelop_stress) |
        test(test_sign_validation_failure) |
        test(test_activate_firmware::test_activate_fw_id_not_in_manifest) |
        test(test_activate_firmware::test_activate_invalid_fw_id) |
@@ -134,10 +128,6 @@ fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 6 }
 
 [[profile.fpga-core.overrides]]
-filter = 'test(test_generate_csr_envelop_stress)'
-slow-timeout = { period = "30s", terminate-after = 180 }
-
-[[profile.fpga-core.overrides]]
 filter = 'test(test_binaries_are_identical)'
 slow-timeout = { period = "30s", terminate-after = 30 }
 
@@ -155,7 +145,6 @@ store-success-output = true
 store-failure-output = true
 
 [profile.nightly]
-default-filter = 'not test(test_generate_csr_envelop_stress)'
 failure-output = "immediate-final"
 fail-fast = false
 slow-timeout = { period = "30s", terminate-after = 6 }

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Run tests
         run: |
-          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked -- --skip test_generate_csr_envelop_stress
+          CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test --locked
           CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" run --manifest-path ./coverage/Cargo.toml
           CPTRA_COVERAGE_PATH=/tmp cargo --config "$EXTRA_CARGO_CONFIG" test -p caliptra-runtime --features ocp-lock test_ocp_lock --locked
 

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -378,6 +378,15 @@ jobs:
               --profile=fpga-subsystem
           )
 
+          # Nightly runs build with `slow_tests`, which makes
+          # test_generate_csr_envelop_stress run many iterations and legitimately
+          # take a long time. Layer in the extended timeout only for those runs;
+          # PR/merge_group runs use the short profile default so a hang fails fast
+          # instead of stalling the pipeline. See .config/nextest-fpga-slow-tests.toml
+          if [[ "${{ inputs.extra-features }}" == *slow_tests* ]]; then
+              COMMON_ARGS+=(--tool-config-file "caliptra:$(pwd)/.config/nextest-fpga-slow-tests.toml")
+          fi
+
 
           cargo-nextest --version
           cargo-nextest nextest list \

--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -309,6 +309,15 @@ jobs:
               --workspace-remap=.
               --profile=fpga-core
           )
+
+          # Nightly runs build with `slow_tests`, which makes
+          # test_generate_csr_envelop_stress run many iterations and legitimately
+          # take a long time. Layer in the extended timeout only for those runs;
+          # PR/merge_group runs use the short profile default so a hang fails fast
+          # instead of stalling the pipeline. See .config/nextest-fpga-slow-tests.toml
+          if [[ "${{ inputs.extra-features }}" == *slow_tests* ]]; then
+              COMMON_ARGS+=(--tool-config-file "caliptra:$(pwd)/.config/nextest-fpga-slow-tests.toml")
+          fi
           cargo-nextest --version
           cargo-nextest nextest list \
               "${COMMON_ARGS[@]}" \

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-63d6a331dfaac3788c7baf0aa6ceeb6a75e60038c6bf531d525795b23078ec5101f24b04acaa925048fe18e2e5dcdc39  caliptra-rom-no-log.bin
-c8e1fb6f3cc3a8a82b4f0cf2bb32d23e0f2d9ccc001cd99aac71c7cb8d4fe5266c05509141d1cc9b4a4a45cfb79c7b8c  caliptra-rom-with-log.bin
+4d6576d5103672eaa965cf95e91278c144135db895871a865c4d9b5874ea960f94c51eccb4c25f4d71d3c32199ea4a05  caliptra-rom-no-log.bin
+cb9cb86900a9ee42663c6a5954d4039c0353eb7e9c59cb28cb0f234afba2d020bbb710961f67277048dd269992899f0f  caliptra-rom-with-log.bin

--- a/ci.sh
+++ b/ci.sh
@@ -111,9 +111,9 @@ fi
 if task_enabled "test"; then
   echo Run tests
   if cargo nextest help > /dev/null 2>/dev/null; then
-    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked -E 'not test(test_generate_csr_envelop_stress)'
+    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked
   else
-    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked -- --skip test_generate_csr_envelop_stress
+    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked
   fi
   CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" CPTRA_COVERAGE_PATH="${cov_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" run --manifest-path ./coverage/Cargo.toml
 fi

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -12,7 +12,7 @@ use caliptra_common::{
     memory_layout::{ROM_ORG, ROM_SIZE, ROM_STACK_ORG, ROM_STACK_SIZE, STACK_ORG, STACK_SIZE},
     FMC_ORG, FMC_SIZE, RUNTIME_ORG, RUNTIME_SIZE,
 };
-use caliptra_drivers::InitDevIdCsrEnvelope;
+use caliptra_drivers::{InitDevIdCsrEnvelope, MfgFlags};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
     BootParams, CodeRange, Fuses, HwModel, ImageInfo, InitParams, SecurityState, StackInfo,
@@ -78,11 +78,30 @@ pub fn build_hw_model_and_image_bundle(
     fuses: Fuses,
     image_options: ImageOptions,
 ) -> (DefaultHwModel, ImageBundle) {
+    build_hw_model_and_image_bundle_with_mfg_flags(fuses, image_options, MfgFlags::empty())
+}
+
+/// Same as [`build_hw_model_and_image_bundle`], but latches `mfg_flags` into
+/// `cptra_dbg_manuf_service_reg` via `BootParams` before Caliptra ROM runs.
+///
+/// Flags that ROM samples during the cold-reset flow (e.g.
+/// `GENERATE_IDEVID_CSR`) must be set this way: on the FPGA subsystem `boot()`
+/// runs ROM far enough that setting the register on the built model can race
+/// ROM and be latched too late.
+pub fn build_hw_model_and_image_bundle_with_mfg_flags(
+    fuses: Fuses,
+    image_options: ImageOptions,
+    mfg_flags: MfgFlags,
+) -> (DefaultHwModel, ImageBundle) {
     let image = build_image_bundle(image_options);
-    (build_hw_model(fuses), image)
+    (build_hw_model_with_mfg_flags(fuses, mfg_flags), image)
 }
 
 pub fn build_hw_model(fuses: Fuses) -> DefaultHwModel {
+    build_hw_model_with_mfg_flags(fuses, MfgFlags::empty())
+}
+
+pub fn build_hw_model_with_mfg_flags(fuses: Fuses, mfg_flags: MfgFlags) -> DefaultHwModel {
     let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env_fpga(cfg!(
         feature = "fpga_subsystem"
     )))
@@ -116,6 +135,7 @@ pub fn build_hw_model(fuses: Fuses) -> DefaultHwModel {
             ..Default::default()
         },
         BootParams {
+            initial_dbg_manuf_service_reg: mfg_flags.bits(),
             ..Default::default()
         },
     )

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -20,11 +20,8 @@ fn generate_csr_envelop(
     image_bundle: &ImageBundle,
     pqc_key_type: FwVerificationPqcKeyType,
 ) -> InitDevIdCsrEnvelope {
-    // Set gen_idev_id_csr to generate CSR.
-    let flags = MfgFlags::GENERATE_IDEVID_CSR;
-    hw.soc_ifc()
-        .cptra_dbg_manuf_service_reg()
-        .write(|_| flags.bits());
+    // GENERATE_IDEVID_CSR is latched via BootParams when the model is built, so
+    // ROM sees it before sampling it during cold reset.
 
     // Download the CSR Envelope from the mailbox.
     let csr_envelop = helpers::get_csr_envelop(hw).unwrap();
@@ -63,7 +60,11 @@ fn test_generate_csr_envelop() {
             fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
-        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
+        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle_with_mfg_flags(
+            fuses,
+            image_options,
+            MfgFlags::GENERATE_IDEVID_CSR,
+        );
         generate_csr_envelop(&mut hw, &image_bundle, *pqc_key_type);
     }
 }
@@ -117,8 +118,11 @@ fn test_generate_csr_envelop_stress() {
         for _ in 0..num_tests {
             let mut fuses = fuses_with_random_uds();
             fuses.fuse_pqc_key_type = *pqc_key_type as u32;
-            let (mut hw, image_bundle) =
-                helpers::build_hw_model_and_image_bundle(fuses.clone(), image_options.clone());
+            let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle_with_mfg_flags(
+                fuses.clone(),
+                image_options.clone(),
+                MfgFlags::GENERATE_IDEVID_CSR,
+            );
 
             let csr_envelop = generate_csr_envelop(&mut hw, &image_bundle, *pqc_key_type);
 


### PR DESCRIPTION
Re-enable test_generate_csr_envelop_stress in PR/merge_group test runs (reverting the CSR-stress parts of #3829) ahead of the upcoming release.

The CSR tests wrote cptra_dbg_manuf_service_reg after building the model, but ROM samples GENERATE_IDEVID_CSR once during cold reset; on the FPGA subsystem boot() runs ROM far enough that random CFI delays could pass that point before the write landed, so idevid_csr_ready never asserted and the test hung. Set the flag via BootParams so it is latched before ROM samples it.

Also drop the long per-test FPGA timeout from the main nextest profile so PR runs fail fast, and reapply it for nightly slow_tests runs via a tool-config file.

Fixes #3853 