### PR TITLE
runtime: support writing response to mailbox SRAM

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -142,7 +142,7 @@ impl<T: ResponseVarSize> Response for T {
     const MIN_SIZE: usize = size_of::<MailboxRespHeaderVarSize>();
 }
 
-fn populate_checksum(msg: &mut [u8]) {
+pub fn populate_checksum(msg: &mut [u8]) {
     let (checksum_bytes, payload_bytes) = msg.split_at_mut(size_of::<u32>());
     let checksum = crate::checksum::calc_checksum(0, payload_bytes);
     checksum_bytes.copy_from_slice(&checksum.to_le_bytes());
@@ -173,6 +173,7 @@ pub enum MailboxResp {
     RevokeExportedCdiHandle(RevokeExportedCdiHandleResp),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsResp),
     GetPcrLog(GetPcrLogResp),
+    InPlace(usize),
 }
 
 impl MailboxResp {
@@ -199,6 +200,9 @@ impl MailboxResp {
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
+            MailboxResp::InPlace(_) => {
+                Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_ALREADY_INPLACE)
+            }
         }
     }
 
@@ -225,6 +229,9 @@ impl MailboxResp {
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::InPlace(_) => {
+                Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_ALREADY_INPLACE)
+            }
         }
     }
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1258,6 +1258,16 @@ impl CaliptraError {
             0x000E0061,
             "Runtime Error: Multiple CCIV contexts found"
         ),
+        (
+            RUNTIME_MAILBOX_API_RESPONSE_ALREADY_INPLACE,
+            0x000E0062,
+            "Runtime Error: Mailbox API response is already written in-place"
+        ),
+        (
+            RUNTIME_MAILBOX_API_RESPONSE_INVALID_SIZE,
+            0x000E0063,
+            "Runtime Error: Mailbox API response has invalid size"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -14,13 +14,13 @@ Abstract:
 
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{
-    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxResp,
+    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, InvokeDpeResp, MailboxResp, MailboxRespHeader,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::commands::{CertifyKeyP384Cmd, Command};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, TryFromBytes};
 
-use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, PauserPrivileges};
+use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, EcDpeView, PauserPrivileges};
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
@@ -50,25 +50,57 @@ impl CertifyKeyExtendedCmd {
         let certify_key_cmd = CertifyKeyP384Cmd::ref_from_bytes(&cmd.certify_key_req[..])
             .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let command = Command::from(certify_key_cmd);
-        let mut certify_key_extended_resp = CertifyKeyExtendedResp::default();
+
+        let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+        let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+        let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+        let locality = drivers.mbox.user();
+        let ec_dpe_view = EcDpeView {
+            sha384: &mut drivers.sha384,
+            trng: &mut drivers.trng,
+            ecc384: &mut drivers.ecc384,
+            hmac384: &mut drivers.hmac384,
+            key_vault: &mut drivers.key_vault,
+            cert_chain: &drivers.cert_chain,
+            persistent_data: drivers.persistent_data.get_mut(),
+        };
+        let (_, resp_buf) = drivers
+            .mbox
+            .raw_mailbox_contents_mut()?
+            .split_at_mut(core::mem::offset_of!(InvokeDpeResp, data));
         let result = invoke_dpe_cmd(
-            drivers,
             &command,
+            ec_dpe_view,
+            hashed_rt_pub_key,
+            key_id_rt_cdi,
+            key_id_rt_priv_key,
             dmtf_device_info,
             None,
-            None,
-            &mut certify_key_extended_resp.certify_key_resp,
+            locality,
+            resp_buf,
         );
+        let (dpe_resp, _) =
+            InvokeDpeResp::try_mut_from_prefix(drivers.mbox.raw_mailbox_contents_mut()?)
+                .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
-        let resp_size = result.map_err(|e| {
-            // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-            if let Some(ext_err) = e.get_error_detail() {
-                drivers.soc_ifc.set_fw_extended_error(ext_err);
-            }
-            CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
-        })?;
-        certify_key_extended_resp.size = resp_size as u32;
+        dpe_resp.hdr = MailboxRespHeader::default();
 
