### PR TITLE
fix(test): fix subsystem mode test failures and update MCU commit

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -86,7 +86,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db8889e8
-      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || 'e3fff331fd3d42f340d17c1fa20e783ac04d943d' }}
+      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '7328113c31713b3ff3da89de7901b8393dafff3c' }}
 
     steps:
       - name: Checkout repo

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -194,6 +194,11 @@ fn test_pcr_log() {
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
 
+        // In subsystem mode, the owner PK hash flows through the DOT
+        // mailbox command, not the fuse controller, so
+        // owner_pub_keys_digest_in_fuses is false.
+        let owner_pk_in_fuses = !hw.subsystem_mode();
+
         check_pcr_log_entry(
             &pcr_entry_arr,
             0,
@@ -208,7 +213,7 @@ fn test_pcr_log() {
                 0_u8,
                 VENDOR_CONFIG_KEY_1.pqc_key_idx as u8,
                 *pqc_key_type as u8,
-                true as u8,
+                owner_pk_in_fuses as u8,
             ],
         );
 
@@ -414,6 +419,11 @@ fn test_pcr_log_fmc_fuse_svn() {
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
 
+        // In subsystem mode, the owner PK hash flows through the DOT
+        // mailbox command, not the fuse controller, so
+        // owner_pub_keys_digest_in_fuses is false.
+        let owner_pk_in_fuses = !hw.subsystem_mode();
+
         check_pcr_log_entry(
             &pcr_entry_arr,
             0,
@@ -428,7 +438,7 @@ fn test_pcr_log_fmc_fuse_svn() {
                 FW_FUSE_SVN as u8,
                 VENDOR_CONFIG_KEY_1.pqc_key_idx as u8,
                 *pqc_key_type as u8,
-                true as u8,
+                owner_pk_in_fuses as u8,
             ],
         );
     }

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -549,11 +549,20 @@ fn test_preamble_owner_pubkey_digest_mismatch() {
 
         let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
 
+        // In subsystem mode, the owner PK hash flows through the DOT mailbox
+        // command (INSTALL_OWNER_PK_HASH) from the MCU ROM, not through the
+        // fuse controller registers. So the verifier hits the DOT check path.
+        let expected_err = if hw.subsystem_mode() {
+            CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH
+        } else {
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH
+        };
+
         helpers::assert_fatal_fw_load(
             &mut hw,
             *pqc_key_type,
             &image_bundle.to_bytes().unwrap(),
-            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH,
+            expected_err,
         );
 
         assert_eq!(

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -47,22 +47,35 @@ pub const MCU_LOAD_ADDRESS: Addr64 = Addr64 {
 };
 
 pub const MCU_STAGING_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x200,
-    hi: 0x0000_0000,
-};
-
-pub const SOC_LOAD_ADDRESS: Addr64 = Addr64 {
-    lo: TEST_SRAM_BASE.lo + 0x100,
-    hi: 0x0000_0000,
-};
-
-pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
     lo: TEST_SRAM_BASE.lo + 0x300,
     hi: 0x0000_0000,
 };
 
-pub const MCU_FW_SIZE: usize = 256;
+pub const SOC_LOAD_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo + 0x200,
+    hi: 0x0000_0000,
+};
+
+pub const SOC_STAGING_ADDRESS: Addr64 = Addr64 {
+    lo: TEST_SRAM_BASE.lo + 0x500,
+    hi: 0x0000_0000,
+};
+
+// Must be > 0x100 so the firmware covers the MCU ROM entry point at
+// MCU_SRAM + 0x100. On FPGA, MCU ROM jumps to that offset after a
+// hitless-update reset.
+pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
+
+/// Create a valid RISC-V firmware image that won't crash with an illegal
+/// instruction exception on real FPGA hardware. Uses `0x37` repeated, which
+/// encodes as `LUI x6, 0x37373` — a valid, harmless RISC-V instruction.
+/// The single-byte pattern is byte-swap invariant, which is required because
+/// `write_payload_to_mcu_sram` applies a BE byte swap when writing to MCU
+/// SRAM via the MCI MMIO window.
+fn mcu_test_firmware() -> Vec<u8> {
+    vec![0x37u8; MCU_FW_SIZE]
+}
 
 #[derive(Debug, Clone)]
 struct Image {
@@ -252,7 +265,7 @@ fn test_activate_mcu_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -282,7 +295,7 @@ fn test_activate_mcu_soc_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -322,7 +335,7 @@ fn test_activate_soc_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -361,7 +374,7 @@ fn test_activate_invalid_fw_id() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -398,7 +411,7 @@ fn test_activate_fw_id_not_in_manifest() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -435,7 +448,7 @@ fn test_invalid_exec_bit_in_manifest() {
         fw_id: MCU_FW_ID_1,
         staging_address: MCU_STAGING_ADDRESS,
         load_address: MCU_LOAD_ADDRESS,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -207,7 +207,7 @@ fn send_activate_firmware_cmd(
     {
         if reset_expected {
             let clear_interrupt = |model: &mut DefaultHwModel| {
-                let mut retry_count = 10;
+                let mut retry_count = 100;
                 loop {
                     let intr_status = model
                         .mmio
@@ -222,7 +222,7 @@ fn send_activate_firmware_cmd(
                     }
                     retry_count -= 1;
                     if retry_count == 0 {
-                        return;
+                        panic!("Timed out waiting for notif_cptra_mcu_reset_req_sts interrupt");
                     }
                     std::thread::sleep(std::time::Duration::from_millis(100));
                 }


### PR DESCRIPTION
## Summary

Fixes ROM integration test failures when running in FPGA subsystem mode, and updates the MCU commit SHA used in CI.

### Changes

1. **`test_preamble_owner_pubkey_digest_mismatch`**: In subsystem mode, the owner PK hash flows through the `INSTALL_OWNER_PK_HASH` mailbox command (DOT path) rather than through fuse controller registers. The test now expects `DOT_OWNER_PUB_KEY_DIGEST_MISMATCH` (0x000B005E) in subsystem mode instead of `OWNER_PUB_KEY_DIGEST_MISMATCH` (0x000B0007).

2. **`test_pcr_log` / `test_pcr_log_fmc_fuse_svn`**: In subsystem mode, the fuse controller returns zero for the owner PK digest, so `owner_pub_keys_digest_in_fuses` should be `false`. Updated both tests to condition on `!hw.subsystem_mode()`.

3.fix test_activate_firmware for FPGA subsystem
Use byte-swap-invariant RISC-V firmware (0x37 = LUI) instead of 0x55
which causes illegal instruction exceptions on real MCU hardware.
Increase MCU_FW_SIZE to 0x200 to cover the MCU ROM entry point at
offset 0x100, and adjust staging/load addresses accordingly.

4. **MCU commit SHA**: Updated `CALIPTRA_MCU_COMMIT` in `fpga-subsystem.yml` to `7328113c31713b3ff3da89de7901b8393dafff3c`.

### Testing

All fixes validated on VCK190 FPGA board running subsystem mode tests.