### PR TITLE
Remove OTP status offset fallback.

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-0a15e3540b58bd1dd4f08a299735181f834e3cc6ffb6afafdb8968f5913b5db7595c58534eb75d0c1822e196e5a056df  caliptra-rom-no-log.bin
-9a63d03bc86ca687bf674d99dbe91cb60b5d41484bc53a1941cd445067d8dc92b90e3cccf623dc38a0e2c87ec81df3d5  caliptra-rom-with-log.bin
+178f7a10b43275c68ae4698569b720678eb349c4d1deb3c8e3faf7a27ecce072e52874b186cb96a8a46a3f2b7bc4fb1d  caliptra-rom-no-log.bin
+5ee14fc648c2fec43556f03ec1422d77b28d1981368217fb6853f1d2feaefc59eca38a587db54cb3e1df8b7ca14f6a55  caliptra-rom-with-log.bin

--- a/common/src/uds_fe_programming.rs
+++ b/common/src/uds_fe_programming.rs
@@ -52,7 +52,7 @@ struct OtpCtrlConfig {
     fuse_controller_base_addr: u64,
     seed_config: SeedConfig,
     dai_idle_bit_num: u32,
-    status_reg_addr: Option<u64>,
+    status_reg_addr: u64,
     direct_access_cmd_reg_addr: u64,
     direct_access_address_reg_addr: u64,
     direct_access_wdata_0_reg_addr: u64,
@@ -69,12 +69,7 @@ impl UdsFeProgrammingFlow {
         let seed_config = self.get_seed_config(soc_ifc);
         let dai_idle_bit_num = soc_ifc.otp_dai_idle_bit_num();
         let status_reg_offset = soc_ifc.otp_status_reg_offset();
-        let status_reg_addr = if status_reg_offset != 0 {
-            Some(fuse_controller_base_addr + status_reg_offset as u64)
-        } else {
-            // TODO: Remove this fallback once MCU programs the OTP status register offset.
-            None
-        };
+        let status_reg_addr = fuse_controller_base_addr + status_reg_offset as u64;
         let direct_access_cmd_reg_addr =
             fuse_controller_base_addr + soc_ifc.otp_direct_access_cmd_reg_offset() as u64;
         let direct_access_address_reg_addr =
@@ -221,14 +216,10 @@ impl UdsFeProgrammingFlow {
             let config = self.init_otp_config(soc_ifc);
             let otp_ctrl = DmaOtpCtrl::new(AxiAddr::from(config.fuse_controller_base_addr), dma);
 
-            let _ = otp_ctrl.with_regs_mut(|regs| {
+            let _ = otp_ctrl.with_regs_mut(|_| {
                 // Helper function to check if DAI is idle using the configurable bit number
                 let is_dai_idle = || -> bool {
-                    let status = if let Some(status_reg_addr) = config.status_reg_addr {
-                        dma.read_dword(AxiAddr::from(status_reg_addr))
-                    } else {
-                        regs.status().read().into()
-                    };
+                    let status = dma.read_dword(AxiAddr::from(config.status_reg_addr));
                     (status & (1 << config.dai_idle_bit_num)) != 0
                 };
 
@@ -338,14 +329,10 @@ impl UdsFeProgrammingFlow {
             4
         };
 
-        let verify_result = otp_ctrl.with_regs_mut(|regs| {
+        let verify_result = otp_ctrl.with_regs_mut(|_| {
             // Helper to wait for DAI idle state
             let wait_dai_idle = || loop {
-                let status = if let Some(status_reg_addr) = config.status_reg_addr {
-                    dma.read_dword(AxiAddr::from(status_reg_addr))
-                } else {
-                    regs.status().read().into()
-                };
+                let status = dma.read_dword(AxiAddr::from(config.status_reg_addr));
                 if (status & (1 << config.dai_idle_bit_num)) != 0 {
                     break;
                 }

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -262,6 +262,8 @@ pub struct InitParams<'a> {
 
     pub otp_dai_idle_bit_offset: u32,
 
+    pub otp_status_reg_offset: u32,
+
     pub otp_direct_access_cmd_reg_offset: u32,
 
     // Keypairs for production debug unlock levels, from low to high.
@@ -353,6 +355,7 @@ impl Default for InitParams<'_> {
             stable_owner_key_en: false,
             uds_fuse_row_granularity_64: true,
             otp_dai_idle_bit_offset: 30,
+            otp_status_reg_offset: 0x10,
             otp_direct_access_cmd_reg_offset: 0x80,
             prod_dbg_unlock_keypairs: Default::default(),
             debug_intent: false,

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -276,7 +276,8 @@ impl HwModel for ModelEmulated {
 
         root_bus.soc_reg.set_generic_input_wires(&[0, 0]);
 
-        let ss_strap_generic_reg_0 = params.otp_dai_idle_bit_offset << 16;
+        let ss_strap_generic_reg_0 =
+            (params.otp_dai_idle_bit_offset << 16) | (params.otp_status_reg_offset & 0xFFFF);
         let ss_strap_generic_reg_1 = params.otp_direct_access_cmd_reg_offset;
         let ss_strap_generic_reg_3 = if params.stable_owner_key_en {
             1u32

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -276,8 +276,8 @@ impl HwModel for ModelEmulated {
 
         root_bus.soc_reg.set_generic_input_wires(&[0, 0]);
 
-        let ss_strap_generic_reg_0 =
-            (params.otp_dai_idle_bit_offset << 16) | (params.otp_status_reg_offset & 0xFFFF);
+        let ss_strap_generic_reg_0 = ((params.otp_dai_idle_bit_offset & 0xFFFF) << 16)
+            | (params.otp_status_reg_offset & 0xFFFF);
         let ss_strap_generic_reg_1 = params.otp_direct_access_cmd_reg_offset;
         let ss_strap_generic_reg_3 = if params.stable_owner_key_en {
             1u32

--- a/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
+++ b/rom/dev/tests/rom_integration_tests/test_uds_fe.rs
@@ -140,15 +140,14 @@ fn test_uds_programming_configurable_status_reg_offset() {
         dbg_manuf_service,
         subsystem_mode: true,
         uds_fuse_row_granularity_64: true,
+        otp_status_reg_offset: OTP_STATUS_REG_OFFSET,
         ..Default::default()
     })
     .unwrap();
 
-    let otp_dai_idle_bit_num = hw.soc_ifc().ss_strap_generic().at(0).read() & 0xFFFF_0000;
-    hw.soc_ifc()
-        .ss_strap_generic()
-        .at(0)
-        .write(|_| otp_dai_idle_bit_num | OTP_STATUS_REG_OFFSET);
+    let status_reg_offset = hw.soc_ifc().ss_strap_generic().at(0).read() & 0xFFFF;
+    assert_eq!(status_reg_offset, OTP_STATUS_REG_OFFSET);
+
     hw.boot(BootParams::default()).unwrap();
 
     hw.step_until(|m| {


### PR DESCRIPTION
Removing the fallback code for the status offset now that it's being programmed.
Summary:
* Removed the fallback code 