-        Ok(MailboxResp::CertifyKeyExtended(certify_key_extended_resp))
+        result
+            .inspect(|data_size| {
+                dpe_resp.data_size = *data_size as u32;
+            })
+            .map_err(|e| {
+                // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+                if let Some(ext_err) = e.get_error_detail() {
+                    drivers.soc_ifc.set_fw_extended_error(ext_err);
+                }
+                CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
+            })?;
+
+        let total_size = core::mem::size_of::<InvokeDpeResp>()
+            - core::mem::size_of_val(&dpe_resp.data)
+            + dpe_resp.data_size as usize;
+
+        Ok(MailboxResp::InPlace(total_size))
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -34,7 +34,7 @@ use caliptra_drivers::KeyId;
 use caliptra_drivers::{
     cprintln,
     pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
-    Array4x12, CaliptraError, CaliptraResult, DataVault, Ecc384, KeyVault, Lms,
+    Array4x12, CaliptraError, CaliptraResult, DataVault, Ecc384, KeyVault, Lms, PersistentData,
     PersistentDataAccessor, Pic, ResetReason, Sha1, SocIfc,
 };
 use caliptra_drivers::{
@@ -71,6 +71,16 @@ use zerocopy::IntoBytes;
 pub enum PauserPrivileges {
     PL0,
     PL1,
+}
+
+pub struct EcDpeView<'a> {
+    pub sha384: &'a mut Sha384,
+    pub trng: &'a mut Trng,
+    pub ecc384: &'a mut Ecc384,
+    pub hmac384: &'a mut Hmac384,
+    pub key_vault: &'a mut KeyVault,
+    pub cert_chain: &'a [u8],
+    pub persistent_data: &'a mut PersistentData,
 }
 
 pub struct Drivers {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,11 +12,12 @@ Abstract:
 
 --*/
 
-use crate::{ec_dpe_env, Drivers, PauserPrivileges};
+use crate::{ec_dpe_env, Drivers, EcDpeView, PauserPrivileges};
 use arrayvec::ArrayVec;
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxResp};
-use caliptra_drivers::{CaliptraError, CaliptraResult};
+use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxResp, MailboxRespHeader};
+use caliptra_drivers::{CaliptraError, CaliptraResult, KeyId};
+use crypto::Digest;
 use dpe::{
     commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
     context::ContextState,
@@ -25,7 +26,7 @@ use dpe::{
 };
 use platform::MAX_OTHER_NAME_SIZE;
 use ufmt::derive::uDebug;
-use zerocopy::IntoBytes;
+use zerocopy::{IntoBytes, TryFromBytes};
 
 #[derive(uDebug, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CaliptraDpeProfile {
@@ -107,8 +108,34 @@ impl InvokeDpeCmd {
             }
 
             let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
-            let mut invoke_resp = InvokeDpeResp::default();
-            let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut invoke_resp.data);
+            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+            let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+            let locality = drivers.mbox.user();
+            let (_, resp_buf) = drivers
+                .mbox
+                .raw_mailbox_contents_mut()?
+                .split_at_mut(core::mem::offset_of!(InvokeDpeResp, data));
+            let ec_dpe_view = EcDpeView {
+                sha384: &mut drivers.sha384,
+                trng: &mut drivers.trng,
+                ecc384: &mut drivers.ecc384,
+                hmac384: &mut drivers.hmac384,
+                key_vault: &mut drivers.key_vault,
+                cert_chain: &drivers.cert_chain,
+                persistent_data: drivers.persistent_data.get_mut(),
+            };
+            let result = invoke_dpe_cmd(
+                &command,
+                ec_dpe_view,
+                hashed_rt_pub_key,
+                key_id_rt_cdi,
+                key_id_rt_priv_key,
+                None,
+                ueid,
+                locality,
+                resp_buf,
+            );
 
             if let Command::DestroyCtx(_) = command {
                 // clear tags for destroyed contexts
@@ -122,6 +149,12 @@ impl InvokeDpeCmd {
                     context_tags,
                 );
             }
+
+            let (invoke_resp, _) =
+                InvokeDpeResp::try_mut_from_prefix(drivers.mbox.raw_mailbox_contents_mut()?)
+                    .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+
+            invoke_resp.hdr = MailboxRespHeader::default();
 
             // If DPE command failed, populate header with error code, but
             // don't fail the mailbox command.
@@ -141,7 +174,11 @@ impl InvokeDpeCmd {
                 }
             };
 
