### PR TITLE
debug: trace ABR zeroize shutdown hang

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,7 +8,15 @@
 # configured from the test harness. Re-enable once MCU ROM populates these straps.
 [profile.fpga-subsystem]
 default-filter = """
-package(caliptra-runtime) & test(test_fips::test_fips_shutdown)
+(package(caliptra-runtime) & test(test_fips::test_fips_shutdown)) |
+(package(caliptra-runtime) & test(test_mldsa::)) |
+(package(caliptra-runtime) & test(test_cryptographic_mailbox::test_mldsa)) |
+(package(caliptra-runtime) & test(test_cryptographic_mailbox::test_mlkem)) |
+(package(caliptra-runtime) & test(test_pcr::test_pcr_quote_mldsa)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_common::test_get_attested_mldsa_csr_invalid_key_id)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_fmc_alias::test_get_attested_fmc_alias_mldsa_csr)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_ldevid::test_get_attested_ldevid_mldsa_csr)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_rt_alias::test_get_attested_rt_alias_mldsa_csr))
 """
 failure-output = "immediate-final"
 fail-fast = false
@@ -51,7 +59,15 @@ store-failure-output = true
 # test(test_csrng_runtime_health_failure): entropy on FPGA seems to be behaving a bit differently and does not fail the test immediately, as expected
 [profile.fpga-core]
 default-filter = """
-package(caliptra-runtime) & test(test_fips::test_fips_shutdown)
+(package(caliptra-runtime) & test(test_fips::test_fips_shutdown)) |
+(package(caliptra-runtime) & test(test_mldsa::)) |
+(package(caliptra-runtime) & test(test_cryptographic_mailbox::test_mldsa)) |
+(package(caliptra-runtime) & test(test_cryptographic_mailbox::test_mlkem)) |
+(package(caliptra-runtime) & test(test_pcr::test_pcr_quote_mldsa)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_common::test_get_attested_mldsa_csr_invalid_key_id)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_fmc_alias::test_get_attested_fmc_alias_mldsa_csr)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_ldevid::test_get_attested_ldevid_mldsa_csr)) |
+(package(caliptra-runtime) & test(test_attested_csr::test_rt_alias::test_get_attested_rt_alias_mldsa_csr))
 """
 failure-output = "immediate-final"
 fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,45 +8,7 @@
 # configured from the test harness. Re-enable once MCU ROM populates these straps.
 [profile.fpga-subsystem]
 default-filter = """
-(package(caliptra-hw-model) and test(tests::test_execution)) |
-(package(caliptra-drivers) and test(test_dma_aes)) |
-(package(caliptra-runtime)
-    - test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys)
-    - test(test_debug_unlock::test_dbg_unlock_prod_wrong_cmd)
-    - test(test_fe_programming::test_fe_programming_invalid_partition)
-    - test(test_pauser_privilege_levels::test_pl0_unset_in_header)
-    - test(test_pauser_privilege_levels::test_pl1_init_ctx_dpe_context_thresholds)
-    - test(test_pauser_privilege_levels::test_user_not_pl0)
-    - test(test_mailbox::test_reserved_pauser)
-    - test(test_pauser_privilege_levels::test_change_locality)
-    - test(test_reallocate_dpe_context_limits)
-    - test(test_invoke_dpe::test_export_cdi_destroyed_root_context)
-    - test(test_fe_programming::test_fe_programming_cmd)
-    - test(test_set_auth_manifest::test_set_auth_manifest_cmd_external)) |
-(package(caliptra-rom)
-    - test(test_debug_unlock::)
-    - test(test_fmcalias_derivation::test_zero_firmware_size)
-    - test(test_uds_fe)
-    - test(test_wdt_activation_and_stoppage::)
-    - test(test_warm_reset::test_warm_reset_during_update_reset)
-    - test(test_warm_reset::test_warm_reset_during_cold_boot_before_image_validation)) |
-(package(caliptra-drivers)
-    - test(test_csrng_adaptive_proportion)
-    - test(test_csrng_repetition_count)
-    - test(test_csrng_runtime_health_failure)
-    - test(test_csrng_entropy_config_warm_reset)
-    - test(test_doe_when_debug_locked)
-    - test(test_doe_when_debug_not_locked)) |
-(package(caliptra-fmc)) |
-(package(caliptra-test) &
-    ((test(smoke_test::) - test(smoke_test::test_fmc_wdt_timeout) - test(smoke_test::test_rt_wdt_timeout))
-    | test(services::)
-    | (test(self_tests::) 
-      - test(self_tests::fw_load_halt_check_no_output))
-    | test(fw_load::)
-    | test(warm_reset::)
-    | test(fake_collateral_boot_test::)
-    | test(security_parameters::)))
+package(caliptra-runtime) & test(test_fips::test_fips_shutdown)
 """
 failure-output = "immediate-final"
 fail-fast = false
@@ -89,39 +51,7 @@ store-failure-output = true
 # test(test_csrng_runtime_health_failure): entropy on FPGA seems to be behaving a bit differently and does not fail the test immediately, as expected
 [profile.fpga-core]
 default-filter = """
-not (package(/caliptra-emu-.*/) |
-       package(caliptra-builder) |
-       package(caliptra-file-header-fix) |
-       package(compliance-test) |
-       test(test_csrng_runtime_health_failure) |
-       test(test_doe_when_debug_not_locked) |
-       test(test_sign_validation_failure) |
-       test(test_activate_firmware::test_activate_fw_id_not_in_manifest) |
-       test(test_activate_firmware::test_activate_invalid_fw_id) |
-       test(test_activate_firmware::test_activate_mcu_fw_success) |
-       test(test_activate_firmware::test_activate_mcu_soc_fw_success) |
-       test(test_activate_firmware::test_activate_soc_fw_success) |
-       test(test_activate_firmware::test_invalid_exec_bit_in_manifest) |
-       test(test_authorize_and_stash::test_authorize_from_load_address) |
-       test(test_authorize_and_stash::test_authorize_from_load_address_incorrect_digest) |
-       test(test_authorize_and_stash::test_authorize_from_staging_address) |
-       test(test_authorize_and_stash::test_authorize_from_staging_address_incorrect_digest) |
-       test(test_debug_unlock::test_dbg_unlock_prod_wrong_public_keys) |
-       test(test_fe_programming::test_fe_programming_cmd) |
-       test(test_fips::test_fips_shutdown) |
-       test(test_lms::test_lms_verify_cmd) |
-       test(test_lms::test_lms_verify_failure) |
-       test(test_lms::test_lms_verify_invalid_key_lms_type) |
-       test(test_lms::test_lms_verify_invalid_lmots_type) |
-       test(test_lms::test_lms_verify_invalid_sig_lms_type) |
-       test(test_doe_when_debug_not_locked) |
-       binary_id(caliptra-test::fips_test_suite) |
-       test(test_update_reset::test_update_reset_verify_image_failure) |
-       test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_success) |
-       test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_failure) |
-       test(test_version::test_version) |
-       test(test_warm_reset::test_warm_reset_version) |
-       test(test_fips::test_fips_version))
+package(caliptra-runtime) & test(test_fips::test_fips_shutdown)
 """
 failure-output = "immediate-final"
 fail-fast = false

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-0a15e3540b58bd1dd4f08a299735181f834e3cc6ffb6afafdb8968f5913b5db7595c58534eb75d0c1822e196e5a056df  caliptra-rom-no-log.bin
-9a63d03bc86ca687bf674d99dbe91cb60b5d41484bc53a1941cd445067d8dc92b90e3cccf623dc38a0e2c87ec81df3d5  caliptra-rom-with-log.bin
+48811a6e8bf4b22026f742046380bff8432627644300e7b161121fa88ad4a561e3bb8bcef6c405a6837ce785b0f04c91  caliptra-rom-no-log.bin
+1fdc44cd656d18957d0a5c497c4fa2aa818731e1faa215a64ff04425c5b428d0a6cd58ef2893ac060a6ce44f025984dd  caliptra-rom-with-log.bin

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -155,11 +155,8 @@ impl<'a> MlKem1024<'a> {
 
     /// Re-run KATs (for FIPS self-test).
     pub fn run_kats(&mut self) -> CaliptraResult<()> {
-        crate::cprintln!("[mlkem] run_kats ++");
-        self.trace_self_abr_status("run_kats entry");
         crate::kats::execute_mlkem1024_kat(self)?;
         self.trace_self_abr_status("run_kats exit");
-        crate::cprintln!("[mlkem] run_kats --");
         Ok(())
     }
 

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -148,86 +148,6 @@ pub struct MlKem1024<'a> {
     mlkem: &'a mut AbrReg,
 }
 
