### PR TITLE
runtime: request stack optimization

### DIFF
--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -24,7 +24,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult};
 use dpe::response::DpeErrorCode;
-use zerocopy::FromBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
 pub const IMAGE_NOT_AUTHORIZED: u32 = 0x21523F21; // FW ID not found in the image metadata entry collection.
@@ -34,8 +34,10 @@ pub struct AuthorizeAndStashCmd;
 impl AuthorizeAndStashCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if let Ok(cmd) = AuthorizeAndStashReq::ref_from_bytes(cmd_args) {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = AuthorizeAndStashReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        {
             if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
                 Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
             }
@@ -90,8 +92,6 @@ impl AuthorizeAndStashCmd {
                 hdr: MailboxRespHeader::default(),
                 auth_req_result: auth_result,
             }))
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -37,62 +37,59 @@ impl AuthorizeAndStashCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut cmd = AuthorizeAndStashReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-        {
-            if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
-                Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
-            }
-
-            // Check if firmware id is present in the image metadata entry collection.
-            let persistent_data = drivers.persistent_data.get();
-            let auth_manifest_image_metadata_col =
-                &persistent_data.auth_manifest_image_metadata_col;
-
-            let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
-            let auth_result = if let Some(metadata_entry) =
-                Self::find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id)
-            {
-                // If 'ignore_auth_check' is set, then skip the image digest comparison and authorize the image.
-                let flags = ImageMetadataFlags(metadata_entry.flags);
-                if flags.ignore_auth_check() {
-                    cfi_assert!(cfi_launder(flags.ignore_auth_check()));
-                    IMAGE_AUTHORIZED
-                } else if cfi_launder(metadata_entry.digest) == cmd.measurement {
-                    caliptra_cfi_lib::cfi_assert_eq_12_words(
-                        &Array4x12::from(metadata_entry.digest).0,
-                        &Array4x12::from(cmd.measurement).0,
-                    );
-                    IMAGE_AUTHORIZED
-                } else {
-                    IMAGE_HASH_MISMATCH
-                }
-            } else {
-                IMAGE_NOT_AUTHORIZED
-            };
-
-            // Stash the measurement if the image is authorized.
-            if auth_result == IMAGE_AUTHORIZED {
-                let flags: AuthAndStashFlags = cmd.flags.into();
-                if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
-                    let dpe_result = StashMeasurementCmd::stash_measurement(
-                        drivers,
-                        &cmd.fw_id,
-                        &cmd.measurement,
-                        cmd.svn,
-                    )?;
-                    if dpe_result != DpeErrorCode::NoError {
-                        drivers
-                            .soc_ifc
-                            .set_fw_extended_error(dpe_result.get_error_code());
-                        Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
-                    }
-                }
-            }
-
-            Ok(MailboxResp::AuthorizeAndStash(AuthorizeAndStashResp {
-                hdr: MailboxRespHeader::default(),
-                auth_req_result: auth_result,
-            }))
+        if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
+            Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
         }
+
+        // Check if firmware id is present in the image metadata entry collection.
+        let persistent_data = drivers.persistent_data.get();
+        let auth_manifest_image_metadata_col = &persistent_data.auth_manifest_image_metadata_col;
+
+        let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
+        let auth_result = if let Some(metadata_entry) =
+            Self::find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id)
+        {
+            // If 'ignore_auth_check' is set, then skip the image digest comparison and authorize the image.
+            let flags = ImageMetadataFlags(metadata_entry.flags);
+            if flags.ignore_auth_check() {
+                cfi_assert!(cfi_launder(flags.ignore_auth_check()));
+                IMAGE_AUTHORIZED
+            } else if cfi_launder(metadata_entry.digest) == cmd.measurement {
+                caliptra_cfi_lib::cfi_assert_eq_12_words(
+                    &Array4x12::from(metadata_entry.digest).0,
+                    &Array4x12::from(cmd.measurement).0,
+                );
+                IMAGE_AUTHORIZED
+            } else {
+                IMAGE_HASH_MISMATCH
+            }
+        } else {
+            IMAGE_NOT_AUTHORIZED
+        };
+
+        // Stash the measurement if the image is authorized.
+        if auth_result == IMAGE_AUTHORIZED {
+            let flags: AuthAndStashFlags = cmd.flags.into();
+            if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
+                let dpe_result = StashMeasurementCmd::stash_measurement(
+                    drivers,
+                    &cmd.fw_id,
+                    &cmd.measurement,
+                    cmd.svn,
+                )?;
+                if dpe_result != DpeErrorCode::NoError {
+                    drivers
+                        .soc_ifc
+                        .set_fw_extended_error(dpe_result.get_error_code());
+                    Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
+                }
+            }
+        }
+
+        Ok(MailboxResp::AuthorizeAndStash(AuthorizeAndStashResp {
+            hdr: MailboxRespHeader::default(),
+            auth_req_result: auth_result,
+        }))
     }
 
     /// Search for a metadata entry in the sorted `AuthManifestImageMetadataCollection` that matches the firmware ID.

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -18,16 +18,16 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::commands::{CertifyKeyP384Cmd, Command};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
 use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, PauserPrivileges};
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = CertifyKeyExtendedReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = CertifyKeyExtendedReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         match drivers.caller_privilege_level() {
             // CERTIFY_KEY_EXTENDED MUST only be called from PL0

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -24,16 +24,15 @@ use caliptra_drivers::{
     PersistentData,
 };
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
-use zerocopy::IntoBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if cmd_args.len() <= core::mem::size_of::<GetIdevCertReq>() {
-            let mut cmd = GetIdevCertReq::default();
-            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
-
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = GetIdevCertReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        {
             // Validate tbs
             if cmd.tbs_size as usize > cmd.tbs.len() {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
@@ -59,8 +58,6 @@ impl IDevIdCertCmd {
                 cert_size: cert_size as u32,
                 cert,
             }))
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 }

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -32,33 +32,32 @@ impl IDevIdCertCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut cmd = GetIdevCertReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-        {
-            // Validate tbs
-            if cmd.tbs_size as usize > cmd.tbs.len() {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-            }
 
-            let sig = Ecdsa384Signature {
-                r: cmd.signature_r,
-                s: cmd.signature_s,
-            };
-
-            let Some(builder) = Ecdsa384CertBuilder::new(&cmd.tbs[..cmd.tbs_size as usize], &sig)
-            else {
-                return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
-            };
-
-            let mut cert = [0; GetIdevCertResp::DATA_MAX_SIZE];
-            let Some(cert_size) = builder.build(&mut cert) else {
-                return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
-            };
-
-            Ok(MailboxResp::GetIdevCert(GetIdevCertResp {
-                hdr: MailboxRespHeader::default(),
-                cert_size: cert_size as u32,
-                cert,
-            }))
+        // Validate tbs
+        if cmd.tbs_size as usize > cmd.tbs.len() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
+
+        let sig = Ecdsa384Signature {
+            r: cmd.signature_r,
+            s: cmd.signature_s,
+        };
+
+        let Some(builder) = Ecdsa384CertBuilder::new(&cmd.tbs[..cmd.tbs_size as usize], &sig)
+        else {
+            return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
+        };
+
+        let mut cert = [0; GetIdevCertResp::DATA_MAX_SIZE];
+        let Some(cert_size) = builder.build(&mut cert) else {
+            return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
+        };
+
+        Ok(MailboxResp::GetIdevCert(GetIdevCertResp {
+            hdr: MailboxRespHeader::default(),
+            cert_size: cert_size as u32,
+            cert,
+        }))
     }
 }
 

