### PR TITLE
test: read IDevID CSR during boot to fix subsystem CSR-stress hang

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -819,6 +819,26 @@ fn retry_acquire_mailbox_lock(
     false
 }
 
+/// Step `ctx` until `predicate` is true, calling `step` between checks. Returns
+/// `false` if `max_wait_cycles` is reached first. Factored out of
+/// [`HwModel::step_until_or_timeout`] so the bound logic is unit-testable.
+fn run_step_until_or_timeout<T: ?Sized>(
+    ctx: &mut T,
+    max_wait_cycles: u32,
+    mut predicate: impl FnMut(&mut T) -> bool,
+    mut step: impl FnMut(&mut T),
+) -> bool {
+    let mut cycle_count = 0u32;
+    while !predicate(ctx) {
+        step(ctx);
+        cycle_count += 1;
+        if cycle_count >= max_wait_cycles {
+            return false;
+        }
+    }
+    true
+}
+
 // Represents a emulator or simulation of the caliptra hardware, to be called
 // from tests. Typically, test cases should use [`crate::new()`] to create a model
 // based on the cargo features (and any model-specific environment variables).
@@ -1047,6 +1067,21 @@ pub trait HwModel: SocManager {
     fn step_until(&mut self, mut predicate: impl FnMut(&mut Self) -> bool) {
         while !predicate(self) {
             self.step();
+        }
+    }
+
+    /// Like [`step_until`](Self::step_until), but panics after `max_wait_cycles`
+    /// steps so a hung device fails fast instead of stalling until the test
+    /// harness timeout. `description` names the awaited condition for the panic
+    /// message.
+    fn step_until_or_timeout(
+        &mut self,
+        description: &str,
+        max_wait_cycles: u32,
+        mut predicate: impl FnMut(&mut Self) -> bool,
+    ) {
+        if !run_step_until_or_timeout(self, max_wait_cycles, |s| predicate(s), |s| s.step()) {
+            panic!("timed out after {max_wait_cycles} cycles waiting for {description}");
         }
     }
 
@@ -1840,6 +1875,41 @@ mod tests {
         };
         assert!(!retry_acquire_mailbox_lock(&mut lock, 5, 10));
         assert_eq!(lock.steps, 50);
+    }
+
+    #[test]
+    fn test_run_step_until_or_timeout() {
+        use crate::run_step_until_or_timeout;
+
+        // Condition met before the budget: returns true, stops stepping early.
+        let mut steps = 0u32;
+        assert!(run_step_until_or_timeout(
+            &mut steps,
+            100,
+            |s| *s >= 5,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 5);
+
+        // Condition already true: returns true without stepping.
+        let mut steps = 10u32;
+        assert!(run_step_until_or_timeout(
+            &mut steps,
+            100,
+            |s| *s >= 5,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 10);
+
+        // Condition never met: returns false after exactly max_wait_cycles steps.
+        let mut steps = 0u32;
+        assert!(!run_step_until_or_timeout(
+            &mut steps,
+            7,
+            |_| false,
+            |s| *s += 1,
+        ));
+        assert_eq!(steps, 7);
     }
 
     #[test]

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -426,6 +426,9 @@ pub struct BootParams<'a> {
     /// Use encrypted firmware boot (RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE).
     /// This sets BootMode::EncryptedFirmware and skips MCU activation in the recovery flow.
     pub encrypted_boot: bool,
+    /// Fire `rom_callback` when `idevid_csr_ready` asserts during boot (to drain
+    /// the CSR from the mailbox) instead of auto-clearing the manufacturing flag.
+    pub read_idevid_csr_in_callback: bool,
 }
 
 impl Default for BootParams<'_> {
@@ -441,6 +444,7 @@ impl Default for BootParams<'_> {
             soc_manifest: Default::default(),
             mcu_fw_image: Default::default(),
             encrypted_boot: false,
+            read_idevid_csr_in_callback: false,
         }
     }
 }
