### PR TITLE
hw-model: gate openocd module to Linux to fix non-Linux unix (macOS) builds

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -41,8 +41,9 @@ pub mod keys;
 pub mod lcc;
 pub mod mmio;
 mod model_emulated;
-#[cfg(unix)]
-//openocd uses linux specifc crates to spawn the server process
+#[cfg(target_os = "linux")]
+// openocd uses Linux-specific syscalls (prctl PR_SET_PDEATHSIG via rustix) to
+// spawn the server process, so gate it to Linux rather than all unix.
 pub mod openocd;
 pub mod otp_digest;
 pub mod otp_provision;


### PR DESCRIPTION
## Summary

Follow-up to #3549. That PR gated the `openocd` module with `#[cfg(unix)]` to fix
Windows builds, and noted: *"Future work may want to make this more platform
independent."* This is that follow-up for non-Linux unix targets.

The module still fails to compile on macOS because its body calls
`rustix::process::set_parent_process_death_signal`, which is Linux-only
(`prctl(PR_SET_PDEATHSIG)`). macOS is `unix` but not `linux`, so `#[cfg(unix)]`
lets the module through and the build breaks:

```
error[E0425]: cannot find function `set_parent_process_death_signal` in module `rustix::process`
   --> hw-model/src/openocd/openocd_server.rs:101:34
```

Since `openocd` is only used by the FPGA/JTAG debug path (`fpga_realtime`) and
not by the sw-emulator, gating it to `#[cfg(target_os = "linux")]` (matching the
module's own "linux specific" comment) lets `caliptra-hw-model` and the
sw-emulator build and run on macOS without touching Linux behavior.

## Change

`hw-model/src/lib.rs`: `#[cfg(unix)]` -> `#[cfg(target_os = "linux")]` on
`pub mod openocd;`.

An alternative would be to keep the module on `unix` and gate only the
Linux-only `pre_exec`/`prctl` call in `openocd_server.rs`. Happy to switch to
that if preferred; I went with the module-level gate to stay consistent with the
approach in #3549.

## Scope / non-goals

This does **not** add macOS (or any non-Linux) CI, and does not ask the project
to support macOS. It only corrects a `cfg` classification so a Linux-specific
module is gated to Linux. CI remains Linux-only, consistent with the discussion
in #2640.

## Testing

On macOS (Apple Silicon, `aarch64-apple-darwin`), toolchain 1.85 as pinned by
`rust-toolchain.toml`:

```
cargo test -p caliptra-drivers test_doe
...
      2,564 UART: doe::test_decrypt...	[ok]
     47,275 UART: doe::test_clear_secrets...	[ok]
* TESTCASE PASSED
test test_doe_when_debug_not_locked ... ok
test test_doe_when_debug_locked ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out
```

Before this change, the same command fails to compile `caliptra-hw-model`.
