### PR TITLE
[hw-model] add option to skip OTP provisioning in subsystem model

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -211,6 +211,9 @@ pub struct SubsystemInitParams<'a> {
     // from strap registers instead of OTP. This gives deterministic
     // IDevID on FPGA, required for attestation tests.
     pub use_strap_secrets: bool,
+
+    // When true, do not provision fuses in OTP. Useful for testing provisioning flows.
+    pub skip_otp_provisioning: bool,
 }
 
 impl Default for SubsystemInitParams<'_> {
@@ -225,6 +228,7 @@ impl Default for SubsystemInitParams<'_> {
             primary_flash_initial_contents: None,
             lc_state: None,
             use_strap_secrets: false,
+            skip_otp_provisioning: false,
         }
     }
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -459,6 +459,7 @@ pub struct ModelFpgaSubsystem {
     pub secondary_flash: Vec<u8>,
     // whether or not to attempt flash boot instead of streaming boot
     pub flash_boot: bool,
+    pub skip_otp_provisioning: bool,
 
     // Saved init params needed for cold_reset re-initialization
     saved_input_wires: [u32; 2],
@@ -1565,147 +1566,152 @@ impl ModelFpgaSubsystem {
         }
 
         // Provision default LC tokens.
-        println!("Provisioning SECRET_LC_TRANSITION partition.");
-        let tokens = &DEFAULT_LIFECYCLE_RAW_TOKENS;
-        let mem = otp_generate_lifecycle_tokens_mem(tokens)?;
-        let offset = OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+        if !self.skip_otp_provisioning {
+            println!("Provisioning SECRET_LC_TRANSITION partition.");
+            let tokens = &DEFAULT_LIFECYCLE_RAW_TOKENS;
+            let mem = otp_generate_lifecycle_tokens_mem(tokens)?;
+            let offset = OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-        // Provision default SW_TEST_UNLOCK partition (manuf debug unlock token).
-        println!("Provisioning SW_TEST_UNLOCK partition.");
-        let mem = otp_generate_manuf_debug_unlock_token_mem(&DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN)?;
-        let offset = OTP_SW_TEST_UNLOCK_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+            // Provision default SW_TEST_UNLOCK partition (manuf debug unlock token).
+            println!("Provisioning SW_TEST_UNLOCK partition.");
+            let mem =
+                otp_generate_manuf_debug_unlock_token_mem(&DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN)?;
+            let offset = OTP_SW_TEST_UNLOCK_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-        // Provision default SW_MANUF partition.
-        // TODO(timothytrippel): enable provisioning prod debug unlock public key hashes for public
-        // keys passed in `prod_dbg_unlock_keypairs` field in InitParams.
-        println!("Provisioning SW_MANUF partition.");
-        let mem = otp_generate_sw_manuf_partition_mem(&OtpSwManufPartition {
-            anti_rollback_disable: u32::from(self.fuses.anti_rollback_disable),
-            idevid_cert_attr: self
-                .fuses
-                .idevid_cert_attr
-                .iter()
-                .flat_map(|f| f.to_le_bytes())
-                .collect::<Vec<_>>()
-                .try_into()
-                .unwrap(),
-            hsm_id: u128::from_le_bytes(
-                self.fuses
-                    .idevid_manuf_hsm_id
+            // Provision default SW_MANUF partition.
+            // TODO(timothytrippel): enable provisioning prod debug unlock public key hashes for public
+            // keys passed in `prod_dbg_unlock_keypairs` field in InitParams.
+            println!("Provisioning SW_MANUF partition.");
+            let mem = otp_generate_sw_manuf_partition_mem(&OtpSwManufPartition {
+                anti_rollback_disable: u32::from(self.fuses.anti_rollback_disable),
+                idevid_cert_attr: self
+                    .fuses
+                    .idevid_cert_attr
                     .iter()
                     .flat_map(|f| f.to_le_bytes())
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap(),
-            ),
-            stepping_id: self.fuses.soc_stepping_id as u32,
-            ..Default::default()
-        })?;
-        let offset = OTP_SW_MANUF_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+                hsm_id: u128::from_le_bytes(
+                    self.fuses
+                        .idevid_manuf_hsm_id
+                        .iter()
+                        .flat_map(|f| f.to_le_bytes())
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap(),
+                ),
+                stepping_id: self.fuses.soc_stepping_id as u32,
+                ..Default::default()
+            })?;
+            let offset = OTP_SW_MANUF_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-        // Provision UDS seed in SECRET_MANUF partition
-        println!("Provisioning UDS seed in SECRET_MANUF partition.");
-        let uds_seed_bytes: Vec<u8> = self
-            .fuses
-            .uds_seed
-            .iter()
-            .flat_map(|&word| word.to_le_bytes())
-            .collect();
-        println!("Setting UDS seed to {:x?}", HexSlice(&uds_seed_bytes));
-        otp_data[UDS_SEED_OFFSET..UDS_SEED_OFFSET + uds_seed_bytes.len()]
-            .copy_from_slice(&uds_seed_bytes);
+            // Provision UDS seed in SECRET_MANUF partition
+            println!("Provisioning UDS seed in SECRET_MANUF partition.");
+            let uds_seed_bytes: Vec<u8> = self
+                .fuses
+                .uds_seed
+                .iter()
+                .flat_map(|&word| word.to_le_bytes())
+                .collect();
+            println!("Setting UDS seed to {:x?}", HexSlice(&uds_seed_bytes));
+            otp_data[UDS_SEED_OFFSET..UDS_SEED_OFFSET + uds_seed_bytes.len()]
+                .copy_from_slice(&uds_seed_bytes);
 
-        // Provision field entropy in SECRET_MANUF partition
-        println!("Provisioning field entropy in SECRET_MANUF partition.");
-        let field_entropy_bytes: Vec<u8> = self
-            .fuses
-            .field_entropy
-            .iter()
-            .flat_map(|&word| word.to_le_bytes())
-            .collect();
-        println!(
-            "Setting field entropy to {:x?}",
-            HexSlice(&field_entropy_bytes)
-        );
-        otp_data[FIELD_ENTROPY_OFFSET..FIELD_ENTROPY_OFFSET + field_entropy_bytes.len()]
-            .copy_from_slice(&field_entropy_bytes);
+            // Provision field entropy in SECRET_MANUF partition
+            println!("Provisioning field entropy in SECRET_MANUF partition.");
+            let field_entropy_bytes: Vec<u8> = self
+                .fuses
+                .field_entropy
+                .iter()
+                .flat_map(|&word| word.to_le_bytes())
+                .collect();
+            println!(
+                "Setting field entropy to {:x?}",
+                HexSlice(&field_entropy_bytes)
+            );
+            otp_data[FIELD_ENTROPY_OFFSET..FIELD_ENTROPY_OFFSET + field_entropy_bytes.len()]
+                .copy_from_slice(&field_entropy_bytes);
 
-        let vendor_pk_hash = self.fuses.vendor_pk_hash.as_bytes();
-        println!(
-            "Setting vendor public key hash to {:x?}",
-            HexSlice(vendor_pk_hash)
-        );
-        otp_data[FUSE_VENDOR_PKHASH_OFFSET..FUSE_VENDOR_PKHASH_OFFSET + vendor_pk_hash.len()]
-            .copy_from_slice(vendor_pk_hash);
+            let vendor_pk_hash = self.fuses.vendor_pk_hash.as_bytes();
+            println!(
+                "Setting vendor public key hash to {:x?}",
+                HexSlice(vendor_pk_hash)
+            );
+            otp_data[FUSE_VENDOR_PKHASH_OFFSET..FUSE_VENDOR_PKHASH_OFFSET + vendor_pk_hash.len()]
+                .copy_from_slice(vendor_pk_hash);
 
-        let vendor_pqc_type = FwVerificationPqcKeyType::from_u8(self.fuses.fuse_pqc_key_type as u8)
-            .unwrap_or(FwVerificationPqcKeyType::LMS);
-        println!(
-            "Setting vendor public key pqc type to {:x?}",
-            vendor_pqc_type
-        );
-        let encoded_pqc = otp_generate_linear_majority_vote(2, 3, vendor_pqc_type as u32)?;
-        otp_data[FUSE_PQC_OFFSET..FUSE_PQC_OFFSET + 4].copy_from_slice(&encoded_pqc.to_le_bytes());
+            let vendor_pqc_type =
+                FwVerificationPqcKeyType::from_u8(self.fuses.fuse_pqc_key_type as u8)
+                    .unwrap_or(FwVerificationPqcKeyType::LMS);
+            println!(
+                "Setting vendor public key pqc type to {:x?}",
+                vendor_pqc_type
+            );
+            let encoded_pqc = otp_generate_linear_majority_vote(2, 3, vendor_pqc_type as u32)?;
+            otp_data[FUSE_PQC_OFFSET..FUSE_PQC_OFFSET + 4]
+                .copy_from_slice(&encoded_pqc.to_le_bytes());
 
-        // Owner public key hash (48 bytes) lives in VENDOR_HASHES_PROD partition
-        let owner_pk_hash = self.fuses.owner_pk_hash.as_bytes();
-        println!(
-            "Setting owner public key hash to {:x?}",
-            HexSlice(owner_pk_hash)
-        );
-        otp_data[FUSE_OWNER_PKHASH_OFFSET..FUSE_OWNER_PKHASH_OFFSET + owner_pk_hash.len()]
-            .copy_from_slice(owner_pk_hash);
+            // Owner public key hash (48 bytes) lives in VENDOR_HASHES_PROD partition
+            let owner_pk_hash = self.fuses.owner_pk_hash.as_bytes();
+            println!(
+                "Setting owner public key hash to {:x?}",
+                HexSlice(owner_pk_hash)
+            );
+            otp_data[FUSE_OWNER_PKHASH_OFFSET..FUSE_OWNER_PKHASH_OFFSET + owner_pk_hash.len()]
+                .copy_from_slice(owner_pk_hash);
 
-        // Owner revocation fields (ECC, LMS, MLDSA) in VENDOR_REVOCATIONS_PROD partition
-        // Note: ECC revocation in API is a 4-bit value; store in low bits of u32 here.
-        let vendor_ecc_revocation: u32 = (u32::from(self.fuses.fuse_ecc_revocation)) & 0xF;
-        let vendor_lms_revocation: u32 = self.fuses.fuse_lms_revocation;
-        let vendor_mldsa_revocation: u32 = self.fuses.fuse_mldsa_revocation;
-        println!(
-            "Setting owner revocations ecc={:#x} lms={:#x} mldsa={:#x}",
-            vendor_ecc_revocation, vendor_lms_revocation, vendor_mldsa_revocation
-        );
-        let encoded_ecc = otp_generate_linear_majority_vote(4, 3, vendor_ecc_revocation)?;
-        otp_data[FUSE_VENDOR_ECC_REVOCATION_OFFSET..FUSE_VENDOR_ECC_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_ecc.to_le_bytes());
-        let encoded_lms = otp_generate_linear_majority_vote(16, 2, vendor_lms_revocation)?;
-        otp_data[FUSE_VENDOR_LMS_REVOCATION_OFFSET..FUSE_VENDOR_LMS_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_lms.to_le_bytes());
-        let encoded_mldsa = otp_generate_linear_majority_vote(4, 3, vendor_mldsa_revocation)?;
-        otp_data[FUSE_VENDOR_REVOCATION_OFFSET..FUSE_VENDOR_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_mldsa.to_le_bytes());
+            // Owner revocation fields (ECC, LMS, MLDSA) in VENDOR_REVOCATIONS_PROD partition
+            // Note: ECC revocation in API is a 4-bit value; store in low bits of u32 here.
+            let vendor_ecc_revocation: u32 = (u32::from(self.fuses.fuse_ecc_revocation)) & 0xF;
+            let vendor_lms_revocation: u32 = self.fuses.fuse_lms_revocation;
+            let vendor_mldsa_revocation: u32 = self.fuses.fuse_mldsa_revocation;
+            println!(
+                "Setting owner revocations ecc={:#x} lms={:#x} mldsa={:#x}",
+                vendor_ecc_revocation, vendor_lms_revocation, vendor_mldsa_revocation
+            );
+            let encoded_ecc = otp_generate_linear_majority_vote(4, 3, vendor_ecc_revocation)?;
+            otp_data[FUSE_VENDOR_ECC_REVOCATION_OFFSET..FUSE_VENDOR_ECC_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_ecc.to_le_bytes());
+            let encoded_lms = otp_generate_linear_majority_vote(16, 2, vendor_lms_revocation)?;
+            otp_data[FUSE_VENDOR_LMS_REVOCATION_OFFSET..FUSE_VENDOR_LMS_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_lms.to_le_bytes());
+            let encoded_mldsa = otp_generate_linear_majority_vote(4, 3, vendor_mldsa_revocation)?;
+            otp_data[FUSE_VENDOR_REVOCATION_OFFSET..FUSE_VENDOR_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_mldsa.to_le_bytes());
 
-        // Firmware/runtime SVN (16 bytes -> 4 words)
-        let fw_svn = self.fuses.fw_svn.as_bytes();
-        println!("Setting runtime FW SVN to {:x?}", HexSlice(fw_svn));
-        otp_data[OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET
-            ..OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET + fw_svn.len()]
-            .copy_from_slice(fw_svn);
+            // Firmware/runtime SVN (16 bytes -> 4 words)
+            let fw_svn = self.fuses.fw_svn.as_bytes();
+            println!("Setting runtime FW SVN to {:x?}", HexSlice(fw_svn));
+            otp_data[OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET
+                ..OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET + fw_svn.len()]
+                .copy_from_slice(fw_svn);
 
-        // SoC manifest SVN (16 bytes -> 4 words)
-        let soc_manifest_svn = self.fuses.soc_manifest_svn.as_bytes();
-        println!(
-            "Setting SoC manifest SVN to {:x?}",
-            HexSlice(soc_manifest_svn)
-        );
-        otp_data[OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET
-            ..OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET + soc_manifest_svn.len()]
-            .copy_from_slice(soc_manifest_svn);
+            // SoC manifest SVN (16 bytes -> 4 words)
+            let soc_manifest_svn = self.fuses.soc_manifest_svn.as_bytes();
+            println!(
+                "Setting SoC manifest SVN to {:x?}",
+                HexSlice(soc_manifest_svn)
+            );
+            otp_data[OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET
+                ..OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET + soc_manifest_svn.len()]
+                .copy_from_slice(soc_manifest_svn);
 
-        println!("Provisioning CPTRA_SS_LOCK_HEK_PROD_0 partition.");
-        let hek_seed_bytes = self.fuses.hek_seed.as_bytes();
-        let offset = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET;
-        otp_data[offset..offset + hek_seed_bytes.len()].copy_from_slice(hek_seed_bytes);
+            println!("Provisioning CPTRA_SS_LOCK_HEK_PROD_0 partition.");
+            let hek_seed_bytes = self.fuses.hek_seed.as_bytes();
+            let offset = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET;
+            otp_data[offset..offset + hek_seed_bytes.len()].copy_from_slice(hek_seed_bytes);
 
-        // Max SOC Manifest SVN (1 byte used)
-        println!(
-            "Burning fuse for SOC MAX SVN {}",
-            self.fuses.soc_manifest_max_svn
-        );
-        otp_data[OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET] = self.fuses.soc_manifest_max_svn;
+            // Max SOC Manifest SVN (1 byte used)
+            println!(
+                "Burning fuse for SOC MAX SVN {}",
+                self.fuses.soc_manifest_max_svn
+            );
+            otp_data[OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET] = self.fuses.soc_manifest_max_svn;
+        }
 
         self.otp_slice().copy_from_slice(&otp_data);
 
@@ -1975,6 +1981,7 @@ impl HwModel for ModelFpgaSubsystem {
                 .ss_init_params
                 .primary_flash_initial_contents
                 .is_some(),
+            skip_otp_provisioning: params.ss_init_params.skip_otp_provisioning,
 
             saved_input_wires,
             saved_cptra_obf_key: params.cptra_obf_key,


### PR DESCRIPTION
We need a hw model with untouched OTP for testing provisioning scenarios, which currently does not exist