### PR TITLE
[ci]: fix hanging job waiting for gce instance

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -291,7 +291,7 @@ jobs:
           retention-days: 1
 
   build_bitstream:
-    runs-on: [e2-standard-8, fpga-tools]
+    runs-on: [e2-standard-8-fpga-tools]
     timeout-minutes: 180
     needs: check_cache
     if: "!needs.check_cache.outputs.rtl_cache_hit"


### PR DESCRIPTION
The instances with the FPGA tools can be stolen by a regular job that only needs an e2-standard-8 instance.