### PR TITLE
mldsa: Make indexing no-panic by construction

### DIFF
--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -87,6 +87,12 @@ pub const APP_WITH_UART_HW_1_0: FwId = FwId {
     features: &["emu", "fips_self_test", "hw-1.0", "cfi"],
 };
 
+pub const APP_MLDSA_ATTESTATION: FwId = FwId {
+    crate_name: "caliptra-runtime",
+    bin_name: "caliptra-runtime",
+    features: &["fips_self_test", "cfi", "mldsa_attestation"],
+};
+
 pub const APP_ZEROS: FwId = FwId {
     crate_name: "caliptra-zeros",
     bin_name: "caliptra-zeros",
@@ -428,6 +434,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &APP_WITH_UART_FIPS_TEST_HOOKS,
     &APP_WITH_UART_FPGA,
     &APP_WITH_UART_HW_1_0,
+    &APP_MLDSA_ATTESTATION,
     &APP_ZEROS,
     &FMC_ZEROS,
     &caliptra_builder_tests::FWID,

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -193,10 +193,10 @@ fn scalar_ntt(s: &mut Scalar) {
         offset >>= 1;
         for (step_root, chunk) in NTT_ROOTS_MONTGOMERY[step..]
             .iter()
-            .zip(s.c.chunks_exact_mut(2 * offset))
+            .zip(s.c.chunks_exact_mut((2 * offset).min(K_DEGREE)))
         {
-            let (evens, odds) = chunk.split_at_mut(offset);
-            for j in 0..offset {
+            let (evens, odds) = chunk.split_at_mut(chunk.len() / 2);
+            for j in 0..evens.len() {
                 let even = evens[j];
                 let odd = reduce_montgomery((*step_root as u64).wrapping_mul(odds[j] as u64));
                 evens[j] = reduce_once(odd.wrapping_add(even));
@@ -212,14 +212,18 @@ fn scalar_inverse_ntt(s: &mut Scalar) {
     let mut offset = 1;
     while offset < K_DEGREE {
         step >>= 1;
-        for (step_root, chunk) in NTT_ROOTS_MONTGOMERY[step..step * 2.min(K_DEGREE)]
+        // The step is always trivially less than or equal to k_degree divided by 2, since it starts
+        // at that value, and offset ends the loop prior to it underflowing.  Add a `min` check to
+        // make it explicit for the compiler so panic checking in the indexes is elided.
+        let safe_step = step.min(K_DEGREE / 2);
+        for (step_root, chunk) in NTT_ROOTS_MONTGOMERY[safe_step..safe_step * 2]
             .iter()
             .rev()
             .zip(s.c.chunks_exact_mut(2 * offset))
         {
             let step_root = K_PRIME.wrapping_sub(*step_root);
-            let (evens, odds) = chunk.split_at_mut(offset);
-            for j in 0..offset {
+            let (evens, odds) = chunk.split_at_mut(chunk.len() / 2);
+            for j in 0..evens.len() {
                 let even = evens[j];
                 let odd = odds[j];
                 evens[j] = reduce_once(odd.wrapping_add(even));
@@ -498,14 +502,17 @@ fn scalar_decode_signed_20_19(out: &mut Scalar, in_val: &[u8]) {
     let k20_bits = (1u32 << 20) - 1;
 
     for (in_chunk, out_chunk) in in_val.chunks_exact(10).zip(out.c.chunks_exact_mut(4)) {
-        let a = u32::from_le_bytes([in_chunk[0], in_chunk[1], in_chunk[2], in_chunk[3]]);
-        let b = u32::from_le_bytes([in_chunk[4], in_chunk[5], in_chunk[6], in_chunk[7]]);
-        let c = u16::from_le_bytes([in_chunk[8], in_chunk[9]]);
+        if let ([b0, b1, b2, b3, b4, b5, b6, b7, b8, b9], [o0, o1, o2, o3]) = (in_chunk, out_chunk)
+        {
+            let a = u32::from_le_bytes([*b0, *b1, *b2, *b3]);
+            let b = u32::from_le_bytes([*b4, *b5, *b6, *b7]);
+            let c = u16::from_le_bytes([*b8, *b9]);
 
-        out_chunk[0] = mod_sub(k_max, a & k20_bits);
-        out_chunk[1] = mod_sub(k_max, (a >> 20) | ((b & 0xFF) << 12));
-        out_chunk[2] = mod_sub(k_max, (b >> 8) & k20_bits);
-        out_chunk[3] = mod_sub(k_max, (b >> 28) | ((c as u32) << 4));
+            *o0 = mod_sub(k_max, a & k20_bits);
+            *o1 = mod_sub(k_max, (a >> 20) | ((b & 0xFF) << 12));
+            *o2 = mod_sub(k_max, (b >> 8) & k20_bits);
+            *o3 = mod_sub(k_max, (b >> 28) | ((c as u32) << 4));
+        }
     }
 }
 
@@ -695,7 +702,12 @@ fn hint_bit_pack(out: &mut [u8; OMEGA + 8], h: &Vector8) {
     for i in 0..8 {
         for j in 0..K_DEGREE {
             if h.v[i].c[j] != 0 {
-                out[index] = j as u8;
+                // This logic is only invoked by the encode_signature against the generated
+                // signature.  By construction (view the conclusion of sign_internal_with_mu), the
+                // signature is guaranteed to have less than OMEGA ones, and thus this is safe.
+                if let Some(o) = out.get_mut(index) {
+                    *o = j as u8
+                };
                 index += 1;
             }
         }

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -191,17 +191,17 @@ fn scalar_ntt(s: &mut Scalar) {
     let mut step = 1;
     while step < K_DEGREE {
         offset >>= 1;
-        let mut k = 0;
-        for i in 0..step {
-            let step_root = NTT_ROOTS_MONTGOMERY[step + i];
-            for j in k..(k + offset) {
-                let even = s.c[j];
-                let odd =
-                    reduce_montgomery((step_root as u64).wrapping_mul(s.c[j + offset] as u64));
-                s.c[j] = reduce_once(odd.wrapping_add(even));
-                s.c[j + offset] = mod_sub(even, odd);
+        for (step_root, chunk) in NTT_ROOTS_MONTGOMERY[step..]
+            .iter()
+            .zip(s.c.chunks_exact_mut(2 * offset))
+        {
+            let (evens, odds) = chunk.split_at_mut(offset);
+            for j in 0..offset {
+                let even = evens[j];
+                let odd = reduce_montgomery((*step_root as u64).wrapping_mul(odds[j] as u64));
+                evens[j] = reduce_once(odd.wrapping_add(even));
+                odds[j] = mod_sub(even, odd);
             }
-            k += 2 * offset;
         }
         step <<= 1;
     }
@@ -212,19 +212,22 @@ fn scalar_inverse_ntt(s: &mut Scalar) {
     let mut offset = 1;
     while offset < K_DEGREE {
         step >>= 1;
-        let mut k = 0;
-        for i in 0..step {
-            let step_root = K_PRIME.wrapping_sub(NTT_ROOTS_MONTGOMERY[step + (step - 1 - i)]);
-            for j in k..(k + offset) {
-                let even = s.c[j];
-                let odd = s.c[j + offset];
-                s.c[j] = reduce_once(odd.wrapping_add(even));
-                s.c[j + offset] = reduce_montgomery(
+        for (step_root, chunk) in NTT_ROOTS_MONTGOMERY[step..step * 2.min(K_DEGREE)]
+            .iter()
+            .rev()
+            .zip(s.c.chunks_exact_mut(2 * offset))
+        {
+            let step_root = K_PRIME.wrapping_sub(*step_root);
+            let (evens, odds) = chunk.split_at_mut(offset);
+            for j in 0..offset {
+                let even = evens[j];
+                let odd = odds[j];
+                evens[j] = reduce_once(odd.wrapping_add(even));
+                odds[j] = reduce_montgomery(
                     (step_root as u64)
                         .wrapping_mul((K_PRIME.wrapping_add(even).wrapping_sub(odd)) as u64),
                 );
             }
-            k += 2 * offset;
         }
         offset <<= 1;
     }
@@ -494,15 +497,15 @@ fn scalar_decode_signed_20_19(out: &mut Scalar, in_val: &[u8]) {
     let k_max = 1u32 << 19;
     let k20_bits = (1u32 << 20) - 1;
 
-    for i in 0..(K_DEGREE / 4) {
-        let a = u32::from_le_bytes(in_val[10 * i..10 * i + 4].try_into().unwrap());
-        let b = u32::from_le_bytes(in_val[10 * i + 4..10 * i + 8].try_into().unwrap());
-        let c = u16::from_le_bytes(in_val[10 * i + 8..10 * i + 10].try_into().unwrap());
+    for (in_chunk, out_chunk) in in_val.chunks_exact(10).zip(out.c.chunks_exact_mut(4)) {
+        let a = u32::from_le_bytes([in_chunk[0], in_chunk[1], in_chunk[2], in_chunk[3]]);
+        let b = u32::from_le_bytes([in_chunk[4], in_chunk[5], in_chunk[6], in_chunk[7]]);
+        let c = u16::from_le_bytes([in_chunk[8], in_chunk[9]]);
 
-        out.c[i * 4] = mod_sub(k_max, a & k20_bits);
-        out.c[i * 4 + 1] = mod_sub(k_max, (a >> 20) | ((b & 0xFF) << 12));
-        out.c[i * 4 + 2] = mod_sub(k_max, (b >> 8) & k20_bits);
-        out.c[i * 4 + 3] = mod_sub(k_max, (b >> 28) | ((c as u32) << 4));
+        out_chunk[0] = mod_sub(k_max, a & k20_bits);
+        out_chunk[1] = mod_sub(k_max, (a >> 20) | ((b & 0xFF) << 12));
+        out_chunk[2] = mod_sub(k_max, (b >> 8) & k20_bits);
+        out_chunk[3] = mod_sub(k_max, (b >> 28) | ((c as u32) << 4));
     }
 }
 
@@ -590,7 +593,7 @@ fn scalar_sample_in_ball_vartime(out: &mut Scalar, seed: &[u8], len: usize) {
     for i in (K_DEGREE - TAU)..K_DEGREE {
         let mut byte: usize;
         loop {
-            if offset == 136 {
+            if offset >= block.len() {
                 shake256.squeeze(&mut block);
                 offset = 0;
             }
@@ -872,17 +875,13 @@ fn generate_key_internal(
 /// Each coefficient is encoded as `(sub - w) mod q` (the FIPS `b - w_i`
 /// transform), matching `BitPack(w, sub-?, sub)` for the appropriate range.
 fn pack_scalar_bits(out: &mut [u8], s: &Scalar, bits: u32, sub: u32) {
-    let mut acc: u64 = 0;
-    let mut nbits: u32 = 0;
-    let mut oi = 0;
-    for i in 0..K_DEGREE {
-        acc |= (mod_sub(sub, s.c[i]) as u64) << nbits;
-        nbits += bits;
-        while nbits >= 8 {
-            out[oi] = (acc & 0xff) as u8;
-            oi += 1;
-            acc >>= 8;
-            nbits -= 8;
+    for (in_chunk, out_chunk) in s.c.chunks_exact(8).zip(out.chunks_exact_mut(bits as usize)) {
+        let mut acc: u128 = 0;
+        for (i, &coeff) in in_chunk.iter().enumerate() {
+            acc |= (mod_sub(sub, coeff) as u128) << (i as u32 * bits);
+        }
+        for (j, byte) in out_chunk.iter_mut().enumerate() {
+            *byte = (acc >> (j * 8)) as u8;
         }
     }
 }

--- a/common/crypto/shake/src/shake_impl.rs
+++ b/common/crypto/shake/src/shake_impl.rs
@@ -17,9 +17,9 @@ pub enum ShakeConfig {
 }
 
 pub struct KeccakSt {
+    config: ShakeConfig,
     state: [u64; 25],
     phase: KeccakPhase,
-    rate_bytes: usize,
     absorb_offset: usize,
     squeeze_offset: usize,
 }
@@ -125,17 +125,19 @@ fn keccak_f(state: &mut [u64; 25]) {
 
 impl KeccakSt {
     pub fn new(config: ShakeConfig) -> Self {
-        let capacity_bytes = match config {
-            ShakeConfig::Shake128 => 256 / 8,
-            ShakeConfig::Shake256 => 512 / 8,
-        };
-
         KeccakSt {
+            config,
             state: [0u64; 25],
             phase: KeccakPhase::Absorb,
-            rate_bytes: 200 - capacity_bytes,
             absorb_offset: 0,
             squeeze_offset: 0,
+        }
+    }
+
+    fn rate(&self) -> usize {
+        match self.config {
+            ShakeConfig::Shake128 => 200 - (256 / 8),
+            ShakeConfig::Shake256 => 200 - (512 / 8),
         }
     }
 
@@ -144,7 +146,7 @@ impl KeccakSt {
 
         // Absorb partial block.
         if self.absorb_offset != 0 {
-            let first_block_len = self.rate_bytes - self.absorb_offset;
+            let first_block_len = self.rate() - self.absorb_offset;
             let todo = core::cmp::min(first_block_len, in_len);
             let start = self.absorb_offset.min(self.state.as_bytes().len());
             for (s, b) in self.state.as_mut_bytes()[start..]
@@ -166,8 +168,8 @@ impl KeccakSt {
 
         // Absorb full blocks.
         let state_words = self.state.len();
-        let rate_words = self.rate_bytes / 8;
-        let rate = self.rate_bytes;
+        let rate_words = self.rate() / 8;
+        let rate = self.rate();
         while in_slice.len() >= rate {
             for (state_word, word_bytes) in self.state[..rate_words.min(state_words)]
                 .iter_mut()
@@ -196,12 +198,12 @@ impl KeccakSt {
     }
 
     fn finalize(&mut self) {
-        let terminator = 0x1fu8;
+        let r = self.rate();
+        let ao = self.absorb_offset.min(self.state.as_bytes().len() - 1);
 
-        // XOR the terminator.
         let state_bytes = self.state.as_mut_bytes();
-        state_bytes[self.absorb_offset] ^= terminator;
-        state_bytes[self.rate_bytes - 1] ^= 0x80;
+        state_bytes[ao] ^= 0x1f;
+        state_bytes[r - 1] ^= 0x80;
 
         keccak_f(&mut self.state);
     }
@@ -212,7 +214,7 @@ impl KeccakSt {
             self.phase = KeccakPhase::Squeeze;
         }
 
-        let rate = self.rate_bytes.min(self.state.as_bytes().len());
+        let rate = self.rate();
 
         while !out_slice.is_empty() {
             if self.squeeze_offset >= rate {
@@ -221,12 +223,10 @@ impl KeccakSt {
             }
 
             let squeeze_off = self.squeeze_offset.min(rate);
-            let remaining = rate - squeeze_off;
-            let todo = core::cmp::min(out_slice.len(), remaining);
-            out_slice[..todo]
-                .copy_from_slice(&self.state.as_bytes()[squeeze_off..squeeze_off + todo]);
-
-            let (_, rest) = out_slice.split_at_mut(todo);
+            let state_tail = &self.state.as_bytes()[squeeze_off..rate];
+            let todo = out_slice.len().min(state_tail.len());
+            let (dst, rest) = out_slice.split_at_mut(todo);
+            dst.copy_from_slice(&state_tail[..todo]);
             out_slice = rest;
             self.squeeze_offset += todo;
         }

--- a/common/crypto/shake/src/shake_impl.rs
+++ b/common/crypto/shake/src/shake_impl.rs
@@ -146,8 +146,12 @@ impl KeccakSt {
         if self.absorb_offset != 0 {
             let first_block_len = self.rate_bytes - self.absorb_offset;
             let todo = core::cmp::min(first_block_len, in_len);
-            for (i, in_byte) in in_slice.iter().enumerate().take(todo) {
-                self.state.as_mut_bytes()[self.absorb_offset + i] ^= in_byte;
+            let start = self.absorb_offset.min(self.state.as_bytes().len());
+            for (s, b) in self.state.as_mut_bytes()[start..]
+                .iter_mut()
+                .zip(in_slice.iter().take(todo))
+            {
+                *s ^= b;
             }
 
             // This input didn't fill the block.
@@ -161,14 +165,27 @@ impl KeccakSt {
         }
 
         // Absorb full blocks.
+        let state_words = self.state.len();
         let rate_words = self.rate_bytes / 8;
-        while in_slice.len() >= self.rate_bytes {
-            for i in 0..rate_words {
-                let word = u64::from_le_bytes(in_slice[8 * i..8 * i + 8].try_into().unwrap());
-                self.state[i] ^= word;
+        let rate = self.rate_bytes;
+        while in_slice.len() >= rate {
+            for (state_word, word_bytes) in self.state[..rate_words.min(state_words)]
+                .iter_mut()
+                .zip(in_slice.chunks_exact(8))
+            {
+                *state_word ^= u64::from_le_bytes([
+                    word_bytes[0],
+                    word_bytes[1],
+                    word_bytes[2],
+                    word_bytes[3],
+                    word_bytes[4],
+                    word_bytes[5],
+                    word_bytes[6],
+                    word_bytes[7],
+                ]);
             }
             keccak_f(&mut self.state);
-            in_slice = &in_slice[self.rate_bytes..];
+            in_slice = &in_slice[rate..];
         }
 
         // Absorb partial block.
@@ -195,17 +212,19 @@ impl KeccakSt {
             self.phase = KeccakPhase::Squeeze;
         }
 
+        let rate = self.rate_bytes.min(self.state.as_bytes().len());
+
         while !out_slice.is_empty() {
-            if self.squeeze_offset == self.rate_bytes {
+            if self.squeeze_offset >= rate {
                 keccak_f(&mut self.state);
                 self.squeeze_offset = 0;
             }
 
-            let remaining = self.rate_bytes - self.squeeze_offset;
+            let squeeze_off = self.squeeze_offset.min(rate);
+            let remaining = rate - squeeze_off;
             let todo = core::cmp::min(out_slice.len(), remaining);
-            out_slice[..todo].copy_from_slice(
-                &self.state.as_bytes()[self.squeeze_offset..self.squeeze_offset + todo],
-            );
+            out_slice[..todo]
+                .copy_from_slice(&self.state.as_bytes()[squeeze_off..squeeze_off + todo]);
 
             let (_, rest) = out_slice.split_at_mut(todo);
             out_slice = rest;

--- a/runtime/tests/runtime_integration_tests/test_panic_missing.rs
+++ b/runtime/tests/runtime_integration_tests/test_panic_missing.rs
@@ -1,5 +1,5 @@
 // Licensed under the Apache-2.0 license
-use caliptra_builder::firmware::APP_WITH_UART;
+use caliptra_builder::firmware::{APP_MLDSA_ATTESTATION, APP_WITH_UART};
 
 #[test]
 fn test_panic_missing() {
@@ -8,6 +8,18 @@ fn test_panic_missing() {
     if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
         panic!(
             "The caliptra RT contains the panic_is_possible symbol, which is not allowed. \
+                Please remove any code that might panic."
+        )
+    }
+}
+
+#[test]
+fn test_panic_missing_mldsa_attestation() {
+    let rt_elf = caliptra_builder::build_firmware_elf(&APP_MLDSA_ATTESTATION).unwrap();
+    let symbols = caliptra_builder::elf_symbols(&rt_elf).unwrap();
+    if symbols.iter().any(|s| s.name.contains("panic_is_possible")) {
+        panic!(
+            "The caliptra RT (mldsa_attestation) contains the panic_is_possible symbol, which is not allowed. \
                 Please remove any code that might panic."
         )
     }


### PR DESCRIPTION
Change the various call sites where indexing was occuring against arrays to ensure the indexing was always provably valid to the compiler.  This allows the panics to be optimized out, a requirement for the caliptra runtime.

There are no functional changes.