### PR TITLE
dpe: Update dpe with size optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=a174f337998359080d5396fc84a5ee2ada4ae83a#a174f337998359080d5396fc84a5ee2ada4ae83a"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
 dependencies = [
  "bitflags 2.4.0",
  "caliptra-cfi-derive",
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=a174f337998359080d5396fc84a5ee2ada4ae83a#a174f337998359080d5396fc84a5ee2ada4ae83a"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=a174f337998359080d5396fc84a5ee2ada4ae83a#a174f337998359080d5396fc84a5ee2ada4ae83a"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
 dependencies = [
  "arrayvec",
  "caliptra-dpe-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,9 +143,9 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "a174f337998359080d5396fc84a5ee2ada4ae83a", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "a174f337998359080d5396fc84a5ee2ada4ae83a", package = "caliptra-dpe-crypto", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "a174f337998359080d5396fc84a5ee2ada4ae83a", package = "caliptra-dpe-platform", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe-crypto", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe-platform", default-features = false }
 elf = "0.7.2"
 fips204 = "0.2.1"
 gdbstub = "0.6.3"


### PR DESCRIPTION
Integrate the DPE updates in the following PRs:
https://github.com/chipsalliance/caliptra-dpe/pull/588 https://github.com/chipsalliance/caliptra-dpe/pull/586 https://github.com/chipsalliance/caliptra-dpe/pull/585

These significantly reduce (~4-5Kb) the size of the DPE library code instantiated in caliptra core fmc and runtime software.