-            Ok(MailboxResp::InvokeDpeCommand(invoke_resp))
+            let total_size = core::mem::size_of::<InvokeDpeResp>()
+                - core::mem::size_of_val(&invoke_resp.data)
+                + invoke_resp.data_size as usize;
+
+            Ok(MailboxResp::InPlace(total_size))
         } else {
             Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
@@ -173,20 +210,30 @@ impl InvokeDpeCmd {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn invoke_dpe_cmd(
-    drivers: &mut Drivers,
     command: &Command<'_>,
+    ec_dpe_view: EcDpeView,
+    hashed_rt_pub_key: Digest,
+    key_id_rt_cdi: KeyId,
+    key_id_rt_priv_key: KeyId,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
-    locality: Option<u32>,
-    out: &mut [u8],
+    locality: u32,
+    resp_buf: &mut [u8],
 ) -> Result<usize, DpeErrorCode> {
-    let locality = locality.unwrap_or(drivers.mbox.user());
-    let mut env = ec_dpe_env(drivers, dmtf_device_info, ueid);
+    let mut env = ec_dpe_env(
+        ec_dpe_view,
+        hashed_rt_pub_key,
+        key_id_rt_cdi,
+        key_id_rt_priv_key,
+        dmtf_device_info,
+        ueid,
+    );
     let env = match env.as_mut() {
         Ok(r) => r,
         Err(_) => Err(DpeErrorCode::InternalError)?,
     };
     let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
-    command.execute_serialized(dpe, env, locality, out)
+    command.execute_serialized(dpe, env, locality, resp_buf)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -46,7 +46,7 @@ use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter,
 };
-pub use drivers::{Drivers, PauserPrivileges};
+pub use drivers::{Drivers, EcDpeView, PauserPrivileges};
 use mailbox::Mailbox;
 
 use crate::capabilities::CapabilitiesCmd;
@@ -60,7 +60,7 @@ pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_A
 pub use caliptra_common::fips::FipsVersionCmd;
 use crypto::{
     ecdsa::{curve_384::EcdsaPub384, EcdsaPubKey},
-    CryptoSuite, PubKey,
+    CryptoSuite, Digest, PubKey,
 };
 pub use dice::{GetFmcAliasCertCmd, GetLdevCertCmd, IDevIdCertCmd};
 pub use disable::DisableAttestationCmd;
@@ -83,14 +83,14 @@ pub use set_auth_manifest::SetAuthManifestCmd;
 pub use stash_measurement::StashMeasurementCmd;
 pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd};
 pub mod packet;
-use caliptra_common::mailbox_api::{CommandId, MailboxResp};
+use caliptra_common::mailbox_api::{populate_checksum, CommandId, MailboxResp};
 use packet::Packet;
 pub mod tagging;
 use tagging::{GetTaggedTciCmd, TagTciCmd};
 
 use caliptra_common::cprintln;
 
-use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult, ResetReason};
+use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult, KeyId, ResetReason};
 use caliptra_registers::mbox::enums::MboxStatusE;
 pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 use dpe::{dpe_instance::DpeEnv, support::Support};
@@ -251,10 +251,26 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         }
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     };
-    let resp = okmutref(&mut resp)?;
 
-    // Send the response
-    Packet::copy_to_mbox(drivers, resp)?;
+    if let Ok(MailboxResp::InPlace(size)) = resp {
+        if size < core::mem::size_of::<u32>() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_INVALID_SIZE);
+        }
+        // The response is already written to the mailbox SRAM. We only have to finalize the
+        // transaction by populating the checksum and updating DLEN.
+        let data = drivers
+            .mbox
+            .raw_mailbox_contents_mut()?
+            .get_mut(..size)
+            .ok_or(CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+        populate_checksum(data);
+        drivers.mbox.set_dlen(size as u32)?;
+    } else {
+        let resp = okmutref(&mut resp)?;
+
+        // Send the response
+        Packet::copy_to_mbox(drivers, resp)?;
+    }
 
     Ok(MboxStatusE::DataReady)
 }
@@ -397,44 +413,43 @@ impl DpeEnv for CaliptraDpeEnv<'_> {
 }
 
 fn ec_dpe_env(
-    drivers: &mut Drivers,
+    ec_dpe_view: EcDpeView,
+    hashed_rt_pub_key: Digest,
+    key_id_rt_cdi: KeyId,
+    key_id_rt_priv_key: KeyId,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
-) -> CaliptraResult<CaliptraDpeEnv<'_>> {
-    let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
-    let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-    let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
-    let pdata = drivers.persistent_data.get_mut();
-    let rt_pub_key = pdata.fht.rt_dice_pub_key;
+) -> CaliptraResult<CaliptraDpeEnv> {
+    let rt_pub_key = ec_dpe_view.persistent_data.fht.rt_dice_pub_key;
     let rt_pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
         &rt_pub_key.x.into(),
         &rt_pub_key.y.into(),
     )));
     let crypto = DpeCrypto::new(
-        &mut drivers.sha384,
-        &mut drivers.trng,
-        &mut drivers.ecc384,
-        &mut drivers.hmac384,
-        &mut drivers.key_vault,
+        ec_dpe_view.sha384,
+        ec_dpe_view.trng,
+        ec_dpe_view.ecc384,
+        ec_dpe_view.hmac384,
+        ec_dpe_view.key_vault,
         rt_pub_key,
         key_id_rt_cdi,
         key_id_rt_priv_key,
-        &mut pdata.exported_cdi_slots,
+        &mut ec_dpe_view.persistent_data.exported_cdi_slots,
     )?;