-#[cfg(feature = "runtime")]
-#[derive(Clone, Copy)]
-struct AbrTraceSnapshot {
-    op: u32,
-    mldsa_status: u32,
-    mlkem_status: u32,
-    error_global: u32,
-    error_internal: u32,
-    kv_mldsa_seed: u32,
-    kv_mlkem_seed: u32,
-    kv_mlkem_msg: u32,
-    kv_mlkem_shared: u32,
-}
-
-#[cfg(feature = "runtime")]
-impl AbrTraceSnapshot {
-    const fn empty() -> Self {
-        Self {
-            op: 0,
-            mldsa_status: 0,
-            mlkem_status: 0,
-            error_global: 0,
-            error_internal: 0,
-            kv_mldsa_seed: 0,
-            kv_mlkem_seed: 0,
-            kv_mlkem_msg: 0,
-            kv_mlkem_shared: 0,
-        }
-    }
-
-    fn capture(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) -> Self {
-        Self {
-            op,
-            mldsa_status: u32::from(regs.mldsa_status().read()),
-            mlkem_status: u32::from(regs.mlkem_status().read()),
-            error_global: u32::from(regs.intr_block_rf().error_global_intr_r().read()),
-            error_internal: u32::from(regs.intr_block_rf().error_internal_intr_r().read()),
-            kv_mldsa_seed: u32::from(regs.kv_mldsa_seed_rd_status().read()),
-            kv_mlkem_seed: u32::from(regs.kv_mlkem_seed_rd_status().read()),
-            kv_mlkem_msg: u32::from(regs.kv_mlkem_msg_rd_status().read()),
-            kv_mlkem_shared: u32::from(regs.kv_mlkem_sharedkey_wr_status().read()),
-        }
-    }
-
-    fn trace(&self, label: &str) {
-        crate::cprintln!(
-            "[abr-debug] {} op={} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
-            label,
-            self.op,
-            self.mldsa_status,
-            self.mlkem_status,
-            self.error_global,
-            self.error_internal
-        );
-        crate::cprintln!(
-            "[abr-debug] {} op={} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
-            label,
-            self.op,
-            self.kv_mldsa_seed,
-            self.kv_mlkem_seed,
-            self.kv_mlkem_msg,
-            self.kv_mlkem_shared
-        );
-    }
-}
-
-#[cfg(feature = "runtime")]
-static mut LAST_MLKEM_OPERATION: AbrTraceSnapshot = AbrTraceSnapshot::empty();
-
-#[cfg(feature = "runtime")]
-const MLKEM_OP_RUN_KATS: u32 = 1;
-#[cfg(feature = "runtime")]
-const MLKEM_OP_KEY_PAIR: u32 = 2;
-#[cfg(feature = "runtime")]
-const MLKEM_OP_ENCAPSULATE: u32 = 3;
-#[cfg(feature = "runtime")]
-const MLKEM_OP_DECAPSULATE: u32 = 4;
-#[cfg(feature = "runtime")]
-const MLKEM_OP_KEYGEN_DECAPSULATE: u32 = 5;
-
 impl<'a> MlKem1024<'a> {
     pub fn new(mlkem: &'a mut AbrReg) -> Self {
         Self { mlkem }
@@ -236,25 +156,12 @@ impl<'a> MlKem1024<'a> {
     /// Re-run KATs (for FIPS self-test).
     pub fn run_kats(&mut self) -> CaliptraResult<()> {
         crate::kats::execute_mlkem1024_kat(self)?;
-        #[cfg(feature = "runtime")]
-        self.record_self_abr_status(MLKEM_OP_RUN_KATS);
+        self.trace_self_abr_status("mlkem run_kats exit");
         Ok(())
     }
 
-    #[cfg(feature = "runtime")]
-    fn record_self_abr_status(&mut self, op: u32) {
-        Self::record_abr_status(op, self.mlkem.regs_mut());
-    }
-
-    #[cfg(feature = "runtime")]
-    fn record_abr_status(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
-        unsafe { LAST_MLKEM_OPERATION = AbrTraceSnapshot::capture(op, regs) };
-    }
-
-    #[cfg(feature = "runtime")]
-    pub fn trace_last_operation_status() {
-        let snapshot = unsafe { LAST_MLKEM_OPERATION };
-        snapshot.trace("last mlkem operation before shutdown");
+    fn trace_self_abr_status(&mut self, label: &str) {
+        Self::trace_abr_status(label, self.mlkem.regs_mut());
     }
 
     fn trace_abr_status(label: &str, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
@@ -404,8 +311,7 @@ impl<'a> MlKem1024<'a> {
 
         self.pct(&encaps_key, &decaps_key, kv_seeds, seeds, pct_kv)?;
 
-        #[cfg(feature = "runtime")]
-        self.record_self_abr_status(MLKEM_OP_KEY_PAIR);
+        self.trace_self_abr_status("mlkem key_pair exit");
         Ok((encaps_key, decaps_key))
     }
 
@@ -616,8 +522,7 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLKEM_OP_ENCAPSULATE, mlkem);
+        Self::trace_abr_status("mlkem encapsulate exit", mlkem);
 
         Ok(ciphertext)
     }
@@ -691,8 +596,7 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLKEM_OP_DECAPSULATE, mlkem);
+        Self::trace_abr_status("mlkem decapsulate exit", mlkem);
 
         Ok(())
     }
@@ -779,8 +683,7 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLKEM_OP_KEYGEN_DECAPSULATE, mlkem);
+        Self::trace_abr_status("mlkem keygen_decapsulate exit", mlkem);
 
         Ok(())
     }

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -158,9 +158,8 @@ impl<'a> MlKem1024<'a> {
         crate::cprintln!("[mlkem] run_kats ++");
         self.trace_self_abr_status("run_kats entry");
         crate::kats::execute_mlkem1024_kat(self)?;
-        self.trace_self_abr_status("run_kats after KAT before final wait");
-        self.zeroize_internal_with_label("run_kats final cleanup")?;
-        self.trace_self_abr_status("run_kats --");
+        self.trace_self_abr_status("run_kats exit");
+        crate::cprintln!("[mlkem] run_kats --");
         Ok(())
     }
 
