### PR TITLE
runtime: make create_cert_chain never inline

### DIFF
--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -617,6 +617,7 @@ impl Drivers {
     }
 
     /// Create certificate chain and store in Drivers
+    #[inline(never)]
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn create_cert_chain(drivers: &mut Drivers) -> CaliptraResult<()> {
         let data_vault = &drivers.data_vault;


### PR DESCRIPTION
This function creates an on-stack 4-KiB buffer as the temporary storage for the cert. If inlined, the stack frame will be shared with subsequent DPE invocations in the reset flow, leaving less stack space available. This patch prevents the function from being inlined.

Here's the the stack frame of `run_reset_flow` before the change, showing a `(5 << 12) + 368 == 20848` byte frame:
```
_ZN16caliptra_runtime7drivers7Drivers20__cfi_run_reset_flow17h1dea0af6622e2226E:
        addi    sp, sp, -256
--
        lui     a1, 5
        addi    a1, a1, 368
        sub     sp, sp, a1
--
        lui     a1, 5
        addi    a1, a1, 368
        add     sp, sp, a1
--
        lw      s10, 208(sp)
        lw      s11, 204(sp)
        addi    sp, sp, 256
```

After this change the same stack frame becomes `(4 << 12) + 1296 == 17680`, saving 3168 bytes:
```
_ZN16caliptra_runtime7drivers7Drivers20__cfi_run_reset_flow17h1dea0af6622e2226E:
        addi    sp, sp, -256
--
        lui     a1, 4
        addi    a1, a1, 1296
        sub     sp, sp, a1
--
        lui     a1, 4
        addi    a1, a1, 1296
        add     sp, sp, a1
--
        lw      s10, 208(sp)
        lw      s11, 204(sp)
        addi    sp, sp, 256
```