### PR TITLE
test: make CSR envelope stress test fail fast on a hung boot

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -819,6 +819,26 @@ fn retry_acquire_mailbox_lock(
     false
 }
 
+/// Step `ctx` until `predicate` is true, calling `step` between checks. Returns
+/// `false` if `max_wait_cycles` is reached first. Factored out of
+/// [`HwModel::step_until_or_timeout`] so the bound logic is unit-testable.
+fn run_step_until_or_timeout<T: ?Sized>(
+    ctx: &mut T,
+    max_wait_cycles: u32,
+    mut predicate: impl FnMut(&mut T) -> bool,
+    mut step: impl FnMut(&mut T),
+) -> bool {
+    let mut cycle_count = 0u32;
+    while !predicate(ctx) {
+        step(ctx);
+        cycle_count += 1;
+        if cycle_count >= max_wait_cycles {
+            return false;
+        }
+    }
+    true
+}
+
 // Represents a emulator or simulation of the caliptra hardware, to be called
 // from tests. Typically, test cases should use [`crate::new()`] to create a model
 // based on the cargo features (and any model-specific environment variables).
@@ -1047,6 +1067,21 @@ pub trait HwModel: SocManager {
     fn step_until(&mut self, mut predicate: impl FnMut(&mut Self) -> bool) {
         while !predicate(self) {
             self.step();
+        }
+    }
+
+    /// Like [`step_until`](Self::step_until), but panics after `max_wait_cycles`
+    /// steps so a hung device fails fast instead of stalling until the test
+    /// harness timeout. `description` names the awaited condition for the panic
+    /// message.
+    fn step_until_or_timeout(
+        &mut self,
+        description: &str,
+        max_wait_cycles: u32,
+        mut predicate: impl FnMut(&mut Self) -> bool,
+    ) {
+        if !run_step_until_or_timeout(self, max_wait_cycles, |s| predicate(s), |s| s.step()) {
+            panic!("timed out after {max_wait_cycles} cycles waiting for {description}");
         }
     }
 
@@ -1840,6 +1875,41 @@ mod tests {
         };
         assert!(!retry_acquire_mailbox_lock(&mut lock, 5, 10));
         assert_eq!(lock.steps, 50);
+    }
+
+    #[test]
+    fn test_run_step_until_or_timeout() {
+        use crate::run_step_until_or_timeout;
+
+        // Condition met before the budget: returns true, stops stepping early.
+        let mut steps = 0u32;
+        assert!(run_step_until_or_timeout(
+            &mut steps,
+            100,
+            |s| *s >= 5,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 5);
+
+        // Condition already true: returns true without stepping.
+        let mut steps = 10u32;
+        assert!(run_step_until_or_timeout(
+            &mut steps,
+            100,
+            |s| *s >= 5,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 10);
+
+        // Condition never met: returns false after exactly max_wait_cycles steps.
+        let mut steps = 0u32;
+        assert!(!run_step_until_or_timeout(
+            &mut steps,
+            7,
+            |_| false,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 7);
     }
 
     #[test]

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -173,7 +173,12 @@ pub fn get_data<'a>(to_match: &str, haystack: &'a str) -> &'a str {
 }
 
 pub fn get_csr_envelop(hw: &mut DefaultHwModel) -> Result<InitDevIdCsrEnvelope, ModelError> {
-    hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().idevid_csr_ready());
+    // Booting to idevid_csr_ready takes well under 30M cycles; bound the wait so
+    // a failed boot fails fast instead of hanging until the harness timeout.
+    const MAX_WAIT_CYCLES: u32 = 30_000_000;
+    hw.step_until_or_timeout("idevid_csr_ready", MAX_WAIT_CYCLES, |m| {
+        m.soc_ifc().cptra_flow_status().read().idevid_csr_ready()
+    });
     let mut txn = hw.wait_for_mailbox_receive()?;
     let result = mem::take(&mut txn.req.data);
     txn.respond_success();

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -26,8 +26,11 @@ fn generate_csr_envelop(
     // Download the CSR Envelope from the mailbox.
     let csr_envelop = helpers::get_csr_envelop(hw).unwrap();
 
-    // Wait for uploading firmware.
-    hw.step_until(|m| {
+    // Wait for uploading firmware. Bound the waits so a failed boot fails fast
+    // instead of hanging until the harness timeout (boot is well under 30M
+    // cycles).
+    const MAX_WAIT_CYCLES: u32 = 30_000_000;
+    hw.step_until_or_timeout("ready_for_mb_processing", MAX_WAIT_CYCLES, |m| {
         m.soc_ifc()
             .cptra_flow_status()
             .read()
@@ -35,7 +38,9 @@ fn generate_csr_envelop(
     });
     helpers::test_upload_firmware(hw, &image_bundle.to_bytes().unwrap(), pqc_key_type);
 
-    hw.step_until_ready_for_runtime();
+    hw.step_until_or_timeout("ready_for_runtime", MAX_WAIT_CYCLES, |m| {
+        m.soc_ifc().cptra_flow_status().read().ready_for_runtime()
+    });
 
     let output = hw.output().take(usize::MAX);
     if crate::helpers::rom_from_env() == &firmware::ROM_WITH_UART {


### PR DESCRIPTION
test_generate_csr_envelop_stress uses unbounded step_until calls, so when a boot fails to reach the expected state the test hangs until nextest's slow timeout (~90 min in nightly), which stalls and fails the whole nightly run.

Add HwModel::step_until_or_timeout (bounded like the existing step_until_boot_status, 30M cycles) and use it for the idevid_csr_ready, ready_for_mb_processing, and ready_for_runtime waits in the CSR envelope path. A hung boot now panics in seconds with the awaited condition named, instead of waiting for the harness timeout.