### PR TITLE
Fix FPGA MCU smoke tests for latest caliptra-mcu-sw ROM

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -61,7 +61,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '781d1f68e752b0810b81f9ec0f0cd175391c53a6' }}
+  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '067e8dbdafc36123f99189aa14eba3ee480182ff' }}
 
 jobs:
   check_cache:

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -86,9 +86,9 @@ const FUSE_VENDOR_REVOCATION_OFFSET: usize = OTP_VENDOR_REVOCATIONS_PROD_PARTITI
                                                                                                 // LIFECYCLE_PARTITION
                                                                                                 // VENDOR_NON_SECRET_PROD_PARTITION
 pub const VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET: usize = 0xaa8;
-const UDS_SEED_OFFSET: usize = VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET; // 64 bytes
-const FIELD_ENTROPY_OFFSET: usize = VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET + 64; // 32 bytes
-                                                                                       // CPTRA_SS_LOCK_HEK_PROD partitions
+const UDS_SEED_OFFSET: usize = 0xba8; // 64 bytes (LO: 0xba8, HI: 0xbc8)
+const FIELD_ENTROPY_OFFSET: usize = 0xbe8; // 32 bytes
+                                           // CPTRA_SS_LOCK_HEK_PROD partitions
 const OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET: usize = 0xCB0;
 const OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET + 48;
 const OTP_CPTRA_SS_LOCK_HEK_PROD_2_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET + 48;

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -199,13 +199,18 @@ fn test_pcr_log() {
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
 
+        // In subsystem mode, the owner PK hash flows through the DOT
+        // mailbox command, not the fuse controller, so
+        // owner_pub_keys_digest_in_fuses is false.
+        let owner_pk_in_fuses = (fuses.owner_pk_hash != [0u32; 12]) && !hw.subsystem_mode();
+
         check_pcr_log_entry(
             &pcr_entry_arr,
             0,
             PcrLogEntryId::DeviceStatus,
             PCR0_AND_PCR1_EXTENDED_ID,
             &[
-                (fuses.owner_pk_hash != [0u32; 12]) as u8, // owner_pub_keys_digest_in_fuses
+                owner_pk_in_fuses as u8,
                 anti_rollback_disable as u8,
                 fuses.fuse_ecc_revocation as u8,
                 fuses.fuse_lms_revocation.to_le_bytes()[0],
@@ -434,13 +439,18 @@ fn test_pcr_log_fmc_fuse_svn() {
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
 
+        // In subsystem mode, the owner PK hash flows through the DOT
+        // mailbox command, not the fuse controller, so
+        // owner_pub_keys_digest_in_fuses is false.
+        let owner_pk_in_fuses = (fuses.owner_pk_hash != [0u32; 12]) && !hw.subsystem_mode();
+
         check_pcr_log_entry(
             &pcr_entry_arr,
             0,
             PcrLogEntryId::DeviceStatus,
             PCR0_AND_PCR1_EXTENDED_ID,
             &[
-                (fuses.owner_pk_hash != [0u32; 12]) as u8, // owner_pub_keys_digest_in_fuses
+                owner_pk_in_fuses as u8,
                 anti_rollback_disable as u8,
                 fuses.fuse_ecc_revocation as u8,
                 fuses.fuse_lms_revocation.to_le_bytes()[0],

--- a/rom/dev/tests/rom_integration_tests/test_image_validation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_image_validation.rs
@@ -554,11 +554,20 @@ fn test_preamble_owner_pubkey_digest_mismatch() {
 
         let (mut hw, image_bundle) = helpers::build_hw_model_and_image_bundle(fuses, image_options);
 
+        // In subsystem mode, the owner PK hash flows through the DOT mailbox
+        // command (INSTALL_OWNER_PK_HASH) from the MCU ROM, not through the
+        // fuse controller registers. So the verifier hits the DOT check path.
+        let expected_err = if hw.subsystem_mode() {
+            CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH
+        } else {
+            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH
+        };
+
         helpers::assert_fatal_fw_load(
             &mut hw,
             *pqc_key_type,
             &image_bundle.to_bytes().unwrap(),
-            CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH,
+            expected_err,
         );
 
         assert_eq!(

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -42,12 +42,25 @@ pub const MCU_LOAD_OFFSET: usize = 0x000;
 
 pub const MCU_STAGING_OFFSET: usize = 0x200;
 
-pub const SOC_LOAD_OFFSET: usize = 0x100;
+pub const SOC_LOAD_OFFSET: usize = 0x200;
 
-pub const SOC_STAGING_OFFSET: usize = 0x300;
+pub const SOC_STAGING_OFFSET: usize = 0x500;
 
-pub const MCU_FW_SIZE: usize = 256;
+// Must be > 0x100 so the firmware covers the MCU ROM entry point at
+// MCU_SRAM + 0x100. On FPGA, MCU ROM jumps to that offset after a
+// hitless-update reset.
+pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
+
+/// Create a valid RISC-V firmware image that won't crash with an illegal
+/// instruction exception on real FPGA hardware. Uses `0x37` repeated, which
+/// encodes as `LUI x6, 0x37373` — a valid, harmless RISC-V instruction.
+/// The single-byte pattern is byte-swap invariant, which is required because
+/// `write_payload_to_mcu_sram` applies a BE byte swap when writing to MCU
+/// SRAM via the MCI MMIO window.
+fn mcu_test_firmware() -> Vec<u8> {
+    vec![0x37u8; MCU_FW_SIZE]
+}
 
 #[derive(Debug, Clone)]
 struct Image {
@@ -232,7 +245,7 @@ fn test_activate_mcu_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -263,7 +276,7 @@ fn test_activate_mcu_soc_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -304,7 +317,7 @@ fn test_activate_soc_fw_success() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -344,7 +357,7 @@ fn test_activate_invalid_fw_id() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -382,7 +395,7 @@ fn test_activate_fw_id_not_in_manifest() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -420,7 +433,7 @@ fn test_invalid_exec_bit_in_manifest() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -462,7 +475,7 @@ fn test_activate_firmware_old_format_no_flags() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -572,7 +585,7 @@ fn test_activate_firmware_unknown_flag_bit_rejected() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -606,7 +619,7 @@ fn test_activate_firmware_initial_activate_wrong_boot_mode() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -639,7 +652,7 @@ fn test_activate_firmware_initial_activate_without_mcu_bit_rejected() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -676,7 +689,7 @@ fn test_activate_mcu_fw_digest_mismatch() {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: [0x55u8; MCU_FW_SIZE].to_vec(),
+        contents: mcu_test_firmware(),
         exec_bit: 2,
     };
 
@@ -684,7 +697,7 @@ fn test_activate_mcu_fw_digest_mismatch() {
 
     // Tamper with the image in the staging area so the digest won't match the manifest
     model
-        .write_payload_to_ss_staging_area(&[0x75u8, 0x55u8, 0x55u8, 0x55u8], MCU_STAGING_OFFSET)
+        .write_payload_to_ss_staging_area(&[0x75u8, 0x37u8, 0x37u8, 0x37u8], MCU_STAGING_OFFSET)
         .unwrap();
 
     // Send ActivateFirmware command

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -222,6 +222,10 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
+        // MCU ROM stashes field_entropy_state measurement
+        let mut fe_hasher = Sha384::new();
+        fe_hasher.update([0u8; 48]);
+        hasher.update(fe_hasher.finalize());
     }
     let expected_measurement_hash = hasher.finalize();
 
@@ -288,6 +292,10 @@ fn test_authorize_and_stash_cmd_success() {
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
+        // MCU ROM stashes field_entropy_state measurement
+        let mut fe_hasher = Sha384::new();
+        fe_hasher.update([0u8; 48]);
+        hasher.update(fe_hasher.finalize());
     }
     hasher.update(IMAGE_DIGEST1);
     let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -232,7 +232,7 @@ fn test_certify_key_with_max_contexts() {
 
     // Fill PL0 contexts
     let max_after_init_contexts = if model.subsystem_mode() {
-        64 - 3
+        64 - 4
     } else {
         64 - 2
     };

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -76,8 +76,8 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     // The RT Journey measurement also is counted against PL0's limit. Thus, we can call derive child
     // from PL0 exactly 14 times, and the last iteration of this loop, is expected to throw a threshold reached error.
     let num_iterations = if model.subsystem_mode() {
-        // Subsystem uses a context for the MCU FW
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        // Subsystem uses contexts for the MCU FW and field entropy state
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -202,7 +202,7 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
 
     // 2 PL0 contexts are used by Caliptra
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -744,9 +744,9 @@ fn test_stash_measurement_pl_context_thresholds() {
     });
 
     // Root node and RT journey (which is technically the Caliptra locality) count as PL0
-    // In subsystem mode, the MCU FW is also measured into a PL0 context.
+    // In subsystem mode, the MCU FW and field entropy state are also measured into PL0 contexts.
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 4
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
     };
@@ -796,8 +796,8 @@ fn test_measurement_log_pl_context_threshold() {
     // Since 2 measurements taken by Caliptra upon startup, this will cause
     // the PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD to be breached.
     let invocations = if model.subsystem_mode() {
-        // MCU uses an extra DPE context
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        // MCU uses extra DPE contexts for MCU FW and field entropy state
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -231,7 +231,9 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
         data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: if model.subsystem_mode() {
-            u32::from_be_bytes(*b"MCFW")
+            // MCU ROM stashes field_entropy_state as the last measurement,
+            // making it the default context with tci_type 0.
+            0
         } else {
             u32::from_be_bytes(*b"CCIV")
         },
@@ -315,7 +317,9 @@ fn test_sign_with_exported_cdi_measurement_update() {
         data: TciMeasurement([0xa; TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: if model.subsystem_mode() {
-            u32::from_be_bytes(*b"MCFW")
+            // MCU ROM stashes field_entropy_state as the last measurement,
+            // making it the default context with tci_type 0.
+            0
         } else {
             u32::from_be_bytes(*b"CCIV")
         },

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_mldsa.rs
@@ -223,7 +223,7 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi_mldsa() {
         data: TciMeasurement([0xa; caliptra_dpe::TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: if model.subsystem_mode() {
-            u32::from_be_bytes(*b"MCFW")
+            0
         } else {
             u32::from_be_bytes(*b"CCIV")
         },
@@ -305,7 +305,7 @@ fn test_sign_with_exported_cdi_measurement_update_mldsa() {
         data: TciMeasurement([0xa; caliptra_dpe::TCI_SIZE]),
         flags: DeriveContextFlags::RECURSIVE,
         tci_type: if model.subsystem_mode() {
-            u32::from_be_bytes(*b"MCFW")
+            0
         } else {
             u32::from_be_bytes(*b"CCIV")
         },

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -87,6 +87,10 @@ fn test_stash_measurement() {
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
+        // MCU ROM stashes field_entropy_state measurement
+        let mut fe_hasher = Sha384::new();
+        fe_hasher.update([0u8; 48]);
+        hasher.update(fe_hasher.finalize());
     }
     hasher.update(measurement);
     let expected_measurement_hash = hasher.finalize();

--- a/test/tests/fips_test_suite/fw_load.rs
+++ b/test/tests/fips_test_suite/fw_load.rs
@@ -277,7 +277,17 @@ fn fw_load_error_flow_base(
         None => {
             if hw.subsystem_mode() {
                 hw.step_until(|m| m.soc_ifc().cptra_fw_error_fatal().read() != 0);
-                assert_eq!(hw.soc_ifc().cptra_fw_error_fatal().read(), exp_error_code);
+                // In subsystem mode, the MCU ROM installs the owner PK hash via
+                // the DOT mechanism, so owner PK digest mismatches are reported
+                // as the DOT variant.
+                let exp = if exp_error_code
+                    == u32::from(CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH)
+                {
+                    u32::from(CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH)
+                } else {
+                    exp_error_code
+                };
+                assert_eq!(hw.soc_ifc().cptra_fw_error_fatal().read(), exp);
             } else {
                 // Verify the correct error was returned from FW load
                 assert_eq!(
@@ -1843,7 +1853,17 @@ fn fw_load_bad_pub_key_flow(fw_image: ImageBundle, exp_error_code: u32) {
     // Make sure we got the right error
     if hw.subsystem_mode() {
         hw.step_until(|m| m.soc_ifc().cptra_fw_error_fatal().read() != 0);
-        assert_eq!(hw.soc_ifc().cptra_fw_error_fatal().read(), exp_error_code);
+        // In subsystem mode, the MCU ROM installs the owner PK hash via
+        // the DOT mechanism, so owner PK digest mismatches are reported
+        // as the DOT variant.
+        let exp = if exp_error_code
+            == u32::from(CaliptraError::IMAGE_VERIFIER_ERR_OWNER_PUB_KEY_DIGEST_MISMATCH)
+        {
+            u32::from(CaliptraError::IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH)
+        } else {
+            exp_error_code
+        };
+        assert_eq!(hw.soc_ifc().cptra_fw_error_fatal().read(), exp);
     } else {
         assert_eq!(
             ModelError::MailboxCmdFailed(exp_error_code),


### PR DESCRIPTION
Root cause: caliptra-mcu-sw commit 22b083bd (PR chipsalliance/caliptra-mcu-sw#1584) moved owner PK hash delivery from direct fuse register writes to the INSTALL_OWNER_PK_HASH mailbox command (DOT flow), and relocated OTP UDS/field-entropy offsets to a new partition layout.

This broke several FPGA subsystem tests in caliptra-sw:

1. model_fpga_subsystem.rs: Update UDS_SEED_OFFSET (0xaa8 -> 0xba8) and FIELD_ENTROPY_OFFSET (0xae8 -> 0xbe8) to match the new MCU ROM OTP partition layout.

2. test_fmcalias_derivation.rs (test_pcr_log, test_pcr_log_fmc_fuse_svn): In subsystem mode, owner_pub_keys_digest_in_fuses is now false because the owner PK hash arrives via DOT mailbox, not fuse registers. Condition

3. test_image_validation.rs (test_preamble_owner_pubkey_digest_mismatch): In subsystem mode the verifier takes the DOT code path, so expect IMAGE_VERIFIER_ERR_DOT_OWNER_PUB_KEY_DIGEST_MISMATCH instead of the fuse-based error.

4. test_activate_firmware.rs: Increase MCU_FW_SIZE to 0x200 to cover the MCU ROM entry point at SRAM+0x100, use 0x37 (valid RISC-V LUI, byte-swap invariant) instead of 0x55 for test firmware, and adjust SOC offsets to avoid overlap.

Aligned with caliptra-sw PR #3879.