--- a/runtime/src/get_fmc_alias_csr.rs
+++ b/runtime/src/get_fmc_alias_csr.rs
@@ -1,19 +1,22 @@
 // Licensed under the Apache-2.0 license
 
+use crate::packet::copy_from_mbox;
 use crate::Drivers;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 
-use caliptra_common::mailbox_api::{GetFmcAliasCsrResp, MailboxResp};
+use caliptra_common::mailbox_api::{GetFmcAliasCsrReq, GetFmcAliasCsrResp, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use caliptra_drivers::FmcAliasCsr;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct GetFmcAliasCsrCmd;
 impl GetFmcAliasCsrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, _cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        copy_from_mbox(drivers, GetFmcAliasCsrReq::new_zeroed().as_mut_bytes())?;
         let csr_persistent_mem = &drivers.persistent_data.get().fmc_alias_csr;
 
         match csr_persistent_mem.get_csr_len() {

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -1,19 +1,22 @@
 // Licensed under the Apache-2.0 license
 
+use crate::packet::copy_from_mbox;
 use crate::Drivers;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 
-use caliptra_common::mailbox_api::{GetIdevCsrResp, MailboxResp};
+use caliptra_common::mailbox_api::{GetIdevCsrReq, GetIdevCsrResp, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use caliptra_drivers::IdevIdCsr;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct GetIdevCsrCmd;
 impl GetIdevCsrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, _cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        copy_from_mbox(drivers, GetIdevCsrReq::new_zeroed().as_mut_bytes())?;
         let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
 
         match csr_persistent_mem.get_csr_len() {

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -47,101 +47,96 @@ impl InvokeDpeCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut cmd = InvokeDpeReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-        {
-            let caller_privilege_level = drivers.caller_privilege_level();
 
-            // Validate data length
-            if cmd.data_size as usize > cmd.data.len() {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        let caller_privilege_level = drivers.caller_privilege_level();
+
+        // Validate data length
+        if cmd.data_size as usize > cmd.data.len() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+        }
+        let command =
+            Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
+                .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+
+        // Determine the target privilege level of a new context then check if we exceed thresholds
+        let new_context_privilege_level = match command {
+            Command::DeriveContext(cmd) if cmd.flags.changes_locality() => {
+                drivers.privilege_level_from_locality(cmd.target_locality)
             }
-            let command =
-                Command::deserialize(DpeProfile::P384Sha384, &cmd.data[..cmd.data_size as usize])
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+            _ => caller_privilege_level,
+        };
+        let dpe_context_threshold_err =
+            drivers.is_dpe_context_threshold_exceeded(new_context_privilege_level);
 
-            // Determine the target privilege level of a new context then check if we exceed thresholds
-            let new_context_privilege_level = match command {
-                Command::DeriveContext(cmd) if cmd.flags.changes_locality() => {
-                    drivers.privilege_level_from_locality(cmd.target_locality)
-                }
-                _ => caller_privilege_level,
-            };
-            let dpe_context_threshold_err =
-                drivers.is_dpe_context_threshold_exceeded(new_context_privilege_level);
-
-            let pdata = drivers.persistent_data.get_mut();
-            let pl0_pauser = pdata.manifest1.header.pl0_pauser;
-            // Check if command can be executed
-            match command {
-                Command::InitCtx(cmd) if InitCtxCmd::flag_is_simulation(cmd) => {
-                    // InitCtx can only create new contexts if they are simulation contexts.
+        let pdata = drivers.persistent_data.get_mut();
+        let pl0_pauser = pdata.manifest1.header.pl0_pauser;
+        // Check if command can be executed
+        match command {
+            Command::InitCtx(cmd) if InitCtxCmd::flag_is_simulation(cmd) => {
+                // InitCtx can only create new contexts if they are simulation contexts.
+                dpe_context_threshold_err?;
+            }
+            Command::DeriveContext(cmd) => {
+                // If the recursive flag is not set, DeriveContext will generate a new context.
+                // If recursive _is_ set, it will extend the existing one, which will not count
+                // against the context threshold.
+                if !cmd.flags.is_recursive() {
+                    // Takes target locality into consideration if applicable. See above
                     dpe_context_threshold_err?;
                 }
-                Command::DeriveContext(cmd) => {
-                    // If the recursive flag is not set, DeriveContext will generate a new context.
-                    // If recursive _is_ set, it will extend the existing one, which will not count
-                    // against the context threshold.
-                    if !cmd.flags.is_recursive() {
-                        // Takes target locality into consideration if applicable. See above
-                        dpe_context_threshold_err?;
-                    }
-                    if cmd.flags.changes_locality()
-                        && cmd.target_locality == pl0_pauser
-                        && caller_privilege_level != PauserPrivileges::PL0
-                    {
-                        return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                    }
-
-                    if cmd.flags.exports_cdi() && caller_privilege_level != PauserPrivileges::PL0 {
-                        return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-                    }
-                }
-                Command::CertifyKey(ref cmd)
-                    if cmd.format() == CertifyKeyCommand::FORMAT_X509
-                        && caller_privilege_level != PauserPrivileges::PL0 =>
+                if cmd.flags.changes_locality()
+                    && cmd.target_locality == pl0_pauser
+                    && caller_privilege_level != PauserPrivileges::PL0
                 {
-                    // PL1 cannot request X509
                     return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
                 }
-                _ => (),
-            }
 
-            let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
-            let mut invoke_resp = InvokeDpeResp::default();
-            let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut invoke_resp.data);
-
-            if let Command::DestroyCtx(_) = command {
-                // clear tags for destroyed contexts
-                let pdata = drivers.persistent_data.get_mut();
-                let state = &mut pdata.dpe;
-                let context_has_tag = &mut pdata.context_has_tag;
-                let context_tags = &mut pdata.context_tags;
-                InvokeDpeCmd::clear_tags_for_inactive_contexts(
-                    state,
-                    context_has_tag,
-                    context_tags,
-                );
-            }
-
-            // If DPE command failed, populate header with error code, but
-            // don't fail the mailbox command.
-            match result {
-                Ok(data_size) => {
-                    invoke_resp.data_size = data_size as u32;
+                if cmd.flags.exports_cdi() && caller_privilege_level != PauserPrivileges::PL0 {
+                    return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
                 }
-                Err(ref e) => {
-                    // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                    if let Some(ext_err) = e.get_error_detail() {
-                        drivers.soc_ifc.set_fw_extended_error(ext_err);
-                    }
-                    let r = ResponseHdr::new(CaliptraDpeProfile::Ecc384.into(), *e);
-                    invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
-                        .copy_from_slice(r.as_bytes());
-                    invoke_resp.data_size = r.as_bytes().len() as u32;
-                }
-            };
-
-            Ok(MailboxResp::InvokeDpeCommand(invoke_resp))
+            }
+            Command::CertifyKey(ref cmd)
+                if cmd.format() == CertifyKeyCommand::FORMAT_X509
+                    && caller_privilege_level != PauserPrivileges::PL0 =>
+            {
+                // PL1 cannot request X509
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+            _ => (),
         }
+
+        let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
+        let mut invoke_resp = InvokeDpeResp::default();
+        let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut invoke_resp.data);
+
+        if let Command::DestroyCtx(_) = command {
+            // clear tags for destroyed contexts
+            let pdata = drivers.persistent_data.get_mut();
+            let state = &mut pdata.dpe;
+            let context_has_tag = &mut pdata.context_has_tag;
+            let context_tags = &mut pdata.context_tags;
+            InvokeDpeCmd::clear_tags_for_inactive_contexts(state, context_has_tag, context_tags);
+        }
+
+        // If DPE command failed, populate header with error code, but
+        // don't fail the mailbox command.
+        match result {
+            Ok(data_size) => {
+                invoke_resp.data_size = data_size as u32;
+            }
+            Err(ref e) => {
+                // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
+                if let Some(ext_err) = e.get_error_detail() {
+                    drivers.soc_ifc.set_fw_extended_error(ext_err);
+                }
+                let r = ResponseHdr::new(CaliptraDpeProfile::Ecc384.into(), *e);
+                invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
+                    .copy_from_slice(r.as_bytes());
+                invoke_resp.data_size = r.as_bytes().len() as u32;
+            }
+        };
+
+        Ok(MailboxResp::InvokeDpeCommand(invoke_resp))
     }
 
     /// Remove context tags for all inactive DPE contexts

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -25,7 +25,7 @@ use dpe::{
 };
 use platform::MAX_OTHER_NAME_SIZE;
 use ufmt::derive::uDebug;
-use zerocopy::IntoBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 #[derive(uDebug, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CaliptraDpeProfile {
@@ -44,11 +44,10 @@ pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if cmd_args.len() <= core::mem::size_of::<InvokeDpeReq>() {
-            let mut cmd = InvokeDpeReq::default();
-            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
-
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = InvokeDpeReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        {
             let caller_privilege_level = drivers.caller_privilege_level();
 
             // Validate data length
@@ -142,8 +141,6 @@ impl InvokeDpeCmd {
             };
 
             Ok(MailboxResp::InvokeDpeCommand(invoke_resp))
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,8 +83,9 @@ pub use set_auth_manifest::SetAuthManifestCmd;
 pub use stash_measurement::StashMeasurementCmd;
 pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd};
 pub mod packet;
-use caliptra_common::mailbox_api::{CommandId, MailboxResp};
-use packet::Packet;
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxResp};
+use packet::{copy_from_mbox, copy_to_mbox};
+use zerocopy::{FromZeros, IntoBytes};
 pub mod tagging;
 use tagging::{GetTaggedTciCmd, TagTciCmd};
 
@@ -183,15 +184,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         );
     }
 
-    // Get the command bytes
-    let mut req_packet = Packet::default();
-    Packet::copy_from_mbox(drivers, &mut req_packet)?;
-    let cmd_bytes = req_packet.as_bytes()?;
-
-    cprintln!("[rt]cmd =0x{:x}, len={}", req_packet.cmd, req_packet.len);
-
     // Handle the request and generate the response
-    let mut resp = match CommandId::from(req_packet.cmd) {
+    let mut resp = match drivers.mbox.cmd() {
         CommandId::FIRMWARE_LOAD => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
         CommandId::GET_IDEV_CERT => IDevIdCertCmd::execute(cmd_bytes),
         CommandId::GET_IDEV_INFO => IDevIdInfoCmd::execute(drivers),
@@ -254,7 +248,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     let resp = okmutref(&mut resp)?;
 
     // Send the response
-    Packet::copy_to_mbox(drivers, resp)?;
+    copy_to_mbox(drivers, resp)?;
 
     Ok(MboxStatusE::DataReady)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -187,62 +187,80 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     // Handle the request and generate the response
     let mut resp = match drivers.mbox.cmd() {
         CommandId::FIRMWARE_LOAD => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
-        CommandId::GET_IDEV_CERT => IDevIdCertCmd::execute(cmd_bytes),
-        CommandId::GET_IDEV_INFO => IDevIdInfoCmd::execute(drivers),
+        CommandId::GET_IDEV_CERT => IDevIdCertCmd::execute(drivers),
+        CommandId::GET_IDEV_INFO => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            IDevIdInfoCmd::execute(drivers)
+        }
         CommandId::GET_LDEV_CERT => GetLdevCertCmd::execute(drivers),
-        CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers, cmd_bytes),
-        CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers, cmd_bytes),
-        CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers, cmd_bytes),
-        CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
-        CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers, cmd_bytes),
-        CommandId::DISABLE_ATTESTATION => DisableAttestationCmd::execute(drivers),
-        CommandId::FW_INFO => FwInfoCmd::execute(drivers),
-        CommandId::DPE_TAG_TCI => TagTciCmd::execute(drivers, cmd_bytes),
-        CommandId::DPE_GET_TAGGED_TCI => GetTaggedTciCmd::execute(drivers, cmd_bytes),
-        CommandId::POPULATE_IDEV_CERT => PopulateIDevIdCertCmd::execute(drivers, cmd_bytes),
+        CommandId::INVOKE_DPE => InvokeDpeCmd::execute(drivers),
+        CommandId::ECDSA384_VERIFY => EcdsaVerifyCmd::execute(drivers),
+        CommandId::LMS_VERIFY => LmsVerifyCmd::execute(drivers),
+        CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers),
+        CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers),
+        CommandId::DISABLE_ATTESTATION => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            DisableAttestationCmd::execute(drivers)
+        }
+        CommandId::FW_INFO => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            FwInfoCmd::execute(drivers)
+        }
+        CommandId::DPE_TAG_TCI => TagTciCmd::execute(drivers),
+        CommandId::DPE_GET_TAGGED_TCI => GetTaggedTciCmd::execute(drivers),
+        CommandId::POPULATE_IDEV_CERT => PopulateIDevIdCertCmd::execute(drivers),
         CommandId::GET_FMC_ALIAS_CERT => GetFmcAliasCertCmd::execute(drivers),
         CommandId::GET_RT_ALIAS_CERT => GetRtAliasCertCmd::execute(drivers),
