### PR TITLE
[rom] Write lock stable keys

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-2bb482eb3fb28b6eae3114854c5a2bcb0bd6daedca3f065c68ccb8345baab364efc08778188e6e025406dc11c52d3c6d  caliptra-rom-no-log.bin
-d31beab212c3874804c4fea5938ab6e6b34dbee97ee8ec08a6136d3a678c9aad19e05178476ae28fb5d265cf37057290  caliptra-rom-with-log.bin
+9c2a1160f96286dac3b28148d3de3574f3d00b28560d0e114239afaf8a8bfa97596057bee98a1734848c605ae23586ac  caliptra-rom-no-log.bin
+adfa63011ac87cc1622eebab42e03863014978173be711ad266a51927be779ef79d780e130e039aca21a39b6af66696e  caliptra-rom-with-log.bin

--- a/rom/dev/src/flow/cold_reset/ldev_id.rs
+++ b/rom/dev/src/flow/cold_reset/ldev_id.rs
@@ -185,6 +185,11 @@ impl LocalDevIdLayer {
             HmacMode::Hmac512,
             KeyUsage::default().set_aes_key_en(),
         )?;
+        // Write-lock the stable identity root slot so later (potentially
+        // compromised) FMC/runtime firmware cannot overwrite or erase the
+        // ROM-anchored root. Consumers only need read access (key usage),
+        // which the write lock does not affect.
+        env.key_vault.set_key_write_lock(stable_idev);
         Ok(())
     }
 
@@ -215,6 +220,11 @@ impl LocalDevIdLayer {
             HmacMode::Hmac512,
             KeyUsage::default().set_aes_key_en(),
         )?;
+        // Write-lock the stable identity root slot so later (potentially
+        // compromised) FMC/runtime firmware cannot overwrite or erase the
+        // ROM-anchored root. Consumers only need read access (key usage),
+        // which the write lock does not affect.
+        env.key_vault.set_key_write_lock(stable_ldev);
         Ok(())
     }
 

--- a/rom/dev/src/flow/update_reset.rs
+++ b/rom/dev/src/flow/update_reset.rs
@@ -19,6 +19,7 @@ use crate::{cprintln, pcr, rom_env::RomEnv};
 
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_common::keyids::{KEY_ID_STABLE_IDEV, KEY_ID_STABLE_LDEV, KEY_ID_STABLE_OWNER};
 use caliptra_common::mailbox_api::CommandId;
 use caliptra_common::verifier::FirmwareImageVerificationEnv;
 use caliptra_common::{handle_fatal_error, RomBootStatus::*};
@@ -45,7 +46,13 @@ impl UpdateResetFlow {
         cprintln!("[update-reset] ++");
         report_boot_status(UpdateResetStarted.into());
 
+        // The Key Vault write/use locks clear on every warm/update reset while
+        // the key contents persist, so every write lock ROM established for its
+        // long-lived keys must be re-applied here.
         ocp_lock::wr_lock_keyvault(&mut env.key_vault);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_IDEV);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_LDEV);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_OWNER);
 
         // Check persistent data is valid
         let pdata = env.persistent_data.get();

--- a/rom/dev/src/flow/warm_reset.rs
+++ b/rom/dev/src/flow/warm_reset.rs
@@ -15,6 +15,7 @@ use crate::{cprintln, flow::cold_reset::ocp_lock, rom_env::RomEnv};
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert_eq, cfi_assert_ne, cfi_launder};
+use caliptra_common::keyids::{KEY_ID_STABLE_IDEV, KEY_ID_STABLE_LDEV, KEY_ID_STABLE_OWNER};
 use caliptra_common::{handle_fatal_error, RomBootStatus::*};
 use caliptra_drivers::RomPersistentData;
 use caliptra_error::{CaliptraError, CaliptraResult};
@@ -33,7 +34,13 @@ impl WarmResetFlow {
     pub fn run(env: &mut RomEnv) -> CaliptraResult<()> {
         cprintln!("[warm-reset] ++");
 
+        // The Key Vault write/use locks clear on every warm/update reset while
+        // the key contents persist, so every write lock ROM established for its
+        // long-lived keys must be re-applied here.
         ocp_lock::wr_lock_keyvault(&mut env.key_vault);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_IDEV);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_LDEV);
+        env.key_vault.set_key_write_lock(KEY_ID_STABLE_OWNER);
 
         // Check persistent data is valid
         let pdata = env.persistent_data.get();


### PR DESCRIPTION
Write lock the stable keys (IDEV, LDEV, OWNER) in all reset types so they can't be overwridden or erased by mutable firmware. This still allows read access to the keys so they can be used by mutable firmware.