### PR TITLE
[release] Add notes in preparation for 2.1.1 FW release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# fw-2.1.1
+
+This is a combined runtime and FMC release.
+
+## Caliptra Firmware 2.1.1 Release Notes
+
+Release notes for changes introduced since Firmware 2.1.0.
+
+### Features
+
+- **DPE & Certification**:
+  - Add support for `SIGN_WITH_EXPORTED_MLDSA` (#3679)
+  - Add a new command to chunk DPE certificates (`CertifyKeyChunks`) (#3765)
+- **Runtime/FMC Functionality**:
+  - Add `ACTIVATE_FIRMWARE` `INITIAL_ACTIVATE` flag (#3720)
+  - Add more telemetry to `fw_info` (#3631)
+
+### Fixes
+
+- **Mailbox & Debug Unlock**:
+  - Fix TAP mailbox availability after debug unlock (#3848)
+  - Bind debug unlock token to device UDI (#3694)
+  - Fix WDT stop after production debug unlock (#3675)
+  - Set `PROD_DBG_UNLOCK_IN_PROGRESS` bit in runtime to match ROM (#3628)
+  - Require non-zeroized SEK & DPK for OCP-LOCK (#3606)
+- **Firmware Activation & Auth**:
+  - Fix `ActivateFirmware` to call `AuthorizeAndStash` correctly (#3719)
+  - Fix `ACTIVATE_FIRMWARE` to use `exec_bit` instead of `fw_id` for activate bitmap (#3619)
+  - Bound auth manifest metadata lookup by `entry_count` (#3732)
+  - Address-based authorize-and-stash measurement (#3688)
+- **FIPS & Cryptography**:
+  - Fix AES-GCM streaming GHASH save/restore bug (#3790)
+  - Add missing KATs in runtime start up (#3799)
+  - Add ML-KEM, ML-DSA, and ECDH pairwise consistency tests (PCT) (#3548, #3547, #3546)
+- **General**:
+  - Expand PAUSER checks for mailbox operations (#3734, #3864, & #3841)
+
 # rom-2.1.2
 
 ## Caliptra ROM 2.1.2 Release Notes

--- a/builder/src/version.rs
+++ b/builder/src/version.rs
@@ -6,11 +6,11 @@ pub const ROM_VERSION_PATCH: u16 = 2;
 
 pub const FMC_VERSION_MAJOR: u16 = 2;
 pub const FMC_VERSION_MINOR: u16 = 1;
-pub const FMC_VERSION_PATCH: u16 = 0;
+pub const FMC_VERSION_PATCH: u16 = 1;
 
 pub const RUNTIME_VERSION_MAJOR: u32 = 2;
 pub const RUNTIME_VERSION_MINOR: u32 = 1;
-pub const RUNTIME_VERSION_PATCH: u32 = 0;
+pub const RUNTIME_VERSION_PATCH: u32 = 1;
 
 // ROM Version - 16 bits
 // Major - 5 bits [15:11]

--- a/builder/test_data/default_image_options.toml
+++ b/builder/test_data/default_image_options.toml
@@ -5,9 +5,9 @@
 # NOTE: Only the first keys in the vendor config are populated. The keys are
 # copied from image/fake-keys/src/lib.rs.
 
-fmc_version = 0x1040
+fmc_version = 0x1041
 fw_svn = 0x0
-app_version = 0x2010000
+app_version = 0x2010001
 pqc_key_type = "MLDSA"
 
 [vendor_config]

--- a/test/tests/fips_test_suite/common.rs
+++ b/test/tests/fips_test_suite/common.rs
@@ -95,7 +95,12 @@ const RT_EXP_2_1_0: RtExpVals = RtExpVals {
     fw_version: 0x02010000, // 2.1.0
 };
 
-const RT_EXP_CURRENT: RtExpVals = RtExpVals { ..RT_EXP_2_1_0 };
+const RT_EXP_2_1_1: RtExpVals = RtExpVals {
+    fmc_version: 0x1041,    // 2.1.1
+    fw_version: 0x02010001, // 2.1.1
+};
+
+const RT_EXP_CURRENT: RtExpVals = RtExpVals { ..RT_EXP_2_1_1 };
 
 // === Getter implementations ===
 // TODO: These could be improved
@@ -142,6 +147,7 @@ impl RtExpVals {
         if let Ok(version) = std::env::var("FIPS_TEST_RT_EXP_VERSION") {
             match version.as_str() {
                 // Add more versions here
+                "2_1_1" => RT_EXP_2_1_1,
                 "2_1_0" => RT_EXP_2_1_0,
                 "2_0_0" => RT_EXP_2_0_0,
                 _ => panic!(


### PR DESCRIPTION
This also updates the expected version numbers and default values for tests and build scripts.