### PR TITLE
WASM emulator demo support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ exclude = [
 
   # Don't pull unnecessary tools into the workspace
   "ci-tools/test-printer",
+
+  # WASM demo uses wasm-specific target and dependencies
+  "wasm-demo",
 ]
 
 members = [

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -8,14 +8,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["coverage"]
-verilator = ["dep:caliptra-verilated"]
-fpga_realtime = ["dep:uio"]
-fpga_subsystem  = ["dep:uio"]
+default = ["coverage", "platform-specific"]
+verilator = ["dep:caliptra-verilated", "platform-specific"]
+fpga_realtime = ["dep:uio", "platform-specific"]
+fpga_subsystem  = ["dep:uio", "platform-specific"]
 itrng = ["caliptra-verilated?/itrng"]
 coverage = ["dep:caliptra-coverage"]
 # Defaults `InitParams` to enable OCP LOCK.
 ocp-lock = []
+# Platform-specific deps (nix, libc, rustix, regex) needed for openocd, FPGA, etc.
+# Disable for wasm32 builds.
+platform-specific = ["dep:nix", "dep:libc", "dep:rustix", "dep:regex"]
 
 [dependencies]
 anyhow.workspace = true
@@ -34,8 +37,8 @@ caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }
 once_cell.workspace = true
 rand.workspace = true
-regex.workspace = true
-rustix.workspace = true
+regex = { workspace = true, optional = true }
+rustix = { workspace = true, optional = true }
 scopeguard.workspace = true
 serde = {workspace = true, features = ['derive']}
 sha2.workspace = true
@@ -45,8 +48,8 @@ thiserror.workspace = true
 uio = { workspace = true, optional = true }
 ureg.workspace = true
 zerocopy.workspace = true
-nix.workspace = true
-libc.workspace = true
+nix = { workspace = true, optional = true }
+libc = { workspace = true, optional = true }
 caliptra-coverage = { workspace = true, optional = true }
 caliptra-image-types.workspace = true
 tock-registers.workspace = true

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -41,6 +41,7 @@ pub mod keys;
 pub mod lcc;
 pub mod mmio;
 mod model_emulated;
+#[cfg(feature = "platform-specific")]
 pub mod openocd;
 pub mod otp_digest;
 pub mod otp_provision;

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -139,6 +139,14 @@ impl ModelEmulated {
     }
 }
 
