### PR TITLE
persistent data: add PQ DevID seed placeholder

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -46,6 +46,11 @@ pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
 pub const IDEVID_CSR_SIZE: u32 = 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 1024;
 pub const DPE_PL_CONTEXT_LIMITS_SIZE: u32 = 2;
+#[cfg(feature = "mldsa_attestation")]
+pub const PQ_DEVID_SEED_SIZE: u32 = 32;
+#[cfg(feature = "mldsa_attestation")]
+pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2 - PQ_DEVID_SEED_SIZE;
+#[cfg(not(feature = "mldsa_attestation"))]
 pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2;
 
 pub const PCR_LOG_MAX_COUNT: usize = 17;
@@ -315,6 +320,9 @@ pub struct PersistentData {
 
     pub dpe_pl0_context_limit: u8,
     pub dpe_pl1_context_limit: u8,
+
+    #[cfg(feature = "mldsa_attestation")]
+    pub pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
 
     // Reserved memory for future objects.
     // New objects should always source memory from this range.

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -320,7 +320,7 @@ pub struct PersistentData {
     #[cfg(feature = "mldsa_attestation")]
     pub pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
     #[cfg(not(feature = "mldsa_attestation"))]
-    reserved12: [u8; PQ_DEVID_SEED_SIZE as usize],
+    pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
 
     // Reserved memory for future objects.
     // New objects should always source memory from this range.
@@ -430,6 +430,12 @@ impl PersistentData {
             );
 
             persistent_data_offset += DPE_PL_CONTEXT_LIMITS_SIZE;
+            assert_eq!(
+                addr_of!((*P).pq_devid_seed) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+
+            persistent_data_offset += PQ_DEVID_SEED_SIZE;
             assert_eq!(
                 addr_of!((*P).reserved_memory) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -46,12 +46,8 @@ pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
 pub const IDEVID_CSR_SIZE: u32 = 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 1024;
 pub const DPE_PL_CONTEXT_LIMITS_SIZE: u32 = 2;
-#[cfg(feature = "mldsa_attestation")]
 pub const PQ_DEVID_SEED_SIZE: u32 = 32;
-#[cfg(feature = "mldsa_attestation")]
 pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2 - PQ_DEVID_SEED_SIZE;
-#[cfg(not(feature = "mldsa_attestation"))]
-pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2;
 
 pub const PCR_LOG_MAX_COUNT: usize = 17;
 pub const FUSE_LOG_MAX_COUNT: usize = 62;
@@ -323,6 +319,8 @@ pub struct PersistentData {
 
     #[cfg(feature = "mldsa_attestation")]
     pub pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
+    #[cfg(not(feature = "mldsa_attestation"))]
+    reserved12: [u8; PQ_DEVID_SEED_SIZE as usize],
 
     // Reserved memory for future objects.
     // New objects should always source memory from this range.


### PR DESCRIPTION
Add a placeholder for PQ DevID seed in persistent data to decouple development work (#3742) on the `SET_PQ_SEED` command and the ML-DSA backend (#3744).