-        CommandId::ADD_SUBJECT_ALT_NAME => AddSubjectAltNameCmd::execute(drivers, cmd_bytes),
-        CommandId::CERTIFY_KEY_EXTENDED => CertifyKeyExtendedCmd::execute(drivers, cmd_bytes),
-        CommandId::INCREMENT_PCR_RESET_COUNTER => {
-            IncrementPcrResetCounterCmd::execute(drivers, cmd_bytes)
-        }
-        CommandId::QUOTE_PCRS => GetPcrQuoteCmd::execute(drivers, cmd_bytes),
+        CommandId::ADD_SUBJECT_ALT_NAME => AddSubjectAltNameCmd::execute(drivers),
+        CommandId::CERTIFY_KEY_EXTENDED => CertifyKeyExtendedCmd::execute(drivers),
+        CommandId::INCREMENT_PCR_RESET_COUNTER => IncrementPcrResetCounterCmd::execute(drivers),
+        CommandId::QUOTE_PCRS => GetPcrQuoteCmd::execute(drivers),
         CommandId::VERSION => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
             FipsVersionCmd::execute(&drivers.soc_ifc).map(MailboxResp::FipsVersion)
         }
-        CommandId::CAPABILITIES => CapabilitiesCmd::execute(),
+        CommandId::CAPABILITIES => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            CapabilitiesCmd::execute()
+        }
         #[cfg(feature = "fips_self_test")]
