### PR TITLE
[ROM]: Update FIPS identifier when in subsystem mode

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-0a15e3540b58bd1dd4f08a299735181f834e3cc6ffb6afafdb8968f5913b5db7595c58534eb75d0c1822e196e5a056df  caliptra-rom-no-log.bin
-9a63d03bc86ca687bf674d99dbe91cb60b5d41484bc53a1941cd445067d8dc92b90e3cccf623dc38a0e2c87ec81df3d5  caliptra-rom-with-log.bin
+cada77dd2e7f0632fe3020144b0ac73adacfb4135580dfc1d208cf70a714eacb3a4286c0e801e4589aa07b40d97aa342  caliptra-rom-no-log.bin
+7fd82773d36460b71022b9ed0f2d766e7b00cb6bc33641ec4c453c9f0c2d5c9b741495a5e49a6c5214aa94e50d63fe54  caliptra-rom-with-log.bin

--- a/common/src/fips.rs
+++ b/common/src/fips.rs
@@ -7,17 +7,24 @@ use caliptra_drivers::SocIfc;
 pub struct FipsVersionCmd;
 impl FipsVersionCmd {
     pub const NAME: [u8; 12] = *b"Caliptra RTM";
+    pub const NAME_ROT: [u8; 12] = *b"Caliptra ROT";
     pub const MODE: u32 = 0x46495053;
 
     #[cfg_attr(feature = "runtime", inline(never))]
     pub fn execute(soc_ifc: &SocIfc) -> FipsVersionResp {
         cprintln!("[rt] FIPS Version");
 
+        let name = if soc_ifc.subsystem_mode() {
+            Self::NAME_ROT
+        } else {
+            Self::NAME
+        };
+
         FipsVersionResp {
             hdr: MailboxRespHeader::default(),
             mode: Self::MODE,
             fips_rev: soc_ifc.get_version(),
-            name: Self::NAME,
+            name,
         }
     }
 }

--- a/rom/dev/tests/rom_integration_tests/helpers.rs
+++ b/rom/dev/tests/rom_integration_tests/helpers.rs
@@ -20,7 +20,7 @@ use caliptra_hw_model::{
 };
 use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, ModelError};
 use caliptra_image_types::{FwVerificationPqcKeyType, ImageBundle};
-use zerocopy::TryFromBytes;
+use zerocopy::{IntoBytes, TryFromBytes};
 
 pub use caliptra_test::{default_soc_manifest_bytes, test_upload_firmware, DEFAULT_MCU_FW};
 
@@ -191,6 +191,14 @@ pub fn change_dword_endianess(data: &mut [u8]) {
     for idx in (0..data.len()).step_by(4) {
         data.swap(idx, idx + 3);
         data.swap(idx + 1, idx + 2);
+    }
+}
+
+pub fn expected_fips_version_name(subsystem_mode: bool) -> &'static [u8] {
+    if subsystem_mode {
+        caliptra_common::fips::FipsVersionCmd::NAME_ROT.as_bytes()
+    } else {
+        caliptra_common::fips::FipsVersionCmd::NAME.as_bytes()
     }
 }
 

--- a/rom/dev/tests/rom_integration_tests/test_version.rs
+++ b/rom/dev/tests/rom_integration_tests/test_version.rs
@@ -53,5 +53,8 @@ fn test_version() {
         [HW_REV_ID, (version::get_rom_version() as u32), 0x0]
     );
     let name = &version_resp.name[..];
-    assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
+    assert_eq!(
+        name,
+        helpers::expected_fips_version_name(hw.subsystem_mode())
+    );
 }

--- a/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
+++ b/rom/dev/tests/rom_integration_tests/test_warm_reset.rs
@@ -288,7 +288,10 @@ fn test_version(
     assert_eq!(received_fmc_version, fmc_version);
     assert_eq!(received_app_version, app_version);
     let name = &version_resp.name[..];
-    assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
+    assert_eq!(
+        name,
+        crate::helpers::expected_fips_version_name(hw.subsystem_mode())
+    );
 }
 
 #[test]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1214,7 +1214,7 @@ Table: `VERSION` output arguments
 | fips_status  | u32       | Indicates if the command is FIPS approved or an error
 | mode         | u32       | Mode identifier
 | fips_rev     | u32[3]    | [31:0] HW rev ID, [47:32] ROM version, [63:48] FMC version, [95:64] FW version
-| name         | u8[12]    | 12 character module name "Caliptra RTM"
+| name         | u8[12]    | 12 character module name ("Caliptra ROT" in subsystem mode, otherwise "Caliptra RTM")
 
 ### SELF\_TEST\_START
 

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -1090,3 +1090,11 @@ pub fn verify_sign_and_certify_key(
         _ => panic!("Wrong response type!"),
     }
 }
+
+pub fn expected_fips_version_name(subsystem_mode: bool) -> &'static [u8] {
+    if subsystem_mode {
+        caliptra_common::fips::FipsVersionCmd::NAME_ROT.as_bytes()
+    } else {
+        caliptra_common::fips::FipsVersionCmd::NAME.as_bytes()
+    }
+}

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -69,7 +69,10 @@ fn test_fips_version() {
         ]
     );
     let name = &fips_version.name[..];
-    assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
+    assert_eq!(
+        name,
+        crate::common::expected_fips_version_name(model.subsystem_mode())
+    );
 }
 
 #[test]

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -46,7 +46,12 @@ pub fn exec_cmd_version<T: HwModel>(hw: &mut T, fmc_version: u16, app_version: u
         ]
     );
     let name = &version_resp.name[..];
-    assert_eq!(name, FipsVersionCmd::NAME.as_bytes());
+    let expected_name = if hw.subsystem_mode() {
+        FipsVersionCmd::NAME_ROT.as_bytes()
+    } else {
+        FipsVersionCmd::NAME.as_bytes()
+    };
+    assert_eq!(name, expected_name);
 }
 
 pub fn exec_cmd_self_test_start<T: HwModel>(hw: &mut T) {


### PR DESCRIPTION
We use a different name for Caliptra subsystem because it has different functionality to the existing core mode "RTM".

This resolves https://github.com/chipsalliance/caliptra-sw/issues/3859.