### PR TITLE
feat(hw-model): Auto-generate OTP controller memory map offsets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,6 +70,9 @@ jobs:
             cargo build -p $proj --locked --no-default-features --features rustcrypto
           done
 
+      - name: Pull Caliptra subsystem RTL submodule
+        run: git submodule update --init hw/latest/caliptra-ss
+
       - name: Build hw-model with fpga_realtime, fpga_subsystem, itrng, coverage
         run: |
           for feature in fpga_realtime fpga_subsystem itrng coverage; do

--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -122,6 +122,9 @@ jobs:
           repository: ${{ inputs.repository || 'chipsalliance/caliptra-sw' }}
           ref: ${{ inputs.branch }}
 
+      - name: Pull Caliptra subsystem RTL submodule
+        run: git submodule update --init hw/latest/caliptra-ss
+
       - name: Restore sysroot from cache
         uses: actions/cache/restore@v3
         id: restore_sysroot_cache
@@ -206,7 +209,14 @@ jobs:
           path: /tmp/caliptra-mcu-binaries.tar.gz
           key: mcu-rom-${{ env.CALIPTRA_MCU_COMMIT }}-${{ env.CACHE_BUSTER }}
 
+      - name: Download MCU fuses.hjson
+        run: |
+          curl -sL "https://raw.githubusercontent.com/chipsalliance/caliptra-mcu-sw/${CALIPTRA_MCU_COMMIT}/hw/fuses.hjson" \
+            -o /tmp/mcu-fuses.hjson
+
       - name: Build test binaries