-        CommandId::SELF_TEST_START => match drivers.self_test_status {
-            SelfTestStatus::Idle => {
-                drivers.self_test_status = SelfTestStatus::InProgress(fips_self_test_cmd::execute);
-                Ok(MailboxResp::default())
+        CommandId::SELF_TEST_START => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            match drivers.self_test_status {
+                SelfTestStatus::Idle => {
+                    drivers.self_test_status =
+                        SelfTestStatus::InProgress(fips_self_test_cmd::execute);
+                    Ok(MailboxResp::default())
+                }
+                _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGRESS),
             }
-            _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGRESS),
-        },
+        }
         #[cfg(feature = "fips_self_test")]
-        CommandId::SELF_TEST_GET_RESULTS => match drivers.self_test_status {
-            SelfTestStatus::Done => {
-                drivers.self_test_status = SelfTestStatus::Idle;
-                Ok(MailboxResp::default())
+        CommandId::SELF_TEST_GET_RESULTS => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            match drivers.self_test_status {
+                SelfTestStatus::Done => {
+                    drivers.self_test_status = SelfTestStatus::Idle;
+                    Ok(MailboxResp::default())
+                }
+                _ => Err(CaliptraError::RUNTIME_SELF_TEST_NOT_STARTED),
             }
-            _ => Err(CaliptraError::RUNTIME_SELF_TEST_NOT_STARTED),
-        },
-        CommandId::SHUTDOWN => FipsShutdownCmd::execute(drivers),
-        CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers, cmd_bytes),
-        CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers, cmd_bytes),
-        CommandId::GET_IDEV_CSR => GetIdevCsrCmd::execute(drivers, cmd_bytes),
-        CommandId::GET_FMC_ALIAS_CSR => GetFmcAliasCsrCmd::execute(drivers, cmd_bytes),
-        CommandId::GET_PCR_LOG => GetPcrLogCmd::execute(drivers, cmd_bytes),
-        CommandId::SIGN_WITH_EXPORTED_ECDSA => {
-            SignWithExportedEcdsaCmd::execute(drivers, cmd_bytes)
         }
-        CommandId::REVOKE_EXPORTED_CDI_HANDLE => {
-            RevokeExportedCdiHandleCmd::execute(drivers, cmd_bytes)
+        CommandId::SHUTDOWN => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            FipsShutdownCmd::execute(drivers)
         }
-        CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => {
-            ReallocateDpeContextLimitsCmd::execute(drivers, cmd_bytes)
+        CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers),
+        CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers),
+        CommandId::GET_IDEV_CSR => GetIdevCsrCmd::execute(drivers),
+        CommandId::GET_FMC_ALIAS_CSR => GetFmcAliasCsrCmd::execute(drivers),
+        CommandId::GET_PCR_LOG => {
+            copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
+            GetPcrLogCmd::execute(drivers)
         }
+        CommandId::SIGN_WITH_EXPORTED_ECDSA => SignWithExportedEcdsaCmd::execute(drivers),
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE => RevokeExportedCdiHandleCmd::execute(drivers),
+        CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => ReallocateDpeContextLimitsCmd::execute(drivers),
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     };
     let resp = okmutref(&mut resp)?;

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -121,6 +121,20 @@ impl Mailbox {
         }
     }
 
+    /// Reads `word_count` words from the FIFO into `buf` as little-endian bytes.
+    /// Handles structs whose size is not a multiple of 4.
+    pub fn copy_from_mbox_bytes(&mut self, buf: &mut [u8], word_count: usize) {
+        let mbox = self.mbox.regs_mut();
+        for i in 0..word_count {
+            let word_bytes = mbox.dataout().read().to_le_bytes();
+            let offset = i * 4;
+            if let Some(dst) = buf.get_mut(offset..) {
+                let len = dst.len().min(4);
+                dst[..len].copy_from_slice(&word_bytes[..len]);
+            }
+        }
+    }
+
     /// Clears the mailbox
     pub fn flush(&mut self) {
         let count = self.dlen_words();

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -37,11 +37,11 @@ pub fn copy_from_mbox(drivers: &mut crate::Drivers, buf: &mut [u8]) -> CaliptraR
 
     cprintln!("[rt]cmd=0x{:x}, len={}", cmd, dlen);
 
-    mbox.copy_from_mbox_bytes(buf, dlen_words);
-
     if dlen < core::mem::size_of::<MailboxReqHeader>() {
         return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
     }
+
+    mbox.copy_from_mbox_bytes(buf, dlen_words);
 
     let clamped = dlen.min(buf.len());
     let payload_bytes = &buf[..clamped];

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -12,103 +12,67 @@ Abstract:
 
 --*/
 
-use caliptra_drivers::CaliptraResult;
-
+use caliptra_common::cprintln;
 use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxResp};
-use caliptra_drivers::CaliptraError;
-use zerocopy::{FromBytes, IntoBytes};
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+use zerocopy::FromBytes;
 