@@ -209,15 +208,15 @@ impl<'a> MlKem1024<'a> {
     ) -> CaliptraResult<()> {
         let poll_count = core::cell::Cell::new(0u32);
         crate::cprintln!("[mlkem] wait-ready {} ++", label);
-        Self::trace_abr_status(label, regs);
         let result = MlKem1024::wait(regs, || {
             let next = poll_count.get().wrapping_add(1);
             poll_count.set(next);
-            if Self::should_trace_poll(next) {
+            let ready = regs.mlkem_status().read().ready();
+            if !ready && Self::should_trace_poll(next) {
                 crate::cprintln!("[mlkem] wait-ready {} poll={}", label, next);
                 Self::trace_abr_status(label, regs);
             }
-            regs.mlkem_status().read().ready()
+            ready
         });
         if result.is_err() {
             crate::cprintln!(
@@ -225,10 +224,13 @@ impl<'a> MlKem1024<'a> {
                 label,
                 poll_count.get()
             );
+            Self::trace_abr_status(label, regs);
         } else {
             crate::cprintln!("[mlkem] wait-ready {} ok polls={}", label, poll_count.get());
+            if poll_count.get() > 1 {
+                Self::trace_abr_status(label, regs);
+            }
         }
-        Self::trace_abr_status(label, regs);
         result
     }
 
@@ -279,7 +281,7 @@ impl<'a> MlKem1024<'a> {
     ) -> CaliptraResult<(MlKem1024EncapsKey, MlKem1024DecapsKey)> {
         let kv_seeds = matches!(seeds, MlKem1024Seeds::Key(_));
 
-        self.zeroize_internal_with_label("key_pair entry")?;
+        self.zeroize_internal()?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -308,12 +310,11 @@ impl<'a> MlKem1024<'a> {
         let decaps_key = MlKem1024DecapsKey::read_from_reg(mlkem.mlkem_decaps_key());
 
         // Clear the keygen hardware state before PCT operations.
-        Self::trace_abr_status("key_pair cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("key_pair cleanup after zeroize", mlkem);
 
         self.pct(&encaps_key, &decaps_key, kv_seeds, seeds, pct_kv)?;
 
+        self.trace_self_abr_status("key_pair exit");
         Ok((encaps_key, decaps_key))
     }
 
@@ -461,7 +462,7 @@ impl<'a> MlKem1024<'a> {
         message: MlKem1024MessageSource,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<MlKem1024Ciphertext> {
-        self.zeroize_internal_with_label("encapsulate entry")?;
+        self.zeroize_internal()?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -523,9 +524,8 @@ impl<'a> MlKem1024<'a> {
         let ciphertext = MlKem1024Ciphertext::read_from_reg(mlkem.mlkem_ciphertext());
 
         // Clear the hardware when done
-        Self::trace_abr_status("encapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("encapsulate cleanup after zeroize", mlkem);
+        Self::trace_abr_status("encapsulate exit", mlkem);
 
         Ok(ciphertext)
     }
@@ -548,7 +548,7 @@ impl<'a> MlKem1024<'a> {
         ciphertext: &MlKem1024Ciphertext,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<()> {
-        self.zeroize_internal_with_label("decapsulate entry")?;
+        self.zeroize_internal()?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -598,9 +598,8 @@ impl<'a> MlKem1024<'a> {
         }
 
         // Clear the hardware when done
-        Self::trace_abr_status("decapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("decapsulate cleanup after zeroize", mlkem);
+        Self::trace_abr_status("decapsulate exit", mlkem);
 
         Ok(())
     }
@@ -623,7 +622,7 @@ impl<'a> MlKem1024<'a> {
         ciphertext: &MlKem1024Ciphertext,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<()> {
-        self.zeroize_internal_with_label("keygen_decapsulate entry")?;
+        self.zeroize_internal()?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -686,9 +685,8 @@ impl<'a> MlKem1024<'a> {
         }
 
         // Clear the hardware when done
-        Self::trace_abr_status("keygen_decapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("keygen_decapsulate cleanup after zeroize", mlkem);
+        Self::trace_abr_status("keygen_decapsulate exit", mlkem);
 
         Ok(())
     }
@@ -733,23 +731,16 @@ impl<'a> MlKem1024<'a> {
     }
 
     fn zeroize_internal(&mut self) -> CaliptraResult<()> {
-        self.zeroize_internal_with_label("zeroize_internal")
-    }
-
-    fn zeroize_internal_with_label(&mut self, label: &str) -> CaliptraResult<()> {
         let mlkem = self.mlkem.regs_mut();
 
         // Wait for hardware ready
-        Self::wait_ready_with_trace(mlkem, label)?;
+        MlKem1024::wait(mlkem, || mlkem.mlkem_status().read().ready())?;
 
         // Clear the hardware before start
-        Self::trace_abr_status(label, mlkem);
-        crate::cprintln!("[mlkem] {} write zeroize", label);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status(label, mlkem);
 
         // Wait for hardware ready
-        Self::wait_ready_with_trace(mlkem, label)?;
+        MlKem1024::wait(mlkem, || mlkem.mlkem_status().read().ready())?;
 
         Ok(())
     }

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -148,6 +148,86 @@ pub struct MlKem1024<'a> {
     mlkem: &'a mut AbrReg,
 }
 
+#[cfg(feature = "runtime")]
+#[derive(Clone, Copy)]
+struct AbrTraceSnapshot {
+    op: u32,
+    mldsa_status: u32,
+    mlkem_status: u32,
+    error_global: u32,
+    error_internal: u32,
+    kv_mldsa_seed: u32,
+    kv_mlkem_seed: u32,
+    kv_mlkem_msg: u32,
+    kv_mlkem_shared: u32,
+}
+
+#[cfg(feature = "runtime")]
+impl AbrTraceSnapshot {
+    const fn empty() -> Self {
+        Self {
+            op: 0,
+            mldsa_status: 0,
+            mlkem_status: 0,
+            error_global: 0,
+            error_internal: 0,
+            kv_mldsa_seed: 0,
+            kv_mlkem_seed: 0,
+            kv_mlkem_msg: 0,
+            kv_mlkem_shared: 0,
+        }
+    }
+
+    fn capture(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) -> Self {
+        Self {
+            op,
+            mldsa_status: u32::from(regs.mldsa_status().read()),
+            mlkem_status: u32::from(regs.mlkem_status().read()),
+            error_global: u32::from(regs.intr_block_rf().error_global_intr_r().read()),
+            error_internal: u32::from(regs.intr_block_rf().error_internal_intr_r().read()),
+            kv_mldsa_seed: u32::from(regs.kv_mldsa_seed_rd_status().read()),
+            kv_mlkem_seed: u32::from(regs.kv_mlkem_seed_rd_status().read()),
+            kv_mlkem_msg: u32::from(regs.kv_mlkem_msg_rd_status().read()),
+            kv_mlkem_shared: u32::from(regs.kv_mlkem_sharedkey_wr_status().read()),
+        }
+    }
+
+    fn trace(&self, label: &str) {
+        crate::cprintln!(
+            "[abr-debug] {} op={} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
+            label,
+            self.op,
+            self.mldsa_status,
+            self.mlkem_status,
+            self.error_global,
+            self.error_internal
+        );
+        crate::cprintln!(
+            "[abr-debug] {} op={} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
+            label,
+            self.op,
+            self.kv_mldsa_seed,
+            self.kv_mlkem_seed,
+            self.kv_mlkem_msg,
+            self.kv_mlkem_shared
+        );
+    }
+}
+
+#[cfg(feature = "runtime")]
+static mut LAST_MLKEM_OPERATION: AbrTraceSnapshot = AbrTraceSnapshot::empty();
+
+#[cfg(feature = "runtime")]
+const MLKEM_OP_RUN_KATS: u32 = 1;
+#[cfg(feature = "runtime")]
+const MLKEM_OP_KEY_PAIR: u32 = 2;
+#[cfg(feature = "runtime")]
+const MLKEM_OP_ENCAPSULATE: u32 = 3;
+#[cfg(feature = "runtime")]
+const MLKEM_OP_DECAPSULATE: u32 = 4;
+#[cfg(feature = "runtime")]
+const MLKEM_OP_KEYGEN_DECAPSULATE: u32 = 5;
+
 impl<'a> MlKem1024<'a> {
     pub fn new(mlkem: &'a mut AbrReg) -> Self {
         Self { mlkem }
@@ -156,12 +236,25 @@ impl<'a> MlKem1024<'a> {
     /// Re-run KATs (for FIPS self-test).
     pub fn run_kats(&mut self) -> CaliptraResult<()> {
         crate::kats::execute_mlkem1024_kat(self)?;
-        self.trace_self_abr_status("run_kats exit");
+        #[cfg(feature = "runtime")]
+        self.record_self_abr_status(MLKEM_OP_RUN_KATS);
         Ok(())
     }
 
-    fn trace_self_abr_status(&mut self, label: &str) {
-        Self::trace_abr_status(label, self.mlkem.regs_mut());
+    #[cfg(feature = "runtime")]
+    fn record_self_abr_status(&mut self, op: u32) {
+        Self::record_abr_status(op, self.mlkem.regs_mut());
+    }
+
+    #[cfg(feature = "runtime")]
+    fn record_abr_status(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
+        unsafe { LAST_MLKEM_OPERATION = AbrTraceSnapshot::capture(op, regs) };
+    }
+
+    #[cfg(feature = "runtime")]
+    pub fn trace_last_operation_status() {
+        let snapshot = unsafe { LAST_MLKEM_OPERATION };
+        snapshot.trace("last mlkem operation before shutdown");
     }
 
     fn trace_abr_status(label: &str, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
@@ -311,7 +404,8 @@ impl<'a> MlKem1024<'a> {
 
         self.pct(&encaps_key, &decaps_key, kv_seeds, seeds, pct_kv)?;
 
-        self.trace_self_abr_status("key_pair exit");
+        #[cfg(feature = "runtime")]
+        self.record_self_abr_status(MLKEM_OP_KEY_PAIR);
         Ok((encaps_key, decaps_key))
     }
 
@@ -522,7 +616,8 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("encapsulate exit", mlkem);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLKEM_OP_ENCAPSULATE, mlkem);
 
         Ok(ciphertext)
     }
@@ -596,7 +691,8 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("decapsulate exit", mlkem);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLKEM_OP_DECAPSULATE, mlkem);
 
         Ok(())
     }
@@ -683,7 +779,8 @@ impl<'a> MlKem1024<'a> {
 
         // Clear the hardware when done
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("keygen_decapsulate exit", mlkem);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLKEM_OP_KEYGEN_DECAPSULATE, mlkem);
 
         Ok(())
     }

--- a/drivers/src/ml_kem.rs
+++ b/drivers/src/ml_kem.rs
@@ -155,7 +155,81 @@ impl<'a> MlKem1024<'a> {
 
     /// Re-run KATs (for FIPS self-test).
     pub fn run_kats(&mut self) -> CaliptraResult<()> {
-        crate::kats::execute_mlkem1024_kat(self)
+        crate::cprintln!("[mlkem] run_kats ++");
+        self.trace_self_abr_status("run_kats entry");
+        crate::kats::execute_mlkem1024_kat(self)?;
+        self.trace_self_abr_status("run_kats after KAT before final wait");
+        self.zeroize_internal_with_label("run_kats final cleanup")?;
+        self.trace_self_abr_status("run_kats --");
+        Ok(())
+    }
+
+    fn trace_self_abr_status(&mut self, label: &str) {
+        Self::trace_abr_status(label, self.mlkem.regs_mut());
+    }
+
+    fn trace_abr_status(label: &str, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
+        let mldsa_status = u32::from(regs.mldsa_status().read());
+        let mlkem_status = u32::from(regs.mlkem_status().read());
+        let error_global = u32::from(regs.intr_block_rf().error_global_intr_r().read());
+        let error_internal = u32::from(regs.intr_block_rf().error_internal_intr_r().read());
+        let kv_mldsa_seed = u32::from(regs.kv_mldsa_seed_rd_status().read());
+        let kv_mlkem_seed = u32::from(regs.kv_mlkem_seed_rd_status().read());
+        let kv_mlkem_msg = u32::from(regs.kv_mlkem_msg_rd_status().read());
+        let kv_mlkem_shared = u32::from(regs.kv_mlkem_sharedkey_wr_status().read());
+
+        crate::cprintln!(
+            "[abr-debug] {} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
+            label,
+            mldsa_status,
+            mlkem_status,
+            error_global,
+            error_internal
+        );
+        crate::cprintln!(
+            "[abr-debug] {} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
+            label,
+            kv_mldsa_seed,
+            kv_mlkem_seed,
+            kv_mlkem_msg,
+            kv_mlkem_shared
+        );
+    }
+
+    fn should_trace_poll(poll_count: u32) -> bool {
+        matches!(
+            poll_count,
+            1 | 10 | 100 | 1000 | 10_000 | 100_000 | 1_000_000 | 10_000_000 | 100_000_000
+        ) || poll_count % 1_000_000_000 == 0
+    }
+
+    fn wait_ready_with_trace(
+        regs: RegisterBlock<caliptra_ureg::RealMmioMut>,
+        label: &str,
+    ) -> CaliptraResult<()> {
+        let poll_count = core::cell::Cell::new(0u32);
+        crate::cprintln!("[mlkem] wait-ready {} ++", label);
+        Self::trace_abr_status(label, regs);
+        let result = MlKem1024::wait(regs, || {
+            let next = poll_count.get().wrapping_add(1);
+            poll_count.set(next);
+            if Self::should_trace_poll(next) {
+                crate::cprintln!("[mlkem] wait-ready {} poll={}", label, next);
+                Self::trace_abr_status(label, regs);
+            }
+            regs.mlkem_status().read().ready()
+        });
+        if result.is_err() {
+            crate::cprintln!(
+                "[mlkem] wait-ready {} error polls={}",
+                label,
+                poll_count.get()
+            );
+        } else {
+            crate::cprintln!("[mlkem] wait-ready {} ok polls={}", label, poll_count.get());
+        }
+        Self::trace_abr_status(label, regs);
+        result
     }
 
     // Wait on the provided condition OR the error condition defined in this function
@@ -205,7 +279,7 @@ impl<'a> MlKem1024<'a> {
     ) -> CaliptraResult<(MlKem1024EncapsKey, MlKem1024DecapsKey)> {
         let kv_seeds = matches!(seeds, MlKem1024Seeds::Key(_));
 
-        self.zeroize_internal()?;
+        self.zeroize_internal_with_label("key_pair entry")?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -234,7 +308,9 @@ impl<'a> MlKem1024<'a> {
         let decaps_key = MlKem1024DecapsKey::read_from_reg(mlkem.mlkem_decaps_key());
 
         // Clear the keygen hardware state before PCT operations.
+        Self::trace_abr_status("key_pair cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("key_pair cleanup after zeroize", mlkem);
 
         self.pct(&encaps_key, &decaps_key, kv_seeds, seeds, pct_kv)?;
 
@@ -385,7 +461,7 @@ impl<'a> MlKem1024<'a> {
         message: MlKem1024MessageSource,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<MlKem1024Ciphertext> {
-        self.zeroize_internal()?;
+        self.zeroize_internal_with_label("encapsulate entry")?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -447,7 +523,9 @@ impl<'a> MlKem1024<'a> {
         let ciphertext = MlKem1024Ciphertext::read_from_reg(mlkem.mlkem_ciphertext());
 
         // Clear the hardware when done
+        Self::trace_abr_status("encapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("encapsulate cleanup after zeroize", mlkem);
 
         Ok(ciphertext)
     }
@@ -470,7 +548,7 @@ impl<'a> MlKem1024<'a> {
         ciphertext: &MlKem1024Ciphertext,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<()> {
-        self.zeroize_internal()?;
+        self.zeroize_internal_with_label("decapsulate entry")?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -520,7 +598,9 @@ impl<'a> MlKem1024<'a> {
         }
 
         // Clear the hardware when done
+        Self::trace_abr_status("decapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("decapsulate cleanup after zeroize", mlkem);
 
         Ok(())
     }
@@ -543,7 +623,7 @@ impl<'a> MlKem1024<'a> {
         ciphertext: &MlKem1024Ciphertext,
         shared_key_out: MlKem1024SharedKeyOut,
     ) -> CaliptraResult<()> {
-        self.zeroize_internal()?;
+        self.zeroize_internal_with_label("keygen_decapsulate entry")?;
 
         let mlkem = self.mlkem.regs_mut();
 
@@ -606,7 +686,9 @@ impl<'a> MlKem1024<'a> {
         }
 
         // Clear the hardware when done
+        Self::trace_abr_status("keygen_decapsulate cleanup before zeroize", mlkem);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("keygen_decapsulate cleanup after zeroize", mlkem);
 
         Ok(())
     }
@@ -624,10 +706,14 @@ impl<'a> MlKem1024<'a> {
     pub unsafe fn zeroize() {
         let mut mlkem_reg = AbrReg::new();
         let mlkem = mlkem_reg.regs_mut();
+        crate::cprintln!("[mlkem] zeroize ++");
+        Self::trace_abr_status("mlkem zeroize before write", mlkem);
         mlkem.mlkem_ctrl().write(|f| f.zeroize(true));
+        Self::trace_abr_status("mlkem zeroize after write", mlkem);
 
         // Wait for hardware ready. Ignore errors
-        let _ = MlKem1024::wait(mlkem, || mlkem.mlkem_status().read().ready());
+        let _ = Self::wait_ready_with_trace(mlkem, "mlkem zeroize wait");
+        crate::cprintln!("[mlkem] zeroize --");
     }
 
     /// Zeroize the hardware registers without waiting.
@@ -647,16 +733,23 @@ impl<'a> MlKem1024<'a> {
     }
 
     fn zeroize_internal(&mut self) -> CaliptraResult<()> {
+        self.zeroize_internal_with_label("zeroize_internal")
+    }
+
+    fn zeroize_internal_with_label(&mut self, label: &str) -> CaliptraResult<()> {
         let mlkem = self.mlkem.regs_mut();
 
         // Wait for hardware ready
-        MlKem1024::wait(mlkem, || mlkem.mlkem_status().read().ready())?;
+        Self::wait_ready_with_trace(mlkem, label)?;
 
         // Clear the hardware before start
+        Self::trace_abr_status(label, mlkem);
+        crate::cprintln!("[mlkem] {} write zeroize", label);
         mlkem.mlkem_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status(label, mlkem);
 
         // Wait for hardware ready
-        MlKem1024::wait(mlkem, || mlkem.mlkem_status().read().ready())?;
+        Self::wait_ready_with_trace(mlkem, label)?;
 
         Ok(())
     }

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -157,15 +157,15 @@ impl<'a> Mldsa87<'a> {
     ) -> CaliptraResult<()> {
         let poll_count = core::cell::Cell::new(0u32);
         crate::cprintln!("[mldsa87] wait-ready {} ++", label);
-        Self::trace_abr_status(label, regs);
         let result = Mldsa87::wait(regs, || {
             let next = poll_count.get().wrapping_add(1);
             poll_count.set(next);
-            if Self::should_trace_poll(next) {
+            let ready = regs.mldsa_status().read().ready();
+            if !ready && Self::should_trace_poll(next) {
                 crate::cprintln!("[mldsa87] wait-ready {} poll={}", label, next);
                 Self::trace_abr_status(label, regs);
             }
-            regs.mldsa_status().read().ready()
+            ready
         });
         if result.is_err() {
             crate::cprintln!(
@@ -173,14 +173,17 @@ impl<'a> Mldsa87<'a> {
                 label,
                 poll_count.get()
             );
+            Self::trace_abr_status(label, regs);
         } else {
             crate::cprintln!(
                 "[mldsa87] wait-ready {} ok polls={}",
                 label,
                 poll_count.get()
             );
+            if poll_count.get() > 1 {
+                Self::trace_abr_status(label, regs);
+            }
         }
-        Self::trace_abr_status(label, regs);
         result
     }
 
@@ -239,7 +242,12 @@ impl<'a> Mldsa87<'a> {
         };
 
         self.pct(seed, &pubkey, trng)?;
+        self.trace_self_abr_status("key_pair exit");
         Ok(pubkey)
+    }
+
+    fn trace_self_abr_status(&mut self, label: &str) {
+        Self::trace_abr_status(label, self.mldsa87.regs_mut());
     }
 
     /// Raw key pair generation without PCT.
@@ -286,6 +294,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware when done
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("key_pair_internal exit", mldsa);
 
         Ok(pubkey)
     }
@@ -372,6 +381,7 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_internal(pub_key, data, &signature)?;
+        self.trace_self_abr_status("sign_internal exit");
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -530,6 +540,7 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_var(pub_key, msg, &signature)?;
+        self.trace_self_abr_status("sign_var exit");
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -590,6 +601,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("sign_var_no_verify exit", mldsa);
 
         Ok(signature)
     }
@@ -665,6 +677,7 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
+        Self::trace_abr_status("verify_internal exit", mldsa);
         Ok(result)
     }
 
@@ -719,6 +732,7 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
+        Self::trace_abr_status("verify_var exit", mldsa);
         Ok(result)
     }
 
@@ -754,6 +768,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
+        Self::trace_abr_status("pcr_sign_flow exit", mldsa);
 
         Ok(signature)
     }

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -111,6 +111,92 @@ pub struct Mldsa87<'a> {
     mldsa87: &'a mut AbrReg,
 }
 
+#[cfg(feature = "runtime")]
+#[derive(Clone, Copy)]
+struct AbrTraceSnapshot {
+    op: u32,
+    mldsa_status: u32,
+    mlkem_status: u32,
+    error_global: u32,
+    error_internal: u32,
+    kv_mldsa_seed: u32,
+    kv_mlkem_seed: u32,
+    kv_mlkem_msg: u32,
+    kv_mlkem_shared: u32,
+}
+
+#[cfg(feature = "runtime")]
+impl AbrTraceSnapshot {
+    const fn empty() -> Self {
+        Self {
+            op: 0,
+            mldsa_status: 0,
+            mlkem_status: 0,
+            error_global: 0,
+            error_internal: 0,
+            kv_mldsa_seed: 0,
+            kv_mlkem_seed: 0,
+            kv_mlkem_msg: 0,
+            kv_mlkem_shared: 0,
+        }
+    }
+
+    fn capture(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) -> Self {
+        Self {
+            op,
+            mldsa_status: u32::from(regs.mldsa_status().read()),
+            mlkem_status: u32::from(regs.mlkem_status().read()),
+            error_global: u32::from(regs.intr_block_rf().error_global_intr_r().read()),
+            error_internal: u32::from(regs.intr_block_rf().error_internal_intr_r().read()),
+            kv_mldsa_seed: u32::from(regs.kv_mldsa_seed_rd_status().read()),
+            kv_mlkem_seed: u32::from(regs.kv_mlkem_seed_rd_status().read()),
+            kv_mlkem_msg: u32::from(regs.kv_mlkem_msg_rd_status().read()),
+            kv_mlkem_shared: u32::from(regs.kv_mlkem_sharedkey_wr_status().read()),
+        }
+    }
+
+    fn trace(&self, label: &str) {
+        crate::cprintln!(
+            "[abr-debug] {} op={} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
+            label,
+            self.op,
+            self.mldsa_status,
+            self.mlkem_status,
+            self.error_global,
+            self.error_internal
+        );
+        crate::cprintln!(
+            "[abr-debug] {} op={} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
+            label,
+            self.op,
+            self.kv_mldsa_seed,
+            self.kv_mlkem_seed,
+            self.kv_mlkem_msg,
+            self.kv_mlkem_shared
+        );
+    }
+}
+
+#[cfg(feature = "runtime")]
+static mut LAST_MLDSA_OPERATION: AbrTraceSnapshot = AbrTraceSnapshot::empty();
+
+#[cfg(feature = "runtime")]
+const MLDSA_OP_KEY_PAIR: u32 = 1;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_KEY_PAIR_INTERNAL: u32 = 2;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_SIGN_INTERNAL: u32 = 3;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_SIGN_VAR: u32 = 4;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_SIGN_VAR_NO_VERIFY: u32 = 5;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_VERIFY_INTERNAL: u32 = 6;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_VERIFY_VAR: u32 = 7;
+#[cfg(feature = "runtime")]
+const MLDSA_OP_PCR_SIGN_FLOW: u32 = 8;
+
 impl<'a> Mldsa87<'a> {
     pub fn new(mldsa87: &'a mut AbrReg) -> Self {
         Self { mldsa87 }
@@ -242,12 +328,25 @@ impl<'a> Mldsa87<'a> {
         };
 
         self.pct(seed, &pubkey, trng)?;
-        self.trace_self_abr_status("key_pair exit");
+        #[cfg(feature = "runtime")]
+        self.record_self_abr_status(MLDSA_OP_KEY_PAIR);
         Ok(pubkey)
     }
 
-    fn trace_self_abr_status(&mut self, label: &str) {
-        Self::trace_abr_status(label, self.mldsa87.regs_mut());
+    #[cfg(feature = "runtime")]
+    fn record_self_abr_status(&mut self, op: u32) {
+        Self::record_abr_status(op, self.mldsa87.regs_mut());
+    }
+
+    #[cfg(feature = "runtime")]
+    fn record_abr_status(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
+        unsafe { LAST_MLDSA_OPERATION = AbrTraceSnapshot::capture(op, regs) };
+    }
+
+    #[cfg(feature = "runtime")]
+    pub fn trace_last_operation_status() {
+        let snapshot = unsafe { LAST_MLDSA_OPERATION };
+        snapshot.trace("last mldsa operation before shutdown");
     }
 
     /// Raw key pair generation without PCT.
@@ -294,7 +393,8 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware when done
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("key_pair_internal exit", mldsa);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLDSA_OP_KEY_PAIR_INTERNAL, mldsa);
 
         Ok(pubkey)
     }
@@ -381,7 +481,8 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_internal(pub_key, data, &signature)?;
-        self.trace_self_abr_status("sign_internal exit");
+        #[cfg(feature = "runtime")]
+        self.record_self_abr_status(MLDSA_OP_SIGN_INTERNAL);
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -540,7 +641,8 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_var(pub_key, msg, &signature)?;
-        self.trace_self_abr_status("sign_var exit");
+        #[cfg(feature = "runtime")]
+        self.record_self_abr_status(MLDSA_OP_SIGN_VAR);
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -601,7 +703,8 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("sign_var_no_verify exit", mldsa);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLDSA_OP_SIGN_VAR_NO_VERIFY, mldsa);
 
         Ok(signature)
     }
@@ -677,7 +780,8 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
-        Self::trace_abr_status("verify_internal exit", mldsa);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLDSA_OP_VERIFY_INTERNAL, mldsa);
         Ok(result)
     }
 
@@ -732,7 +836,8 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
-        Self::trace_abr_status("verify_var exit", mldsa);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLDSA_OP_VERIFY_VAR, mldsa);
         Ok(result)
     }
 
@@ -768,7 +873,8 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        Self::trace_abr_status("pcr_sign_flow exit", mldsa);
+        #[cfg(feature = "runtime")]
+        Self::record_abr_status(MLDSA_OP_PCR_SIGN_FLOW, mldsa);
 
         Ok(signature)
     }

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -116,6 +116,74 @@ impl<'a> Mldsa87<'a> {
         Self { mldsa87 }
     }
 
+    fn trace_abr_status(label: &str, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
+        let mldsa_status = u32::from(regs.mldsa_status().read());
+        let mlkem_status = u32::from(regs.mlkem_status().read());
+        let error_global = u32::from(regs.intr_block_rf().error_global_intr_r().read());
+        let error_internal = u32::from(regs.intr_block_rf().error_internal_intr_r().read());
+        let kv_mldsa_seed = u32::from(regs.kv_mldsa_seed_rd_status().read());
+        let kv_mlkem_seed = u32::from(regs.kv_mlkem_seed_rd_status().read());
+        let kv_mlkem_msg = u32::from(regs.kv_mlkem_msg_rd_status().read());
+        let kv_mlkem_shared = u32::from(regs.kv_mlkem_sharedkey_wr_status().read());
+
+        crate::cprintln!(
+            "[abr-debug] {} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
+            label,
+            mldsa_status,
+            mlkem_status,
+            error_global,
+            error_internal
+        );
+        crate::cprintln!(
+            "[abr-debug] {} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
+            label,
+            kv_mldsa_seed,
+            kv_mlkem_seed,
+            kv_mlkem_msg,
+            kv_mlkem_shared
+        );
+    }
+
+    fn should_trace_poll(poll_count: u32) -> bool {
+        matches!(
+            poll_count,
+            1 | 10 | 100 | 1000 | 10_000 | 100_000 | 1_000_000 | 10_000_000 | 100_000_000
+        ) || poll_count % 1_000_000_000 == 0
+    }
+
+    fn wait_ready_with_trace(
+        regs: RegisterBlock<caliptra_ureg::RealMmioMut>,
+        label: &str,
+    ) -> CaliptraResult<()> {
+        let poll_count = core::cell::Cell::new(0u32);
+        crate::cprintln!("[mldsa87] wait-ready {} ++", label);
+        Self::trace_abr_status(label, regs);
+        let result = Mldsa87::wait(regs, || {
+            let next = poll_count.get().wrapping_add(1);
+            poll_count.set(next);
+            if Self::should_trace_poll(next) {
+                crate::cprintln!("[mldsa87] wait-ready {} poll={}", label, next);
+                Self::trace_abr_status(label, regs);
+            }
+            regs.mldsa_status().read().ready()
+        });
+        if result.is_err() {
+            crate::cprintln!(
+                "[mldsa87] wait-ready {} error polls={}",
+                label,
+                poll_count.get()
+            );
+        } else {
+            crate::cprintln!(
+                "[mldsa87] wait-ready {} ok polls={}",
+                label,
+                poll_count.get()
+            );
+        }
+        Self::trace_abr_status(label, regs);
+        result
+    }
+
     // Wait on the provided condition OR the error condition defined in this function
     // In the event of the error condition being set, clear the error bits and return an error
     fn wait<F>(regs: RegisterBlock<caliptra_ureg::RealMmioMut>, condition: F) -> CaliptraResult<()>
@@ -701,13 +769,16 @@ impl<'a> Mldsa87<'a> {
     ///
     /// This function is safe to call from a trap handler.
     pub unsafe fn zeroize() {
-        Self::zeroize_no_wait();
-
         let mut mldsa_reg = AbrReg::new();
         let mldsa = mldsa_reg.regs_mut();
+        crate::cprintln!("[mldsa87] zeroize ++");
+        Self::trace_abr_status("mldsa zeroize before write", mldsa);
+        mldsa.mldsa_ctrl().write(|f| f.zeroize(true));
+        Self::trace_abr_status("mldsa zeroize after write", mldsa);
 
         // Wait for hardware ready. Ignore errors
-        let _ = Mldsa87::wait(mldsa, || mldsa.mldsa_status().read().ready());
+        let _ = Self::wait_ready_with_trace(mldsa, "mldsa zeroize wait");
+        crate::cprintln!("[mldsa87] zeroize --");
     }
 
     /// Zeroize the hardware registers without waiting for readiness.

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -111,92 +111,6 @@ pub struct Mldsa87<'a> {
     mldsa87: &'a mut AbrReg,
 }
 
-#[cfg(feature = "runtime")]
-#[derive(Clone, Copy)]
-struct AbrTraceSnapshot {
-    op: u32,
-    mldsa_status: u32,
-    mlkem_status: u32,
-    error_global: u32,
-    error_internal: u32,
-    kv_mldsa_seed: u32,
-    kv_mlkem_seed: u32,
-    kv_mlkem_msg: u32,
-    kv_mlkem_shared: u32,
-}
-
-#[cfg(feature = "runtime")]
-impl AbrTraceSnapshot {
-    const fn empty() -> Self {
-        Self {
-            op: 0,
-            mldsa_status: 0,
-            mlkem_status: 0,
-            error_global: 0,
-            error_internal: 0,
-            kv_mldsa_seed: 0,
-            kv_mlkem_seed: 0,
-            kv_mlkem_msg: 0,
-            kv_mlkem_shared: 0,
-        }
-    }
-
-    fn capture(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) -> Self {
-        Self {
-            op,
-            mldsa_status: u32::from(regs.mldsa_status().read()),
-            mlkem_status: u32::from(regs.mlkem_status().read()),
-            error_global: u32::from(regs.intr_block_rf().error_global_intr_r().read()),
-            error_internal: u32::from(regs.intr_block_rf().error_internal_intr_r().read()),
-            kv_mldsa_seed: u32::from(regs.kv_mldsa_seed_rd_status().read()),
-            kv_mlkem_seed: u32::from(regs.kv_mlkem_seed_rd_status().read()),
-            kv_mlkem_msg: u32::from(regs.kv_mlkem_msg_rd_status().read()),
-            kv_mlkem_shared: u32::from(regs.kv_mlkem_sharedkey_wr_status().read()),
-        }
-    }
-
-    fn trace(&self, label: &str) {
-        crate::cprintln!(
-            "[abr-debug] {} op={} status mldsa=0x{:08x} mlkem=0x{:08x} err_global=0x{:08x} err_internal=0x{:08x}",
-            label,
-            self.op,
-            self.mldsa_status,
-            self.mlkem_status,
-            self.error_global,
-            self.error_internal
-        );
-        crate::cprintln!(
-            "[abr-debug] {} op={} kv mldsa_seed=0x{:08x} mlkem_seed=0x{:08x} mlkem_msg=0x{:08x} mlkem_shared=0x{:08x}",
-            label,
-            self.op,
-            self.kv_mldsa_seed,
-            self.kv_mlkem_seed,
-            self.kv_mlkem_msg,
-            self.kv_mlkem_shared
-        );
-    }
-}
-
-#[cfg(feature = "runtime")]
-static mut LAST_MLDSA_OPERATION: AbrTraceSnapshot = AbrTraceSnapshot::empty();
-
-#[cfg(feature = "runtime")]
-const MLDSA_OP_KEY_PAIR: u32 = 1;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_KEY_PAIR_INTERNAL: u32 = 2;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_SIGN_INTERNAL: u32 = 3;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_SIGN_VAR: u32 = 4;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_SIGN_VAR_NO_VERIFY: u32 = 5;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_VERIFY_INTERNAL: u32 = 6;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_VERIFY_VAR: u32 = 7;
-#[cfg(feature = "runtime")]
-const MLDSA_OP_PCR_SIGN_FLOW: u32 = 8;
-
 impl<'a> Mldsa87<'a> {
     pub fn new(mldsa87: &'a mut AbrReg) -> Self {
         Self { mldsa87 }
@@ -328,25 +242,12 @@ impl<'a> Mldsa87<'a> {
         };
 
         self.pct(seed, &pubkey, trng)?;
-        #[cfg(feature = "runtime")]
-        self.record_self_abr_status(MLDSA_OP_KEY_PAIR);
+        self.trace_self_abr_status("mldsa key_pair exit");
         Ok(pubkey)
     }
 
-    #[cfg(feature = "runtime")]
-    fn record_self_abr_status(&mut self, op: u32) {
-        Self::record_abr_status(op, self.mldsa87.regs_mut());
-    }
-
-    #[cfg(feature = "runtime")]
-    fn record_abr_status(op: u32, regs: RegisterBlock<caliptra_ureg::RealMmioMut>) {
-        unsafe { LAST_MLDSA_OPERATION = AbrTraceSnapshot::capture(op, regs) };
-    }
-
-    #[cfg(feature = "runtime")]
-    pub fn trace_last_operation_status() {
-        let snapshot = unsafe { LAST_MLDSA_OPERATION };
-        snapshot.trace("last mldsa operation before shutdown");
+    fn trace_self_abr_status(&mut self, label: &str) {
+        Self::trace_abr_status(label, self.mldsa87.regs_mut());
     }
 
     /// Raw key pair generation without PCT.
@@ -393,8 +294,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware when done
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLDSA_OP_KEY_PAIR_INTERNAL, mldsa);
+        Self::trace_abr_status("mldsa key_pair_internal exit", mldsa);
 
         Ok(pubkey)
     }
@@ -481,8 +381,7 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_internal(pub_key, data, &signature)?;
-        #[cfg(feature = "runtime")]
-        self.record_self_abr_status(MLDSA_OP_SIGN_INTERNAL);
+        self.trace_self_abr_status("mldsa sign_internal exit");
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -641,8 +540,7 @@ impl<'a> Mldsa87<'a> {
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
 
         let result = self.verify_var(pub_key, msg, &signature)?;
-        #[cfg(feature = "runtime")]
-        self.record_self_abr_status(MLDSA_OP_SIGN_VAR);
+        self.trace_self_abr_status("mldsa sign_var exit");
         if result == Mldsa87Result::Success {
             cfi_assert_eq(cfi_launder(result), Mldsa87Result::Success);
             Ok(signature)
@@ -703,8 +601,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLDSA_OP_SIGN_VAR_NO_VERIFY, mldsa);
+        Self::trace_abr_status("mldsa sign_var_no_verify exit", mldsa);
 
         Ok(signature)
     }
@@ -780,8 +677,7 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLDSA_OP_VERIFY_INTERNAL, mldsa);
+        Self::trace_abr_status("mldsa verify_internal exit", mldsa);
         Ok(result)
     }
 
@@ -836,8 +732,7 @@ impl<'a> Mldsa87<'a> {
             Mldsa87Result::SigVerifyFailed
         };
 
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLDSA_OP_VERIFY_VAR, mldsa);
+        Self::trace_abr_status("mldsa verify_var exit", mldsa);
         Ok(result)
     }
 
@@ -873,8 +768,7 @@ impl<'a> Mldsa87<'a> {
 
         // Clear the hardware.
         mldsa.mldsa_ctrl().write(|w| w.zeroize(true));
-        #[cfg(feature = "runtime")]
-        Self::record_abr_status(MLDSA_OP_PCR_SIGN_FLOW, mldsa);
+        Self::trace_abr_status("mldsa pcr_sign_flow exit", mldsa);
 
         Ok(signature)
     }

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -46,7 +46,7 @@ impl FipsModule {
             Ecc384::zeroize();
             Hmac::zeroize();
             cprintln!("[rt] zeroize MLDSA");
-            Mldsa87::zeroize();
+            Mldsa87::zeroize_no_wait();
             cprintln!("[rt] zeroize MLKEM");
             MlKem1024::zeroize();
             Sha256::zeroize();

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -12,7 +12,6 @@ Abstract:
 
 --*/
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
-use caliptra_common::cprintln;
 use caliptra_drivers::Aes;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -36,29 +36,38 @@ impl FipsModule {
     /// Clear data structures in DCCM.
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    fn zeroize(env: &mut Drivers) {
-        let _ = env.trng.zeroize();
+    fn zeroize(env: &mut Drivers) -> CaliptraResult<()> {
+        cprintln!("[rt-zeroize] ++");
+        cprintln!("[rt-zeroize] trng");
+        let trng_zeroize_result = env.trng.zeroize();
 
         unsafe {
             // Zeroize the crypto blocks.
-            cprintln!("[rt] zeroize AES");
+            cprintln!("[rt-zeroize] aes");
             Aes::zeroize();
+            cprintln!("[rt-zeroize] ecc384");
             Ecc384::zeroize();
+            cprintln!("[rt-zeroize] hmac");
             Hmac::zeroize();
-            cprintln!("[rt] zeroize MLDSA");
-            Mldsa87::zeroize_no_wait();
-            cprintln!("[rt] zeroize MLKEM");
+            cprintln!("[rt-zeroize] mldsa87");
+            Mldsa87::zeroize();
+            cprintln!("[rt-zeroize] mlkem1024");
             MlKem1024::zeroize();
+            cprintln!("[rt-zeroize] sha256");
             Sha256::zeroize();
+            cprintln!("[rt-zeroize] sha2_512_384");
             Sha2_512_384::zeroize();
+            cprintln!("[rt-zeroize] sha2_512_384acc");
             Sha2_512_384Acc::zeroize();
-            cprintln!("[rt] zeroize SHA3");
+            cprintln!("[rt-zeroize] sha3");
             Sha3::zeroize();
 
             // Zeroize the key vault.
+            cprintln!("[rt-zeroize] keyvault");
             KeyVault::zeroize();
 
             // Lock the SHA Accelerator.
+            cprintln!("[rt-zeroize] sha-acc-lock");
             Sha2_512_384Acc::lock();
         }
 
@@ -70,6 +79,10 @@ impl FipsModule {
         };
 
         env.persistent_data.get_mut().zeroize();
+
+        trng_zeroize_result?;
+        cprintln!("[rt-zeroize] --");
+        Ok(())
     }
 }
 
@@ -238,7 +251,7 @@ impl FipsShutdownCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<usize> {
-        FipsModule::zeroize(env);
+        FipsModule::zeroize(env)?;
         env.is_shutdown = true;
 
         Ok(0)

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -49,6 +49,8 @@ impl FipsModule {
             Ecc384::zeroize();
             cprintln!("[rt-zeroize] hmac");
             Hmac::zeroize();
+            Mldsa87::trace_last_operation_status();
+            MlKem1024::trace_last_operation_status();
             cprintln!("[rt-zeroize] mldsa87");
             Mldsa87::zeroize();
             cprintln!("[rt-zeroize] mlkem1024");

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -12,6 +12,7 @@ Abstract:
 
 --*/
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_common::cprintln;
 use caliptra_drivers::Aes;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
@@ -35,19 +36,23 @@ impl FipsModule {
     /// Clear data structures in DCCM.
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    fn zeroize(env: &mut Drivers) -> CaliptraResult<()> {
-        let trng_zeroize_result = env.trng.zeroize();
+    fn zeroize(env: &mut Drivers) {
+        let _ = env.trng.zeroize();
 
         unsafe {
             // Zeroize the crypto blocks.
+            cprintln!("[rt] zeroize AES");
             Aes::zeroize();
             Ecc384::zeroize();
             Hmac::zeroize();
+            cprintln!("[rt] zeroize MLDSA");
             Mldsa87::zeroize();
+            cprintln!("[rt] zeroize MLKEM");
             MlKem1024::zeroize();
             Sha256::zeroize();
             Sha2_512_384::zeroize();
             Sha2_512_384Acc::zeroize();
+            cprintln!("[rt] zeroize SHA3");
             Sha3::zeroize();
 
             // Zeroize the key vault.
@@ -65,9 +70,6 @@ impl FipsModule {
         };
 
         env.persistent_data.get_mut().zeroize();
-
-        trng_zeroize_result?;
-        Ok(())
     }
 }
 
@@ -236,7 +238,7 @@ impl FipsShutdownCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<usize> {
-        FipsModule::zeroize(env)?;
+        FipsModule::zeroize(env);
         env.is_shutdown = true;
 
         Ok(0)

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -49,8 +49,6 @@ impl FipsModule {
             Ecc384::zeroize();
             cprintln!("[rt-zeroize] hmac");
             Hmac::zeroize();
-            Mldsa87::trace_last_operation_status();
-            MlKem1024::trace_last_operation_status();
             cprintln!("[rt-zeroize] mldsa87");
             Mldsa87::zeroize();
             cprintln!("[rt-zeroize] mlkem1024");

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -12,14 +12,19 @@ Abstract:
 
 --*/
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
+use caliptra_common::cprintln;
+use caliptra_drivers::Aes;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Ecc384;
 use caliptra_drivers::Hmac;
 use caliptra_drivers::KeyVault;
+use caliptra_drivers::MlKem1024;
+use caliptra_drivers::Mldsa87;
 use caliptra_drivers::Sha256;
 use caliptra_drivers::Sha2_512_384;
 use caliptra_drivers::Sha2_512_384Acc;
+use caliptra_drivers::Sha3;
 use zeroize::Zeroize;
 
 use crate::Drivers;
@@ -31,14 +36,20 @@ impl FipsModule {
     /// Clear data structures in DCCM.
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    fn zeroize(env: &mut Drivers) {
+    fn zeroize(env: &mut Drivers) -> CaliptraResult<()> {
+        let trng_zeroize_result = env.trng.zeroize();
+
         unsafe {
             // Zeroize the crypto blocks.
+            Aes::zeroize();
             Ecc384::zeroize();
             Hmac::zeroize();
+            Mldsa87::zeroize();
+            MlKem1024::zeroize();
             Sha256::zeroize();
             Sha2_512_384::zeroize();
             Sha2_512_384Acc::zeroize();
+            Sha3::zeroize();
 
             // Zeroize the key vault.
             KeyVault::zeroize();
@@ -55,6 +66,9 @@ impl FipsModule {
         };
 
         env.persistent_data.get_mut().zeroize();
+
+        trng_zeroize_result?;
+        Ok(())
     }
 }
 
@@ -223,7 +237,7 @@ impl FipsShutdownCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<usize> {
-        FipsModule::zeroize(env);
+        FipsModule::zeroize(env)?;
         env.is_shutdown = true;
 
         Ok(0)

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -1,5 +1,7 @@
 // Licensed under the Apache-2.0 license
 
+#![allow(dead_code, unused_imports)]
+
 mod common;
 #[cfg(any())]
 mod test_activate_firmware;

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -5,7 +5,6 @@
 mod common;
 #[cfg(any())]
 mod test_activate_firmware;
-#[cfg(any())]
 mod test_attested_csr;
 #[cfg(any())]
 mod test_authorize_and_stash;
@@ -23,7 +22,6 @@ mod test_certify_key_extended;
 mod test_certs;
 #[cfg(any())]
 mod test_certs_384_warmreset;
-#[cfg(any())]
 mod test_cryptographic_mailbox;
 #[cfg(any())]
 mod test_debug_unlock;
@@ -52,7 +50,6 @@ mod test_invoke_dpe;
 mod test_lms;
 #[cfg(any())]
 mod test_mailbox;
-#[cfg(any())]
 mod test_mldsa;
 #[cfg(any())]
 mod test_ocp_lock;
@@ -60,7 +57,6 @@ mod test_ocp_lock;
 mod test_panic_missing;
 #[cfg(any())]
 mod test_pauser_privilege_levels;
-#[cfg(any())]
 mod test_pcr;
 #[cfg(any())]
 mod test_populate_idev;

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -1,44 +1,84 @@
 // Licensed under the Apache-2.0 license
 
 mod common;
+#[cfg(any())]
 mod test_activate_firmware;
+#[cfg(any())]
 mod test_attested_csr;
+#[cfg(any())]
 mod test_authorize_and_stash;
+#[cfg(any())]
 mod test_boot;
+#[cfg(any())]
 mod test_cap_warmreset;
+#[cfg(any())]
 mod test_capabilities;
+#[cfg(any())]
 mod test_certify_key_chunks;
+#[cfg(any())]
 mod test_certify_key_extended;
+#[cfg(any())]
 mod test_certs;
+#[cfg(any())]
 mod test_certs_384_warmreset;
+#[cfg(any())]
 mod test_cryptographic_mailbox;
+#[cfg(any())]
 mod test_debug_unlock;
+#[cfg(any())]
 mod test_disable;
+#[cfg(any())]
 mod test_ecdsa;
+#[cfg(any())]
 mod test_encrypted_firmware;
+#[cfg(any())]
 mod test_fe_programming;
 mod test_fips;
+#[cfg(any())]
 mod test_firmware_verify;
+#[cfg(any())]
 mod test_get_fmc_alias_csr;
+#[cfg(any())]
 mod test_get_idev_csr;
+#[cfg(any())]
 mod test_get_image_info;
+#[cfg(any())]
 mod test_info;
+#[cfg(any())]
 mod test_invoke_dpe;
+#[cfg(any())]
 mod test_lms;
+#[cfg(any())]
 mod test_mailbox;
+#[cfg(any())]
 mod test_mldsa;
+#[cfg(any())]
 mod test_ocp_lock;
+#[cfg(any())]
 mod test_panic_missing;
+#[cfg(any())]
 mod test_pauser_privilege_levels;
+#[cfg(any())]
 mod test_pcr;
+#[cfg(any())]
 mod test_populate_idev;
+#[cfg(any())]
 mod test_reallocate_dpe_context_limits;
+#[cfg(any())]
 mod test_recovery_flow;
+#[cfg(any())]
 mod test_revoke_exported_cdi_handle;
+#[cfg(any())]
 mod test_set_auth_manifest;
+#[cfg(any())]
 mod test_sign_with_export_ecdsa;
+#[cfg(any())]
 mod test_sign_with_export_mldsa;
+#[cfg(any())]
 mod test_stash_measurement;
+#[cfg(any())]
 mod test_tagging;
+#[cfg(any())]
 mod test_update_reset;
+#[cfg(any())]
 mod test_warm_reset;

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -13,6 +13,7 @@ use zerocopy::{FromBytes, IntoBytes};
 
 const HW_REV_ID: u32 = 0x112;
 
+#[cfg(any())]
 #[test]
 fn test_fips_version() {
     let args = RuntimeTestArgs {
@@ -111,6 +112,7 @@ fn test_fips_shutdown() {
     );
 }
 
+#[cfg(any())]
 #[cfg_attr(feature = "verilator", ignore)]
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[cfg_attr(feature = "fpga_subsystem", ignore)]

--- a/test/tests/fips_test_suite/security_parameters.rs
+++ b/test/tests/fips_test_suite/security_parameters.rs
@@ -285,6 +285,8 @@ pub fn attempt_ssp_access_rt() {
 pub fn zeroize_check_inaccessible() {
     let mut hw = fips_test_init_to_rt(None, None);
 
+    hw.step_until_ready_for_runtime();
+
     // SHUTDOWN/Zeroize
     crate::services::exec_cmd_shutdown(&mut hw);
 


### PR DESCRIPTION
Debug-only PR to collect FPGA subsystem traces for the runtime FIPS shutdown zeroize hang.\n\nThis branch intentionally narrows runtime integration tests to test_fips::test_fips_shutdown and adds ABR/MLDSA/ML-KEM/KV status traces around startup ML-KEM KAT cleanup and shutdown zeroize.

DO NOT MERGE.