### PR TITLE
[fpga]: Update UDS and FE offsets

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -61,7 +61,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '781d1f68e752b0810b81f9ec0f0cd175391c53a6' }}
+  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '47810a48a4fcf6f80b50bac7a7e6721eb9123d6c' }}
 
 jobs:
   check_cache:

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -86,9 +86,9 @@ const FUSE_VENDOR_REVOCATION_OFFSET: usize = OTP_VENDOR_REVOCATIONS_PROD_PARTITI
                                                                                                 // LIFECYCLE_PARTITION
                                                                                                 // VENDOR_NON_SECRET_PROD_PARTITION
 pub const VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET: usize = 0xaa8;
-const UDS_SEED_OFFSET: usize = VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET; // 64 bytes
-const FIELD_ENTROPY_OFFSET: usize = VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + 64; // 32 bytes
-                                                                                       // CPTRA_SS_LOCK_HEK_PROD partitions
+const UDS_SEED_OFFSET: usize = 0xba8;
+const FIELD_ENTROPY_OFFSET: usize = 0xbe8;
+// CPTRA_SS_LOCK_HEK_PROD partitions
 const OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET: usize = 0xCB0;
 const OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET + 48;
 const OTP_CPTRA_SS_LOCK_HEK_PROD_2_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET + 48;

--- a/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_idevid_derivation.rs
@@ -100,16 +100,8 @@ fn fuses_with_random_uds() -> Fuses {
     const UDS_LEN: usize = core::mem::size_of::<u32>() * 16;
     let mut uds_bytes = [0; UDS_LEN];
     rand_bytes(&mut uds_bytes).unwrap();
-
-    // WORKAROUND: On FPGA subsystem (core_test mode), UDS words 8-15 are written to OTP at
-    // 0xac8 (DOT_FUSE_ARRAY). MCU ROM treats an odd total popcount as DOT-locked,
-    // and if the DOT blob is absent, it errors out. This ensures an even number of bits are set.
-    let dot_fuse_bits: u32 = uds_bytes[32..64].iter().map(|b| b.count_ones()).sum();
-    if dot_fuse_bits & 1 == 1 {
-        uds_bytes[32] ^= 1;
-    }
-
     let mut uds_seed = [0u32; 16];
+
     for (word, bytes) in uds_seed.iter_mut().zip(uds_bytes.chunks_exact(4)) {
         *word = u32::from_be_bytes(bytes.try_into().unwrap());
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -300,6 +300,42 @@ fn finish_debug_unlock_mailbox_access(drivers: &mut Drivers) {
         .set_ss_dbg_unlock_tap_mailbox_available(false);
 }
 
+/// # Safety
+///
+/// This function is unsafe because it exposes internal cryptographic mailbox
+/// commands directly. It should ONLY be used by integration tests (e.g. the mock runtime).
+pub unsafe fn sha_init(
+    drivers: &mut Drivers,
+    cmd_bytes: &[u8],
+    resp: &mut [u8],
+) -> CaliptraResult<usize> {
+    cryptographic_mailbox::Commands::sha_init(drivers, cmd_bytes, resp)
+}
+
+/// # Safety
+///
+/// This function is unsafe because it exposes internal cryptographic mailbox
+/// commands directly. It should ONLY be used by integration tests (e.g. the mock runtime).
+pub unsafe fn sha_update(
+    drivers: &mut Drivers,
+    cmd_bytes: &[u8],
+    resp: &mut [u8],
+) -> CaliptraResult<usize> {
+    cryptographic_mailbox::Commands::sha_update(drivers, cmd_bytes, resp)
+}
+
+/// # Safety
+///
+/// This function is unsafe because it exposes internal cryptographic mailbox
+/// commands directly. It should ONLY be used by integration tests (e.g. the mock runtime).
+pub unsafe fn sha_final(
+    drivers: &mut Drivers,
+    cmd_bytes: &[u8],
+    resp: &mut [u8],
+) -> CaliptraResult<usize> {
+    cryptographic_mailbox::Commands::sha_final(drivers, cmd_bytes, resp)
+}
+
 fn execute_command(
     drivers: &mut Drivers,
     cmd_id: u32,

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -368,6 +368,48 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 drivers.persistent_data.get_mut().fw.dpe.runtime_cmd_active = U8Bool::new(true);
                 write_response(&mut drivers.mbox, &[]);
             }
+            CommandId::CM_SHA_INIT | CommandId::CM_SHA_UPDATE | CommandId::CM_SHA_FINAL => {
+                let (ptr, len) = {
+                    let raw_data = read_request(&drivers.mbox);
+                    (raw_data.as_ptr(), raw_data.len())
+                };
+                let cmd_bytes = unsafe { core::slice::from_raw_parts(ptr, len) };
+                let mut resp = [0u8; 256];
+
+                // The MCU ROM relies on these SHA commands to calculate the ROM image. We need to
+                // implement them in this responder to be able to boot to the runtime.
+                //
+                // SAFETY: These functions are unsafe as they expose internal crypto commands,
+                // but are safe to use here in the mock runtime for testing.
+                let res = unsafe {
+                    match cmd {
+                        CommandId::CM_SHA_INIT => {
+                            caliptra_runtime::sha_init(drivers, cmd_bytes, &mut resp)
+                        }
+                        CommandId::CM_SHA_UPDATE => {
+                            caliptra_runtime::sha_update(drivers, cmd_bytes, &mut resp)
+                        }
+                        CommandId::CM_SHA_FINAL => {
+                            caliptra_runtime::sha_final(drivers, cmd_bytes, &mut resp)
+                        }
+                        _ => unreachable!(),
+                    }
+                };
+                match res {
+                    Ok(len) => {
+                        let len = len.max(8);
+                        let resp_slice = &mut resp[..len];
+                        let checksum =
+                            caliptra_common::checksum::calc_checksum(0, &resp_slice[4..]);
+                        resp_slice[..4].copy_from_slice(&checksum.to_ne_bytes());
+                        write_response(&mut drivers.mbox, resp_slice);
+                        return Ok(MboxStatusE::DataReady);
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
             _ => {
                 drivers.mbox.set_status(MboxStatusE::CmdFailure);
             }

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -12,7 +12,7 @@ mod configurations;
 
 mod utils;
 
-const DEFAULT_MCU_REV: &str = "02ea798304ccccff8e6b5a065781b3d5ed38b118";
+const DEFAULT_MCU_REV: &str = "47810a48a4fcf6f80b50bac7a7e6721eb9123d6c";
 
 pub struct BuildArgs<'a> {
     pub fw_id: &'a Option<String>,


### PR DESCRIPTION
Otherwise they collide with the DOT fuses.

This reflects the fuse changes from https://github.com/chipsalliance/caliptra-mcu-sw/pull/1628