### PR TITLE
[update] ROM: Gate fatal error reporting on recovery reset strap

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-3cbfc053c6d7aec4710a3ff3b13cebe75ee67f088467fe04a9ae114d2e81b5373f92c953a1e42a4e6000c6844211e698  caliptra-rom-no-log.bin
-682d868e4713235351a35a76d0ebd43521d3cc952ec76a3793f4a58ebf2c11a04eec785fbb86faa02657605b48b0a726  caliptra-rom-with-log.bin
+b57b99073a46211378418dff7cfdfe6b4ccb9af5922f531f0ab18b2d1b0ea30991a3e2f2cec0ba90ca0da4fb1c8e0192  caliptra-rom-no-log.bin
+9c2bc58516027f29e6128c866322ff6a5432d1d0414336132995ab7b95f69fdf8b49081bdf4b0bead1d88c29c816737f  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-9c2a1160f96286dac3b28148d3de3574f3d00b28560d0e114239afaf8a8bfa97596057bee98a1734848c605ae23586ac  caliptra-rom-no-log.bin
-adfa63011ac87cc1622eebab42e03863014978173be711ad266a51927be779ef79d780e130e039aca21a39b6af66696e  caliptra-rom-with-log.bin
+3cbfc053c6d7aec4710a3ff3b13cebe75ee67f088467fe04a9ae114d2e81b5373f92c953a1e42a4e6000c6844211e698  caliptra-rom-no-log.bin
+682d868e4713235351a35a76d0ebd43521d3cc952ec76a3793f4a58ebf2c11a04eec785fbb86faa02657605b48b0a726  caliptra-rom-with-log.bin

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-b57b99073a46211378418dff7cfdfe6b4ccb9af5922f531f0ab18b2d1b0ea30991a3e2f2cec0ba90ca0da4fb1c8e0192  caliptra-rom-no-log.bin
-9c2bc58516027f29e6128c866322ff6a5432d1d0414336132995ab7b95f69fdf8b49081bdf4b0bead1d88c29c816737f  caliptra-rom-with-log.bin
+0a15e3540b58bd1dd4f08a299735181f834e3cc6ffb6afafdb8968f5913b5db7595c58534eb75d0c1822e196e5a056df  caliptra-rom-no-log.bin
+9a63d03bc86ca687bf674d99dbe91cb60b5d41484bc53a1941cd445067d8dc92b90e3cccf623dc38a0e2c87ec81df3d5  caliptra-rom-with-log.bin

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -382,6 +382,11 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
+    pub const SOC_IFC_WAIT_FOR_DEVICE_RESET: FwId = FwId {
+        bin_name: "soc_ifc_wait_for_device_reset",
+        ..BASE_FWID
+    };
+
     pub const TEST_LMS_24: FwId = FwId {
         bin_name: "test_lms_24",
         ..BASE_FWID
@@ -684,6 +689,7 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::SHA512,
     &driver_tests::SHA2_512_384ACC,
     &driver_tests::STATUS_REPORTER,
+    &driver_tests::SOC_IFC_WAIT_FOR_DEVICE_RESET,
     &driver_tests::TEST_LMS_24,
     &driver_tests::TEST_LMS_32,
     &driver_tests::TEST_NEGATIVE_LMS,

--- a/common/src/error_handler.rs
+++ b/common/src/error_handler.rs
@@ -3,10 +3,23 @@ use caliptra_drivers::{
     cprintln, report_fw_error_fatal, report_fw_error_non_fatal, Aes, Ecc384, Hmac, KeyVault,
     Mailbox, MlKem1024, Mldsa87, Sha256, Sha2_512_384, Sha2_512_384Acc, Sha3, SocIfc,
 };
+#[cfg(feature = "rom")]
+use caliptra_drivers::{Dma, DmaRecovery};
+#[cfg(feature = "rom")]
+use caliptra_registers::soc_ifc::SocIfcReg;
 
 #[allow(clippy::empty_loop)]
 pub fn handle_fatal_error(code: u32) -> ! {
     cprintln!("Fatal Error: 0x{:08X}", code);
+
+    #[cfg(feature = "rom")]
+    {
+        let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+        if soc_ifc.wait_for_device_reset_before_fatal_error() {
+            wait_for_device_reset_before_fatal_error(&soc_ifc);
+        }
+    }
+
     report_fw_error_fatal(code);
     // Populate the non-fatal error code too; if there was a
     // non-fatal error stored here before we don't want somebody
@@ -43,4 +56,25 @@ pub fn handle_fatal_error(code: u32) -> ! {
         // we've failed.
         unsafe { Mailbox::abort_pending_soc_to_uc_transactions() };
     }
+}
+
+#[cfg(feature = "rom")]
+/// Wait for the recovery interface to request a device reset before reporting a fatal error.
+///
+/// This is only called when SS_STRAP_GENERIC[3][1] is set in subsystem mode. Stop WDT1 before
+/// polling because the wait is intentionally controlled by the recovery initiator, then poll
+/// DEVICE_RESET.RESET_CTRL until it reaches 0x1 (Reset Device).
+fn wait_for_device_reset_before_fatal_error(soc_ifc: &SocIfc) {
+    unsafe {
+        SocIfc::stop_wdt1();
+    }
+
+    let dma = Dma::default();
+    let dma_recovery = DmaRecovery::new(
+        soc_ifc.recovery_interface_base_addr().into(),
+        soc_ifc.caliptra_base_axi_addr().into(),
+        soc_ifc.mci_base_addr().into(),
+        &dma,
+    );
+    let _ = dma_recovery.wait_for_device_reset();
 }

--- a/common/src/error_handler.rs
+++ b/common/src/error_handler.rs
@@ -1,4 +1,6 @@
 // Licensed under the Apache-2.0 license
+#[cfg(feature = "rom")]
+use caliptra_cfi_lib::{cfi_assert_bool, cfi_launder};
 use caliptra_drivers::{
     cprintln, report_fw_error_fatal, report_fw_error_non_fatal, Aes, Ecc384, Hmac, KeyVault,
     Mailbox, MlKem1024, Mldsa87, Sha256, Sha2_512_384, Sha2_512_384Acc, Sha3, SocIfc,
@@ -15,8 +17,12 @@ pub fn handle_fatal_error(code: u32) -> ! {
     #[cfg(feature = "rom")]
     {
         let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
-        if soc_ifc.wait_for_device_reset_before_fatal_error() {
+        let wait_for_device_reset = soc_ifc.wait_for_device_reset_before_fatal_error();
+        if cfi_launder(wait_for_device_reset) {
+            cfi_assert_bool(wait_for_device_reset);
             wait_for_device_reset_before_fatal_error(&soc_ifc);
+        } else {
+            cfi_assert_bool(!wait_for_device_reset);
         }
     }
 

--- a/common/src/error_handler.rs
+++ b/common/src/error_handler.rs
@@ -14,25 +14,6 @@ use caliptra_registers::soc_ifc::SocIfcReg;
 pub fn handle_fatal_error(code: u32) -> ! {
     cprintln!("Fatal Error: 0x{:08X}", code);
 
-    #[cfg(feature = "rom")]
-    {
-        let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
-        let wait_for_device_reset = soc_ifc.wait_for_device_reset_before_fatal_error();
-        if cfi_launder(wait_for_device_reset) {
-            cfi_assert_bool(wait_for_device_reset);
-            wait_for_device_reset_before_fatal_error(&soc_ifc);
-        } else {
-            cfi_assert_bool(!wait_for_device_reset);
-        }
-    }
-
-    report_fw_error_fatal(code);
-    // Populate the non-fatal error code too; if there was a
-    // non-fatal error stored here before we don't want somebody
-    // mistakenly thinking that was the reason for their mailbox
-    // command failure.
-    report_fw_error_non_fatal(code);
-
     unsafe {
         // Zeroize the crypto blocks.
         Aes::zeroize();
@@ -55,6 +36,25 @@ pub fn handle_fatal_error(code: u32) -> ! {
         // Note: This is an idempotent operation.
         SocIfc::stop_wdt1();
     }
+
+    #[cfg(feature = "rom")]
+    {
+        let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+        let wait_for_device_reset = soc_ifc.wait_for_device_reset_before_fatal_error();
+        if cfi_launder(wait_for_device_reset) {
+            cfi_assert_bool(wait_for_device_reset);
+            wait_for_device_reset_before_fatal_error(&soc_ifc);
+        } else {
+            cfi_assert_bool(!wait_for_device_reset);
+        }
+    }
+
+    report_fw_error_fatal(code);
+    // Populate the non-fatal error code too; if there was a
+    // non-fatal error stored here before we don't want somebody
+    // mistakenly thinking that was the reason for their mailbox
+    // command failure.
+    report_fw_error_non_fatal(code);
 
     loop {
         // SoC firmware might be stuck waiting for Caliptra to finish

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -544,6 +544,8 @@ impl<'a> DmaRecovery<'a> {
     pub const DEVICE_STATUS_BOOT_FAILURE: u32 = 0xE;
     pub const DEVICE_STATUS_FATAL_ERROR: u32 = 0xF;
 
+    const DEVICE_RESET_CTRL_RESET_DEVICE: u32 = 0x1;
+
     const ACTIVATE_RECOVERY_IMAGE_CMD: u32 = 0xF;
 
     const RESET_VAL: u32 = 0x1;
@@ -815,6 +817,15 @@ impl<'a> DmaRecovery<'a> {
             // Read RECOVERY_CTRL register 'Activate Recovery Image' field for 'Activate Recovery Image' (0xF) command.
             while recovery.recovery_ctrl().read().activate_rec_img()
                 != Self::ACTIVATE_RECOVERY_IMAGE_CMD
+            {}
+        })
+    }
+
+    pub fn wait_for_device_reset(&self) -> CaliptraResult<()> {
+        self.with_regs(|regs| {
+            let recovery = regs.sec_fw_recovery_if();
+            while recovery.device_reset().read().reset_ctrl()
+                != Self::DEVICE_RESET_CTRL_RESET_DEVICE
             {}
         })
     }

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -24,6 +24,9 @@ use crate::{memory_layout, FuseBank};
 
 pub type Lifecycle = DeviceLifecycleE;
 
+const SS_STRAP_GENERIC_3_STABLE_OWNER_KEY_ENABLE: u32 = 1 << 0;
+const SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR: u32 = 1 << 1;
+
 pub fn report_boot_status(val: u32) {
     let mut soc_ifc = unsafe { soc_ifc::SocIfcReg::new() };
 
@@ -656,7 +659,17 @@ impl SocIfc {
 
     /// Check if the Stable Owner Key feature is enabled via SS_STRAP_GENERIC[3] bit 0.
     pub fn stable_owner_key_enabled(&self) -> bool {
-        self.soc_ifc.regs().ss_strap_generic().at(3).read() & 1 != 0
+        self.soc_ifc.regs().ss_strap_generic().at(3).read()
+            & SS_STRAP_GENERIC_3_STABLE_OWNER_KEY_ENABLE
+            != 0
+    }
+
+    /// Check if ROM should wait for DEVICE_RESET before reporting fatal errors.
+    pub fn wait_for_device_reset_before_fatal_error(&self) -> bool {
+        self.subsystem_mode()
+            && self.soc_ifc.regs().ss_strap_generic().at(3).read()
+                & SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR
+                != 0
     }
 
     /// Check if the Stable Owner Key feature is available.

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -142,6 +142,11 @@ path = "src/bin/status_reporter_tests.rs"
 required-features = ["riscv"]
 
 [[bin]]
+name = "soc_ifc_wait_for_device_reset"
+path = "src/bin/soc_ifc_wait_for_device_reset_tests.rs"
+required-features = ["riscv"]
+
+[[bin]]
 name = "test_success"
 path = "src/bin/test_success.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/soc_ifc_wait_for_device_reset_tests.rs
+++ b/drivers/test-fw/src/bin/soc_ifc_wait_for_device_reset_tests.rs
@@ -1,0 +1,17 @@
+// Licensed under the Apache-2.0 license
+
+#![no_std]
+#![no_main]
+
+use caliptra_drivers::SocIfc;
+use caliptra_registers::soc_ifc::SocIfcReg;
+use caliptra_test_harness::test_suite;
+
+fn test_wait_for_device_reset_before_fatal_error() {
+    let soc_ifc = SocIfc::new(unsafe { SocIfcReg::new() });
+    assert!(soc_ifc.wait_for_device_reset_before_fatal_error());
+}
+
+test_suite! {
+    test_wait_for_device_reset_before_fatal_error,
+}

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -836,6 +836,10 @@ fn test_status_reporter() {
 }
 
 #[test]
+#[cfg_attr(
+    any(feature = "fpga_realtime", feature = "fpga_subsystem"),
+    ignore = "requires SS_STRAP_GENERIC_3 strap override, which is not supported on FPGA"
+)]
 fn test_soc_ifc_wait_for_device_reset_before_fatal_error() {
     const SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR: u32 = 1 << 1;
 

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -38,7 +38,10 @@ fn default_init_params() -> InitParams<'static> {
     }
 }
 
-fn start_driver_test(test_rom: &'static FwId) -> Result<DefaultHwModel, Box<dyn Error>> {
+fn start_driver_test_with_boot_params(
+    test_rom: &'static FwId,
+    boot_params: BootParams,
+) -> Result<DefaultHwModel, Box<dyn Error>> {
     let rom = caliptra_builder::build_firmware_rom(test_rom)?;
     let image_info = vec![ImageInfo::new(
         StackRange::new(STACK_START, STACK_END),
@@ -52,8 +55,12 @@ fn start_driver_test(test_rom: &'static FwId) -> Result<DefaultHwModel, Box<dyn 
             stack_info: Some(StackInfo::new(image_info)),
             ..default_init_params()
         },
-        BootParams::default(),
+        boot_params,
     )
+}
+
+fn start_driver_test(test_rom: &'static FwId) -> Result<DefaultHwModel, Box<dyn Error>> {
+    start_driver_test_with_boot_params(test_rom, BootParams::default())
 }
 
 fn run_driver_test(test_rom: &'static FwId) {
@@ -826,6 +833,23 @@ fn test_sha3() {
 #[test]
 fn test_status_reporter() {
     run_driver_test(&firmware::driver_tests::STATUS_REPORTER);
+}
+
+#[test]
+fn test_soc_ifc_wait_for_device_reset_before_fatal_error() {
+    const SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR: u32 = 1 << 1;
+
+    let mut model = start_driver_test_with_boot_params(
+        &firmware::driver_tests::SOC_IFC_WAIT_FOR_DEVICE_RESET,
+        BootParams {
+            initial_ss_strap_generic_3: Some(
+                SS_STRAP_GENERIC_3_WAIT_FOR_DEVICE_RESET_BEFORE_FATAL_ERROR,
+            ),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    model.step_until_exit_success().unwrap();
 }
 
 #[test]

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -417,6 +417,7 @@ pub struct BootParams<'a> {
     pub initial_repcnt_thresh_reg: Option<CptraItrngEntropyConfig1WriteVal>,
     pub initial_adaptp_thresh_reg: Option<CptraItrngEntropyConfig0WriteVal>,
     pub initial_ss_strap_generic_2: Option<u32>,
+    pub initial_ss_strap_generic_3: Option<u32>,
     pub valid_axi_user: Vec<u32>,
     pub wdt_timeout_cycles: u64,
     // SoC manifest passed via the recovery interface
@@ -436,6 +437,7 @@ impl Default for BootParams<'_> {
             initial_repcnt_thresh_reg: Default::default(),
             initial_adaptp_thresh_reg: Default::default(),
             initial_ss_strap_generic_2: Default::default(),
+            initial_ss_strap_generic_3: Default::default(),
             valid_axi_user: vec![0, 1, 2, 3, 4],
             wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
             soc_manifest: Default::default(),
@@ -884,6 +886,9 @@ pub trait HwModel: SocManager {
         // sets CPTRA_FUSE_WR_DONE, so the strap must be written first.
         if let Some(reg) = boot_params.initial_ss_strap_generic_2 {
             self.soc_ifc().ss_strap_generic().at(2).write(|_| reg);
+        }
+        if let Some(reg) = boot_params.initial_ss_strap_generic_3 {
+            self.soc_ifc().ss_strap_generic().at(3).write(|_| reg);
         }
 
         HwModel::init_fuses(self);

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2062,6 +2062,10 @@ impl HwModel for ModelFpgaSubsystem {
             self.soc_ifc().ss_strap_generic().at(2).write(|_| reg);
         }
 
+        if let Some(reg) = boot_params.initial_ss_strap_generic_3 {
+            self.soc_ifc().ss_strap_generic().at(3).write(|_| reg);
+        }
+
         let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
         let current = gpio.extract().get();
         // Notify MCU ROM it can start loading the fuse registers

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -1201,6 +1201,12 @@ ROM locks the following entities to prevent any updates:
 ROM performs the same initialization sequence as specified [here](#Initialization)
 
 ### Error handling
+Fatal error reporting can be configured by the following subsystem strap:
+
+| Register                         | Field/Bits | Description                                             |
+| :------------------------------- | :--------- | :------------------------------------------------------ |
+| SS_STRAP_GENERIC[3]              | [1]        | Wait for device reset before fatal error reporting. When set to 1 in subsystem mode, ROM waits for the recovery interface `DEVICE_RESET.RESET_CTRL` field to be set to `0x1` (`Reset Device`) before updating `CPTRA_FW_ERROR_FATAL` in the fatal error handler. When clear, ROM reports fatal errors immediately. |
+
 The ROM executes the following operations:
   - Updates the `cptra_fw_error_fatal` and `cptra_fw_error_non_fatal` registers with the error code ROM_UNKNOWN_RESET_FLOW (0x01040020) error code.
   - Zeroizes the following cryptographic hardware modules:


### PR DESCRIPTION
Add SS_STRAP_GENERIC[3][1] as a ROM-controlled subsystem strap that delays fatal error reporting until the recovery interface requests a device reset via DEVICE_RESET.RESET_CTRL == 0x1.

When the strap is set, ROM stops WDT1 and waits for the recovery initiator to request Reset Device before writing CPTRA_FW_ERROR_FATAL. When the strap is clear, fatal error reporting remains unchanged.