### PR TITLE
[ci]: Fix dispatch type for MCU commit check

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -95,7 +95,7 @@ jobs:
 
   check_mcu_commit:
     runs-on: ubuntu-22.04
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'workflow_call'
     steps:
       - name: Check MCU Commit validity
         run: |


### PR DESCRIPTION
This fixes a noisy error in caliptra-mcu-sw. The `dispatch` variant was not correct.