@@ -933,7 +937,11 @@ pub trait HwModel: SocManager {
                 // Generally the CSR should be read from the mailbox at this point, but to
                 // accommodate test cases that ignore the CSR mailbox, we will ignore it here.
                 if self.soc_ifc().cptra_flow_status().read().idevid_csr_ready() {
-                    self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+                    if boot_params.read_idevid_csr_in_callback {
+                        self.run_idevid_csr_callback();
+                    } else {
+                        self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+                    }
                 }
 
                 self.step();
@@ -1071,9 +1079,7 @@ pub trait HwModel: SocManager {
     }
 
     /// Like [`step_until`](Self::step_until), but panics after `max_wait_cycles`
-    /// steps so a hung device fails fast instead of stalling until the test
-    /// harness timeout. `description` names the awaited condition for the panic
-    /// message.
+    /// so a hung device fails fast. `description` names the awaited condition.
     fn step_until_or_timeout(
         &mut self,
         description: &str,
@@ -1141,6 +1147,12 @@ pub trait HwModel: SocManager {
                 format!("Fuse initializaton error: {}", ModelError::from(e))
             );
         }
+    }
+
+    /// Boot hook for `read_idevid_csr_in_callback`. Models with a `rom_callback`
+    /// override this to run it; the default just clears the manufacturing flag.
+    fn run_idevid_csr_callback(&mut self) {
+        self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
     }
 
     fn step_until_exit_success(&mut self) -> std::io::Result<()> {

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -356,6 +356,19 @@ impl HwModel for ModelEmulated {
         self.trng_mode
     }
 
+    fn run_idevid_csr_callback(&mut self) {
+        #[cfg(all(
+            not(feature = "verilator"),
+            not(feature = "fpga_realtime"),
+            not(feature = "fpga_subsystem")
+        ))]
+        if let Some(cb) = self.rom_callback.take() {
+            cb(self);
+            return;
+        }
+        self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+    }
+
     fn ready_for_fw(&self) -> bool {
         self.ready_for_fw.get()
     }