+impl ModelEmulated {
+    /// Snapshot of the Caliptra Key Vault (keys, PCRs, and control registers).
+    /// Intended for inspection / debugging by external code such as the WASM demo UI.
+    pub fn key_vault_snapshot(&self) -> caliptra_emu_periph::KeyVaultSnapshot {
+        self.cpu.bus.bus.key_vault.snapshot()
+    }
+}
+
 fn hash_slice(slice: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     std::hash::Hash::hash_slice(slice, &mut hasher);

--- a/sw-emulator/lib/periph/src/key_vault.rs
+++ b/sw-emulator/lib/periph/src/key_vault.rs
@@ -144,6 +144,21 @@ pub struct KeyVault {
     regs: Rc<RefCell<KeyVaultRegs>>,
 }
 
+/// Snapshot of the entire KeyVault contents — keys, PCRs, and their
+/// associated control registers. Returned by `KeyVault::snapshot` for
+/// inspection / debugging by external code (e.g. the WASM demo UI).
+#[derive(Debug, Clone)]
+pub struct KeyVaultSnapshot {
+    /// Raw key data: 24 keys × 64 bytes = 1536 bytes.
+    pub keys: Vec<u8>,
+    /// Per-key control register values (24 entries).
+    pub key_control: Vec<u32>,
+    /// PCR values: 32 PCRs × 48 bytes each.
+    pub pcrs: Vec<Vec<u8>>,
+    /// Per-PCR control register values (32 entries).
+    pub pcr_control: Vec<u32>,
+}
+
 impl KeyVault {
     pub const PCR_SIZE: usize = 48;
     pub const KEY_COUNT: u32 = 24;
@@ -192,6 +207,14 @@ impl KeyVault {
     /// Internal emulator interface to read pcr from key vault
     pub fn read_pcr(&self, pcr_id: u32) -> [u8; constants::PCR_SIZE_BYTES] {
         self.regs.borrow().read_pcr(pcr_id)
+    }
+
+    /// Snapshot of all key vault state for inspection / debugging.
+    /// Returns the raw key bytes (24 keys × 64 bytes = 1536 bytes), the 24
+    /// key-control register values, the 32 PCRs (each 48 bytes), and the
+    /// 32 PCR-control register values.
+    pub fn snapshot(&self) -> KeyVaultSnapshot {
+        self.regs.borrow().snapshot()
     }
 
     /// Internal emulator interface to write pcr to key vault
@@ -413,6 +436,30 @@ impl KeyVaultRegs {
                 STICKY_LOCKABLE_SCRATCH_CTRL_REG_RESET_VAL,
             ),
             sticky_lockable_scratch: ReadWriteRegisterArray::new(0),
+        }
+    }
+
+    /// Snapshot of all key vault state. See `KeyVault::snapshot` for details.
+    pub fn snapshot(&self) -> KeyVaultSnapshot {
+        let mut keys = vec![0u8; (KeyVault::KEY_COUNT as usize) * KeyVault::KEY_SIZE];
+        keys.copy_from_slice(self.keys.data());
+        let mut key_control = Vec::with_capacity(KeyVault::KEY_COUNT as usize);
+        for i in 0..(KeyVault::KEY_COUNT as usize) {
+            key_control.push(self.key_control[i].get());
+        }
+        let mut pcrs = Vec::with_capacity(constants::PCR_COUNT as usize);
+        for i in 0..(constants::PCR_COUNT as usize) {
+            pcrs.push(self.read_pcr(i as u32).to_vec());
+        }
+        let mut pcr_control = Vec::with_capacity(constants::PCR_COUNT as usize);
+        for i in 0..(constants::PCR_COUNT as usize) {
+            pcr_control.push(self.pcr_control[i].get());
+        }
+        KeyVaultSnapshot {
+            keys,
+            key_control,
+            pcrs,
+            pcr_control,
         }
     }
 

--- a/sw-emulator/lib/periph/src/key_vault.rs
+++ b/sw-emulator/lib/periph/src/key_vault.rs
@@ -441,8 +441,11 @@ impl KeyVaultRegs {
 
     /// Snapshot of all key vault state. See `KeyVault::snapshot` for details.
     pub fn snapshot(&self) -> KeyVaultSnapshot {
-        let mut keys = vec![0u8; (KeyVault::KEY_COUNT as usize) * KeyVault::KEY_SIZE];
-        keys.copy_from_slice(self.keys.data());
+        let key_bytes = (KeyVault::KEY_COUNT as usize) * KeyVault::KEY_SIZE;
+        let mut keys = vec![0u8; key_bytes];
+        // self.keys.data() is KEY_REG_SIZE bytes (padded for register layout),
+        // which may exceed KEY_COUNT*KEY_SIZE. Only copy the valid portion.
+        keys.copy_from_slice(&self.keys.data()[..key_bytes]);
         let mut key_control = Vec::with_capacity(KeyVault::KEY_COUNT as usize);
         for i in 0..(KeyVault::KEY_COUNT as usize) {
             key_control.push(self.key_control[i].get());

--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -50,6 +50,7 @@ pub use hmac::HmacSha;
 pub use iccm::Iccm;
 pub use key_vault::KeyUsage;
 pub use key_vault::KeyVault;
+pub use key_vault::KeyVaultSnapshot;
 pub use mailbox::{MailboxExternal, MailboxInternal, MailboxRam, MailboxRequester};
 pub use mci::Mci;
 pub use root_bus::{

--- a/wasm-demo/.gitignore
+++ b/wasm-demo/.gitignore
@@ -3,4 +3,7 @@
 /www/caliptra_wasm_demo_bg.wasm
 /www/caliptra_wasm_demo.js
 /www/default-rom.bin
+/www/default-fw.bin
+/www/defaults.json
+/tools/target/
 Cargo.lock

--- a/wasm-demo/.gitignore
+++ b/wasm-demo/.gitignore
@@ -1,0 +1,6 @@
+/target/
+/pkg/
+/www/caliptra_wasm_demo_bg.wasm
+/www/caliptra_wasm_demo.js
+/www/default-rom.bin
+Cargo.lock

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -1,0 +1,29 @@
+# Licensed under the Apache-2.0 license
+
+[package]
+name = "caliptra-wasm-demo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+caliptra-hw-model = { path = "../hw-model", default-features = false }
+caliptra-api-types = { path = "../api/types" }
+caliptra-hw-model-types = { path = "../hw-model/types" }
+caliptra-emu-periph = { path = "../sw-emulator/lib/periph" }
+rand = { version = "0.8", features = ["std_rng"] }
+rand_core = "0.6"
+getrandom = { version = "0.2", features = ["js"] }
+
+# Patch caliptra-cfi-lib with a no-asm shim for WASM (CFI uses inline asm
+# that doesn't compile for wasm32; CFI is a firmware security feature not
+# needed by the emulator).
+[patch."https://github.com/chipsalliance/caliptra-cfi.git"]
+caliptra-cfi-lib = { path = "cfi-shim" }
+
+[profile.release]
+opt-level = "s"
+lto = true

--- a/wasm-demo/build-wasm.sh
+++ b/wasm-demo/build-wasm.sh
@@ -34,6 +34,34 @@ else
     echo "You will need to upload a ROM manually in the UI."
 fi
 
+# Build default FW image bundle (uses fake/test keys)
+echo "Building default FW image bundle..."
+FW_TMP="$(mktemp)"
+cd "$SCRIPT_DIR/.."
+cargo run -p caliptra-builder -- --fw "$FW_TMP" 2>/dev/null
+cp "$FW_TMP" "$SCRIPT_DIR/www/default-fw.bin"
+echo "Built default FW bundle ($(wc -c < "$FW_TMP") bytes)"
+
+# Extract PK hashes from the FW image
+echo "Extracting PK hashes from FW image..."
+cd "$SCRIPT_DIR/tools"
+HASHES=$(cargo run --quiet -- "$FW_TMP" 2>/dev/null)
+rm -f "$FW_TMP"
+
+VENDOR_PK_HASH=$(echo "$HASHES" | grep VENDOR_PK_HASH | cut -d= -f2)
+OWNER_PK_HASH=$(echo "$HASHES" | grep OWNER_PK_HASH | cut -d= -f2)
+echo "  Vendor PK hash: $VENDOR_PK_HASH"
+echo "  Owner PK hash:  $OWNER_PK_HASH"
+
+# Write defaults JSON for the web UI
+cat > "$SCRIPT_DIR/www/defaults.json" << JSONEOF
+{
+  "vendor_pk_hash": "$VENDOR_PK_HASH",
+  "owner_pk_hash": "$OWNER_PK_HASH"
+}
+JSONEOF
+echo "Wrote www/defaults.json"
+
 echo ""
 echo "Build complete! To run:"
 echo "  cd $SCRIPT_DIR/www"

--- a/wasm-demo/build-wasm.sh
+++ b/wasm-demo/build-wasm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Build the Caliptra WASM emulator and set up the www/ directory for serving.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Check for wasm-pack
+if ! command -v wasm-pack &>/dev/null; then
+    echo "wasm-pack not found. Installing..."
+    cargo install wasm-pack --locked
+fi
+
+# Check for wasm32 target
+if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
+    echo "Adding wasm32-unknown-unknown target..."
+    rustup target add wasm32-unknown-unknown
+fi
+
+echo "Building WASM (release)..."
+wasm-pack build --target web --release
+
+echo "Copying WASM output to www/..."
+cp pkg/caliptra_wasm_demo_bg.wasm www/
+cp pkg/caliptra_wasm_demo.js www/
+
+# Copy default ROM if not already present
+ROM_SRC="../rom/ci_frozen_rom/2.1/caliptra-rom-with-log-2.1.0-a72a76f.bin"
+if [ -f "$ROM_SRC" ]; then
+    cp "$ROM_SRC" www/default-rom.bin
+    echo "Copied default ROM (with-log variant) to www/default-rom.bin"
+else
+    echo "WARNING: Default ROM not found at $ROM_SRC"
+    echo "You will need to upload a ROM manually in the UI."
+fi
+
+echo ""
+echo "Build complete! To run:"
+echo "  cd $SCRIPT_DIR/www"
+echo "  python3 -m http.server 8080"
+echo "  Then open http://localhost:8080"

--- a/wasm-demo/cfi-shim/Cargo.toml
+++ b/wasm-demo/cfi-shim/Cargo.toml
@@ -1,0 +1,17 @@
+# Licensed under the Apache-2.0 license
+# No-assembly shim of caliptra-cfi-lib for WASM builds.
+# CFI is a firmware security feature not needed by the emulator.
+
+[package]
+name = "caliptra-cfi-lib"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+doctest = false
+
+[features]
+default = []
+cfi = []
+cfi-counter = []
+cfi-test = []

--- a/wasm-demo/cfi-shim/src/lib.rs
+++ b/wasm-demo/cfi-shim/src/lib.rs
@@ -1,0 +1,238 @@
+// Licensed under the Apache-2.0 license
+//
+// No-assembly shim of caliptra-cfi-lib for WASM builds.
+// CFI (Control Flow Integrity) is a firmware security feature for hardened
+// RISC-V targets. The emulator doesn't need it, so all functions are no-ops.
+
+#![no_std]
+extern crate core;
+
+use core::cmp::{Eq, Ord, PartialEq, PartialOrd};
+use core::marker::{Copy, PhantomData};
+
+// --- CfiPanicInfo ---
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum CfiPanicInfo {
+    CounterCorrupt,
+    CounterOverflow,
+    CounterUnderflow,
+    CounterMismatch,
+    AssertEqFail,
+    AssertNeFail,
+    AssertGtFail,
+    AssertLtFail,
+    AssertGeFail,
+    AssertLeFail,
+    TrngError,
+    UnexpectedMatchBranch,
+    UnknownError,
+}
+
+impl From<CfiPanicInfo> for u32 {
+    fn from(val: CfiPanicInfo) -> Self {
+        val as u32
+    }
+}
+
+// --- Launder (no-op, no asm) ---
+
+pub fn cfi_launder<T>(val: T) -> T
+where
+    Launder<T>: LaunderTrait<T>,
+{
+    val
+}
+
+pub trait LaunderTrait<T> {
+    fn launder(&self, val: T) -> T {
+        core::hint::black_box(val)
+    }
+}
+
+pub struct Launder<T> {
+    _val: PhantomData<T>,
+}
+
+impl LaunderTrait<u32> for Launder<u32> {
+    fn launder(&self, val: u32) -> u32 {
+        core::hint::black_box(val)
+    }
+}
+
+impl LaunderTrait<bool> for Launder<bool> {
+    fn launder(&self, val: bool) -> bool {
+        core::hint::black_box(val)
+    }
+}
+
+impl LaunderTrait<usize> for Launder<usize> {
+    fn launder(&self, val: usize) -> usize {
+        core::hint::black_box(val)
+    }
+}
+
+impl<const N: usize, T> LaunderTrait<[T; N]> for Launder<[T; N]> {}
+impl<'a, const N: usize, T> LaunderTrait<&'a [T; N]> for Launder<&'a [T; N]> {}
+impl LaunderTrait<Option<u32>> for Launder<Option<u32>> {}
+impl LaunderTrait<CfiPanicInfo> for Launder<CfiPanicInfo> {}
+
+// --- cfi_panic ---
+
+#[inline(never)]
+pub fn cfi_panic(_info: CfiPanicInfo) -> ! {
+    panic!("CFI panic (no-op shim)")
+}
+
+// --- Assertions (all no-ops) ---
+
+#[inline(always)]
+pub fn cfi_assert_eq<T>(_lhs: T, _rhs: T)
+where
+    T: Eq + PartialEq,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_ne<T>(_lhs: T, _rhs: T)
+where
+    T: Eq + PartialEq,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_gt<T>(_lhs: T, _rhs: T)
+where
+    T: Ord + PartialOrd,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_lt<T>(_lhs: T, _rhs: T)
+where
+    T: Ord + PartialOrd,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_ge<T>(_lhs: T, _rhs: T)
+where
+    T: Ord + PartialOrd,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_le<T>(_lhs: T, _rhs: T)
+where
+    T: Ord + PartialOrd,
+    Launder<T>: LaunderTrait<T>,
+{
+}
+
+#[inline(always)]
+pub fn cfi_assert_bool(_cond: bool) {}
+
+#[macro_export]
+macro_rules! cfi_assert {
+    ($cond:expr) => {
+        cfi_assert_bool($cond)
+    };
+}
+
+pub fn cfi_assert_eq_16_words(_a: &[u32; 16], _b: &[u32; 16]) {}
+pub fn cfi_assert_ne_16_words(_a: &[u32; 16], _b: &[u32; 16]) {}
+pub fn cfi_assert_eq_12_words(_a: &[u32; 12], _b: &[u32; 12]) {}
+pub fn cfi_assert_eq_8_words(_a: &[u32; 8], _b: &[u32; 8]) {}
+pub fn cfi_assert_eq_6_words(_a: &[u32; 6], _b: &[u32; 6]) {}
+
+// --- CfiInt / CfiCounter (no-ops) ---
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct CfiInt {
+    val: u32,
+    masked_val: u32,
+}
+
+impl Default for CfiInt {
+    fn default() -> Self {
+        Self {
+            val: 0,
+            masked_val: 0,
+        }
+    }
+}
+
+pub enum CfiCounter {}
+
+impl CfiCounter {
+    pub fn reset(_entropy_gen: &mut impl FnMut() -> CfiResult<(u32, u32, u32, u32)>) {}
+    #[cfg(feature = "cfi-test")]
+    pub fn reset_for_test() {}
+    pub fn corrupt() {}
+    pub fn increment() -> CfiInt {
+        CfiInt::default()
+    }
+    pub fn decrement() -> CfiInt {
+        CfiInt::default()
+    }
+    pub fn assert_eq(_val1: CfiInt, _val2: CfiInt) {}
+    pub fn delay() {}
+    pub fn read() -> CfiInt {
+        CfiInt::default()
+    }
+}
+
+// --- Error types ---
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct CfiError(pub u32);
+
+impl CfiError {
+    pub const ROM_CFI_PANIC_ASSERT_EQ_FAILURE: Self = Self(0x01040055);
+}
+
+impl From<CfiError> for u32 {
+    fn from(val: CfiError) -> Self {
+        val.0
+    }
+}
+
+pub type CfiResult<T> = core::result::Result<T, CfiError>;
+
+// --- Xoshiro128 (minimal stub) ---
+
+#[repr(C)]
+pub struct Xoshiro128 {
+    s0: u32,
+    s1: u32,
+    s2: u32,
+    s3: u32,
+}
+
+impl Xoshiro128 {
+    pub const fn new_unseeded() -> Self {
+        Self::new_with_seed(0, 0, 0, 0)
+    }
+    pub const fn new_with_seed(s0: u32, s1: u32, s2: u32, s3: u32) -> Self {
+        Self { s0, s1, s2, s3 }
+    }
+    pub fn mix_entropy(&self, _entropy_gen: &mut impl FnMut() -> CfiResult<(u32, u32, u32, u32)>) {
+    }
+    pub fn next(&self) -> u32 {
+        0
+    }
+}
+
+// --- CfiState (for completeness) ---
+
+#[repr(C)]
+pub struct CfiState {
+    pub val: u32,
+    pub mask: u32,
+    pub prng: Xoshiro128,
+}

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -1,0 +1,174 @@
+// Licensed under the Apache-2.0 license
+
+//! WASM wrapper for the Caliptra hardware emulator.
+//!
+//! Provides a JavaScript-friendly API to initialize and run the Caliptra
+//! emulator with custom ROM, vendor/owner PK hashes, and UART output capture.
+
+use std::cell::RefCell;
+use std::io::Write;
+use std::rc::Rc;
+
+use caliptra_api_types::{DeviceLifecycle, Fuses, SecurityState, DEFAULT_CPTRA_OBF_KEY, DEFAULT_CSR_HMAC_KEY};
+use caliptra_emu_periph::MailboxRequester;
+use caliptra_hw_model::{BootParams, ExitStatus, HwModel, InitParams, ModelEmulated, TrngMode};
+use caliptra_hw_model_types::{EtrngResponse, RandomEtrngResponses, RandomNibbles};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use wasm_bindgen::prelude::*;
+
+/// A shared buffer that captures log/UART output via the `Write` trait.
+#[derive(Clone)]
+struct SharedBuffer(Rc<RefCell<Vec<u8>>>);
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Parse a hex string (e.g. "aabbccdd...") into a `[u32; 12]` array (big-endian words).
+/// Expects exactly 96 hex characters (48 bytes = 12 × 4-byte words).
+fn parse_pk_hash(hex: &str) -> Result<[u32; 12], String> {
+    let hex = hex.trim();
+    if hex.is_empty() {
+        return Ok([0u32; 12]);
+    }
+
+    // Strip optional "0x" prefix
+    let hex = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
+
+    if hex.len() != 96 {
+        return Err(format!(
+            "PK hash must be 96 hex characters (48 bytes), got {} characters",
+            hex.len()
+        ));
+    }
+
+    let mut result = [0u32; 12];
+    for (i, chunk) in hex.as_bytes().chunks(8).enumerate() {
+        let s = std::str::from_utf8(chunk).map_err(|e| format!("Invalid UTF-8: {e}"))?;
+        result[i] = u32::from_str_radix(s, 16).map_err(|e| format!("Invalid hex at word {i}: {e}"))?;
+    }
+    Ok(result)
+}
+
+/// The Caliptra emulator, exposed to JavaScript via wasm-bindgen.
+#[wasm_bindgen]
+pub struct CaliptraEmulator {
+    model: ModelEmulated,
+    log_buffer: SharedBuffer,
+    total_steps: u64,
+}
+
+#[wasm_bindgen]
+impl CaliptraEmulator {
+    /// Create a new emulator instance.
+    ///
+    /// # Arguments
+    /// * `rom` - The ROM binary image (96KB expected)
+    /// * `vendor_pk_hash_hex` - Vendor PK hash as 96-char hex string (or empty for zeros)
+    /// * `owner_pk_hash_hex` - Owner PK hash as 96-char hex string (or empty for zeros)
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        rom: &[u8],
+        vendor_pk_hash_hex: &str,
+        owner_pk_hash_hex: &str,
+    ) -> Result<CaliptraEmulator, JsValue> {
+        // Parse PK hashes
+        let vendor_pk_hash =
+            parse_pk_hash(vendor_pk_hash_hex).map_err(|e| JsValue::from_str(&e))?;
+        let owner_pk_hash =
+            parse_pk_hash(owner_pk_hash_hex).map_err(|e| JsValue::from_str(&e))?;
+
+        let log_buffer = SharedBuffer(Rc::new(RefCell::new(Vec::new())));
+
+        // Use a fixed seed for deterministic TRNG in the browser
+        let trng_seed: u64 = 42;
+        let itrng_nibbles: Box<dyn Iterator<Item = u8> + Send> =
+            Box::new(RandomNibbles(StdRng::seed_from_u64(trng_seed)));
+        let etrng_responses: Box<dyn Iterator<Item = EtrngResponse> + Send> =
+            Box::new(RandomEtrngResponses(StdRng::seed_from_u64(trng_seed)));
+
+        let fuses = Fuses {
+            vendor_pk_hash,
+            owner_pk_hash,
+            life_cycle: DeviceLifecycle::Unprovisioned,
+            ..Default::default()
+        };
+
+        let init_params = InitParams {
+            rom,
+            fuses,
+            log_writer: Box::new(log_buffer.clone()),
+            security_state: *SecurityState::default()
+                .set_device_lifecycle(DeviceLifecycle::Unprovisioned),
+            cptra_obf_key: DEFAULT_CPTRA_OBF_KEY,
+            csr_hmac_key: DEFAULT_CSR_HMAC_KEY,
+            itrng_nibbles,
+            etrng_responses,
+            trng_mode: Some(TrngMode::Internal),
+            random_sram_puf: false,
+            trace_path: None,
+            soc_user: MailboxRequester::SocUser(1),
+            ..Default::default()
+        };
+
+        let boot_params = BootParams::default();
+
+        let model = caliptra_hw_model::ModelEmulated::new(init_params, boot_params)
+            .map_err(|e| JsValue::from_str(&format!("Failed to initialize emulator: {e}")))?;
+
+        Ok(CaliptraEmulator {
+            model,
+            log_buffer,
+            total_steps: 0,
+        })
+    }
+
+    /// Step the emulator by `n` clock cycles. Returns true if the emulator
+    /// is still running (has not exited).
+    pub fn step(&mut self, n: u32) -> bool {
+        for _ in 0..n {
+            self.model.step();
+            self.total_steps += 1;
+        }
+        !self.model.output().exit_requested()
+    }
+
+    /// Get accumulated UART output text since the last call to this method.
+    pub fn get_uart_output(&mut self) -> String {
+        self.model.output().take(usize::MAX)
+    }
+
+    /// Peek at accumulated UART output without consuming it.
+    pub fn peek_uart_output(&mut self) -> String {
+        self.model.output().peek().to_string()
+    }
+
+    /// Get the full log buffer contents (includes timestamped UART + system messages).
+    pub fn get_log(&mut self) -> String {
+        let bytes = self.log_buffer.0.borrow().clone();
+        self.log_buffer.0.borrow_mut().clear();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    /// Get the total number of steps executed so far.
+    pub fn total_steps(&self) -> u64 {
+        self.total_steps
+    }
+
+    /// Check if the emulator has signaled an exit (pass or fail).
+    pub fn has_exited(&mut self) -> bool {
+        self.model.output().exit_requested()
+    }
+
+    /// Check if the emulator exited with a PASS status.
+    pub fn passed(&mut self) -> bool {
+        self.model.output().exit_status() == Some(ExitStatus::Passed)
+    }
+}

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -3,13 +3,16 @@
 //! WASM wrapper for the Caliptra hardware emulator.
 //!
 //! Provides a JavaScript-friendly API to initialize and run the Caliptra
-//! emulator with custom ROM, vendor/owner PK hashes, and UART output capture.
+//! emulator with custom ROM, vendor/owner PK hashes, FW image, and UART
+//! output capture.
 
 use std::cell::RefCell;
 use std::io::Write;
 use std::rc::Rc;
 
-use caliptra_api_types::{DeviceLifecycle, Fuses, SecurityState, DEFAULT_CPTRA_OBF_KEY, DEFAULT_CSR_HMAC_KEY};
+use caliptra_api_types::{
+    DeviceLifecycle, Fuses, SecurityState, DEFAULT_CPTRA_OBF_KEY, DEFAULT_CSR_HMAC_KEY,
+};
 use caliptra_emu_periph::MailboxRequester;
 use caliptra_hw_model::{BootParams, ExitStatus, HwModel, InitParams, ModelEmulated, TrngMode};
 use caliptra_hw_model_types::{EtrngResponse, RandomEtrngResponses, RandomNibbles};
@@ -40,7 +43,10 @@ fn parse_pk_hash(hex: &str) -> Result<[u32; 12], String> {
     }
 
     // Strip optional "0x" prefix
-    let hex = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
+    let hex = hex
+        .strip_prefix("0x")
+        .or_else(|| hex.strip_prefix("0X"))
+        .unwrap_or(hex);
 
     if hex.len() != 96 {
         return Err(format!(
@@ -52,7 +58,8 @@ fn parse_pk_hash(hex: &str) -> Result<[u32; 12], String> {
     let mut result = [0u32; 12];
     for (i, chunk) in hex.as_bytes().chunks(8).enumerate() {
         let s = std::str::from_utf8(chunk).map_err(|e| format!("Invalid UTF-8: {e}"))?;
-        result[i] = u32::from_str_radix(s, 16).map_err(|e| format!("Invalid hex at word {i}: {e}"))?;
+        result[i] =
+            u32::from_str_radix(s, 16).map_err(|e| format!("Invalid hex at word {i}: {e}"))?;
     }
     Ok(result)
 }
@@ -73,11 +80,15 @@ impl CaliptraEmulator {
     /// * `rom` - The ROM binary image (96KB expected)
     /// * `vendor_pk_hash_hex` - Vendor PK hash as 96-char hex string (or empty for zeros)
     /// * `owner_pk_hash_hex` - Owner PK hash as 96-char hex string (or empty for zeros)
+    /// * `fw_image` - Optional firmware image bundle (serialized ImageBundle)
+    /// * `soc_manifest` - Optional SoC manifest (authorization manifest bytes)
     #[wasm_bindgen(constructor)]
     pub fn new(
         rom: &[u8],
         vendor_pk_hash_hex: &str,
         owner_pk_hash_hex: &str,
+        fw_image: Option<Vec<u8>>,
+        soc_manifest: Option<Vec<u8>>,
     ) -> Result<CaliptraEmulator, JsValue> {
         // Parse PK hashes
         let vendor_pk_hash =
@@ -118,7 +129,11 @@ impl CaliptraEmulator {
             ..Default::default()
         };
 
-        let boot_params = BootParams::default();
+        let boot_params = BootParams {
+            fw_image: fw_image.as_deref(),
+            soc_manifest: soc_manifest.as_deref(),
+            ..Default::default()
+        };
 
         let model = caliptra_hw_model::ModelEmulated::new(init_params, boot_params)
             .map_err(|e| JsValue::from_str(&format!("Failed to initialize emulator: {e}")))?;

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -70,6 +70,7 @@ pub struct CaliptraEmulator {
     model: ModelEmulated,
     log_buffer: SharedBuffer,
     total_steps: u64,
+    boot_error: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -82,6 +83,7 @@ impl CaliptraEmulator {
     /// * `owner_pk_hash_hex` - Owner PK hash as 96-char hex string (or empty for zeros)
     /// * `fw_image` - Optional firmware image bundle (serialized ImageBundle)
     /// * `soc_manifest` - Optional SoC manifest (authorization manifest bytes)
+    /// * `lifecycle` - Device lifecycle: "unprovisioned", "manufacturing", or "production"
     #[wasm_bindgen(constructor)]
     pub fn new(
         rom: &[u8],
@@ -89,6 +91,7 @@ impl CaliptraEmulator {
         owner_pk_hash_hex: &str,
         fw_image: Option<Vec<u8>>,
         soc_manifest: Option<Vec<u8>>,
+        lifecycle: &str,
     ) -> Result<CaliptraEmulator, JsValue> {
         // Parse PK hashes
         let vendor_pk_hash =
@@ -97,6 +100,13 @@ impl CaliptraEmulator {
             parse_pk_hash(owner_pk_hash_hex).map_err(|e| JsValue::from_str(&e))?;
 
         let log_buffer = SharedBuffer(Rc::new(RefCell::new(Vec::new())));
+
+        let device_lifecycle = match lifecycle.to_lowercase().as_str() {
+            "unprovisioned" => DeviceLifecycle::Unprovisioned,
+            "manufacturing" => DeviceLifecycle::Manufacturing,
+            "production" => DeviceLifecycle::Production,
+            _ => DeviceLifecycle::Manufacturing,
+        };
 
         // Use a fixed seed for deterministic TRNG in the browser
         let trng_seed: u64 = 42;
@@ -108,7 +118,7 @@ impl CaliptraEmulator {
         let fuses = Fuses {
             vendor_pk_hash,
             owner_pk_hash,
-            life_cycle: DeviceLifecycle::Unprovisioned,
+            life_cycle: device_lifecycle,
             ..Default::default()
         };
 
@@ -117,7 +127,7 @@ impl CaliptraEmulator {
             fuses,
             log_writer: Box::new(log_buffer.clone()),
             security_state: *SecurityState::default()
-                .set_device_lifecycle(DeviceLifecycle::Unprovisioned),
+                .set_device_lifecycle(device_lifecycle),
             cptra_obf_key: DEFAULT_CPTRA_OBF_KEY,
             csr_hmac_key: DEFAULT_CSR_HMAC_KEY,
             itrng_nibbles,
@@ -135,14 +145,27 @@ impl CaliptraEmulator {
             ..Default::default()
         };
 
-        let model = caliptra_hw_model::ModelEmulated::new(init_params, boot_params)
-            .map_err(|e| JsValue::from_str(&format!("Failed to initialize emulator: {e}")))?;
+        // Use new_unbooted + boot separately so we keep the model even if
+        // boot fails (e.g., PK hash mismatch). This lets the user see UART
+        // output and logs from the failed boot attempt.
+        let mut model = caliptra_hw_model::ModelEmulated::new_unbooted(init_params)
+            .map_err(|e| JsValue::from_str(&format!("Failed to create emulator: {e}")))?;
 
-        Ok(CaliptraEmulator {
+        let boot_error = model.boot(boot_params).err();
+
+        let mut emu = CaliptraEmulator {
             model,
             log_buffer,
             total_steps: 0,
-        })
+            boot_error: None,
+        };
+
+        if let Some(e) = boot_error {
+            let msg = format!("[WASM] Boot error: {e}\n");
+            emu.boot_error = Some(msg);
+        }
+
+        Ok(emu)
     }
 
     /// Step the emulator by `n` clock cycles. Returns true if the emulator
@@ -185,5 +208,10 @@ impl CaliptraEmulator {
     /// Check if the emulator exited with a PASS status.
     pub fn passed(&mut self) -> bool {
         self.model.output().exit_status() == Some(ExitStatus::Passed)
+    }
+
+    /// Get the boot error message, if boot failed.
+    pub fn boot_error(&self) -> Option<String> {
+        self.boot_error.clone()
     }
 }

--- a/wasm-demo/tools/Cargo.toml
+++ b/wasm-demo/tools/Cargo.toml
@@ -1,0 +1,16 @@
+# Licensed under the Apache-2.0 license
+# Helper tool to extract PK hashes from a Caliptra FW image bundle.
+
+[package]
+name = "caliptra-wasm-hash-tool"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "extract-pk-hashes"
+path = "src/main.rs"
+
+[dependencies]
+caliptra-image-types = { path = "../../image/types" }
+sha2 = "0.10"
+zerocopy = { version = "0.8", features = ["derive"] }

--- a/wasm-demo/tools/src/main.rs
+++ b/wasm-demo/tools/src/main.rs
@@ -1,0 +1,34 @@
+// Licensed under the Apache-2.0 license
+//! Extracts vendor and owner PK hashes from a Caliptra FW image bundle.
+//! Usage: extract-pk-hashes <fw-image.bin>
+
+use caliptra_image_types::ImageManifest;
+use sha2::{Digest, Sha384};
+use zerocopy::IntoBytes;
+use zerocopy::FromBytes;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("Usage: extract-pk-hashes <fw-image.bin>");
+    let data = std::fs::read(&path).expect("Failed to read file");
+
+    let (manifest, _) =
+        ImageManifest::ref_from_prefix(&data).expect("Failed to parse manifest from image");
+
+    let vendor_hash = Sha384::digest(manifest.preamble.vendor_pub_key_info.as_bytes());
+    let owner_hash = Sha384::digest(manifest.preamble.owner_pub_keys.as_bytes());
+
+    // Convert to big-endian u32 words and print as hex
+    let to_hex = |hash: &[u8]| -> String {
+        let mut s = String::with_capacity(96);
+        for chunk in hash.chunks(4) {
+            s.push_str(&format!(
+                "{:08x}",
+                u32::from_be_bytes(chunk.try_into().unwrap())
+            ));
+        }
+        s
+    };
+
+    println!("VENDOR_PK_HASH={}", to_hex(&vendor_hash));
+    println!("OWNER_PK_HASH={}", to_hex(&owner_hash));
+}

--- a/wasm-demo/www/app.js
+++ b/wasm-demo/www/app.js
@@ -1,0 +1,200 @@
+// Caliptra WASM Emulator - JavaScript glue
+import init, { CaliptraEmulator } from "./caliptra_wasm_demo.js";
+
+// DOM elements
+const romFileInput = document.getElementById("rom-file");
+const romInfo = document.getElementById("rom-info");
+const vendorPkInput = document.getElementById("vendor-pk");
+const ownerPkInput = document.getElementById("owner-pk");
+const btnRun = document.getElementById("btn-run");
+const btnStop = document.getElementById("btn-stop");
+const btnReset = document.getElementById("btn-reset");
+const statusEl = document.getElementById("status");
+const statsEl = document.getElementById("stats");
+const uartOutput = document.getElementById("uart-output");
+const logOutput = document.getElementById("log-output");
+
+// State
+let emulator = null;
+let running = false;
+let animFrameId = null;
+let defaultRom = null;
+let customRom = null;
+let startTime = 0;
+
+// Steps per animation frame — balance between speed and UI responsiveness
+const STEPS_PER_FRAME = 50_000;
+
+// Initialize WASM module and load default ROM
+async function startup() {
+  try {
+    await init();
+    setStatus("Loading default ROM...", "");
+
+    // Try to load the default ROM
+    try {
+      const resp = await fetch("default-rom.bin");
+      if (resp.ok) {
+        defaultRom = new Uint8Array(await resp.arrayBuffer());
+        romInfo.textContent = `Default ROM loaded (${(defaultRom.length / 1024).toFixed(0)} KB)`;
+      } else {
+        romInfo.textContent = "No default ROM — please upload one";
+      }
+    } catch {
+      romInfo.textContent = "No default ROM — please upload one";
+    }
+
+    setStatus("Ready", "");
+    btnRun.disabled = false;
+    btnReset.disabled = false;
+  } catch (err) {
+    setStatus(`WASM init failed: ${err}`, "exited");
+    console.error("WASM init error:", err);
+  }
+}
+
+// Handle custom ROM file upload
+romFileInput.addEventListener("change", (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    customRom = new Uint8Array(reader.result);
+    romInfo.textContent = `${file.name} (${(customRom.length / 1024).toFixed(0)} KB)`;
+  };
+  reader.readAsArrayBuffer(file);
+});
+
+// Get the ROM to use (custom upload takes priority)
+function getRom() {
+  return customRom || defaultRom;
+}
+
+// Create emulator instance
+function createEmulator() {
+  const rom = getRom();
+  if (!rom) {
+    setStatus("No ROM loaded — upload a ROM file", "stopped");
+    return false;
+  }
+
+  const vendorPk = vendorPkInput.value.trim();
+  const ownerPk = ownerPkInput.value.trim();
+
+  try {
+    // Free previous emulator if any
+    if (emulator) {
+      emulator.free();
+      emulator = null;
+    }
+    emulator = new CaliptraEmulator(rom, vendorPk, ownerPk);
+    uartOutput.textContent = "";
+    logOutput.textContent = "";
+    statsEl.textContent = "";
+    return true;
+  } catch (err) {
+    setStatus(`Error: ${err}`, "exited");
+    console.error("Emulator creation error:", err);
+    return false;
+  }
+}
+
+// Run loop using requestAnimationFrame
+function runLoop() {
+  if (!running || !emulator) return;
+
+  const stillRunning = emulator.step(STEPS_PER_FRAME);
+
+  // Collect output
+  const uart = emulator.get_uart_output();
+  if (uart) {
+    uartOutput.textContent += uart;
+    uartOutput.scrollTop = uartOutput.scrollHeight;
+  }
+
+  const log = emulator.get_log();
+  if (log) {
+    logOutput.textContent += log;
+    logOutput.scrollTop = logOutput.scrollHeight;
+  }
+
+  // Update stats
+  const steps = Number(emulator.total_steps());
+  const elapsed = (performance.now() - startTime) / 1000;
+  const mhz = (steps / elapsed / 1_000_000).toFixed(2);
+  statsEl.textContent = `${steps.toLocaleString()} cycles | ${elapsed.toFixed(1)}s | ${mhz} MHz effective`;
+
+  if (!stillRunning) {
+    running = false;
+    const passed = emulator.passed();
+    setStatus(
+      passed ? "Exited — PASSED ✓" : "Exited — FAILED ✗",
+      passed ? "passed" : "exited"
+    );
+    btnRun.disabled = true;
+    btnStop.disabled = true;
+    return;
+  }
+
+  animFrameId = requestAnimationFrame(runLoop);
+}
+
+// Button handlers
+btnRun.addEventListener("click", () => {
+  if (running) return;
+
+  if (!emulator) {
+    if (!createEmulator()) return;
+  }
+
+  running = true;
+  startTime = performance.now();
+  setStatus("Running...", "running");
+  btnRun.disabled = true;
+  btnStop.disabled = false;
+  romFileInput.disabled = true;
+  vendorPkInput.disabled = true;
+  ownerPkInput.disabled = true;
+
+  animFrameId = requestAnimationFrame(runLoop);
+});
+
+btnStop.addEventListener("click", () => {
+  running = false;
+  if (animFrameId) {
+    cancelAnimationFrame(animFrameId);
+    animFrameId = null;
+  }
+  setStatus("Stopped", "stopped");
+  btnRun.disabled = false;
+  btnStop.disabled = true;
+});
+
+btnReset.addEventListener("click", () => {
+  running = false;
+  if (animFrameId) {
+    cancelAnimationFrame(animFrameId);
+    animFrameId = null;
+  }
+  if (emulator) {
+    emulator.free();
+    emulator = null;
+  }
+  uartOutput.textContent = "";
+  logOutput.textContent = "";
+  statsEl.textContent = "";
+  setStatus("Ready", "");
+  btnRun.disabled = false;
+  btnStop.disabled = true;
+  romFileInput.disabled = false;
+  vendorPkInput.disabled = false;
+  ownerPkInput.disabled = false;
+});
+
+function setStatus(text, className) {
+  statusEl.textContent = text;
+  statusEl.className = "status" + (className ? " " + className : "");
+}
+
+// Start
+startup();

--- a/wasm-demo/www/app.js
+++ b/wasm-demo/www/app.js
@@ -4,6 +4,10 @@ import init, { CaliptraEmulator } from "./caliptra_wasm_demo.js";
 // DOM elements
 const romFileInput = document.getElementById("rom-file");
 const romInfo = document.getElementById("rom-info");
+const fwFileInput = document.getElementById("fw-file");
+const fwInfo = document.getElementById("fw-info");
+const socManifestFileInput = document.getElementById("soc-manifest-file");
+const socManifestInfo = document.getElementById("soc-manifest-info");
 const vendorPkInput = document.getElementById("vendor-pk");
 const ownerPkInput = document.getElementById("owner-pk");
 const btnRun = document.getElementById("btn-run");
@@ -20,28 +24,49 @@ let running = false;
 let animFrameId = null;
 let defaultRom = null;
 let customRom = null;
+let defaultFw = null;
+let customFw = null;
+let customSocManifest = null;
 let startTime = 0;
 
 // Steps per animation frame — balance between speed and UI responsiveness
 const STEPS_PER_FRAME = 50_000;
 
-// Initialize WASM module and load default ROM
+// Initialize WASM module and load defaults
 async function startup() {
   try {
     await init();
-    setStatus("Loading default ROM...", "");
+    setStatus("Loading defaults...", "");
 
-    // Try to load the default ROM
-    try {
-      const resp = await fetch("default-rom.bin");
-      if (resp.ok) {
-        defaultRom = new Uint8Array(await resp.arrayBuffer());
-        romInfo.textContent = `Default ROM loaded (${(defaultRom.length / 1024).toFixed(0)} KB)`;
-      } else {
-        romInfo.textContent = "No default ROM — please upload one";
-      }
-    } catch {
+    // Load default ROM, FW, and hash defaults in parallel
+    const [romResp, fwResp, defaultsResp] = await Promise.allSettled([
+      fetch("default-rom.bin"),
+      fetch("default-fw.bin"),
+      fetch("defaults.json"),
+    ]);
+
+    if (romResp.status === "fulfilled" && romResp.value.ok) {
+      defaultRom = new Uint8Array(await romResp.value.arrayBuffer());
+      romInfo.textContent = `Default ROM loaded (${(defaultRom.length / 1024).toFixed(0)} KB)`;
+    } else {
       romInfo.textContent = "No default ROM — please upload one";
+    }
+
+    if (fwResp.status === "fulfilled" && fwResp.value.ok) {
+      defaultFw = new Uint8Array(await fwResp.value.arrayBuffer());
+      fwInfo.textContent = `Default FW loaded (${(defaultFw.length / 1024).toFixed(0)} KB)`;
+    } else {
+      fwInfo.textContent = "(optional) No default FW";
+    }
+
+    if (defaultsResp.status === "fulfilled" && defaultsResp.value.ok) {
+      const defaults = await defaultsResp.value.json();
+      if (defaults.vendor_pk_hash) {
+        vendorPkInput.value = defaults.vendor_pk_hash;
+      }
+      if (defaults.owner_pk_hash && defaults.owner_pk_hash !== "0".repeat(96)) {
+        ownerPkInput.value = defaults.owner_pk_hash;
+      }
     }
 
     setStatus("Ready", "");
@@ -65,9 +90,39 @@ romFileInput.addEventListener("change", (e) => {
   reader.readAsArrayBuffer(file);
 });
 
-// Get the ROM to use (custom upload takes priority)
+// Handle custom FW file upload
+fwFileInput.addEventListener("change", (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    customFw = new Uint8Array(reader.result);
+    fwInfo.textContent = `${file.name} (${(customFw.length / 1024).toFixed(0)} KB)`;
+  };
+  reader.readAsArrayBuffer(file);
+});
+
+// Handle SoC manifest file upload
+socManifestFileInput.addEventListener("change", (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    customSocManifest = new Uint8Array(reader.result);
+    socManifestInfo.textContent = `${file.name} (${(customSocManifest.length / 1024).toFixed(0)} KB)`;
+  };
+  reader.readAsArrayBuffer(file);
+});
+
+// Get the ROM/FW to use (custom upload takes priority)
 function getRom() {
   return customRom || defaultRom;
+}
+function getFw() {
+  return customFw || defaultFw || null;
+}
+function getSocManifest() {
+  return customSocManifest || null;
 }
 
 // Create emulator instance
@@ -80,6 +135,8 @@ function createEmulator() {
 
   const vendorPk = vendorPkInput.value.trim();
   const ownerPk = ownerPkInput.value.trim();
+  const fw = getFw();
+  const socManifest = getSocManifest();
 
   try {
     // Free previous emulator if any
@@ -87,7 +144,7 @@ function createEmulator() {
       emulator.free();
       emulator = null;
     }
-    emulator = new CaliptraEmulator(rom, vendorPk, ownerPk);
+    emulator = new CaliptraEmulator(rom, vendorPk, ownerPk, fw, socManifest);
     uartOutput.textContent = "";
     logOutput.textContent = "";
     statsEl.textContent = "";
@@ -153,6 +210,8 @@ btnRun.addEventListener("click", () => {
   btnRun.disabled = true;
   btnStop.disabled = false;
   romFileInput.disabled = true;
+  fwFileInput.disabled = true;
+  socManifestFileInput.disabled = true;
   vendorPkInput.disabled = true;
   ownerPkInput.disabled = true;
 
@@ -187,6 +246,8 @@ btnReset.addEventListener("click", () => {
   btnRun.disabled = false;
   btnStop.disabled = true;
   romFileInput.disabled = false;
+  fwFileInput.disabled = false;
+  socManifestFileInput.disabled = false;
   vendorPkInput.disabled = false;
   ownerPkInput.disabled = false;
 });

--- a/wasm-demo/www/app.js
+++ b/wasm-demo/www/app.js
@@ -10,6 +10,7 @@ const socManifestFileInput = document.getElementById("soc-manifest-file");
 const socManifestInfo = document.getElementById("soc-manifest-info");
 const vendorPkInput = document.getElementById("vendor-pk");
 const ownerPkInput = document.getElementById("owner-pk");
+const lifecycleSelect = document.getElementById("lifecycle");
 const btnRun = document.getElementById("btn-run");
 const btnStop = document.getElementById("btn-stop");
 const btnReset = document.getElementById("btn-reset");
@@ -137,6 +138,7 @@ function createEmulator() {
   const ownerPk = ownerPkInput.value.trim();
   const fw = getFw();
   const socManifest = getSocManifest();
+  const lifecycle = lifecycleSelect.value;
 
   try {
     // Free previous emulator if any
@@ -144,9 +146,18 @@ function createEmulator() {
       emulator.free();
       emulator = null;
     }
-    emulator = new CaliptraEmulator(rom, vendorPk, ownerPk, fw, socManifest);
-    uartOutput.textContent = "";
-    logOutput.textContent = "";
+    emulator = new CaliptraEmulator(rom, vendorPk, ownerPk, fw, socManifest, lifecycle);
+
+    // Check for boot error — show logs even if boot failed
+    const bootErr = emulator.boot_error();
+    if (bootErr) {
+      uartOutput.textContent = bootErr;
+      const log = emulator.get_log();
+      if (log) logOutput.textContent = log;
+    } else {
+      uartOutput.textContent = "";
+      logOutput.textContent = "";
+    }
     statsEl.textContent = "";
     return true;
   } catch (err) {
@@ -214,6 +225,7 @@ btnRun.addEventListener("click", () => {
   socManifestFileInput.disabled = true;
   vendorPkInput.disabled = true;
   ownerPkInput.disabled = true;
+  lifecycleSelect.disabled = true;
 
   animFrameId = requestAnimationFrame(runLoop);
 });
@@ -250,6 +262,7 @@ btnReset.addEventListener("click", () => {
   socManifestFileInput.disabled = false;
   vendorPkInput.disabled = false;
   ownerPkInput.disabled = false;
+  lifecycleSelect.disabled = false;
 });
 
 function setStatus(text, className) {

--- a/wasm-demo/www/index.html
+++ b/wasm-demo/www/index.html
@@ -195,6 +195,18 @@
   </div>
 
   <div class="form-row">
+    <label for="fw-file">FW Bundle:</label>
+    <input type="file" id="fw-file" accept=".bin,.bundle">
+    <span class="rom-info" id="fw-info">Loading default FW...</span>
+  </div>
+
+  <div class="form-row">
+    <label for="soc-manifest-file">SoC Manifest:</label>
+    <input type="file" id="soc-manifest-file" accept=".bin,.manifest">
+    <span class="rom-info" id="soc-manifest-info">(optional)</span>
+  </div>
+
+  <div class="form-row">
     <label for="vendor-pk">Vendor PK Hash:</label>
     <input type="text" id="vendor-pk" placeholder="96 hex chars (48 bytes) or empty for zeros"
            value="" spellcheck="false">
@@ -208,7 +220,9 @@
 
   <p class="help">
     Leave PK hashes empty for all-zeros (unprovisioned mode).
-    The default ROM binary is the frozen 2.1 release with UART logging enabled.
+    Default ROM is the frozen 2.1 release with UART logging.
+    Default FW bundle is built with test keys (vendor PK hash pre-filled).
+    SoC manifest is only needed for subsystem mode.
   </p>
 </div>
 

--- a/wasm-demo/www/index.html
+++ b/wasm-demo/www/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Caliptra Emulator</title>
+<style>
+  :root {
+    --bg: #1e1e2e;
+    --surface: #2a2a3c;
+    --border: #3a3a4c;
+    --text: #cdd6f4;
+    --muted: #888;
+    --accent: #89b4fa;
+    --green: #a6e3a1;
+    --red: #f38ba8;
+    --yellow: #f9e2af;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 20px;
+    min-height: 100vh;
+  }
+  h1 {
+    font-size: 1.5rem;
+    margin-bottom: 4px;
+    color: var(--accent);
+  }
+  .subtitle {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-bottom: 20px;
+  }
+  .panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .panel h2 {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+    margin-bottom: 12px;
+  }
+  .form-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+  }
+  label {
+    font-size: 0.85rem;
+    min-width: 120px;
+    color: var(--text);
+  }
+  input[type="text"], input[type="file"] {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 6px 10px;
+    font-family: 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 0.8rem;
+    flex: 1;
+    min-width: 200px;
+  }
+  input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  input[type="file"] {
+    cursor: pointer;
+  }
+  .rom-info {
+    font-size: 0.75rem;
+    color: var(--muted);
+    margin-left: 4px;
+  }
+  .btn-row {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  button {
+    background: var(--accent);
+    color: var(--bg);
+    border: none;
+    border-radius: 4px;
+    padding: 8px 20px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  button:hover { opacity: 0.85; }
+  button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+  button.stop {
+    background: var(--red);
+  }
+  button.reset {
+    background: var(--border);
+    color: var(--text);
+  }
+  .status {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-left: 8px;
+  }
+  .status.running { color: var(--green); }
+  .status.stopped { color: var(--yellow); }
+  .status.exited  { color: var(--red); }
+  .status.passed  { color: var(--green); }
+  #uart-output {
+    background: #11111b;
+    color: #a6e3a1;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 12px;
+    font-family: 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 0.78rem;
+    line-height: 1.4;
+    width: 100%;
+    height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    resize: vertical;
+  }
+  #log-output {
+    background: #11111b;
+    color: #bac2de;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 12px;
+    font-family: 'Cascadia Code', 'Fira Code', monospace;
+    font-size: 0.72rem;
+    line-height: 1.3;
+    width: 100%;
+    height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    resize: vertical;
+  }
+  .stats {
+    font-size: 0.78rem;
+    color: var(--muted);
+    margin-top: 8px;
+    font-family: 'Cascadia Code', 'Fira Code', monospace;
+  }
+  details {
+    margin-top: 8px;
+  }
+  details summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .help {
+    font-size: 0.75rem;
+    color: var(--muted);
+    line-height: 1.5;
+    margin-top: 6px;
+  }
+  @media (max-width: 600px) {
+    .form-row { flex-direction: column; align-items: stretch; }
+    label { min-width: auto; }
+  }
+</style>
+</head>
+<body>
+
+<h1>⚙ Caliptra Emulator</h1>
+<p class="subtitle">RISC-V emulator running in WebAssembly</p>
+
+<!-- Configuration Panel -->
+<div class="panel">
+  <h2>Configuration</h2>
+
+  <div class="form-row">
+    <label for="rom-file">ROM Binary:</label>
+    <input type="file" id="rom-file" accept=".bin,.rom">
+    <span class="rom-info" id="rom-info">Loading default ROM...</span>
+  </div>
+
+  <div class="form-row">
+    <label for="vendor-pk">Vendor PK Hash:</label>
+    <input type="text" id="vendor-pk" placeholder="96 hex chars (48 bytes) or empty for zeros"
+           value="" spellcheck="false">
+  </div>
+
+  <div class="form-row">
+    <label for="owner-pk">Owner PK Hash:</label>
+    <input type="text" id="owner-pk" placeholder="96 hex chars (48 bytes) or empty for zeros"
+           value="" spellcheck="false">
+  </div>
+
+  <p class="help">
+    Leave PK hashes empty for all-zeros (unprovisioned mode).
+    The default ROM binary is the frozen 2.1 release with UART logging enabled.
+  </p>
+</div>
+
+<!-- Controls -->
+<div class="panel">
+  <h2>Controls</h2>
+  <div class="btn-row">
+    <button id="btn-run" disabled>▶ Run</button>
+    <button id="btn-stop" class="stop" disabled>■ Stop</button>
+    <button id="btn-reset" class="reset" disabled>↻ Reset</button>
+    <span class="status" id="status">Initializing WASM...</span>
+  </div>
+  <div class="stats" id="stats"></div>
+</div>
+
+<!-- UART Output -->
+<div class="panel">
+  <h2>UART Output</h2>
+  <div id="uart-output"></div>
+</div>
+
+<!-- Log Output (collapsible) -->
+<div class="panel">
+  <details>
+    <summary>Timestamped Log Output</summary>
+    <div id="log-output" style="margin-top: 8px;"></div>
+  </details>
+</div>
+
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/wasm-demo/www/index.html
+++ b/wasm-demo/www/index.html
@@ -75,6 +75,19 @@
     outline: none;
     border-color: var(--accent);
   }
+  select {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 6px 10px;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  select:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
   input[type="file"] {
     cursor: pointer;
   }
@@ -218,11 +231,21 @@
            value="" spellcheck="false">
   </div>
 
+  <div class="form-row">
+    <label for="lifecycle">Device Lifecycle:</label>
+    <select id="lifecycle">
+      <option value="manufacturing" selected>Manufacturing</option>
+      <option value="unprovisioned">Unprovisioned</option>
+      <option value="production">Production</option>
+    </select>
+  </div>
+
   <p class="help">
     Leave PK hashes empty for all-zeros (unprovisioned mode).
     Default ROM is the frozen 2.1 release with UART logging.
     Default FW bundle is built with test keys (vendor PK hash pre-filled).
     SoC manifest is only needed for subsystem mode.
+    Manufacturing lifecycle validates PK hashes; Unprovisioned skips validation.
   </p>
 </div>
 


### PR DESCRIPTION
## Summary

This PR collects the `caliptra-sw` changes needed to run Caliptra in a
browser via WebAssembly. They back the standalone WASM emulator demo at
https://swenson.github.io/caliptra-wasm/ (source:
https://github.com/swenson/caliptra-wasm).

> **Note:** This branch (`swenson:wasm`) is intentionally **out of date**
> relative to `main`. It is opened as a **draft** so others can review the
> current state of the WASM-enabling changes, not as a ready-to-merge PR.
> The WASM demo currently pins this work at commit `0615298`.

## What's here

The substantive emulator/model changes that the WASM build depends on:

- **`sw-emulator/.../key_vault.rs`** – Add a `KeyVault` snapshot accessor so
  the demo UI can display key-vault state, and fix a `snapshot` panic
  (keys storage is padded to 2048 bytes).
- **`hw-model/`** – Expose the snapshot accessor through `ModelEmulated`
  / the `HwModel` trait, plus the dependency wiring needed to build for
  `wasm32-unknown-unknown`.
- **Lifecycle flexing** – Allow booting straight to FW in the emulated model
  for the demo flow.

Plus an early embedded prototype of the demo itself under `wasm-demo/`. That
prototype has since graduated into the standalone
[`caliptra-wasm`](https://github.com/swenson/caliptra-wasm) repository; it is
included here only for historical context and is not intended to live in
`caliptra-sw` long-term.

## Commits

- Add WASM demo
- WASM demo core FW
- Flex lifecycle; boot to FW
- Add KeyVault snapshot accessor for WASM demo UI
- Fix KeyVault::snapshot panic (keys storage padded to 2048 bytes)

## Why open it now

Folks have asked to see the current state of the WASM-enabling changes. This
draft makes them reviewable in one place even though the branch needs a
rebase onto current `main` before it could merge.