-    let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-    let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);
+    let pl0_pauser = ec_dpe_view.persistent_data.manifest1.header.pl0_pauser;
+    let (nb, nf) = Drivers::get_cert_validity_info(&ec_dpe_view.persistent_data.manifest1);
     Ok(CaliptraDpeEnv {
         crypto,
         platform: DpePlatform::new(
             CaliptraDpeProfile::Ecc384,
             pl0_pauser,
             hashed_rt_pub_key,
-            &drivers.cert_chain,
+            ec_dpe_view.cert_chain,
             nb,
             nf,
             dmtf_device_info,
             ueid,
         ),
-        state: &mut pdata.dpe,
+        state: &mut ec_dpe_view.persistent_data.dpe,
     })
 }

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -173,4 +173,17 @@ impl Mailbox {
             )
         }
     }
+
+    /// Retrieve a mutable slice with the contents of the mailbox
+    pub fn raw_mailbox_contents_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if !self.cmd_busy() {
+            return Err(CaliptraError::DRIVER_MAILBOX_INVALID_STATE);
+        }
+        unsafe {
+            Ok(slice::from_raw_parts_mut(
+                memory_layout::MBOX_ORG as *mut u8,
+                memory_layout::MBOX_SIZE as usize,
+            ))
+        }
+    }
 }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -12,19 +12,19 @@ Abstract:
 
 --*/
 
-use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, PauserPrivileges};
+use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, EcDpeView, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
+    InvokeDpeResp, MailboxResp, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    response::{DeriveContextExportedCdiResp, DpeErrorCode},
+    response::DpeErrorCode,
     tci::TciMeasurement,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, IntoBytes, TryFromBytes};
 
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
@@ -65,12 +65,44 @@ impl StashMeasurementCmd {
             };
             let command = Command::from(&cmd);
             let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
-            let mut buf = [0u8; size_of::<DeriveContextExportedCdiResp>()];
-            let derive_context_resp =
-                invoke_dpe_cmd(drivers, &command, None, ueid, Some(locality), &mut buf);
+            let hashed_rt_pub_key = drivers.compute_rt_alias_sn()?;
+            let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
+            let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
+            let ec_dpe_view = EcDpeView {
+                sha384: &mut drivers.sha384,
+                trng: &mut drivers.trng,
+                ecc384: &mut drivers.ecc384,
+                hmac384: &mut drivers.hmac384,
+                key_vault: &mut drivers.key_vault,
+                cert_chain: &drivers.cert_chain,
+                persistent_data: drivers.persistent_data.get_mut(),
+            };
+            let (_, resp_buf) = drivers
+                .mbox
+                .raw_mailbox_contents_mut()?
+                .split_at_mut(core::mem::offset_of!(InvokeDpeResp, data));
+            let result = invoke_dpe_cmd(
+                &command,
+                ec_dpe_view,
+                hashed_rt_pub_key,
+                key_id_rt_cdi,
+                key_id_rt_priv_key,
+                None,
+                ueid,
+                locality,
+                resp_buf,
+            );
+            let (dpe_resp, _) =
+                InvokeDpeResp::try_mut_from_prefix(drivers.mbox.raw_mailbox_contents_mut()?)
+                    .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
-            match derive_context_resp {
-                Ok(_) => DpeErrorCode::NoError,
+            dpe_resp.hdr = MailboxRespHeader::default();
+
+            match result {
+                Ok(data_size) => {
+                    dpe_resp.data_size = data_size as u32;
+                    DpeErrorCode::NoError
+                }
                 Err(e) => {
                     // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
                     if let Some(ext_err) = e.get_error_detail() {


### PR DESCRIPTION
This change introduces support for writing mailbox responses directly to the SRAM without stashing them on the stack. This pattern is then applied to commands that involve big buffers in the their responses, namely,

- `INVOKE_DPE`
- `CERTIFY_KEY`
- `DERIVE_CONTEXT`

Related to #3822 