### PR TITLE
[FPGA]: Wait for cold boot complete in model harness

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -61,7 +61,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '781d1f68e752b0810b81f9ec0f0cd175391c53a6' }}
+  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '47810a48a4fcf6f80b50bac7a7e6721eb9123d6c' }}
 
 jobs:
   check_cache:

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -476,6 +476,10 @@ pub struct ModelFpgaSubsystem {
 }
 
 impl ModelFpgaSubsystem {
+    fn mci_boot_milestones(&mut self) -> McuBootMilestones {
+        McuBootMilestones::from((self.mci_flow_status() >> 16) as u16)
+    }
+
     fn set_bootfsm_break(&mut self, val: bool) {
         if val {
             self.wrapper
@@ -1758,10 +1762,6 @@ impl ModelFpgaSubsystem {
         (self.mci_flow_status() & 0x0000_ffff) as u16
     }
 
-    pub fn mci_boot_milestones(&mut self) -> McuBootMilestones {
-        McuBootMilestones::from((self.mci_flow_status() >> 16) as u16)
-    }
-
     fn caliptra_axi_bus(&mut self) -> Option<FpgaRealtimeBus<'_>> {
         self.mmio.caliptra_axi_bus()
     }
@@ -2339,7 +2339,13 @@ impl HwModel for ModelFpgaSubsystem {
         // MCU ROM will wait after reaching the mailbox for this bit before booting RT
         gpio.set(current | 1 << 31);
 
-        // ironically, we don't need to support this
+        // Wait for MCU to finish cold boot (including ROM integrity check)
+        // to avoid mailbox contention with the host.
+        self.step_until(|m| {
+            m.mci_boot_milestones()
+                .contains(McuBootMilestones::COLD_BOOT_FLOW_COMPLETE)
+        });
+
         Ok(())
     }
 


### PR DESCRIPTION
This reduces race conditions for the mailbox lock.