### PR TITLE
runtime: Force run_reset_flow to not inline

### DIFF
--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -156,6 +156,13 @@ impl Drivers {
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    // Keep the reset flow out-of-line. It runs once at boot, but if inlined into
+    // the runtime entry point its large transient scratch (cert-chain assembly,
+    // DPE initialization/validation) stays reserved on the entry frame for the
+    // entire mailbox-command lifetime, inflating the stack floor every command
+    // pays. Forcing it out-of-line lets that scratch be reclaimed before the
+    // mailbox loop begins.
+    #[inline(never)]
     pub fn run_reset_flow(&mut self) -> CaliptraResult<()> {
         Self::create_cert_chain(self)?;
         if self.persistent_data.get().attestation_disabled.get() {


### PR DESCRIPTION
The run_reset_flow was previously inlined as part of the runtime entry point.  This method was only invoked once during initialization, but due to being inlined its stack requirements (~6Kb) persisted for the entire duration of the runtime execution.

By forcing the function to no longer be inlined its stack usage is recovered after completion, saving ~6Kb of stack space, and ~400 bytes of instruction memory.

Firmware stats after change:


## FW Size

| Component    | text+data before | text+data after | Δ      | Budget            | Used before → after |
|--------------|------------------:|----------------:|-------:|-------------------|---------------------|
| ROM          | 42,536            | 42,536          | 0      | 48 KiB (49,152)   | 86.5% → 86.5%       |
| FMC          | 20,300            | 20,300          | 0      | 24 KiB (24,576)   | 82.6% → 82.6%       |
| **Runtime**  | 83,568            | **83,176**      | **−392** | 96 KiB (98,304) | 85.0% → **84.6%**   |
| Image Bundle | 109,752           | **109,360**     | **−392** | 128 KiB (131,072) | 83.7% → **83.4%**  |

ROM and FMC are unaffected (RT-only change). Runtime gains ~0.38 KiB of ICCM
headroom. Image-bundle free space: 21,320 B → 21,712 B.

## Stack Usage (peak per command)

All commands improve by the same 6,032 B because the reduction is in the shared
entry-frame floor that sits beneath every command.

| Command                       | before  | after   | Δ      | % stack after |
|-------------------------------|--------:|--------:|-------:|--------------:|
| INVOKE_DPE(CertifyKey/X509)   | 50,704  | 44,672  | −6,032 | 51.3%         |
| INVOKE_DPE(GetProfile)        | 43,008  | 36,976  | −6,032 | 42.5%         |
| SET_AUTH_MANIFEST             | 41,264  | 35,232  | −6,032 | 40.5%         |
| CERTIFY_KEY_EXTENDED          | 40,288  | 34,256  | −6,032 | 39.4%         |
| STASH_MEASUREMENT             | 39,712  | 33,680  | −6,032 | 38.7%         |
| AUTHORIZE_AND_STASH           | 39,248  | 33,216  | −6,032 | 38.2%         |
| LMS_VERIFY                    | 32,960  | 26,928  | −6,032 | 30.9%         |
| QUOTE_PCRS                    | 32,464  | 26,432  | −6,032 | 30.4%         |
| POPULATE_IDEV_CERT            | 31,088  | 25,056  | −6,032 | 28.8%         |
| SELF_TEST_GET_RESULTS(+KATs)  | 29,968  | 23,936  | −6,032 | 27.5%         |
| SIGN_WITH_EXPORTED_ECDSA      | 28,912  | 22,880  | −6,032 | 26.3%         |
| GET_IDEV_CERT                 | 28,160  | 22,128  | −6,032 | 25.4%         |
| GET_LDEV_CERT                 | 27,552  | 21,520  | −6,032 | 24.7%         |
| GET_FMC_ALIAS_CERT            | 27,552  | 21,520  | −6,032 | 24.7%         |
| GET_RT_ALIAS_CERT             | 27,296  | 21,264  | −6,032 | 24.4%         |
| DISABLE_ATTESTATION           | 27,056  | 21,024  | −6,032 | 24.2%         |
| GET_PCR_LOG                   | 26,784  | 20,752  | −6,032 | 23.8%         |
| GET_FMC_ALIAS_CSR             | 26,688  | 20,656  | −6,032 | 23.7%         |
| ECDSA384_VERIFY               | 26,608  | 20,576  | −6,032 | 23.6%         |
| GET_IDEV_CSR                  | 26,432  | 20,400  | −6,032 | 23.4%         |
| EXTEND_PCR                    | 26,288  | 20,256  | −6,032 | 23.3%         |
| ADD_SUBJECT_ALT_NAME          | 26,192  | 20,160  | −6,032 | 23.2%         |
| DPE_TAG_TCI                   | 25,968  | 19,936  | −6,032 | 22.9%         |
| REVOKE_EXPORTED_CDI_HANDLE    | 25,968  | 19,936  | −6,032 | 22.9%         |
| DPE_GET_TAGGED_TCI            | 25,936  | 19,904  | −6,032 | 22.9%         |
| REALLOCATE_DPE_CONTEXT_LIMITS | 25,936  | 19,904  | −6,032 | 22.9%         |
| INCREMENT_PCR_RESET_COUNTER   | 25,920  | 19,888  | −6,032 | 22.8%         |
| VERSION                       | 25,904  | 19,872  | −6,032 | 22.8%         |
| CAPABILITIES                  | 25,904  | 19,872  | −6,032 | 22.8%         |
| FW_INFO                       | 25,904  | 19,872  | −6,032 | 22.8%         |
| GET_IDEV_INFO                 | 25,904  | 19,872  | −6,032 | 22.8%         |
| SELF_TEST_START               | 25,904  | 19,872  | −6,032 | 22.8%         |
| SHUTDOWN                      | 25,904  | 19,872  | −6,032 | 22.8%         |
| **Baseline floor**            | **25,904** | **19,872** | **−6,032** | **22.8%** |