+        env:
+          CALIPTRA_MCU_FUSES_HJSON: /tmp/mcu-fuses.hjson
         run: |
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
           export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=--sysroot=$FARGO_SYSROOT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -821,6 +821,7 @@ dependencies = [
  "caliptra-test-harness-types",
  "caliptra-ureg",
  "caliptra-verilated",
+ "deser-hjson",
  "libc",
  "nix",
  "once_cell",
@@ -1579,7 +1580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1943,6 +1944,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "deser-hjson"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d49a923edd92dc1ca5819822f540ea83f094ab5ac6940e4044e03c1d8e6576"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4276,7 +4286,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5668,7 +5678,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ convert_case = "0.6.0"
 cms = "0.2.2"
 ctr = "0.9.2"
 der = { version = "0.7.10", features = ["derive", "alloc"] }
+deser-hjson = "2.2.6"
 elf = "0.7.2"
 fips204 = "0.4.6"
 fslock = "0.2.1"

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -51,6 +51,10 @@ caliptra-coverage = { workspace = true, optional = true }
 caliptra-image-types.workspace = true
 tock-registers.workspace = true
 
+[build-dependencies]
+deser-hjson.workspace = true
+serde = { workspace = true, features = ["derive"] }
+
 [dev-dependencies]
 caliptra-builder.workspace = true
 caliptra-registers.workspace = true

--- a/hw-model/build.rs
+++ b/hw-model/build.rs
@@ -1,8 +1,252 @@
 // Licensed under the Apache-2.0 license
 
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct OtpCtrlMmap {
+    partitions: Vec<Partition>,
+}
+
+#[derive(Deserialize)]
+struct Partition {
+    name: String,
+    #[serde(default)]
+    sw_digest: bool,
+    #[serde(default)]
+    hw_digest: bool,
+    #[serde(default)]
+    zeroizable: bool,
+    #[serde(default)]
+    items: Vec<Item>,
+}
+
+#[derive(Deserialize)]
+struct Item {
+    name: String,
+    size: String,
+}
+
+#[derive(Deserialize)]
+struct FusesHjson {
+    #[serde(default)]
+    fields: Vec<FuseField>,
+}
+
+#[derive(Deserialize)]
+struct FuseField {
+    name: String,
+    otp_item: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    bits: u32,
+    #[allow(dead_code)]
+    #[serde(default)]
+    description: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    partition: String,
+}
+
 fn main() {
     println!(
         "cargo:rustc-env=OPENOCD_SYSFSGPIO_ADAPTER_CFG=../../../hw/fpga/openocd_sysfsgpio_adapter.cfg"
     );
     println!("cargo:rustc-env=OPENOCD_TAP_CFG=../../../hw/fpga/openocd_ss.cfg");
+    println!("cargo:rerun-if-env-changed=CALIPTRA_MCU_FUSES_HJSON");
+    println!("cargo:rerun-if-env-changed=CALIPTRA_MCU_COMMIT");
+
+    if env::var_os("CARGO_FEATURE_FPGA_SUBSYSTEM").is_some() {
+        generate_otp_ctrl_mmap_offsets();
+    }
+}
+
+fn generate_otp_ctrl_mmap_offsets() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo");
+    let mmap_path = Path::new(&manifest_dir)
+        .join("../hw/latest/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson");
+    println!("cargo:rerun-if-changed={}", mmap_path.display());
+
+    let input = fs::read_to_string(&mmap_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read OTP controller memory map {}: {err}",
+            mmap_path.display()
+        )
+    });
+    let mmap: OtpCtrlMmap = deser_hjson::from_str(&input)
+        .unwrap_or_else(|err| panic!("failed to parse {}: {err}", mmap_path.display()));
+
+    // Build a map from OTP item name → list of fuse field names from fuses.hjson.
+    // These field names become additional offset constants aliasing the same OTP item offset.
+    let fuse_aliases = build_fuse_aliases();
+
+    let generated = otp_ctrl_mmap_offsets_rs(&mmap.partitions, &fuse_aliases);
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is set by Cargo");
+    fs::write(
+        Path::new(&out_dir).join("otp_ctrl_mmap_offsets.rs"),
+        generated,
+    )
+    .expect("failed to write generated OTP controller memory map offsets");
+}
+
+/// Build a map from OTP item name (uppercased) → vec of fuse field names
+/// that should be emitted as alias constants.
+fn build_fuse_aliases() -> HashMap<String, Vec<String>> {
+    let fuses_input = if let Ok(fuses_path) = env::var("CALIPTRA_MCU_FUSES_HJSON") {
+        println!("cargo:rerun-if-changed={fuses_path}");
+        fs::read_to_string(&fuses_path)
+            .unwrap_or_else(|err| panic!("failed to read MCU fuses.hjson {fuses_path}: {err}"))
+    } else {
+        let commit = env::var("CALIPTRA_MCU_COMMIT").unwrap_or_else(|_| mcu_commit_from_workflow());
+        download_fuses_hjson(&commit)
+    };
+
+    let fuses: FusesHjson = deser_hjson::from_str(&fuses_input)
+        .unwrap_or_else(|err| panic!("failed to parse fuses.hjson: {err}"));
+
+    let mut aliases: HashMap<String, Vec<String>> = HashMap::new();
+    for field in &fuses.fields {
+        let key = const_name(&field.otp_item);
+        aliases
+            .entry(key)
+            .or_default()
+            .push(const_name(&field.name));
+    }
+    aliases
+}
+
+/// Parse the default CALIPTRA_MCU_COMMIT from .github/workflows/fpga-subsystem.yml.
+fn mcu_commit_from_workflow() -> String {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let workflow_path = Path::new(&manifest_dir).join("../.github/workflows/fpga-subsystem.yml");
+    let content = fs::read_to_string(&workflow_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read workflow file {}: {err}",
+            workflow_path.display()
+        )
+    });
+    // Look for: CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '<sha>' }}
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("CALIPTRA_MCU_COMMIT:") {
+            // Extract the SHA from between the last pair of single quotes.
+            if let Some(start) = trimmed.rfind('\'') {
+                let before = &trimmed[..start];
+                if let Some(end) = before.rfind('\'') {
+                    let sha = &before[end + 1..];
+                    if !sha.is_empty() {
+                        return sha.to_string();
+                    }
+                }
+            }
+        }
+    }
+    panic!(
+        "could not find CALIPTRA_MCU_COMMIT default SHA in {}",
+        workflow_path.display()
+    )
+}
+
+/// Download fuses.hjson from GitHub at the given commit.
+fn download_fuses_hjson(commit: &str) -> String {
+    let url = format!(
+        "https://raw.githubusercontent.com/chipsalliance/caliptra-mcu-sw/{commit}/hw/fuses.hjson"
+    );
+    let output = Command::new("curl")
+        .args(["-sfL", &url])
+        .output()
+        .expect("failed to run curl to download fuses.hjson");
+    if !output.status.success() {
+        panic!(
+            "curl failed to download {url}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    String::from_utf8(output.stdout).expect("fuses.hjson is not valid UTF-8")
+}
+
+fn otp_ctrl_mmap_offsets_rs(
+    partitions: &[Partition],
+    fuse_aliases: &HashMap<String, Vec<String>>,
+) -> String {
+    let mut output = String::from(
+        "// Licensed under the Apache-2.0 license\n\
+         //\n\
+         // @generated by hw-model/build.rs from hw/latest/caliptra-ss/src/fuse_ctrl/data/otp_ctrl_mmap.hjson.\n\
+         // Do not edit by hand.\n\n",
+    );
+    let mut offset = 0usize;
+
+    for partition in partitions {
+        let partition_offset = offset;
+        output.push_str(&format!(
+            "pub(crate) const {}_OFFSET: usize = {:#05x};\n",
+            const_name(&partition.name),
+            partition_offset
+        ));
+
+        for item in &partition.items {
+            let item_const = const_name(&item.name);
+            output.push_str(&format!(
+                "pub(crate) const {item_const}_OFFSET: usize = {offset:#05x};\n",
+            ));
+
+            // Emit alias constants for any fuses.hjson fields mapped to this OTP item.
+            if let Some(aliases) = fuse_aliases.get(&item_const) {
+                for alias in aliases {
+                    output.push_str(&format!(
+                        "pub(crate) const {alias}_OFFSET: usize = {offset:#05x};\n",
+                    ));
+                }
+            }
+
+            offset += item_size(item);
+        }
+
+        if partition.sw_digest || partition.hw_digest {
+            offset = offset.next_multiple_of(8);
+            offset += 8;
+        }
+        if partition.zeroizable {
+            offset += 8;
+        }
+
+        output.push_str(&format!(
+            "pub(crate) const {}_SIZE: usize = {:#05x};\n\n",
+            const_name(&partition.name),
+            offset - partition_offset
+        ));
+    }
+
+    output.push_str(&format!(
+        "pub(crate) const OTP_CTRL_MMAP_SIZE: usize = {offset:#05x};\n"
+    ));
+    output
+}
+
+fn item_size(item: &Item) -> usize {
+    item.size.parse().unwrap_or_else(|err| {
+        panic!(
+            "invalid OTP item size {:?} for {}: {err}",
+            item.size, item.name
+        )
+    })
+}
+
+fn const_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -54,51 +54,14 @@ const OTP_MAPPING: (usize, usize) = (1, 4);
 // Default flash size: 16MB each, initialized to 0xFF
 const DEFAULT_FLASH_SIZE: usize = 16 * 1024 * 1024;
 
-// TODO(timothytrippel): autogenerate these from the OTP memory map definition
-// Offsets in the OTP for all partitions.
-// SW_TEST_UNLOCK_PARTITION
-const OTP_SW_TEST_UNLOCK_PARTITION_OFFSET: usize = 0x0;
-// SW_MANUF_PARTITION
-const OTP_SW_MANUF_PARTITION_OFFSET: usize = 0x0F8;
-// SECRET_LC_TRANSITION_PARTITION
-const OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET: usize = 0x300;
-// SVN_PARTITION
-const OTP_SVN_PARTITION_OFFSET: usize = 0x3B8;
-const OTP_SVN_PARTITION_FMC_SVN_FIELD_OFFSET: usize = OTP_SVN_PARTITION_OFFSET + 0; // 4 bytes
-const OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET: usize = OTP_SVN_PARTITION_OFFSET + 4; // 16 bytes
-const OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET: usize = OTP_SVN_PARTITION_OFFSET + 20; // 16 bytes
-const OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET: usize = OTP_SVN_PARTITION_OFFSET + 36; // 1 byte used
+#[allow(dead_code)]
+mod otp_ctrl_mmap {
+    include!(concat!(env!("OUT_DIR"), "/otp_ctrl_mmap_offsets.rs"));
+}
+use otp_ctrl_mmap as otp;
 
-// VENDOR_HASHES_MANUF_PARTITION
-const OTP_VENDOR_HASHES_MANUF_PARTITION_OFFSET: usize = 0x420;
-const FUSE_VENDOR_PKHASH_OFFSET: usize = OTP_VENDOR_HASHES_MANUF_PARTITION_OFFSET;
-const FUSE_PQC_OFFSET: usize = OTP_VENDOR_HASHES_MANUF_PARTITION_OFFSET + 48;
-
-// VENDOR_HASHES_PROD_PARTITION
-const OTP_VENDOR_HASHES_PROD_PARTITION_OFFSET: usize = 0x460;
-const FUSE_OWNER_PKHASH_OFFSET: usize = OTP_VENDOR_HASHES_PROD_PARTITION_OFFSET; // 48 bytes
-
-// VENDOR_REVOCATIONS_PROD_PARTITION
-const OTP_VENDOR_REVOCATIONS_PROD_PARTITION_OFFSET: usize = 0x7C0;
-const FUSE_VENDOR_ECC_REVOCATION_OFFSET: usize = OTP_VENDOR_REVOCATIONS_PROD_PARTITION_OFFSET + 12; // 4 bytes
-const FUSE_VENDOR_LMS_REVOCATION_OFFSET: usize = OTP_VENDOR_REVOCATIONS_PROD_PARTITION_OFFSET + 16; // 4 bytes
-const FUSE_VENDOR_REVOCATION_OFFSET: usize = OTP_VENDOR_REVOCATIONS_PROD_PARTITION_OFFSET + 20; // 4 bytes
-                                                                                                // LIFECYCLE_PARTITION
-                                                                                                // VENDOR_NON_SECRET_PROD_PARTITION
-pub const VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET: usize = 0xaa8;
-const UDS_SEED_OFFSET: usize = 0xba8;
-const FIELD_ENTROPY_OFFSET: usize = 0xbe8;
-// CPTRA_SS_LOCK_HEK_PROD partitions
-const OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET: usize = 0xCB0;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_2_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_1_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_3_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_2_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_4_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_3_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_5_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_4_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_6_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_5_OFFSET + 48;
-const OTP_CPTRA_SS_LOCK_HEK_PROD_7_OFFSET: usize = OTP_CPTRA_SS_LOCK_HEK_PROD_6_OFFSET + 48;
-// LIFECYCLE_PARTITION
-const OTP_LIFECYCLE_PARTITION_OFFSET: usize = 0xE30;
+pub const VENDOR_NON_SECRET_PROD_PARTITION_BYTE_OFFSET: usize =
+    otp::VENDOR_NON_SECRET_PROD_PARTITION_OFFSET;
 
 // These are the default physical addresses for the peripherals. The addresses listed in
 // FPGA_MEMORY_MAP are physical addresses specific to the FPGA. These addresses are used over the
@@ -196,7 +159,8 @@ const OTP_FULL_SIZE: usize = 16384;
 const FLASH_SIZE: usize = 8192;
 const OTP_SIZE: usize = 8192;
 const _: () = assert!(OTP_SIZE + FLASH_SIZE == OTP_FULL_SIZE);
-const _: () = assert!(OTP_LIFECYCLE_PARTITION_OFFSET + 88 + 8 <= OTP_SIZE);
+const _: () = assert!(otp::OTP_CTRL_MMAP_SIZE <= OTP_SIZE);
+const _: () = assert!(otp::LIFE_CYCLE_OFFSET + 88 + 8 <= OTP_SIZE);
 const AXI_CLK_HZ: u32 = 199_999_000;
 const I3C_CLK_HZ: u32 = 12_500_000;
 
@@ -1561,7 +1525,7 @@ impl ModelFpgaSubsystem {
         if let Some(lc_state) = lc_state {
             println!("Provisioning lifecycle partition (State: {}).", lc_state);
             let mem = lc_generate_memory(lc_state, 1)?;
-            let offset = OTP_LIFECYCLE_PARTITION_OFFSET;
+            let offset = otp::LIFE_CYCLE_OFFSET;
             otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
         }
 
@@ -1570,14 +1534,14 @@ impl ModelFpgaSubsystem {
             println!("Provisioning SECRET_LC_TRANSITION partition.");
             let tokens = &DEFAULT_LIFECYCLE_RAW_TOKENS;
             let mem = otp_generate_lifecycle_tokens_mem(tokens)?;
-            let offset = OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET;
+            let offset = otp::SECRET_LC_TRANSITION_PARTITION_OFFSET;
             otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
             // Provision default SW_TEST_UNLOCK partition (manuf debug unlock token).
             println!("Provisioning SW_TEST_UNLOCK partition.");
             let mem =
                 otp_generate_manuf_debug_unlock_token_mem(&DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN)?;
-            let offset = OTP_SW_TEST_UNLOCK_PARTITION_OFFSET;
+            let offset = otp::SW_TEST_UNLOCK_PARTITION_OFFSET;
             otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
             // Provision default SW_MANUF partition.
@@ -1606,11 +1570,13 @@ impl ModelFpgaSubsystem {
                 stepping_id: self.fuses.soc_stepping_id as u32,
                 ..Default::default()
             })?;
-            let offset = OTP_SW_MANUF_PARTITION_OFFSET;
+            let offset = otp::SW_MANUF_PARTITION_OFFSET;
             otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-            // Provision UDS seed in SECRET_MANUF partition
-            println!("Provisioning UDS seed in SECRET_MANUF partition.");
+            // Provision UDS seed in FPGA test vendor non-secret fuse slots.
+            // The MCU ROM `core_test` path reads UDS from these slots because the
+            // real SECRET_MANUF partition is hardware-scrambled and not DAI-accessible.
+            println!("Provisioning UDS seed in FPGA test fuse slots.");
             let uds_seed_bytes: Vec<u8> = self
                 .fuses
                 .uds_seed
@@ -1618,11 +1584,16 @@ impl ModelFpgaSubsystem {
                 .flat_map(|&word| word.to_le_bytes())
                 .collect();
             println!("Setting UDS seed to {:x?}", HexSlice(&uds_seed_bytes));
-            otp_data[UDS_SEED_OFFSET..UDS_SEED_OFFSET + uds_seed_bytes.len()]
-                .copy_from_slice(&uds_seed_bytes);
+            let (uds_lo, uds_hi) = uds_seed_bytes.split_at(32);
+            otp_data[otp::FPGA_TEST_UDS_SEED_LO_OFFSET
+                ..otp::FPGA_TEST_UDS_SEED_LO_OFFSET + uds_lo.len()]
+                .copy_from_slice(uds_lo);
+            otp_data[otp::FPGA_TEST_UDS_SEED_HI_OFFSET
+                ..otp::FPGA_TEST_UDS_SEED_HI_OFFSET + uds_hi.len()]
+                .copy_from_slice(uds_hi);
 
-            // Provision field entropy in SECRET_MANUF partition
-            println!("Provisioning field entropy in SECRET_MANUF partition.");
+            // Provision field entropy in FPGA test vendor non-secret fuse slot.
+            println!("Provisioning field entropy in FPGA test fuse slot.");
             let field_entropy_bytes: Vec<u8> = self
                 .fuses
                 .field_entropy
@@ -1633,7 +1604,8 @@ impl ModelFpgaSubsystem {
                 "Setting field entropy to {:x?}",
                 HexSlice(&field_entropy_bytes)
             );
-            otp_data[FIELD_ENTROPY_OFFSET..FIELD_ENTROPY_OFFSET + field_entropy_bytes.len()]
+            otp_data[otp::FPGA_TEST_FIELD_ENTROPY_OFFSET
+                ..otp::FPGA_TEST_FIELD_ENTROPY_OFFSET + field_entropy_bytes.len()]
                 .copy_from_slice(&field_entropy_bytes);
 
             let vendor_pk_hash = self.fuses.vendor_pk_hash.as_bytes();
@@ -1641,7 +1613,8 @@ impl ModelFpgaSubsystem {
                 "Setting vendor public key hash to {:x?}",
                 HexSlice(vendor_pk_hash)
             );
-            otp_data[FUSE_VENDOR_PKHASH_OFFSET..FUSE_VENDOR_PKHASH_OFFSET + vendor_pk_hash.len()]
+            otp_data[otp::CPTRA_CORE_VENDOR_PK_HASH_0_OFFSET
+                ..otp::CPTRA_CORE_VENDOR_PK_HASH_0_OFFSET + vendor_pk_hash.len()]
                 .copy_from_slice(vendor_pk_hash);
 
             let vendor_pqc_type =
@@ -1652,7 +1625,8 @@ impl ModelFpgaSubsystem {
                 vendor_pqc_type
             );
             let encoded_pqc = otp_generate_linear_majority_vote(2, 3, vendor_pqc_type as u32)?;
-            otp_data[FUSE_PQC_OFFSET..FUSE_PQC_OFFSET + 4]
+            otp_data
+                [otp::CPTRA_CORE_PQC_KEY_TYPE_0_OFFSET..otp::CPTRA_CORE_PQC_KEY_TYPE_0_OFFSET + 4]
                 .copy_from_slice(&encoded_pqc.to_le_bytes());
 
             // Owner public key hash (48 bytes) lives in VENDOR_HASHES_PROD partition
@@ -1661,7 +1635,8 @@ impl ModelFpgaSubsystem {
                 "Setting owner public key hash to {:x?}",
                 HexSlice(owner_pk_hash)
             );
-            otp_data[FUSE_OWNER_PKHASH_OFFSET..FUSE_OWNER_PKHASH_OFFSET + owner_pk_hash.len()]
+            otp_data[otp::CPTRA_SS_OWNER_PK_HASH_OFFSET
+                ..otp::CPTRA_SS_OWNER_PK_HASH_OFFSET + owner_pk_hash.len()]
                 .copy_from_slice(owner_pk_hash);
 
             // Owner revocation fields (ECC, LMS, MLDSA) in VENDOR_REVOCATIONS_PROD partition
@@ -1674,20 +1649,23 @@ impl ModelFpgaSubsystem {
                 vendor_ecc_revocation, vendor_lms_revocation, vendor_mldsa_revocation
             );
             let encoded_ecc = otp_generate_linear_majority_vote(4, 3, vendor_ecc_revocation)?;
-            otp_data[FUSE_VENDOR_ECC_REVOCATION_OFFSET..FUSE_VENDOR_ECC_REVOCATION_OFFSET + 4]
+            otp_data[otp::CPTRA_CORE_ECC_REVOCATION_0_OFFSET
+                ..otp::CPTRA_CORE_ECC_REVOCATION_0_OFFSET + 4]
                 .copy_from_slice(&encoded_ecc.to_le_bytes());
             let encoded_lms = otp_generate_linear_majority_vote(16, 2, vendor_lms_revocation)?;
-            otp_data[FUSE_VENDOR_LMS_REVOCATION_OFFSET..FUSE_VENDOR_LMS_REVOCATION_OFFSET + 4]
+            otp_data[otp::CPTRA_CORE_LMS_REVOCATION_0_OFFSET
+                ..otp::CPTRA_CORE_LMS_REVOCATION_0_OFFSET + 4]
                 .copy_from_slice(&encoded_lms.to_le_bytes());
             let encoded_mldsa = otp_generate_linear_majority_vote(4, 3, vendor_mldsa_revocation)?;
-            otp_data[FUSE_VENDOR_REVOCATION_OFFSET..FUSE_VENDOR_REVOCATION_OFFSET + 4]
+            otp_data[otp::CPTRA_CORE_MLDSA_REVOCATION_0_OFFSET
+                ..otp::CPTRA_CORE_MLDSA_REVOCATION_0_OFFSET + 4]
                 .copy_from_slice(&encoded_mldsa.to_le_bytes());
 
             // Firmware/runtime SVN (16 bytes -> 4 words)
             let fw_svn = self.fuses.fw_svn.as_bytes();
             println!("Setting runtime FW SVN to {:x?}", HexSlice(fw_svn));
-            otp_data[OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET
-                ..OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET + fw_svn.len()]
+            otp_data[otp::CPTRA_CORE_RUNTIME_SVN_OFFSET
+                ..otp::CPTRA_CORE_RUNTIME_SVN_OFFSET + fw_svn.len()]
                 .copy_from_slice(fw_svn);
 
             // SoC manifest SVN (16 bytes -> 4 words)
@@ -1696,13 +1674,13 @@ impl ModelFpgaSubsystem {
                 "Setting SoC manifest SVN to {:x?}",
                 HexSlice(soc_manifest_svn)
             );
-            otp_data[OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET
-                ..OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET + soc_manifest_svn.len()]
+            otp_data[otp::CPTRA_CORE_SOC_MANIFEST_SVN_OFFSET
+                ..otp::CPTRA_CORE_SOC_MANIFEST_SVN_OFFSET + soc_manifest_svn.len()]
                 .copy_from_slice(soc_manifest_svn);
 
             println!("Provisioning CPTRA_SS_LOCK_HEK_PROD_0 partition.");
             let hek_seed_bytes = self.fuses.hek_seed.as_bytes();
-            let offset = OTP_CPTRA_SS_LOCK_HEK_PROD_0_OFFSET;
+            let offset = otp::CPTRA_SS_LOCK_HEK_PROD_0_OFFSET;
             otp_data[offset..offset + hek_seed_bytes.len()].copy_from_slice(hek_seed_bytes);
 
             // Max SOC Manifest SVN (1 byte used)
@@ -1710,7 +1688,7 @@ impl ModelFpgaSubsystem {
                 "Burning fuse for SOC MAX SVN {}",
                 self.fuses.soc_manifest_max_svn
             );
-            otp_data[OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET] = self.fuses.soc_manifest_max_svn;
+            otp_data[otp::CPTRA_CORE_SOC_MANIFEST_MAX_SVN_OFFSET] = self.fuses.soc_manifest_max_svn;
         }
 
         self.otp_slice().copy_from_slice(&otp_data);


### PR DESCRIPTION
Parse `otp_ctrl_mmap.hjson` at build time to generate OTP partition
and item offsets, replacing the previously hand-maintained constants
in `model_fpga_subsystem.rs`.

Signed-off-by: Arthur Heymans <arthur.heymans@9elements.com>