--- a/hw-model/src/model_fpga_realtime.rs
+++ b/hw-model/src/model_fpga_realtime.rs
@@ -138,6 +138,7 @@ pub struct ModelFpgaRealtime {
 
     trng_mode: TrngMode,
     openocd: Option<Child>,
+    rom_callback: Option<crate::ModelCallback>,
 }
 
 impl ModelFpgaRealtime {
@@ -529,6 +530,7 @@ impl HwModel for ModelFpgaRealtime {
             trng_mode: desired_trng_mode,
 
             openocd: None,
+            rom_callback: params.rom_callback,
         };
 
         // Check if the FPGA image is valid
@@ -683,6 +685,14 @@ impl HwModel for ModelFpgaRealtime {
             )
             .ready_for_fw()
                 != 0
+        }
+    }
+
+    fn run_idevid_csr_callback(&mut self) {
+        if let Some(cb) = self.rom_callback.take() {
+            cb(self);
+        } else {
+            self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
         }
     }
 

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2116,13 +2116,19 @@ impl HwModel for ModelFpgaSubsystem {
         while self.cycle_count().wrapping_sub(start) < 20_000_000 {
             self.step();
             let flow_status = self.soc_ifc().cptra_flow_status().read();
-            if flow_status.idevid_csr_ready() && boot_params.fw_image.is_some() {
-                // If GENERATE_IDEVID_CSR was set then we need to clear cptra_dbg_manuf_service_reg
-                // once the CSR is ready to continue making progress.
-                //
-                // Generally the CSR should be read from the mailbox at this point, but to
-                // accommodate test cases that ignore the CSR mailbox, we will ignore it here.
-                self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+            if flow_status.idevid_csr_ready() {
+                if boot_params.read_idevid_csr_in_callback {
+                    // Drain the CSR via the callback while the MCU is still held
+                    // at the firmware-download gate, so the host doesn't race it.
+                    if let Some(cb) = self.rom_callback.take() {
+                        cb(self);
+                    } else {
+                        self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+                    }
+                } else if boot_params.fw_image.is_some() {
+                    // Clear the flag to let boot proceed, ignoring the CSR.
+                    self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+                }
             }
             if flow_status.ready_for_mb_processing() {
                 break;

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -93,6 +93,7 @@ pub struct ModelVerilated {
     log: Rc<RefCell<BusLogger<NullBus>>>,
 
     soc_axi_user: u32,
+    rom_callback: Option<crate::ModelCallback>,
 }
 
 impl ModelVerilated {
@@ -204,6 +205,7 @@ impl HwModel for ModelVerilated {
             log,
 
             soc_axi_user: DEFAULT_AXI_USER,
+            rom_callback: params.rom_callback,
         };
 
         m.tracing_hint(true);
@@ -231,6 +233,14 @@ impl HwModel for ModelVerilated {
 
     fn trng_mode(&self) -> TrngMode {
         self.trng_mode
+    }
+
+    fn run_idevid_csr_callback(&mut self) {
+        if let Some(cb) = self.rom_callback.take() {
+            cb(self);
+        } else {
+            self.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
+        }
     }
 
     fn apb_bus(&mut self) -> Self::TBus<'_> {

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -18,7 +18,7 @@ use caliptra_hw_model::{
     BootParams, CodeRange, Fuses, HwModel, ImageInfo, InitParams, SecurityState, StackInfo,
     StackRange, SubsystemInitParams,
 };
-use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, ModelError};
+use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, ModelCallback, ModelError};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
 use zerocopy::TryFromBytes;
 
@@ -172,11 +172,70 @@ pub fn get_data<'a>(to_match: &str, haystack: &'a str) -> &'a str {
         .unwrap_or("")
 }
 
+/// Boot takes well under 30M cycles, so a longer wait means the device is hung.
+const BOOT_MAX_WAIT_CYCLES: u32 = 30_000_000;
+
+/// Step until `predicate` is true, failing fast (with a register dump) if the
+/// ROM reports a fatal error or the wait exceeds [`BOOT_MAX_WAIT_CYCLES`]. `what`
+/// names the awaited condition.
+pub fn step_until_boot_or_diagnose(
+    hw: &mut DefaultHwModel,
+    what: &str,
+    mut predicate: impl FnMut(&mut DefaultHwModel) -> bool,
+) {
+    let mut cycles = 0u32;
+    loop {
+        if predicate(hw) {
+            return;
+        }
+        let fatal = hw.soc_ifc().cptra_fw_error_fatal().read();
+        if fatal != 0 {
+            panic!("{}", diagnose(hw, what, "ROM reported a FATAL error"));
+        }
+        if cycles >= BOOT_MAX_WAIT_CYCLES {
+            panic!(
+                "{}",
+                diagnose(
+                    hw,
+                    what,
+                    "timed out (no fatal error reported \u{2013} device hung)"
+                )
+            );
+        }
+        hw.step();
+        cycles += 1;
+    }
+}
+
+fn diagnose(hw: &mut DefaultHwModel, what: &str, summary: &str) -> String {
+    // Read the mailbox FSM (not the lock, which acquires on read) to show whether
+    // the ROM is still contending for the mailbox to send the CSR.
+    let mbox_status = hw.soc_mbox().status().read();
+    let mbox_fsm = mbox_status.mbox_fsm_ps();
+    let soc_ifc = hw.soc_ifc();
+    let flow = soc_ifc.cptra_flow_status().read();
+    format!(
+        "CSR-stress diagnose: {summary} while waiting for `{what}`.\n  \
+         cptra_fw_error_fatal     = 0x{:08x}\n  \
+         cptra_fw_error_non_fatal = 0x{:08x}\n  \
+         cptra_boot_status        = 0x{:08x}\n  \
+         cptra_flow_status        = 0x{:08x} (idevid_csr_ready={} ready_for_mb_processing={} ready_for_runtime={})\n  \
+         mbox_fsm_ps              = idle={} exec_uc={} exec_soc={}",
+        soc_ifc.cptra_fw_error_fatal().read(),
+        soc_ifc.cptra_fw_error_non_fatal().read(),
+        soc_ifc.cptra_boot_status().read(),
+        u32::from(flow),
+        flow.idevid_csr_ready(),
+        flow.ready_for_mb_processing(),
+        flow.ready_for_runtime(),
+        mbox_fsm.mbox_idle(),
+        mbox_fsm.mbox_execute_uc(),
+        mbox_fsm.mbox_execute_soc(),
+    )
+}
+
 pub fn get_csr_envelop(hw: &mut DefaultHwModel) -> Result<InitDevIdCsrEnvelope, ModelError> {
-    // Booting to idevid_csr_ready takes well under 30M cycles; bound the wait so
-    // a failed boot fails fast instead of hanging until the harness timeout.
-    const MAX_WAIT_CYCLES: u32 = 30_000_000;
-    hw.step_until_or_timeout("idevid_csr_ready", MAX_WAIT_CYCLES, |m| {
+    step_until_boot_or_diagnose(hw, "idevid_csr_ready", |m| {
         m.soc_ifc().cptra_flow_status().read().idevid_csr_ready()
     });
     let mut txn = hw.wait_for_mailbox_receive()?;
@@ -185,6 +244,75 @@ pub fn get_csr_envelop(hw: &mut DefaultHwModel) -> Result<InitDevIdCsrEnvelope, 
     hw.soc_ifc().cptra_dbg_manuf_service_reg().write(|_| 0);
     let (csr_envelop, _) = InitDevIdCsrEnvelope::try_read_from_prefix(&result).unwrap();
     Ok(csr_envelop)
+}
+
+/// Holds the IDevID CSR captured during boot for the test to retrieve.
+pub type CapturedCsr = std::sync::Arc<std::sync::Mutex<Option<InitDevIdCsrEnvelope>>>;
+
+/// Build a model that requests the IDevID CSR and drains it from the mailbox
+/// during boot (via `rom_callback`, when `idevid_csr_ready` asserts), then boots
+/// to runtime. The returned cell holds the captured CSR.
+pub fn build_hw_model_capturing_idevid_csr(
+    fuses: Fuses,
+    image_options: ImageOptions,
+    pqc_key_type: FwVerificationPqcKeyType,
+) -> (DefaultHwModel, CapturedCsr) {
+    let csr_cell: CapturedCsr = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let cb_cell = csr_cell.clone();
+    let rom_callback: ModelCallback = Box::new(move |hw: &mut DefaultHwModel| {
+        let csr = get_csr_envelop(hw).expect("failed to read IDevID CSR in rom_callback");
+        *cb_cell.lock().unwrap() = Some(csr);
+    });
+
+    let rom = caliptra_builder::build_firmware_rom(firmware::rom_from_env_fpga(cfg!(
+        feature = "fpga_subsystem"
+    )))
+    .unwrap();
+    let image_bytes = build_image_bundle(image_options).to_bytes().unwrap();
+    let soc_manifest = default_soc_manifest_bytes(pqc_key_type, 1);
+
+    let image_info = vec![
+        ImageInfo::new(
+            StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
+            CodeRange::new(ROM_ORG, ROM_ORG + ROM_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(FMC_ORG, FMC_ORG + FMC_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(RUNTIME_ORG, RUNTIME_ORG + RUNTIME_SIZE),
+        ),
+    ];
+    let mut security_state = SecurityState::from(fuses.life_cycle as u32);
+    security_state.set_debug_locked(fuses.debug_locked);
+
+    let model = caliptra_hw_model::new(
+        InitParams {
+            fuses,
+            rom: &rom,
+            security_state,
+            stack_info: Some(StackInfo::new(image_info)),
+            rom_callback: Some(rom_callback),
+            ss_init_params: SubsystemInitParams {
+                enable_mcu_uart_log: cfg!(feature = "fpga_subsystem"),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        BootParams {
+            initial_dbg_manuf_service_reg: MfgFlags::GENERATE_IDEVID_CSR.bits(),
+            read_idevid_csr_in_callback: true,
+            fw_image: Some(&image_bytes),
+            soc_manifest: Some(&soc_manifest),
+            mcu_fw_image: Some(&DEFAULT_MCU_FW),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    (model, csr_cell)
 }
 
 pub fn change_dword_endianess(data: &mut [u8]) {

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -173,7 +173,12 @@ pub fn get_data<'a>(to_match: &str, haystack: &'a str) -> &'a str {
 }
 
 pub fn get_csr_envelop(hw: &mut DefaultHwModel) -> Result<InitDevIdCsrEnvelope, ModelError> {
-    hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().idevid_csr_ready());
+    // Booting to idevid_csr_ready takes well under 30M cycles; bound the wait so
+    // a failed boot fails fast instead of hanging until the harness timeout.
+    const MAX_WAIT_CYCLES: u32 = 30_000_000;
+    hw.step_until_or_timeout("idevid_csr_ready", MAX_WAIT_CYCLES, |m| {
+        m.soc_ifc().cptra_flow_status().read().idevid_csr_ready()
+    });
     let mut txn = hw.wait_for_mailbox_receive()?;
     let result = mem::take(&mut txn.req.data);
     txn.respond_success();

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -26,8 +26,11 @@ fn generate_csr_envelop(
     // Download the CSR Envelope from the mailbox.
     let csr_envelop = helpers::get_csr_envelop(hw).unwrap();
 
-    // Wait for uploading firmware.
-    hw.step_until(|m| {
+    // Wait for uploading firmware. Bound the waits so a failed boot fails fast
+    // instead of hanging until the harness timeout (boot is well under 30M
+    // cycles).
+    const MAX_WAIT_CYCLES: u32 = 30_000_000;
+    hw.step_until_or_timeout("ready_for_mb_processing", MAX_WAIT_CYCLES, |m| {
         m.soc_ifc()
             .cptra_flow_status()
             .read()
@@ -35,7 +38,9 @@ fn generate_csr_envelop(
     });
     helpers::test_upload_firmware(hw, &image_bundle.to_bytes().unwrap(), pqc_key_type);
 
-    hw.step_until_ready_for_runtime();
+    hw.step_until_or_timeout("ready_for_runtime", MAX_WAIT_CYCLES, |m| {
+        m.soc_ifc().cptra_flow_status().read().ready_for_runtime()
+    });
 
     let output = hw.output().take(usize::MAX);
     if crate::helpers::rom_from_env() == &firmware::ROM_WITH_UART {

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -1,11 +1,11 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::SocManager;
-use caliptra_builder::{firmware, ImageOptions};
+use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, GetLdevCertResp, MailboxReqHeader};
-use caliptra_drivers::{IdevidCertAttr, InitDevIdCsrEnvelope, MfgFlags, X509KeyIdAlgo};
+use caliptra_drivers::{IdevidCertAttr, InitDevIdCsrEnvelope, X509KeyIdAlgo};
 use caliptra_hw_model::{DefaultHwModel, Fuses, HwModel};
-use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
+use caliptra_image_types::FwVerificationPqcKeyType;
 use openssl::pkey::{PKey, Public};
 use openssl::x509::X509;
 use openssl::{rand::rand_bytes, x509::X509Req};
@@ -15,43 +15,25 @@ use crate::helpers;
 
 const ROM_READY_FOR_FW_PROCESSOR: u32 = 70;
 
-fn generate_csr_envelop(
-    hw: &mut DefaultHwModel,
-    image_bundle: &ImageBundle,
+fn boot_and_capture_idevid_csr(
+    fuses: Fuses,
+    image_options: ImageOptions,
     pqc_key_type: FwVerificationPqcKeyType,
-) -> InitDevIdCsrEnvelope {
-    // GENERATE_IDEVID_CSR is latched via BootParams when the model is built, so
-    // ROM sees it before sampling it during cold reset.
+) -> (DefaultHwModel, InitDevIdCsrEnvelope) {
+    // The CSR is drained during boot; then boot to runtime for the cert checks.
+    let (mut hw, csr_cell) =
+        helpers::build_hw_model_capturing_idevid_csr(fuses, image_options, pqc_key_type);
 
-    // Download the CSR Envelope from the mailbox.
-    let csr_envelop = helpers::get_csr_envelop(hw).unwrap();
-
-    // Wait for uploading firmware. Bound the waits so a failed boot fails fast
-    // instead of hanging until the harness timeout (boot is well under 30M
-    // cycles).
-    const MAX_WAIT_CYCLES: u32 = 30_000_000;
-    hw.step_until_or_timeout("ready_for_mb_processing", MAX_WAIT_CYCLES, |m| {
-        m.soc_ifc()
-            .cptra_flow_status()
-            .read()
-            .ready_for_mb_processing()
-    });
-    helpers::test_upload_firmware(hw, &image_bundle.to_bytes().unwrap(), pqc_key_type);
-
-    hw.step_until_or_timeout("ready_for_runtime", MAX_WAIT_CYCLES, |m| {
+    helpers::step_until_boot_or_diagnose(&mut hw, "ready_for_runtime", |m| {
         m.soc_ifc().cptra_flow_status().read().ready_for_runtime()
     });
 
-    let output = hw.output().take(usize::MAX);
-    if crate::helpers::rom_from_env() == &firmware::ROM_WITH_UART {
-        let csr_str = helpers::get_data("[idev] ECC CSR = ", &output);
-        let uploaded = hex::decode(csr_str).unwrap();
-        assert_eq!(
-            uploaded,
-            &csr_envelop.ecc_csr.csr[..csr_envelop.ecc_csr.csr_len as usize]
-        );
-    }
-    csr_envelop
+    let csr_envelop = csr_cell
+        .lock()
+        .unwrap()
+        .take()
+        .expect("IDevID CSR was not captured during boot");
+    (hw, csr_envelop)
 }
 
 #[test]
@@ -65,12 +47,7 @@ fn test_generate_csr_envelop() {
             fuse_pqc_key_type: *pqc_key_type as u32,
             ..Default::default()
         };
-        let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle_with_mfg_flags(
-            fuses,
-            image_options,
-            MfgFlags::GENERATE_IDEVID_CSR,
-        );
-        generate_csr_envelop(&mut hw, &image_bundle, *pqc_key_type);
+        let (_hw, _csr_envelop) = boot_and_capture_idevid_csr(fuses, image_options, *pqc_key_type);
     }
 }
 
@@ -123,13 +100,8 @@ fn test_generate_csr_envelop_stress() {
         for _ in 0..num_tests {
             let mut fuses = fuses_with_random_uds();
             fuses.fuse_pqc_key_type = *pqc_key_type as u32;
-            let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle_with_mfg_flags(
-                fuses.clone(),
-                image_options.clone(),
-                MfgFlags::GENERATE_IDEVID_CSR,
-            );
-
-            let csr_envelop = generate_csr_envelop(&mut hw, &image_bundle, *pqc_key_type);
+            let (mut hw, csr_envelop) =
+                boot_and_capture_idevid_csr(fuses.clone(), image_options.clone(), *pqc_key_type);
 
             // Ensure ECC CSR is valid X.509
             let req =


### PR DESCRIPTION
The CSR stress test deferred reading the IDevID CSR until after model
construction, so on the FPGA subsystem the host's mailbox read raced the
MCU's RI_DOWNLOAD_FIRMWARE and the test hung until the harness timeout.

Drain the CSR at one point on every backend: when idevid_csr_ready asserts
during boot, via the model's rom_callback (gated by a new
BootParams::read_idevid_csr_in_callback). On the subsystem this runs while
the MCU is still held at the download gate, so there's no race. Firmware is
supplied via BootParams so the model still boots to runtime for the
LDEV/FMC/RT cert checks. Boot waits are also bounded so a stall fails fast
with a register dump instead of timing out.