-#[derive(Debug, Clone)]
-pub struct Packet {
-    pub cmd: u32,
-    pub payload: [u32; MAX_PAYLOAD_SIZE],
-    pub len: usize, // Length in bytes
+/// Reads the pending mailbox command payload into `buf`.
+///
+/// Performs bounds check, FIFO drain, header size check, and checksum
+/// verification. `buf` must be sized to the caller's request type
+/// (e.g. `req.as_mut_bytes()`). Marked `#[inline(never)]` so this function
+/// compiles once regardless of how many command handlers call it.
+#[inline(never)]
+pub fn copy_from_mbox(drivers: &mut crate::Drivers, buf: &mut [u8]) -> CaliptraResult<()> {
+    let mbox = &mut drivers.mbox;
+    let cmd = u32::from(mbox.cmd());
+    let dlen = mbox.dlen() as usize;
+    let dlen_words = mbox.dlen_words() as usize;
+
+    let max_words = buf.len().div_ceil(4);
+    if dlen_words > max_words {
+        return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
+    }
+
+    cprintln!("[rt]cmd=0x{:x}, len={}", cmd, dlen);
+
+    mbox.copy_from_mbox_bytes(buf, dlen_words);
+
+    if dlen < core::mem::size_of::<MailboxReqHeader>() {
+        return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+    }
+
+    let clamped = dlen.min(buf.len());
+    let payload_bytes = &buf[..clamped];
+    let req_hdr: &MailboxReqHeader = MailboxReqHeader::ref_from_bytes(
+        &payload_bytes[..core::mem::size_of::<MailboxReqHeader>()],
+    )
+    .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+    if !caliptra_common::checksum::verify_checksum(
+        req_hdr.chksum,
+        cmd,
+        &payload_bytes[core::mem::size_of_val(&req_hdr.chksum)..],
+    ) {
+        return Err(CaliptraError::RUNTIME_INVALID_CHECKSUM);
+    }
+
+    Ok(())
 }
 
-const MAX_PAYLOAD_SIZE: usize = 3586; // in dwords
+/// Writes `resp` to the mailbox
+///
+/// # Arguments
+///
+/// * `drivers` - Drivers
+/// * `resp` - Response from a mailbox command that is to be copied to mailbox
+pub fn copy_to_mbox(drivers: &mut crate::Drivers, resp: &mut MailboxResp) -> CaliptraResult<()> {
+    let mbox = &mut drivers.mbox;
 
-impl Default for Packet {
-    fn default() -> Self {
-        Self {
-            cmd: 0,
-            payload: [0u32; MAX_PAYLOAD_SIZE],
-            len: 0,
-        }
-    }
-}
+    // Generate response checksum
+    resp.populate_chksum()?;
 
-impl Packet {
-    /// Retrieves the data in the mailbox and converts it into a Packet
-    //
-    // Note: The packet is the largest stack value (~14Kb) created during the processing of a
-    // command.  Explicitely create the packet in place to ensure that the return value isn't copied
-    // resulting in 2 stack copies.
-    pub fn copy_from_mbox(drivers: &mut crate::Drivers, packet: &mut Self) -> CaliptraResult<()> {
-        let mbox = &mut drivers.mbox;
-        let cmd = mbox.cmd();
-        let dlen_words = mbox.dlen_words() as usize;
-
-        if dlen_words > MAX_PAYLOAD_SIZE {
-            return Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY);
-        }
-
-        packet.cmd = cmd.into();
-        packet.len = mbox.dlen() as usize;
-        mbox.copy_from_mbox(
-            packet
-                .payload
-                .get_mut(..dlen_words)
-                .ok_or(CaliptraError::RUNTIME_INTERNAL)?,
-        );
-
-        // Verify incoming checksum
-        // Make sure enough data was sent to even have a checksum
-        if packet.len < core::mem::size_of::<MailboxReqHeader>() {
-            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-        }
-
-        // Assumes chksum is always offset 0
-        let payload_bytes = packet.as_bytes()?;
-        let req_hdr: &MailboxReqHeader = MailboxReqHeader::ref_from_bytes(
-            &payload_bytes[..core::mem::size_of::<MailboxReqHeader>()],
-        )
-        .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
-
-        if !caliptra_common::checksum::verify_checksum(
-            req_hdr.chksum,
-            packet.cmd,
-            &payload_bytes[core::mem::size_of_val(&req_hdr.chksum)..],
-        ) {
-            return Err(CaliptraError::RUNTIME_INVALID_CHECKSUM);
-        }
-
-        Ok(())
-    }
-
-    /// Writes `resp` to the mailbox
-    ///
-    /// # Arguments
-    ///
-    /// * `drivers` - Drivers
-    /// * `resp` - Response from a mailbox command that is to be copied to mailbox
-    pub fn copy_to_mbox(
-        drivers: &mut crate::Drivers,
-        resp: &mut MailboxResp,
-    ) -> CaliptraResult<()> {
-        let mbox = &mut drivers.mbox;
-
-        // Generate response checksum
-        resp.populate_chksum()?;
-
-        // Send the payload
-        mbox.write_response(resp.as_bytes()?)
-    }
-
-    /// Retrieves the byte representation of the packet's payload
-    pub fn as_bytes(&self) -> CaliptraResult<&[u8]> {
-        self.payload
-            .as_bytes()
-            .get(..self.len)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
-    }
+    // Send the payload
+    mbox.write_response(resp.as_bytes()?)
 }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use crate::packet::copy_from_mbox;
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
@@ -19,15 +20,15 @@ use caliptra_common::mailbox_api::{
     QuotePcrsReq, QuotePcrsResp,
 };
 use caliptra_drivers::{CaliptraError, CaliptraResult, PcrId};
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct IncrementPcrResetCounterCmd;
 impl IncrementPcrResetCounterCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = IncrementPcrResetCounterReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = IncrementPcrResetCounterReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         let index =
             u8::try_from(cmd.index).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
@@ -47,9 +48,9 @@ pub struct GetPcrQuoteCmd;
 impl GetPcrQuoteCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
-        let args: &QuotePcrsReq = QuotePcrsReq::ref_from_bytes(cmd_bytes)
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut args = QuotePcrsReq::new_zeroed();
+        copy_from_mbox(drivers, args.as_mut_bytes())?;
 
         let pcr_hash = drivers.sha384.gen_pcr_hash(args.nonce.into())?;
         let signature = drivers.ecc384.pcr_sign_flow(&mut drivers.trng)?;
@@ -76,9 +77,9 @@ pub struct ExtendPcrCmd;
 impl ExtendPcrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = ExtendPcrReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = ExtendPcrReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         let idx =
             u8::try_from(cmd.pcr_idx).map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
@@ -103,7 +104,7 @@ pub struct GetPcrLogCmd;
 impl GetPcrLogCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, _cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let next_available = drivers.persistent_data.get().fht.pcr_log_index as usize;
         let Some(pcr_logs) = drivers.persistent_data.get().pcr_log.get(..next_available) else {
             return Err(CaliptraError::RUNTIME_PCR_INVALID_INDEX);

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -26,27 +26,26 @@ impl PopulateIDevIdCertCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut cmd = PopulateIdevCertReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-        {
-            let cert_size = cmd.cert_size as usize;
-            if cert_size > cmd.cert.len() {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-            }
 
-            // PL1 cannot call this mailbox command
-            if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-                Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?
-            }
-
-            let mut tmp_chain = ArrayVec::<u8, MAX_CERT_CHAIN_SIZE>::new();
-            tmp_chain
-                .try_extend_from_slice(&cmd.cert[..cert_size])
-                .map_err(|_| CaliptraError::RUNTIME_IDEV_CERT_POPULATION_FAILED)?;
-            tmp_chain
-                .try_extend_from_slice(drivers.cert_chain.as_slice())
-                .map_err(|_| CaliptraError::RUNTIME_IDEV_CERT_POPULATION_FAILED)?;
-            drivers.cert_chain = tmp_chain;
-
-            Ok(MailboxResp::default())
+        let cert_size = cmd.cert_size as usize;
+        if cert_size > cmd.cert.len() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
+
+        // PL1 cannot call this mailbox command
+        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
+            Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?
+        }
+
+        let mut tmp_chain = ArrayVec::<u8, MAX_CERT_CHAIN_SIZE>::new();
+        tmp_chain
+            .try_extend_from_slice(&cmd.cert[..cert_size])
+            .map_err(|_| CaliptraError::RUNTIME_IDEV_CERT_POPULATION_FAILED)?;
+        tmp_chain
+            .try_extend_from_slice(drivers.cert_chain.as_slice())
+            .map_err(|_| CaliptraError::RUNTIME_IDEV_CERT_POPULATION_FAILED)?;
+        drivers.cert_chain = tmp_chain;
+
+        Ok(MailboxResp::default())
     }
 }

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -16,18 +16,17 @@ use crate::PauserPrivileges;
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{MailboxResp, PopulateIdevCertReq};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::IntoBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 use crate::{Drivers, MAX_CERT_CHAIN_SIZE};
 
 pub struct PopulateIDevIdCertCmd;
 impl PopulateIDevIdCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if cmd_args.len() <= core::mem::size_of::<PopulateIdevCertReq>() {
-            let mut cmd = PopulateIdevCertReq::default();
-            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
-
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = PopulateIdevCertReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        {
             let cert_size = cmd.cert_size as usize;
             if cert_size > cmd.cert.len() {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
@@ -48,8 +47,6 @@ impl PopulateIDevIdCertCmd {
             drivers.cert_chain = tmp_chain;
 
             Ok(MailboxResp::default())
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 }

--- a/runtime/src/reallocate_dpe_context_limits.rs
+++ b/runtime/src/reallocate_dpe_context_limits.rs
@@ -22,14 +22,14 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 
-use zerocopy::FromBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct ReallocateDpeContextLimitsCmd;
 impl ReallocateDpeContextLimitsCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = ReallocateDpeContextLimitsReq::ref_from_bytes(cmd_bytes)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = ReallocateDpeContextLimitsReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         const TOTAL_DPE_CONTEXT_LIMIT: usize =
             PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD + PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD;

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -15,16 +15,16 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use constant_time_eq::constant_time_eq;
 use dpe::U8Bool;
-use zerocopy::FromBytes;
+use zerocopy::{FromZeros, IntoBytes};
 use zeroize::Zeroize;
 
 pub struct RevokeExportedCdiHandleCmd;
 impl RevokeExportedCdiHandleCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = RevokeExportedCdiHandleReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = RevokeExportedCdiHandleReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         match drivers.caller_privilege_level() {
             // REVOKE_EXPORTED_CDI_HANDLE MUST only be called from PL0

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,6 +15,7 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
+use crate::packet::copy_from_mbox;
 use crate::Drivers;
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
@@ -31,8 +32,7 @@ use caliptra_image_types::{
     ImageDigest, ImageEccPubKey, ImageEccSignature, ImageLmsPublicKey, ImageLmsSignature,
     ImagePreamble, SHA192_DIGEST_WORD_SIZE, SHA384_DIGEST_BYTE_SIZE,
 };
-use memoffset::offset_of;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
 use zeroize::Zeroize;
 
 pub struct SetAuthManifestCmd;
@@ -444,32 +444,20 @@ impl SetAuthManifestCmd {
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        // Validate cmd length
-        let manifest_size: usize = {
-            let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
-            let offset = offset_of!(SetAuthManifestReq, manifest_size);
-            u32::from_le_bytes(
-                cmd_args
-                    .get(offset..offset + 4)
-                    .ok_or(err)?
-                    .try_into()
-                    .map_err(|_| err)?,
-            )
-            .try_into()
-            .unwrap()
-        };
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut req = SetAuthManifestReq::new_zeroed();
+        copy_from_mbox(drivers, req.as_mut_bytes())?;
+
+        let manifest_size: usize = req.manifest_size as usize;
 
         if manifest_size > SetAuthManifestReq::MAX_MAN_SIZE {
             Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
         }
 
-        let manifest_buf = {
-            let offset = offset_of!(SetAuthManifestReq, manifest);
-            cmd_args
-                .get(offset..offset + manifest_size)
-                .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?
-        };
+        let manifest_buf = req
+            .manifest
+            .get(..manifest_size)
+            .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
         let preamble_size = size_of::<AuthManifestPreamble>();
         let auth_manifest_preamble = {

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -18,7 +18,7 @@ use crypto::{
     Crypto, Digest, PubKey, SignData, Signature,
 };
 use dpe::MAX_EXPORTED_CDI_SIZE;
-use zerocopy::FromBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SignWithExportedEcdsaCmd;
 impl SignWithExportedEcdsaCmd {
@@ -61,9 +61,9 @@ impl SignWithExportedEcdsaCmd {
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = SignWithExportedEcdsaReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = SignWithExportedEcdsaReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         match drivers.caller_privilege_level() {
             // SIGN_WITH_EXPORTED_ECDSA MUST only be called from PL0

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -24,7 +24,7 @@ use dpe::{
     response::{DeriveContextExportedCdiResp, DpeErrorCode},
     tci::TciMeasurement,
 };
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
@@ -93,9 +93,9 @@ impl StashMeasurementCmd {
         Ok(dpe_result)
     }
 
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = StashMeasurementReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = StashMeasurementReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         let dpe_result =
             Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement, cmd.svn)?;

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -29,22 +29,21 @@ impl AddSubjectAltNameCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
         let mut cmd = AddSubjectAltNameReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-        {
-            let dmtf_device_info_size = cmd.dmtf_device_info_size as usize;
-            if dmtf_device_info_size > cmd.dmtf_device_info.len() {
-                return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-            }
 
-            Self::validate_dmtf_device_info(&cmd.dmtf_device_info[..dmtf_device_info_size])?;
-
-            let mut dmtf_device_info = ArrayVec::new();
-            dmtf_device_info
-                .try_extend_from_slice(&cmd.dmtf_device_info[..dmtf_device_info_size])
-                .map_err(|_| CaliptraError::RUNTIME_STORE_DMTF_DEVICE_INFO_FAILED)?;
-            drivers.dmtf_device_info = Some(dmtf_device_info);
-
-            Ok(MailboxResp::default())
+        let dmtf_device_info_size = cmd.dmtf_device_info_size as usize;
+        if dmtf_device_info_size > cmd.dmtf_device_info.len() {
+            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
+
+        Self::validate_dmtf_device_info(&cmd.dmtf_device_info[..dmtf_device_info_size])?;
+
+        let mut dmtf_device_info = ArrayVec::new();
+        dmtf_device_info
+            .try_extend_from_slice(&cmd.dmtf_device_info[..dmtf_device_info_size])
+            .map_err(|_| CaliptraError::RUNTIME_STORE_DMTF_DEVICE_INFO_FAILED)?;
+        drivers.dmtf_device_info = Some(dmtf_device_info);
+
+        Ok(MailboxResp::default())
     }
 
     /// Verifies that `dmtf_device_info` only contains ascii characters and contains exactly 2 ':'

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -15,7 +15,7 @@ Abstract:
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
-use zerocopy::IntoBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 use crate::Drivers;
 
@@ -26,11 +26,10 @@ impl AddSubjectAltNameCmd {
         &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0x1C, 0x82, 0x12, 0x01];
 
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        if cmd_args.len() <= core::mem::size_of::<AddSubjectAltNameReq>() {
-            let mut cmd = AddSubjectAltNameReq::default();
-            cmd.as_mut_bytes()[..cmd_args.len()].copy_from_slice(cmd_args);
-
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = AddSubjectAltNameReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        {
             let dmtf_device_info_size = cmd.dmtf_device_info_size as usize;
             if dmtf_device_info_size > cmd.dmtf_device_info.len() {
                 return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
@@ -45,8 +44,6 @@ impl AddSubjectAltNameCmd {
             drivers.dmtf_device_info = Some(dmtf_device_info);
 
             Ok(MailboxResp::default())
-        } else {
-            Err(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)
         }
     }
 

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -12,13 +12,14 @@ Abstract:
 
 --*/
 
+use crate::packet::copy_from_mbox;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
     GetTaggedTciReq, GetTaggedTciResp, MailboxResp, MailboxRespHeader, TagTciReq,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::{context::ContextHandle, U8Bool, MAX_HANDLES};
-use zerocopy::FromBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 use crate::Drivers;
 
@@ -26,9 +27,9 @@ pub struct TagTciCmd;
 impl TagTciCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = TagTciReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = TagTciReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
         let pdata_mut = drivers.persistent_data.get_mut();
         let dpe = &mut pdata_mut.dpe;
         let context_has_tag = &mut pdata_mut.context_has_tag;
@@ -65,9 +66,9 @@ pub struct GetTaggedTciCmd;
 impl GetTaggedTciCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = GetTaggedTciReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = GetTaggedTciReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
         let persistent_data = drivers.persistent_data.get();
         let context_has_tag = &persistent_data.context_has_tag;
         let context_tags = &persistent_data.context_tags;

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 
+use crate::packet::copy_from_mbox;
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxResp};
@@ -22,15 +23,16 @@ use caliptra_drivers::{
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
 };
-use zerocopy::{BigEndian, FromBytes, LittleEndian, U32};
+use zerocopy::{BigEndian, FromBytes, FromZeros, IntoBytes, LittleEndian, U32};
 
 pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
-        let cmd = EcdsaVerifyReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = EcdsaVerifyReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
         // Won't panic, full_digest is always larger than digest
         let full_digest = drivers.sha_acc.regs().digest().read();
         let mut digest = Array4x12::default();
@@ -61,7 +63,10 @@ pub struct LmsVerifyCmd;
 impl LmsVerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+        let mut cmd = LmsVerifyReq::new_zeroed();
+        copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
         // Re-run LMS KAT once (since LMS is more SW-based than other crypto)
         if let Err(e) =
             caliptra_kat::LmsKat::default().execute_once(&mut drivers.sha256, &mut drivers.lms)
@@ -77,8 +82,6 @@ impl LmsVerifyCmd {
         const LMS_ALGORITHM_TYPE: LmsAlgorithmType = LmsAlgorithmType::new(12);
         const LMOTS_ALGORITHM_TYPE: LmotsAlgorithmType = LmotsAlgorithmType::new(7);
 
-        let cmd = LmsVerifyReq::ref_from_bytes(cmd_args)
-            .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         // Get the digest from the SHA accelerator
         let msg_digest_be = drivers.sha_acc.regs().digest().truncate::<12>().read();
         // Flip the endianness since LMS treats this as raw message bytes

--- a/runtime/tests/runtime_integration_tests/test_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_mailbox.rs
@@ -58,6 +58,127 @@ fn test_unimplemented_cmds() {
 }
 
 #[test]
+fn test_oversized_payload_rejected() {
+    use caliptra_common::mailbox_api::*;
+    use std::mem::size_of;
+
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| m.soc_mbox().status().read().mbox_fsm_ps().mbox_idle());
+
+    // For each command that calls copy_from_mbox, sending one extra byte beyond the
+    // request struct size must return RUNTIME_INSUFFICIENT_MEMORY. Commands that do
+    // not call copy_from_mbox (GET_LDEV_CERT, GET_FMC_ALIAS_CERT, GET_RT_ALIAS_CERT)
+    // are excluded.
+    let cmds: &[(u32, usize)] = &[
+        (u32::from(CommandId::VERSION), size_of::<MailboxReqHeader>()),
+        (
+            u32::from(CommandId::CAPABILITIES),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (u32::from(CommandId::FW_INFO), size_of::<MailboxReqHeader>()),
+        (
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::GET_IDEV_INFO),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::GET_PCR_LOG),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::SELF_TEST_START),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::SELF_TEST_GET_RESULTS),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::SHUTDOWN),
+            size_of::<MailboxReqHeader>(),
+        ),
+        (
+            u32::from(CommandId::GET_IDEV_CERT),
+            size_of::<GetIdevCertReq>(),
+        ),
+        (u32::from(CommandId::INVOKE_DPE), size_of::<InvokeDpeReq>()),
+        (
+            u32::from(CommandId::ECDSA384_VERIFY),
+            size_of::<EcdsaVerifyReq>(),
+        ),
+        (u32::from(CommandId::LMS_VERIFY), size_of::<LmsVerifyReq>()),
+        (u32::from(CommandId::EXTEND_PCR), size_of::<ExtendPcrReq>()),
+        (
+            u32::from(CommandId::STASH_MEASUREMENT),
+            size_of::<StashMeasurementReq>(),
+        ),
+        (u32::from(CommandId::DPE_TAG_TCI), size_of::<TagTciReq>()),
+        (
+            u32::from(CommandId::DPE_GET_TAGGED_TCI),
+            size_of::<GetTaggedTciReq>(),
+        ),
+        (
+            u32::from(CommandId::POPULATE_IDEV_CERT),
+            size_of::<PopulateIdevCertReq>(),
+        ),
+        (
+            u32::from(CommandId::ADD_SUBJECT_ALT_NAME),
+            size_of::<AddSubjectAltNameReq>(),
+        ),
+        (
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED),
+            size_of::<CertifyKeyExtendedReq>(),
+        ),
+        (
+            u32::from(CommandId::INCREMENT_PCR_RESET_COUNTER),
+            size_of::<IncrementPcrResetCounterReq>(),
+        ),
+        (u32::from(CommandId::QUOTE_PCRS), size_of::<QuotePcrsReq>()),
+        (
+            u32::from(CommandId::SET_AUTH_MANIFEST),
+            size_of::<SetAuthManifestReq>(),
+        ),
+        (
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            size_of::<AuthorizeAndStashReq>(),
+        ),
+        (
+            u32::from(CommandId::GET_IDEV_CSR),
+            size_of::<GetIdevCsrReq>(),
+        ),
+        (
+            u32::from(CommandId::GET_FMC_ALIAS_CSR),
+            size_of::<GetFmcAliasCsrReq>(),
+        ),
+        (
+            u32::from(CommandId::SIGN_WITH_EXPORTED_ECDSA),
+            size_of::<SignWithExportedEcdsaReq>(),
+        ),
+        (
+            u32::from(CommandId::REVOKE_EXPORTED_CDI_HANDLE),
+            size_of::<RevokeExportedCdiHandleReq>(),
+        ),
+        (
+            u32::from(CommandId::REALLOCATE_DPE_CONTEXT_LIMITS),
+            size_of::<ReallocateDpeContextLimitsReq>(),
+        ),
+    ];
+
+    for &(cmd, req_size) in cmds {
+        let oversized = vec![0u8; req_size + 1];
+        let resp = model.mailbox_execute(cmd, &oversized).unwrap_err();
+        assert_error(
+            &mut model,
+            caliptra_drivers::CaliptraError::RUNTIME_INSUFFICIENT_MEMORY,
+            resp,
+        );
+    }
+}
+
+#[test]
 // Changing PAUSER not supported on sw emulator
 #[cfg(any(feature = "verilator", feature = "fpga_realtime"))]
 fn test_reserved_pauser() {

--- a/runtime/tests/runtime_integration_tests/test_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_mailbox.rs
@@ -19,7 +19,7 @@ fn test_error_cleared() {
     let resp = model.mailbox_execute(0xffffffff, &[]).unwrap_err();
     assert_error(
         &mut model,
-        caliptra_drivers::CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS,
+        caliptra_drivers::CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
         resp,
     );
 


### PR DESCRIPTION
Alter the runtime so that each Command arm only allocates the space required for its own request instead of the szie of the entire mailbox.  Since the majority of the commands use less then 1Kb, this saves a significant amount of stack space (excluding SET_AUTH_MANIFEST, which is still comfortably within the stack envelope) without resulting in significant addition instruction memory usage.

Stats:

### Caliptra FW Size: `feature/request-stack-optimization@8925418f`

| Component | text | data | bss | Total (text+data) | KiB | Budget | Used |
|-----------|------|------|-----|-------------------|-----|--------|------|
| ROM       | 42,536 | 0 | 16,384 | 42,536 | 41.54 | 48 KiB (49,152 B) | 86.5% |
| FMC       | 20,300 | 0 | 89,088 | 20,300 | 19.82 | 24 KiB (24,576 B) | 82.6% |
| Runtime   | 83,432 | 128 | 89,088 | 83,560 | 81.60 | 96 KiB (98,304 B) | 85.0% |

| Image Bundle (FMC+RT+manifests) | Size | KiB | Free | Free KiB | Budget | Used |
|---------------------------------|------|-----|------|----------|--------|------|
| image-bundle.bin | 109,744 | 107.17 | 21,328 | 20.83 | 128 KiB (131,072 B) | 83.7% |

---

### mldsa_attestation Feature Impact (Runtime)

| Runtime build              | text   | data | bss    | text+data | KiB   | Used  |
|----------------------------|--------|------|--------|-----------|-------|-------|
| without mldsa_attestation  | 81,528 | 128  | 89,088 | 81,656    | 79.74 | 83.1% |
| with mldsa_attestation     | 94,912 | 128  | 89,088 | 95,040    | 92.81 | 96.7% |
| **Δ (feature cost)**       | +13,384 | 0   | 0      | +13,384   | +13.07 | +13.6 pp |

Runtime ICCM budget: with feature = 95,040 B (92.81 KiB) → 96.7% used, 3,264 B (3.19 KiB) free.

---

### Runtime Stack Usage: `feature/request-stack-optimization@8925418f` vs `caliptra-1.x`

Stack budget: 87,040 B. Sorted by PR peak usage (descending).

| Command | Before (B) | Before % | After (B) | After % | Δ (B) |
|---------|-----------|----------|-----------|---------|-------|
| INVOKE_DPE(CertifyKey/X509)   | 60,448 | 69.4% | 50,704 | 58.3% | -9,744 |
| INVOKE_DPE(GetProfile)        | 52,752 | 60.6% | 43,008 | 49.4% | -9,744 |
| SET_AUTH_MANIFEST             | 36,448 | 41.9% | 41,264 | 47.4% | +4,816 |
| CERTIFY_KEY_EXTENDED          | 49,952 | 57.4% | 40,288 | 46.3% | -9,664 |
| STASH_MEASUREMENT             | 49,504 | 56.9% | 39,712 | 45.6% | -9,792 |
| AUTHORIZE_AND_STASH           | 48,880 | 56.2% | 39,248 | 45.1% | -9,632 |
| LMS_VERIFY                    | 41,024 | 47.1% | 32,960 | 37.9% | -8,064 |
| QUOTE_PCRS                    | 43,920 | 50.5% | 32,464 | 37.3% | -11,456 |
| POPULATE_IDEV_CERT            | 40,720 | 46.8% | 31,088 | 35.7% | -9,632 |
| SELF_TEST_GET_RESULTS(+KATs)  | 39,712 | 45.6% | 29,968 | 34.4% | -9,744 |
| SIGN_WITH_EXPORTED_ECDSA      | 38,576 | 44.3% | 28,912 | 33.2% | -9,664 |
| GET_IDEV_CERT                 | 37,920 | 43.6% | 28,160 | 32.4% | -9,760 |
| GET_LDEV_CERT                 | 37,296 | 42.8% | 27,552 | 31.7% | -9,744 |
| GET_FMC_ALIAS_CERT            | 37,296 | 42.8% | 27,552 | 31.7% | -9,744 |
| GET_RT_ALIAS_CERT             | 37,040 | 42.6% | 27,296 | 31.4% | -9,744 |
| DISABLE_ATTESTATION           | 36,800 | 42.3% | 27,056 | 31.1% | -9,744 |
| GET_PCR_LOG                   | 36,528 | 42.0% | 26,784 | 30.8% | -9,744 |
| GET_FMC_ALIAS_CSR             | 36,336 | 41.7% | 26,688 | 30.7% | -9,648 |
| ECDSA384_VERIFY               | 36,144 | 41.5% | 26,608 | 30.6% | -9,536 |
| GET_IDEV_CSR                  | 36,064 | 41.4% | 26,432 | 30.4% | -9,632 |
| EXTEND_PCR                    | 35,968 | 41.3% | 26,288 | 30.2% | -9,680 |
| ADD_SUBJECT_ALT_NAME          | 35,840 | 41.2% | 26,192 | 30.1% | -9,648 |
| REVOKE_EXPORTED_CDI_HANDLE    | 35,584 | 40.9% | 25,968 | 29.8% | -9,616 |
| DPE_TAG_TCI                   | 35,648 | 41.0% | 25,968 | 29.8% | -9,680 |
| REALLOCATE_DPE_CONTEXT_LIMITS | 35,584 | 40.9% | 25,936 | 29.8% | -9,648 |
| DPE_GET_TAGGED_TCI            | 35,584 | 40.9% | 25,936 | 29.8% | -9,648 |
| INCREMENT_PCR_RESET_COUNTER   | 35,584 | 40.9% | 25,920 | 29.8% | -9,664 |
| VERSION                       | 35,584 | 40.9% | 25,904 | 29.8% | -9,680 |
| SELF_TEST_START               | 35,584 | 40.9% | 25,904 | 29.8% | -9,680 |
| SHUTDOWN                      | 35,648 | 41.0% | 25,904 | 29.8% | -9,744 |
| GET_IDEV_INFO                 | 35,616 | 40.9% | 25,904 | 29.8% | -9,712 |
| FW_INFO                       | 35,600 | 40.9% | 25,904 | 29.8% | -9,696 |
| CAPABILITIES                  | 35,584 | 40.9% | 25,904 | 29.8% | -9,680 |