### PR TITLE
runtime: response in mbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "bitflags 2.4.0",
  "caliptra-api-types",
  "caliptra-builder",
+ "caliptra-dpe-response-buffer",
  "caliptra-emu-types",
  "caliptra-error",
  "caliptra-image-types",
@@ -319,7 +320,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958#72c75dc70cde4120a9ce149d4f5cb21621399958"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -330,7 +331,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958#72c75dc70cde4120a9ce149d4f5cb21621399958"
 
 [[package]]
 name = "caliptra-coverage"
@@ -361,13 +362,14 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
 dependencies = [
  "bitflags 2.4.0",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
+ "caliptra-dpe-response-buffer",
  "cfg-if 1.0.0",
  "constant_time_eq",
  "ufmt",
@@ -378,11 +380,12 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
+ "caliptra-dpe-response-buffer",
  "constant_time_eq",
  "zerocopy",
  "zeroize",
@@ -391,13 +394,18 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=bde76549610ea2446952661a9ddf717e4a58f0fa#bde76549610ea2446952661a9ddf717e4a58f0fa"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
 dependencies = [
  "arrayvec",
  "caliptra-dpe-crypto",
  "cfg-if 1.0.0",
  "ufmt",
 ]
+
+[[package]]
+name = "caliptra-dpe-response-buffer"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
 
 [[package]]
 name = "caliptra-drivers"
@@ -876,6 +884,7 @@ dependencies = [
  "caliptra-dpe",
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
+ "caliptra-dpe-response-buffer",
  "caliptra-drivers",
  "caliptra-error",
  "caliptra-gen-linker-scripts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=cf3224c41b64789aa556e4f0c78e7395c6528a43#cf3224c41b64789aa556e4f0c78e7395c6528a43"
 dependencies = [
  "bitflags 2.4.0",
  "caliptra-cfi-derive",
@@ -380,7 +380,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=cf3224c41b64789aa556e4f0c78e7395c6528a43#cf3224c41b64789aa556e4f0c78e7395c6528a43"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
@@ -394,7 +394,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=cf3224c41b64789aa556e4f0c78e7395c6528a43#cf3224c41b64789aa556e4f0c78e7395c6528a43"
 dependencies = [
  "arrayvec",
  "caliptra-dpe-crypto",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-response-buffer"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=ce921a0a1fb919837b86700f627c64c4864335c6#ce921a0a1fb919837b86700f627c64c4864335c6"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=cf3224c41b64789aa556e4f0c78e7395c6528a43#cf3224c41b64789aa556e4f0c78e7395c6528a43"
 
 [[package]]
 name = "caliptra-drivers"
@@ -900,6 +900,7 @@ dependencies = [
  "caliptra-lms-types",
  "caliptra-mldsa",
  "caliptra-registers",
+ "caliptra-shake",
  "caliptra-x509",
  "caliptra_common",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ caliptra-api-test-bin = { path = "api/test-fw" }
 caliptra-api-types = { path = "api/types" }
 caliptra-auth-man-gen = { path = "auth-manifest/gen", default-features = false }
 caliptra-auth-man-types = { path = "auth-manifest/types", default-features = false }
-caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e", default-features = false, features = ["cfi", "cfi-counter"] }
-caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e" }
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "72c75dc70cde4120a9ce149d4f5cb21621399958", default-features = false, features = ["cfi", "cfi-counter"] }
+caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "72c75dc70cde4120a9ce149d4f5cb21621399958" }
 caliptra_common = { path = "common", default-features = false, features = ["cfi"] }
 caliptra-coverage = { path = "coverage" }
 caliptra-builder = { path = "builder" }
@@ -143,9 +143,10 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe-crypto", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "bde76549610ea2446952661a9ddf717e4a58f0fa", package = "caliptra-dpe-platform", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe-crypto", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe-platform", default-features = false }
+caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", default-features = false }
 elf = "0.7.2"
 fips204 = "0.2.1"
 gdbstub = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,10 +143,10 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe-crypto", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", package = "caliptra-dpe-platform", default-features = false }
-caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "ce921a0a1fb919837b86700f627c64c4864335c6", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe-crypto", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe-platform", default-features = false }
+caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", default-features = false }
 elf = "0.7.2"
 fips204 = "0.2.1"
 gdbstub = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,9 @@ lto = true
 opt-level = "s"
 codegen-units = 1
 
+[profile.firmware.package.caliptra-dpe]
+opt-level = "z"
+
 [patch.crates-io]
 # Fork of https://github.com/teythoon/rust-openssl.git/justus/pqc
 openssl = { git = "https://github.com/clundin25/rust-openssl.git", rev = "4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7" } # MLDSA

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ bitflags.workspace = true
 caliptra-error.workspace = true
 caliptra-mldsa.workspace = true
 zerocopy.workspace = true
+caliptra-dpe-response-buffer.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-registers.workspace = true
 caliptra-api-types.workspace = true

--- a/api/src/checksum.rs
+++ b/api/src/checksum.rs
@@ -1,5 +1,9 @@
 // Licensed under the Apache-2.0 license
 
+use core::ops::Range;
+
+use caliptra_dpe_response_buffer::{ResponseBufError, ResponseBuffer};
+
 /// Verify checksum
 pub fn verify_checksum(checksum: u32, cmd: u32, data: &[u8]) -> bool {
     calc_checksum(cmd, data) == checksum
@@ -18,8 +22,28 @@ pub fn calc_checksum(cmd: u32, data: &[u8]) -> u32 {
     0u32.wrapping_sub(checksum)
 }
 
+/// Calculate the checksum on top of a ResponseBuffer.  Since this is a response the command is
+/// automatically assigned to be 0, and thus only the data is added to the checksum.
+pub fn response_buffer_checksum(
+    buffer: &dyn ResponseBuffer,
+    range: Range<usize>,
+) -> Result<u32, ResponseBufError> {
+    let mut checksum = 0u32;
+    buffer.read_range(range, &mut |data| {
+        for d in data {
+            checksum = checksum.wrapping_add(*d as u32);
+        }
+
+        Ok(())
+    })?;
+
+    Ok(0u32.wrapping_sub(checksum))
+}
+
 #[cfg(all(test, target_family = "unix"))]
 mod tests {
+    use caliptra_dpe_response_buffer::SliceResponseBuffer;
+
     use super::*;
 
     #[test]
@@ -63,5 +87,13 @@ mod tests {
         let data = [0x00000000u32; 1];
         let checksum = calc_checksum(cmd, data[0].to_le_bytes().as_ref());
         assert!(verify_checksum(checksum, cmd, &data[0].to_le_bytes()));
+    }
+
+    #[test]
+    fn test_response_buffer_round_trip() {
+        let mut data = [0x01, 0x02, 0x03, 0x04];
+        let checksum =
+            response_buffer_checksum(&SliceResponseBuffer::new(&mut data), 0..4).unwrap();
+        assert!(verify_checksum(checksum, 0, &data));
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,13 +2,13 @@
 #![cfg_attr(not(test), no_std)]
 
 mod capabilities;
-mod checksum;
+pub mod checksum;
 pub mod mailbox;
 pub mod soc_mgr;
 
 pub use caliptra_error as error;
 pub use capabilities::Capabilities;
-pub use checksum::{calc_checksum, verify_checksum};
+pub use checksum::{calc_checksum, response_buffer_checksum, verify_checksum};
 pub use soc_mgr::SocManager;
 
 #[derive(Debug, Eq, PartialEq)]

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -152,7 +152,7 @@ impl<T: ResponseVarSize> Response for T {
     const MIN_SIZE: usize = size_of::<MailboxRespHeaderVarSize>();
 }
 
-fn populate_checksum(msg: &mut [u8]) {
+pub fn populate_checksum(msg: &mut [u8]) {
     let (checksum_bytes, payload_bytes) = msg.split_at_mut(size_of::<u32>());
     let checksum = crate::checksum::calc_checksum(0, payload_bytes);
     checksum_bytes.copy_from_slice(&checksum.to_le_bytes());

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -938,6 +938,7 @@ fn generate_priv_internal(
     );
 }
 
+#[inline(never)]
 fn sign_internal_with_mu(
     out_encoded_signature: &mut [u8; MLDSA87_SIGNATURE_BYTES],
     priv_key: &PrivateKey,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,7 @@ pub mod capabilities {
     pub use caliptra_api::Capabilities;
 }
 pub mod checksum {
-    pub use caliptra_api::{calc_checksum, verify_checksum};
+    pub use caliptra_api::{calc_checksum, response_buffer_checksum, verify_checksum};
 }
 pub mod crypto;
 pub mod dice;

--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -86,9 +86,9 @@ pub use lms::{
 pub use mailbox::{Mailbox, MailboxRecvTxn, MailboxSendTxn};
 #[cfg(feature = "mldsa_attestation")]
 pub use mldsa87::{
-    Mldsa87, Mldsa87PrivKey, Mldsa87PubKey, Mldsa87Result, Mldsa87Seed, Mldsa87Signature,
-    MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES,
-    MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
+    Mldsa87, Mldsa87Mu, Mldsa87PrivKey, Mldsa87PubKey, Mldsa87Result, Mldsa87Seed,
+    Mldsa87Signature, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
+    MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
 };
 pub use okref::okmutref;
 pub use okref::okref;

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -21,8 +21,8 @@ use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 
 pub use caliptra_mldsa::{
-    Mldsa87Result, MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES,
-    MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
+    Mldsa87Result, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
+    MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
 };
 
 /// ML-DSA-87 deterministic key-generation / signing seed (32 bytes).
@@ -36,6 +36,8 @@ pub type Mldsa87PrivKey = [u8; MLDSA87_PRIVATE_KEY_BYTES];
 
 /// ML-DSA-87 encoded signature (4,627 bytes).
 pub type Mldsa87Signature = [u8; MLDSA87_SIGNATURE_BYTES];
+
+pub type Mldsa87Mu = [u8; MLDSA87_MU_BYTES];
 
 /// Software ML-DSA-87 engine.
 ///
@@ -71,6 +73,26 @@ impl Mldsa87 {
             Some(priv_key) => Mldsa87Sw::key_pair_from_seed(seed, pub_key, priv_key),
             None => Mldsa87Sw::pub_from_seed(seed, pub_key),
         }
+        Ok(())
+    }
+
+    /// Deterministically sign `mu` with the key derived from `seed`.
+    ///
+    /// Determinism (no per-signature randomizer) means the same seed and message
+    /// always produce the same signature, which is what lets the CSR and DPE
+    /// artifacts be regenerated on demand instead of being stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `seed` - 32-byte private seed
+    /// * `mu` - Message digest to be signed
+    /// * `sig` - Buffer that receives the encoded signature
+    pub fn sign_mu_deterministic(
+        seed: &Mldsa87Seed,
+        mu: &Mldsa87Mu,
+        sig: &mut Mldsa87Signature,
+    ) -> CaliptraResult<()> {
+        Mldsa87Sw::sign_mu_deterministic(seed, mu, sig);
         Ok(())
     }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,6 +18,7 @@ caliptra-auth-man-types = { workspace = true, default-features = false }
 caliptra-kat.workspace = true
 caliptra-lms-types.workspace = true
 caliptra-registers.workspace = true
+caliptra-shake.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
 dpe           = { workspace = true, features = ["arbitrary_max_handles"] }
 constant_time_eq.workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,6 +23,7 @@ dpe           = { workspace = true, features = ["arbitrary_max_handles"] }
 constant_time_eq.workspace = true
 crypto.workspace = true
 platform.workspace = true
+caliptra-dpe-response-buffer.workspace = true
 ufmt.workspace = true
 zerocopy.workspace = true
 arrayvec.workspace = true

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -19,11 +19,11 @@ use caliptra_auth_man_types::{
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 use caliptra_common::mailbox_api::{
-    AuthAndStashFlags, AuthorizeAndStashReq, AuthorizeAndStashResp, ImageHashSource, MailboxResp,
+    AuthAndStashFlags, AuthorizeAndStashReq, AuthorizeAndStashResp, ImageHashSource,
     MailboxRespHeader,
 };
 use caliptra_drivers::{Array4x12, CaliptraError, CaliptraResult};
-use dpe::response::DpeErrorCode;
+use dpe::error::DpeErrorCode;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
@@ -34,7 +34,7 @@ pub struct AuthorizeAndStashCmd;
 impl AuthorizeAndStashCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = AuthorizeAndStashReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
         if ImageHashSource::from(cmd.source) != ImageHashSource::InRequest {
@@ -86,10 +86,11 @@ impl AuthorizeAndStashCmd {
             }
         }
 
-        Ok(MailboxResp::AuthorizeAndStash(AuthorizeAndStashResp {
+        let mut resp = AuthorizeAndStashResp {
             hdr: MailboxRespHeader::default(),
             auth_req_result: auth_result,
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 
     /// Search for a metadata entry in the sorted `AuthManifestImageMetadataCollection` that matches the firmware ID.

--- a/runtime/src/capabilities.rs
+++ b/runtime/src/capabilities.rs
@@ -14,20 +14,24 @@ Abstract:
 
 use caliptra_common::{
     capabilities::Capabilities,
-    mailbox_api::{CapabilitiesResp, MailboxResp, MailboxRespHeader},
+    mailbox_api::{CapabilitiesResp, MailboxRespHeader},
 };
 use caliptra_error::CaliptraResult;
+use zerocopy::IntoBytes;
+
+use crate::Drivers;
 
 pub struct CapabilitiesCmd;
 impl CapabilitiesCmd {
     #[inline(never)]
-    pub(crate) fn execute() -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut capabilities = Capabilities::default();
         capabilities |= Capabilities::RT_BASE;
 
-        Ok(MailboxResp::Capabilities(CapabilitiesResp {
+        let mut resp = CapabilitiesResp {
             hdr: MailboxRespHeader::default(),
             capabilities: capabilities.to_bytes(),
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,20 +12,20 @@ Abstract:
 
 --*/
 
+use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, MboxResponseWriter, PauserPrivileges};
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{
-    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CertifyKeyExtendedResp, MailboxResp,
+    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, MailboxRespHeader, MailboxRespHeaderVarSize,
 };
-use caliptra_error::{CaliptraError, CaliptraResult};
+use caliptra_dpe_response_buffer::{OffsetResponseBuffer, ResponseBuffer};
+use caliptra_drivers::{CaliptraError, CaliptraResult};
 use dpe::commands::{CertifyKeyP384Cmd, Command};
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
-
-use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, PauserPrivileges};
 
 pub struct CertifyKeyExtendedCmd;
 impl CertifyKeyExtendedCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = CertifyKeyExtendedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -50,25 +50,24 @@ impl CertifyKeyExtendedCmd {
         let certify_key_cmd = CertifyKeyP384Cmd::ref_from_bytes(&cmd.certify_key_req[..])
             .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let command = Command::from(certify_key_cmd);
-        let mut certify_key_extended_resp = CertifyKeyExtendedResp::default();
-        let result = invoke_dpe_cmd(
-            drivers,
-            &command,
-            dmtf_device_info,
-            None,
-            None,
-            &mut certify_key_extended_resp.certify_key_resp,
-        );
 
-        let resp_size = result.map_err(|e| {
-            // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-            if let Some(ext_err) = e.get_error_detail() {
-                drivers.soc_ifc.set_fw_extended_error(ext_err);
-            }
-            CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
-        })?;
-        certify_key_extended_resp.size = resp_size as u32;
+        let mut writer = MboxResponseWriter {};
+        let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
 
-        Ok(MailboxResp::CertifyKeyExtended(certify_key_extended_resp))
+        let resp_size = invoke_dpe_cmd(drivers, &command, dmtf_device_info, None, None, &mut w)
+            .map_err(|e| {
+                drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
+                // The Mbox writer cannot encounter an error during clear, and the Certify Key
+                // extended error is more important.
+                let _ = writer.clear();
+                CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
+            })?;
+
+        let header = MailboxRespHeaderVarSize {
+            hdr: MailboxRespHeader::default(),
+            data_len: resp_size as u32,
+        };
+        crate::packet::finalize_mbox_buffer(&mut drivers.mbox, &mut writer, header)?;
+        Ok(())
     }
 }

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -51,7 +51,7 @@ impl CertifyKeyExtendedCmd {
             .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
         let command = Command::from(certify_key_cmd);
 
-        let mut writer = MboxResponseWriter {};
+        let mut writer = MboxResponseWriter::from_mbox_base();
         let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
 
         let resp_size = invoke_dpe_cmd(drivers, &command, dmtf_device_info, None, None, &mut w)

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -14,7 +14,6 @@ Abstract:
 
 use caliptra_common::mailbox_api::{
     GetFmcAliasCertResp, GetIdevCertReq, GetIdevCertResp, GetLdevCertResp, GetRtAliasCertResp,
-    MailboxResp, MailboxRespHeader,
 };
 
 use crate::Drivers;
@@ -29,7 +28,7 @@ use zerocopy::{FromZeros, IntoBytes};
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = GetIdevCertReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -48,23 +47,20 @@ impl IDevIdCertCmd {
             return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
         };
 
-        let mut cert = [0; GetIdevCertResp::DATA_MAX_SIZE];
-        let Some(cert_size) = builder.build(&mut cert) else {
+        let mut resp = GetIdevCertResp::default();
+        let Some(cert_size) = builder.build(&mut resp.cert) else {
             return Err(CaliptraError::RUNTIME_GET_IDEVID_CERT_FAILED);
         };
 
-        Ok(MailboxResp::GetIdevCert(GetIdevCertResp {
-            hdr: MailboxRespHeader::default(),
-            cert_size: cert_size as u32,
-            cert,
-        }))
+        resp.cert_size = cert_size as u32;
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 
 pub struct GetLdevCertCmd;
 impl GetLdevCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut resp = GetLdevCertResp::default();
 
         resp.data_size = copy_ldevid_cert(
@@ -73,14 +69,14 @@ impl GetLdevCertCmd {
             &mut resp.data,
         )? as u32;
 
-        Ok(MailboxResp::GetLdevCert(resp))
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 
 pub struct GetFmcAliasCertCmd;
 impl GetFmcAliasCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut resp = GetFmcAliasCertResp::default();
 
         resp.data_size = copy_fmc_alias_cert(
@@ -89,19 +85,19 @@ impl GetFmcAliasCertCmd {
             &mut resp.data,
         )? as u32;
 
-        Ok(MailboxResp::GetFmcAliasCert(resp))
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 
 pub struct GetRtAliasCertCmd;
 impl GetRtAliasCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut resp = GetRtAliasCertResp::default();
 
         resp.data_size = copy_rt_alias_cert(drivers.persistent_data.get(), &mut resp.data)? as u32;
 
-        Ok(MailboxResp::GetRtAliasCert(resp))
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::{keyids::KEY_ID_EXPORTED_DPE_CDI, mailbox_api::MailboxResp};
+use caliptra_common::keyids::KEY_ID_EXPORTED_DPE_CDI;
 use caliptra_drivers::{
     hmac384_kdf, Array4x12, CaliptraResult, Ecc384Seed, Hmac384Key, KeyId, KeyReadArgs, KeyUsage,
     KeyWriteArgs,
@@ -25,14 +25,14 @@ pub struct DisableAttestationCmd;
 impl DisableAttestationCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         Self::erase_keys(drivers)?;
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         Self::zero_cdi(drivers, key_id_rt_cdi)?;
         Self::zero_cdi(drivers, KEY_ID_EXPORTED_DPE_CDI)?;
         Self::generate_dice_key(drivers)?;
         drivers.persistent_data.get_mut().attestation_disabled = U8Bool::new(true);
-        Ok(MailboxResp::default())
+        Ok(())
     }
 
     /// Erase the RT CDI and RT Private Key from the key vault

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -16,6 +16,7 @@ use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::keyids::{
     KEY_ID_DPE_CDI, KEY_ID_DPE_PRIV_KEY, KEY_ID_EXPORTED_DPE_CDI, KEY_ID_TMP,
 };
+use caliptra_dpe_response_buffer::ResponseBufError;
 use caliptra_drivers::{
     hmac384_kdf, sha384::DpeHasher, Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Scalar,
     Ecc384Seed, ExportedCdiEntry, ExportedCdiHandles, Hmac384, KeyId, KeyReadArgs, KeyUsage,
@@ -224,6 +225,20 @@ impl<'a> DpeCrypto<'a> {
         };
         let digest = match data {
             SignData::Digest(Digest::Sha384(crypto::Sha384(digest))) => Ecc384Scalar::from(digest),
+            SignData::ResponseBuffer(buf, range) => {
+                let mut op = sha384
+                    .digest_init()
+                    .map_err(|_| CryptoError::HashError(0))?;
+                buf.read_range(range.clone(), &mut |d| {
+                    op.update(d).map_err(|_| ResponseBufError::Overflow)
+                })
+                .map_err(|_| CryptoError::HashError(0))?;
+
+                let mut digest = Array4x12::default();
+                op.finalize(&mut digest)
+                    .map_err(|_| CryptoError::HashError(0))?;
+                digest
+            }
             SignData::Raw(msg) => sha384.digest(msg).map_err(|_| CryptoError::HashError(0))?,
             _ => return Err(CryptoError::MismatchedAlgorithm),
         };

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -37,9 +37,8 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 use {
     caliptra_drivers::{
         Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES,
-        MLDSA87_SIGNATURE_BYTES,
     },
-    crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
+    crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey},
     zeroize::Zeroizing,
 };
 
@@ -280,11 +279,9 @@ impl<'a> DpeCrypto<'a> {
     }
 
     #[cfg(feature = "mldsa_attestation")]
-    fn sign_helper_mldsa(data: &SignData, seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
-        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
-        Mldsa87::sign_deterministic(seed, data.as_slice(), &mut sig)
-            .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-        Ok(Signature::Mldsa(MldsaSignature(sig)))
+    fn sign_helper_mldsa(_data: &SignData, _seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
+        // TODO: Issue #3936 - Implement MLDSA DPE Hash.
+        Err(CryptoError::MismatchedAlgorithm)
     }
 }
 

--- a/runtime/src/dpe_platform.rs
+++ b/runtime/src/dpe_platform.rs
@@ -15,6 +15,7 @@ Abstract:
 use core::cmp::min;
 
 use arrayvec::ArrayVec;
+use caliptra_dpe_response_buffer::SliceResponseBuffer;
 use caliptra_drivers::cprintln;
 use caliptra_x509::{NotAfter, NotBefore};
 use crypto::Digest;
@@ -110,7 +111,8 @@ impl Platform for DpePlatform<'_> {
         out: &mut [u8; MAX_ISSUER_NAME_SIZE],
     ) -> Result<usize, PlatformError> {
         const CALIPTRA_CN: &[u8] = b"Caliptra 1.0 Rt Alias";
-        let mut issuer_writer = CertWriter::new(out, self.profile.into(), true);
+        let mut issuer_buf = SliceResponseBuffer::new(out.as_mut_slice());
+        let mut issuer_writer = CertWriter::new(&mut issuer_buf, self.profile.into(), true);
 
         // Caliptra RDN SerialNumber field is always a Sha256 hash
         let mut serial = [0u8; 64];
@@ -124,7 +126,7 @@ impl Platform for DpePlatform<'_> {
         };
         let issuer_len = issuer_writer
             .encode_rdn(&name)
-            .map_err(|e| PlatformError::IssuerNameError(e.get_error_detail().unwrap_or(0)))?;
+            .map_err(|e| PlatformError::IssuerNameError(e.get_error_code()))?;
 
         Ok(issuer_len)
     }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -567,9 +567,7 @@ impl Drivers {
         .execute_serialized(&mut dpe, &mut env, CALIPTRA_LOCALITY, &mut buf);
         if let Err(e) = derive_context_resp {
             // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-            if let Some(ext_err) = e.get_error_detail() {
-                drivers.soc_ifc.set_fw_extended_error(ext_err);
-            }
+            drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
             Err(CaliptraError::RUNTIME_ADD_CCIV_MEASUREMENT_TO_DPE_FAILED)?
         }
 
@@ -609,9 +607,7 @@ impl Drivers {
             .execute_serialized(&mut dpe, &mut env, pl0_pauser_locality, &mut buf);
             if let Err(e) = derive_context_resp {
                 // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                if let Some(ext_err) = e.get_error_detail() {
-                    drivers.soc_ifc.set_fw_extended_error(ext_err);
-                }
+                drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
                 Err(CaliptraError::RUNTIME_ADD_ROM_MEASUREMENTS_TO_DPE_FAILED)?
             }
         }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -30,6 +30,7 @@ use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_eq_12_words, cfi_launder,
 };
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
+use caliptra_dpe_response_buffer::SliceResponseBuffer;
 use caliptra_drivers::KeyId;
 use caliptra_drivers::{
     cprintln,
@@ -551,7 +552,7 @@ impl Drivers {
 
         // Call DeriveContext to create a measurement for the caliptra configured initialization values and change
         // locality to the pl0 pauser locality
-        let mut buf = [0u8; size_of::<DeriveContextResp>()];
+        let mut buf_storage = [0u8; size_of::<DeriveContextResp>()];
         let derive_context_resp = DeriveContextCmd {
             handle: ContextHandle::default(),
             data: TciMeasurement(<[u8; 48]>::from(initialization_values_hash)),
@@ -564,7 +565,12 @@ impl Drivers {
             target_locality: pl0_pauser_locality,
             svn: 0,
         }
-        .execute_serialized(&mut dpe, &mut env, CALIPTRA_LOCALITY, &mut buf);
+        .execute_serialized(
+            &mut dpe,
+            &mut env,
+            CALIPTRA_LOCALITY,
+            &mut SliceResponseBuffer::new(&mut buf_storage),
+        );
         if let Err(e) = derive_context_resp {
             // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
             drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
@@ -604,7 +610,12 @@ impl Drivers {
                 target_locality: pl0_pauser_locality,
                 svn: 0,
             }
-            .execute_serialized(&mut dpe, &mut env, pl0_pauser_locality, &mut buf);
+            .execute_serialized(
+                &mut dpe,
+                &mut env,
+                pl0_pauser_locality,
+                &mut SliceResponseBuffer::new(&mut buf_storage),
+            );
             if let Err(e) = derive_context_resp {
                 // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
                 drivers.soc_ifc.set_fw_extended_error(e.get_error_code());

--- a/runtime/src/fips.rs
+++ b/runtime/src/fips.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_common::cprintln;
-use caliptra_common::mailbox_api::MailboxResp;
+use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::CaliptraError;
 use caliptra_drivers::CaliptraResult;
 use caliptra_drivers::Ecc384;
@@ -22,6 +22,7 @@ use caliptra_drivers::KeyVault;
 use caliptra_drivers::Sha256;
 use caliptra_drivers::Sha2_512_384Acc;
 use caliptra_drivers::Sha384;
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 use crate::Drivers;
@@ -211,10 +212,10 @@ pub struct FipsShutdownCmd;
 impl FipsShutdownCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(env: &mut Drivers) -> CaliptraResult<()> {
         FipsModule::zeroize(env);
         env.is_shutdown = true;
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(env, MailboxRespHeader::default().as_mut_bytes())
     }
 }

--- a/runtime/src/get_fmc_alias_csr.rs
+++ b/runtime/src/get_fmc_alias_csr.rs
@@ -1,21 +1,21 @@
 // Licensed under the Apache-2.0 license
 
-use crate::packet::copy_from_mbox;
+use crate::packet::{copy_from_mbox, copy_to_mbox};
 use crate::Drivers;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 
-use caliptra_common::mailbox_api::{GetFmcAliasCsrReq, GetFmcAliasCsrResp, MailboxResp};
+use caliptra_common::mailbox_api::{GetFmcAliasCsrReq, GetFmcAliasCsrResp};
+use caliptra_drivers::FmcAliasCsr;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
-use caliptra_drivers::FmcAliasCsr;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct GetFmcAliasCsrCmd;
 impl GetFmcAliasCsrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         copy_from_mbox(drivers, GetFmcAliasCsrReq::new_zeroed().as_mut_bytes())?;
         let csr_persistent_mem = &drivers.persistent_data.get().fmc_alias_csr;
 
@@ -23,11 +23,6 @@ impl GetFmcAliasCsrCmd {
             FmcAliasCsr::UNPROVISIONED_CSR => Err(CaliptraError::RUNTIME_GET_FMC_CSR_UNPROVISIONED),
             0 => Err(CaliptraError::RUNTIME_GET_FMC_CSR_UNSUPPORTED_FMC),
             len => {
-                let mut resp = GetFmcAliasCsrResp {
-                    data_size: len,
-                    ..Default::default()
-                };
-
                 let csr = csr_persistent_mem
                     .get()
                     .ok_or(CaliptraError::RUNTIME_GET_FMC_CSR_UNPROVISIONED)?;
@@ -39,9 +34,11 @@ impl GetFmcAliasCsrCmd {
                 //
                 // A valid `FmcAliasCsr` cannot be larger than `MAX_FMC_ALIAS_CSR_SIZE`, which is the max
                 // size of the buffer in `GetIdevCsrResp`
-                resp.data[..resp.data_size as usize].copy_from_slice(csr);
+                let mut resp = GetFmcAliasCsrResp::new_zeroed();
+                resp.data_size = len;
+                resp.data[..len as usize].copy_from_slice(csr);
 
-                Ok(MailboxResp::GetFmcAliasCsr(resp))
+                copy_to_mbox(drivers, resp.as_mut_bytes())
             }
         }
     }

--- a/runtime/src/get_idev_csr.rs
+++ b/runtime/src/get_idev_csr.rs
@@ -1,21 +1,21 @@
 // Licensed under the Apache-2.0 license
 
-use crate::packet::copy_from_mbox;
+use crate::packet::{copy_from_mbox, copy_to_mbox};
 use crate::Drivers;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 
-use caliptra_common::mailbox_api::{GetIdevCsrReq, GetIdevCsrResp, MailboxResp};
+use caliptra_common::mailbox_api::{GetIdevCsrReq, GetIdevCsrResp};
+use caliptra_drivers::IdevIdCsr;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
-use caliptra_drivers::IdevIdCsr;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct GetIdevCsrCmd;
 impl GetIdevCsrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         copy_from_mbox(drivers, GetIdevCsrReq::new_zeroed().as_mut_bytes())?;
         let csr_persistent_mem = &drivers.persistent_data.get().idevid_csr;
 
@@ -27,10 +27,6 @@ impl GetIdevCsrCmd {
                     .get()
                     .ok_or(CaliptraError::RUNTIME_GET_IDEV_ID_UNPROVISIONED)?;
 
-                let mut resp = GetIdevCsrResp {
-                    data_size: len,
-                    ..Default::default()
-                };
                 // NOTE: This code will not panic.
                 //
                 // csr is guranteed to be the same size as `len`, and therefore
@@ -38,9 +34,10 @@ impl GetIdevCsrCmd {
                 //
                 // A valid `IDevIDCsr` cannot be larger than `MAX_IDEVID_CSR_SIZE`, which is the max
                 // size of the buffer in `GetIdevIdCsrResp`
-                resp.data[..resp.data_size as usize].copy_from_slice(csr);
-
-                Ok(MailboxResp::GetIdevCsr(resp))
+                let mut resp = GetIdevCsrResp::new_zeroed();
+                resp.data_size = len;
+                resp.data[..len as usize].copy_from_slice(csr);
+                copy_to_mbox(drivers, resp.as_mut_bytes())
             }
         }
     }

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -13,13 +13,14 @@ Abstract:
 --*/
 
 use crate::{handoff::RtHandoff, Drivers};
-use caliptra_common::mailbox_api::{FwInfoResp, GetIdevInfoResp, MailboxResp, MailboxRespHeader};
+use caliptra_common::mailbox_api::{FwInfoResp, GetIdevInfoResp, MailboxRespHeader};
 use caliptra_drivers::CaliptraResult;
+use zerocopy::IntoBytes;
 
 pub struct FwInfoCmd;
 impl FwInfoCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let pdata = drivers.persistent_data.get();
 
         let handoff = RtHandoff {
@@ -32,7 +33,7 @@ impl FwInfoCmd {
         let fmc_manifest_svn = handoff.fmc_svn()?;
         let rom_info = handoff.fht.rom_info_addr.get()?;
 
-        Ok(MailboxResp::FwInfo(FwInfoResp {
+        let mut resp = FwInfoResp {
             hdr: MailboxRespHeader::default(),
             pl0_pauser: pdata.manifest1.header.pl0_pauser,
             runtime_svn,
@@ -47,21 +48,23 @@ impl FwInfoCmd {
             runtime_sha384_digest: pdata.manifest1.runtime.digest,
             owner_pub_key_hash: drivers.data_vault.owner_pk_hash().into(),
             authman_sha384_digest: pdata.auth_manifest_digest,
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 
 pub struct IDevIdInfoCmd;
 impl IDevIdInfoCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let pdata = drivers.persistent_data.get();
         let pub_key = pdata.fht.idev_dice_pub_key;
 
-        Ok(MailboxResp::GetIdevInfo(GetIdevInfoResp {
+        let mut resp = GetIdevInfoResp {
             hdr: MailboxRespHeader::default(),
             idev_pub_x: pub_key.x.into(),
             idev_pub_y: pub_key.y.into(),
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -110,7 +110,7 @@ impl InvokeDpeCmd {
 
         let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
 
-        let mut writer = MboxResponseWriter {};
+        let mut writer = MboxResponseWriter::from_mbox_base();
         let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
 
         let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut w);

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -12,15 +12,18 @@ Abstract:
 
 --*/
 
-use crate::{ec_dpe_env, Drivers, PauserPrivileges};
+use caliptra_dpe_response_buffer::{OffsetResponseBuffer, ResponseBuffer};
+
+use crate::{ec_dpe_env, Drivers, MboxResponseWriter, PauserPrivileges};
 use arrayvec::ArrayVec;
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxResp};
+use caliptra_common::mailbox_api::{InvokeDpeReq, MailboxRespHeader, MailboxRespHeaderVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use dpe::{
     commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
     context::ContextState,
-    response::{DpeErrorCode, ResponseHdr},
+    error::DpeErrorCode,
+    response::ResponseHdr,
     DpeInstance, DpeProfile, State, U8Bool, MAX_HANDLES,
 };
 use platform::MAX_OTHER_NAME_SIZE;
@@ -44,7 +47,7 @@ pub struct InvokeDpeCmd;
 impl InvokeDpeCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = InvokeDpeReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -106,8 +109,11 @@ impl InvokeDpeCmd {
         }
 
         let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
-        let mut invoke_resp = InvokeDpeResp::default();
-        let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut invoke_resp.data);
+
+        let mut writer = MboxResponseWriter {};
+        let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
+
+        let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut w);
 
         if let Command::DestroyCtx(_) = command {
             // clear tags for destroyed contexts
@@ -118,25 +124,29 @@ impl InvokeDpeCmd {
             InvokeDpeCmd::clear_tags_for_inactive_contexts(state, context_has_tag, context_tags);
         }
 
-        // If DPE command failed, populate header with error code, but
-        // don't fail the mailbox command.
-        match result {
-            Ok(data_size) => {
-                invoke_resp.data_size = data_size as u32;
+        let data_len: u32 = match result {
+            Ok(n) => {
+                // writer already populated data[0..n] in SRAM
+                n as u32
             }
             Err(ref e) => {
-                // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                if let Some(ext_err) = e.get_error_detail() {
-                    drivers.soc_ifc.set_fw_extended_error(ext_err);
-                }
+                // Error: write a ResponseHdr into the data field.
+                drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
                 let r = ResponseHdr::new(CaliptraDpeProfile::Ecc384.into(), *e);
-                invoke_resp.data[..core::mem::size_of::<ResponseHdr>()]
-                    .copy_from_slice(r.as_bytes());
-                invoke_resp.data_size = r.as_bytes().len() as u32;
+                w.clear()
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?;
+                w.write_at(0, r.as_bytes())
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_RESPONSE_SERIALIZATION_FAILED)?;
+                size_of::<ResponseHdr>() as u32
             }
         };
 
-        Ok(MailboxResp::InvokeDpeCommand(invoke_resp))
+        let header = MailboxRespHeaderVarSize {
+            hdr: MailboxRespHeader::default(),
+            data_len,
+        };
+        crate::packet::finalize_mbox_buffer(&mut drivers.mbox, &mut writer, header)?;
+        Ok(())
     }
 
     /// Remove context tags for all inactive DPE contexts
@@ -171,13 +181,17 @@ pub fn invoke_dpe_cmd(
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
     locality: Option<u32>,
-    out: &mut [u8],
+    out: &mut dyn ResponseBuffer,
 ) -> Result<usize, DpeErrorCode> {
     let locality = locality.unwrap_or(drivers.mbox.user());
     let mut env = ec_dpe_env(drivers, dmtf_device_info, ueid);
     let env = match env.as_mut() {
         Ok(r) => r,
-        Err(_) => Err(DpeErrorCode::InternalError)?,
+        Err(_) => {
+            return Err(DpeErrorCode::InternalError(
+                dpe::error::InternalErrorCode::ActiveContextNotFound,
+            ))
+        }
     };
     let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
     command.execute_serialized(dpe, env, locality, out)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod handoff;
 mod hmac;
 pub mod info;
 mod invoke_dpe;
+pub mod mbox_response_writer;
 mod pcr;
 mod populate_idev;
 mod reallocate_dpe_context_limits;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -81,6 +81,7 @@ pub use get_fmc_alias_csr::GetFmcAliasCsrCmd;
 pub use get_idev_csr::GetIdevCsrCmd;
 pub use info::{FwInfoCmd, IDevIdInfoCmd};
 pub use invoke_dpe::InvokeDpeCmd;
+pub use mbox_response_writer::MboxResponseWriter;
 pub use pcr::{GetPcrLogCmd, IncrementPcrResetCounterCmd};
 pub use reallocate_dpe_context_limits::ReallocateDpeContextLimitsCmd;
 pub use set_auth_manifest::SetAuthManifestCmd;
@@ -89,7 +90,7 @@ pub use stash_measurement::StashMeasurementCmd;
 pub use verify::Mldsa87VerifyCmd;
 pub use verify::{EcdsaVerifyCmd, LmsVerifyCmd};
 pub mod packet;
-use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxResp};
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
 use packet::{copy_from_mbox, copy_to_mbox};
 use zerocopy::{FromZeros, IntoBytes};
 pub mod tagging;
@@ -97,7 +98,7 @@ use tagging::{GetTaggedTciCmd, TagTciCmd};
 
 use caliptra_common::cprintln;
 
-use caliptra_drivers::{okmutref, CaliptraError, CaliptraResult, ResetReason};
+use caliptra_drivers::{CaliptraError, CaliptraResult, ResetReason};
 use caliptra_registers::mbox::enums::MboxStatusE;
 pub use dpe::{context::ContextState, tci::TciMeasurement, DpeInstance, U8Bool, MAX_HANDLES};
 use dpe::{dpe_instance::DpeEnv, support::Support};
@@ -190,9 +191,9 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         );
     }
 
-    // Handle the request and generate the response
-    let mut resp = match drivers.mbox.cmd() {
-        CommandId::FIRMWARE_LOAD => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
+    // Handle the request; each arm writes its response directly to MBOX SRAM.
+    match drivers.mbox.cmd() {
+        CommandId::FIRMWARE_LOAD => return Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
         CommandId::GET_IDEV_CERT => IDevIdCertCmd::execute(drivers),
         CommandId::GET_IDEV_INFO => {
             copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
@@ -208,7 +209,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers),
         CommandId::DISABLE_ATTESTATION => {
             copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
-            DisableAttestationCmd::execute(drivers)
+            DisableAttestationCmd::execute(drivers)?;
+            copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
         }
         CommandId::FW_INFO => {
             copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
@@ -225,11 +227,12 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::QUOTE_PCRS => GetPcrQuoteCmd::execute(drivers),
         CommandId::VERSION => {
             copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
-            FipsVersionCmd::execute(&drivers.soc_ifc).map(MailboxResp::FipsVersion)
+            let mut resp = FipsVersionCmd::execute(&drivers.soc_ifc)?;
+            copy_to_mbox(drivers, resp.as_mut_bytes())
         }
         CommandId::CAPABILITIES => {
             copy_from_mbox(drivers, MailboxReqHeader::new_zeroed().as_mut_bytes())?;
-            CapabilitiesCmd::execute()
+            CapabilitiesCmd::execute(drivers)
         }
         #[cfg(feature = "fips_self_test")]
         CommandId::SELF_TEST_START => {
@@ -238,7 +241,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 SelfTestStatus::Idle => {
                     drivers.self_test_status =
                         SelfTestStatus::InProgress(fips_self_test_cmd::execute);
-                    Ok(MailboxResp::default())
+                    copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
                 }
                 _ => Err(CaliptraError::RUNTIME_SELF_TEST_IN_PROGRESS),
             }
@@ -249,7 +252,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
             match drivers.self_test_status {
                 SelfTestStatus::Done => {
                     drivers.self_test_status = SelfTestStatus::Idle;
-                    Ok(MailboxResp::default())
+                    copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
                 }
                 _ => Err(CaliptraError::RUNTIME_SELF_TEST_NOT_STARTED),
             }
@@ -271,12 +274,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::SIGN_WITH_EXPORTED_ECDSA => SignWithExportedEcdsaCmd::execute(drivers),
         CommandId::REVOKE_EXPORTED_CDI_HANDLE => RevokeExportedCdiHandleCmd::execute(drivers),
         CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => ReallocateDpeContextLimitsCmd::execute(drivers),
-        _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
-    };
-    let resp = okmutref(&mut resp)?;
-
-    // Send the response
-    copy_to_mbox(drivers, resp)?;
+        _ => return Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
+    }?;
 
     Ok(MboxStatusE::DataReady)
 }

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -172,6 +172,31 @@ impl Mailbox {
         Ok(())
     }
 
+    /// Re-copies SRAM[0..total_len] via the `datain` register to advance
+    /// `mbox_wrptr` to match the response length.
+    ///
+    /// `MboxResponseWriter` writes directly to SRAM via AHB without advancing
+    /// `mbox_wrptr`. At the ExecUc→ExecSoc state transition (triggered by
+    /// `set_status(DataReady)`), the RTL latches the effective read limit as
+    /// `min(mbox_wrptr, mbox_dlen_in_dws)` (mbox.sv:228) and drives `dataout`
+    /// to zero whenever that limit is zero (mbox.sv:541). If `mbox_wrptr` was
+    /// never advanced the SOC reads all zeros regardless of SRAM content.
+    /// Replaying the response words via `datain` advances `mbox_wrptr` to
+    /// `total_len / 4` so the latch captures the correct limit.
+    pub fn flush_sram_to_datain(&mut self, total_len: usize) -> CaliptraResult<()> {
+        self.set_dlen(total_len as u32)?;
+        let total_words = total_len.div_ceil(4);
+        let sram_ptr = memory_layout::MBOX_ORG as *const u32;
+        let mbox = self.mbox.regs_mut();
+        for i in 0..total_words {
+            // SAFETY: set_dlen bounds-checks total_len <= MBOX_SIZE; MBOX_ORG is
+            // the start of the mailbox SRAM window, so offsets 0..total_words are valid.
+            let word = unsafe { sram_ptr.add(i).read_volatile() };
+            mbox.datain().write(|_| word);
+        }
+        Ok(())
+    }
+
     /// Set mailbox status to `status`
     pub fn set_status(&mut self, status: MboxStatusE) {
         let mbox = self.mbox.regs_mut();

--- a/runtime/src/mailbox.rs
+++ b/runtime/src/mailbox.rs
@@ -176,13 +176,11 @@ impl Mailbox {
     /// `mbox_wrptr` to match the response length.
     ///
     /// `MboxResponseWriter` writes directly to SRAM via AHB without advancing
-    /// `mbox_wrptr`. At the ExecUc→ExecSoc state transition (triggered by
-    /// `set_status(DataReady)`), the RTL latches the effective read limit as
+    /// `mbox_wrptr`. T he RTL latches the effective read limit as
     /// `min(mbox_wrptr, mbox_dlen_in_dws)` (mbox.sv:228) and drives `dataout`
-    /// to zero whenever that limit is zero (mbox.sv:541). If `mbox_wrptr` was
-    /// never advanced the SOC reads all zeros regardless of SRAM content.
-    /// Replaying the response words via `datain` advances `mbox_wrptr` to
-    /// `total_len / 4` so the latch captures the correct limit.
+    /// to zero whenever that limit is zero (mbox.sv:541). As such we need to
+    /// explicitely use datain for populating the mbox sram prior to marking the
+    /// buffer ready.
     pub fn flush_sram_to_datain(&mut self, total_len: usize) -> CaliptraResult<()> {
         self.set_dlen(total_len as u32)?;
         let total_words = total_len.div_ceil(4);

--- a/runtime/src/mbox_response_writer.rs
+++ b/runtime/src/mbox_response_writer.rs
@@ -8,32 +8,51 @@ use caliptra_drivers::memory_layout;
 /// All writes are word-aligned internally via private helpers: word writes use
 /// the fast direct-write path; unaligned bytes use read-modify-write of the
 /// containing word.
-pub struct MboxResponseWriter {}
+pub struct MboxResponseWriter {
+    pub base: usize,
+}
 
 impl MboxResponseWriter {
-    const BASE: usize = memory_layout::MBOX_ORG as usize;
     const SIZE: usize = memory_layout::MBOX_SIZE as usize;
+
+    // Note: Allow the creation of a mbox response buffer.  This is useful for unit tests, where
+    // the mbox will not be instantiated.
+    #[cfg(test)]
+    fn new(base: usize) -> Self {
+        Self { base }
+    }
+
+    // Create a default MboxResponseWriter utilizing the MBOX SRAM.
+    pub fn from_mbox_base() -> Self {
+        Self {
+            base: memory_layout::MBOX_ORG as usize,
+        }
+    }
 
     /// Return a pointer to `MBOX_ORG + byte_offset` cast to `*mut u32`.
     ///
-    /// `byte_offset` must be word-aligned.
+    /// Safety: `byte_offset` must be word-aligned.
     #[inline(always)]
-    fn word_ptr(&self, byte_offset: usize) -> *mut u32 {
-        (Self::BASE + byte_offset) as *mut u32
+    unsafe fn word_ptr(&self, byte_offset: usize) -> *mut u32 {
+        (self.base + byte_offset) as *mut u32
     }
 
     /// Read the word at `byte_offset` (word-aligned) from SRAM.
+    ///
+    /// Safety: The `byte_offset` must be word aligned.
     #[inline(always)]
-    fn read_word(&self, byte_offset: usize) -> u32 {
+    unsafe fn read_word(&self, byte_offset: usize) -> u32 {
         // SAFETY: The caller guarantees the region is within mailbox SRAM.
-        unsafe { core::ptr::read_volatile(self.word_ptr(byte_offset)) }
+        core::ptr::read_volatile(self.word_ptr(byte_offset))
     }
 
     /// Write `word` to `byte_offset` (word-aligned) in SRAM.
+    ///
+    /// Safety: The `byte_offset` must be word aligned.
     #[inline(always)]
-    fn write_word(&self, byte_offset: usize, word: u32) {
+    unsafe fn write_word(&self, byte_offset: usize, word: u32) {
         // SAFETY: The caller guarantees the region is within mailbox SRAM.
-        unsafe { core::ptr::write_volatile(self.word_ptr(byte_offset), word) }
+        core::ptr::write_volatile(self.word_ptr(byte_offset), word)
     }
 }
 
@@ -58,15 +77,16 @@ impl ResponseBuffer for MboxResponseWriter {
         let misalign = pos & 3;
         if misalign != 0 && !src.is_empty() {
             let leading = (4 - misalign).min(src.len());
-            for &b in &src[..leading] {
-                let abs_b = pos;
-                let word_off = abs_b & !3;
-                let lane = abs_b & 3;
-                let mut word = self.read_word(word_off);
-                word = (word & !(0xFF << (lane * 8))) | ((b as u32) << (lane * 8));
-                self.write_word(word_off, word);
-                pos += 1;
+            let word_off = pos & !3;
+
+            // Safety: By the above word offset is 4 byte aligned, and thus the following are safe.
+            unsafe {
+                let mut word_bytes = self.read_word(word_off).to_le_bytes();
+                word_bytes[misalign..misalign + leading].copy_from_slice(&src[..leading]);
+                self.write_word(word_off, u32::from_le_bytes(word_bytes));
             }
+
+            pos += leading;
             src = &src[leading..];
         }
 
@@ -74,7 +94,9 @@ impl ResponseBuffer for MboxResponseWriter {
         let words = src.len() / 4;
         for chunk in src[..words * 4].chunks_exact(4) {
             let w = u32::from_le_bytes(chunk.try_into().unwrap());
-            self.write_word(pos, w);
+            // Safety: Since pos is word aligned at the start of the loop, and all chunks are on
+            // the boundary this remains safe.
+            unsafe { self.write_word(pos, w) };
             pos += 4;
         }
         src = &src[words * 4..];
@@ -84,9 +106,11 @@ impl ResponseBuffer for MboxResponseWriter {
             let abs_b = pos;
             let word_off = abs_b & !3;
             let lane = abs_b & 3;
-            let mut word = self.read_word(word_off);
-            word = (word & !(0xFF << (lane * 8))) | ((b as u32) << (lane * 8));
-            self.write_word(word_off, word);
+            unsafe {
+                let mut word = self.read_word(word_off);
+                word = (word & !(0xFF << (lane * 8))) | ((b as u32) << (lane * 8));
+                self.write_word(word_off, word);
+            }
             pos += 1;
         }
 
@@ -110,7 +134,8 @@ impl ResponseBuffer for MboxResponseWriter {
             let remaining = range.end - pos;
             let chunk_len = bytes_in_word.min(remaining);
 
-            let word = self.read_word(word_offset);
+            // Safety: By word_offset construction it must be 4 byte aligned.
+            let word = unsafe { self.read_word(word_offset) };
             let word_bytes = word.to_le_bytes();
             f(&word_bytes[byte_lane..byte_lane + chunk_len])?;
 
@@ -123,8 +148,110 @@ impl ResponseBuffer for MboxResponseWriter {
     fn clear(&mut self) -> Result<(), ResponseBufError> {
         // The MBOX SRAM is word aligned so this will clear the entire buffer.
         for i in 0..Self::SIZE / 4 {
-            self.write_word(i * 4, 0);
+            unsafe { self.write_word(i * 4, 0) };
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use std::{vec, vec::Vec};
+
+    fn make_writer() -> (MboxResponseWriter, Vec<u8>) {
+        let size = memory_layout::MBOX_SIZE as usize;
+        let mut buf: Vec<u8> = vec![0; size];
+        let base = buf.as_mut_ptr() as usize;
+        // SAFETY: buf lives for the duration of the returned tuple; MboxResponseWriter
+        // only accesses memory within MBOX_SIZE of base.
+        let writer = MboxResponseWriter::new(base);
+        (writer, buf)
+    }
+
+    fn collect(w: &MboxResponseWriter, range: core::ops::Range<usize>) -> Vec<u8> {
+        let mut out = Vec::new();
+        w.read_range(range, &mut |chunk| {
+            out.extend_from_slice(chunk);
+            Ok(())
+        })
+        .unwrap();
+        out
+    }
+
+    // Aligned full-word writes (the interior-word fast path).
+    #[test]
+    fn write_at_aligned() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(0, &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        assert_eq!(collect(&w, 0..8), [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    // Leading unaligned bytes that fit entirely within the remainder of one word.
+    #[test]
+    fn write_at_leading_within_word() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(1, &[0xAA, 0xBB, 0xCC]).unwrap();
+        assert_eq!(collect(&w, 0..4), [0, 0xAA, 0xBB, 0xCC]);
+    }
+
+    // Leading unaligned (misalign=2) followed by aligned interior words.
+    #[test]
+    fn write_at_leading_then_aligned() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(2, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).unwrap();
+        assert_eq!(collect(&w, 0..12), [0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    }
+
+    // Aligned interior word followed by trailing partial-word bytes.
+    #[test]
+    fn write_at_trailing_partial() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(0, &[1, 2, 3, 4, 5, 6, 7]).unwrap();
+        assert_eq!(collect(&w, 0..8), [1, 2, 3, 4, 5, 6, 7, 0]);
+    }
+
+    // Leading unaligned (misalign=1) followed by aligned interior words.
+    // Exercises the pos-advance path where leading != misalign.
+    #[test]
+    fn write_at_misalign1_then_aligned() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(1, &[1, 2, 3, 4, 5, 6, 7]).unwrap();
+        assert_eq!(collect(&w, 0..8), [0, 1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    // Leading unaligned (misalign=3) followed by aligned interior words.
+    #[test]
+    fn write_at_misalign3_then_aligned() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(3, &[1, 2, 3, 4, 5]).unwrap();
+        assert_eq!(collect(&w, 0..8), [0, 0, 0, 1, 2, 3, 4, 5]);
+    }
+
+    // Overflow is rejected.
+    #[test]
+    fn write_at_overflow() {
+        let (mut w, _buf) = make_writer();
+        assert!(w
+            .write_at(memory_layout::MBOX_SIZE as usize - 1, &[1, 2])
+            .is_err());
+    }
+
+    // read_range with unaligned head and tail crossing a word boundary.
+    #[test]
+    fn read_range_unaligned() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(0, &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        assert_eq!(collect(&w, 1..7), [2, 3, 4, 5, 6, 7]);
+    }
+
+    // clear zeroes previously-written data.
+    #[test]
+    fn clear_zeroes() {
+        let (mut w, _buf) = make_writer();
+        w.write_at(0, &[0xFF; 8]).unwrap();
+        w.clear().unwrap();
+        assert_eq!(collect(&w, 0..8), [0u8; 8]);
     }
 }

--- a/runtime/src/mbox_response_writer.rs
+++ b/runtime/src/mbox_response_writer.rs
@@ -1,0 +1,130 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_dpe_response_buffer::{ResponseBufError, ResponseBuffer};
+use caliptra_drivers::memory_layout;
+
+/// Streams bytes directly into mailbox SRAM via the memory-mapped window.
+///
+/// All writes are word-aligned internally via private helpers: word writes use
+/// the fast direct-write path; unaligned bytes use read-modify-write of the
+/// containing word.
+pub struct MboxResponseWriter {}
+
+impl MboxResponseWriter {
+    const BASE: usize = memory_layout::MBOX_ORG as usize;
+    const SIZE: usize = memory_layout::MBOX_SIZE as usize;
+
+    /// Return a pointer to `MBOX_ORG + byte_offset` cast to `*mut u32`.
+    ///
+    /// `byte_offset` must be word-aligned.
+    #[inline(always)]
+    fn word_ptr(&self, byte_offset: usize) -> *mut u32 {
+        (Self::BASE + byte_offset) as *mut u32
+    }
+
+    /// Read the word at `byte_offset` (word-aligned) from SRAM.
+    #[inline(always)]
+    fn read_word(&self, byte_offset: usize) -> u32 {
+        // SAFETY: The caller guarantees the region is within mailbox SRAM.
+        unsafe { core::ptr::read_volatile(self.word_ptr(byte_offset)) }
+    }
+
+    /// Write `word` to `byte_offset` (word-aligned) in SRAM.
+    #[inline(always)]
+    fn write_word(&self, byte_offset: usize, word: u32) {
+        // SAFETY: The caller guarantees the region is within mailbox SRAM.
+        unsafe { core::ptr::write_volatile(self.word_ptr(byte_offset), word) }
+    }
+}
+
+impl ResponseBuffer for MboxResponseWriter {
+    fn capacity(&self) -> usize {
+        memory_layout::MBOX_SIZE as usize
+    }
+
+    /// Write `bytes` starting at `offset`.
+    fn write_at(&mut self, offset: usize, bytes: &[u8]) -> Result<(), ResponseBufError> {
+        let end = offset
+            .checked_add(bytes.len())
+            .ok_or(ResponseBufError::Overflow)?;
+        if end > Self::SIZE {
+            return Err(ResponseBufError::Overflow);
+        }
+
+        let mut src = bytes;
+        let mut pos = offset;
+
+        // Leading unaligned bytes.
+        let misalign = pos & 3;
+        if misalign != 0 && !src.is_empty() {
+            let leading = (4 - misalign).min(src.len());
+            for &b in &src[..leading] {
+                let abs_b = pos;
+                let word_off = abs_b & !3;
+                let lane = abs_b & 3;
+                let mut word = self.read_word(word_off);
+                word = (word & !(0xFF << (lane * 8))) | ((b as u32) << (lane * 8));
+                self.write_word(word_off, word);
+                pos += 1;
+            }
+            src = &src[leading..];
+        }
+
+        // Aligned interior words.
+        let words = src.len() / 4;
+        for chunk in src[..words * 4].chunks_exact(4) {
+            let w = u32::from_le_bytes(chunk.try_into().unwrap());
+            self.write_word(pos, w);
+            pos += 4;
+        }
+        src = &src[words * 4..];
+
+        // Trailing partial word.
+        for &b in src {
+            let abs_b = pos;
+            let word_off = abs_b & !3;
+            let lane = abs_b & 3;
+            let mut word = self.read_word(word_off);
+            word = (word & !(0xFF << (lane * 8))) | ((b as u32) << (lane * 8));
+            self.write_word(word_off, word);
+            pos += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Read back a range of already-written bytes.  The range is relative to
+    /// the first byte written (offset 0 = `MBOX_ORG + self.base`).  Calls `f`
+    /// one or more times: once per word boundary crossing to handle unaligned
+    /// head and tail bytes.
+    fn read_range(
+        &self,
+        range: core::ops::Range<usize>,
+        f: &mut dyn FnMut(&[u8]) -> Result<(), ResponseBufError>,
+    ) -> Result<(), ResponseBufError> {
+        let mut pos = range.start;
+        while pos < range.end {
+            let word_offset = pos & !3;
+            let byte_lane = pos & 3;
+            let bytes_in_word = 4 - byte_lane;
+            let remaining = range.end - pos;
+            let chunk_len = bytes_in_word.min(remaining);
+
+            let word = self.read_word(word_offset);
+            let word_bytes = word.to_le_bytes();
+            f(&word_bytes[byte_lane..byte_lane + chunk_len])?;
+
+            pos += chunk_len;
+        }
+        Ok(())
+    }
+
+    /// Zero the entire backing region.
+    fn clear(&mut self) -> Result<(), ResponseBufError> {
+        // The MBOX SRAM is word aligned so this will clear the entire buffer.
+        for i in 0..Self::SIZE / 4 {
+            self.write_word(i * 4, 0);
+        }
+        Ok(())
+    }
+}

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -94,5 +94,5 @@ pub fn finalize_mbox_buffer(
         .write_at(0, &checksum.to_le_bytes())
         .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
 
-    mbox.set_dlen(total_len as u32)
+    mbox.flush_sram_to_datain(total_len)
 }

--- a/runtime/src/packet.rs
+++ b/runtime/src/packet.rs
@@ -12,10 +12,13 @@ Abstract:
 
 --*/
 
-use caliptra_common::cprintln;
-use caliptra_common::mailbox_api::{MailboxReqHeader, MailboxResp};
+use caliptra_common::mailbox_api::{populate_checksum, MailboxReqHeader, MailboxRespHeaderVarSize};
+use caliptra_common::{checksum::response_buffer_checksum, cprintln};
+use caliptra_dpe_response_buffer::ResponseBuffer;
 use caliptra_drivers::{CaliptraError, CaliptraResult};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::MboxResponseWriter;
 
 /// Reads the pending mailbox command payload into `buf`.
 ///
@@ -61,18 +64,35 @@ pub fn copy_from_mbox(drivers: &mut crate::Drivers, buf: &mut [u8]) -> CaliptraR
     Ok(())
 }
 
-/// Writes `resp` to the mailbox
-///
-/// # Arguments
-///
-/// * `drivers` - Drivers
-/// * `resp` - Response from a mailbox command that is to be copied to mailbox
-pub fn copy_to_mbox(drivers: &mut crate::Drivers, resp: &mut MailboxResp) -> CaliptraResult<()> {
-    let mbox = &mut drivers.mbox;
+/// Write a fixed-size response `resp` to MBOX SRAM.
+/// Fills `resp[0..4]` with the Caliptra checksum
+/// then calls `mbox.write_response` which sets dlen and copies bytes.
+#[inline(never)]
+pub fn copy_to_mbox(drivers: &mut crate::Drivers, resp: &mut [u8]) -> CaliptraResult<()> {
+    if resp.len() < 4 {
+        return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+    }
+    populate_checksum(resp);
+    drivers.mbox.write_response(resp)
+}
 
-    // Generate response checksum
-    resp.populate_chksum()?;
+/// Finalise a variable-length response written via `MboxResponseWriter`, including
+/// writing the VarSize header and populating the checksum.
+#[inline(never)]
+pub fn finalize_mbox_buffer(
+    mbox: &mut crate::Mailbox,
+    buffer: &mut MboxResponseWriter,
+    mut header: MailboxRespHeaderVarSize,
+) -> CaliptraResult<()> {
+    let total_len = size_of::<MailboxRespHeaderVarSize>() + (header.data_len as usize);
+    buffer
+        .write_at(0, header.as_mut_bytes())
+        .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+    let checksum = response_buffer_checksum(buffer, size_of::<u32>()..total_len)
+        .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
+    buffer
+        .write_at(0, &checksum.to_le_bytes())
+        .map_err(|_| CaliptraError::RUNTIME_MAILBOX_API_RESPONSE_DATA_LEN_TOO_LARGE)?;
 
-    // Send the payload
-    mbox.write_response(resp.as_bytes()?)
+    mbox.set_dlen(total_len as u32)
 }

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -12,12 +12,12 @@ Abstract:
 
 --*/
 
-use crate::packet::copy_from_mbox;
+use crate::packet::{copy_from_mbox, copy_to_mbox};
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
-    ExtendPcrReq, GetPcrLogResp, IncrementPcrResetCounterReq, MailboxResp, MailboxRespHeader,
-    QuotePcrsReq, QuotePcrsResp,
+    ExtendPcrReq, GetPcrLogResp, IncrementPcrResetCounterReq, MailboxRespHeader, QuotePcrsReq,
+    QuotePcrsResp,
 };
 use caliptra_drivers::{CaliptraError, CaliptraResult, PcrId};
 use zerocopy::{FromZeros, IntoBytes};
@@ -26,7 +26,7 @@ pub struct IncrementPcrResetCounterCmd;
 impl IncrementPcrResetCounterCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = IncrementPcrResetCounterReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -40,7 +40,7 @@ impl IncrementPcrResetCounterCmd {
             return Err(CaliptraError::RUNTIME_INCREMENT_PCR_RESET_MAX_REACHED);
         }
 
-        Ok(MailboxResp::default())
+        copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 
@@ -48,7 +48,7 @@ pub struct GetPcrQuoteCmd;
 impl GetPcrQuoteCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut args = QuotePcrsReq::new_zeroed();
         copy_from_mbox(drivers, args.as_mut_bytes())?;
 
@@ -61,7 +61,7 @@ impl GetPcrQuoteCmd {
             pcrs[i] = p.into()
         }
 
-        Ok(MailboxResp::QuotePcrs(QuotePcrsResp {
+        let mut resp = QuotePcrsResp {
             hdr: MailboxRespHeader::default(),
             nonce: args.nonce,
             pcrs,
@@ -69,7 +69,8 @@ impl GetPcrQuoteCmd {
             digest: pcr_hash.into(),
             signature_r: signature.r.into(),
             signature_s: signature.s.into(),
-        }))
+        };
+        copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }
 
@@ -77,7 +78,7 @@ pub struct ExtendPcrCmd;
 impl ExtendPcrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = ExtendPcrReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -96,7 +97,7 @@ impl ExtendPcrCmd {
             .pcr_bank
             .extend_pcr(pcr_index, &mut drivers.sha384, &cmd.data)?;
 
-        Ok(MailboxResp::default())
+        copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 
@@ -104,25 +105,18 @@ pub struct GetPcrLogCmd;
 impl GetPcrLogCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let next_available = drivers.persistent_data.get().fht.pcr_log_index as usize;
         let Some(pcr_logs) = drivers.persistent_data.get().pcr_log.get(..next_available) else {
             return Err(CaliptraError::RUNTIME_PCR_INVALID_INDEX);
         };
-        let pcr_log = pcr_logs.as_bytes();
-        let len = pcr_log.len();
-
-        let mut get_pcr_log_resp = GetPcrLogResp {
-            hdr: MailboxRespHeader::default(),
-            data_size: len as u32,
-            data: [0u8; GetPcrLogResp::DATA_MAX_SIZE],
-        };
-        let data = get_pcr_log_resp
-            .data
-            .get_mut(..len)
-            .ok_or(CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
-        data.copy_from_slice(pcr_log);
-
-        Ok(MailboxResp::GetPcrLog(get_pcr_log_resp))
+        let pcr_log_bytes = pcr_logs.as_bytes();
+        let mut resp = GetPcrLogResp::new_zeroed();
+        resp.data_size = pcr_log_bytes.len() as u32;
+        resp.data
+            .get_mut(..pcr_log_bytes.len())
+            .ok_or(CaliptraError::RUNTIME_PCR_INVALID_INDEX)?
+            .copy_from_slice(pcr_log_bytes);
+        copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::PauserPrivileges;
 use arrayvec::ArrayVec;
-use caliptra_common::mailbox_api::{MailboxResp, PopulateIdevCertReq};
+use caliptra_common::mailbox_api::{MailboxRespHeader, PopulateIdevCertReq};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::{FromZeros, IntoBytes};
 
@@ -23,7 +23,7 @@ use crate::{Drivers, MAX_CERT_CHAIN_SIZE};
 pub struct PopulateIDevIdCertCmd;
 impl PopulateIDevIdCertCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = PopulateIdevCertReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -46,6 +46,6 @@ impl PopulateIDevIdCertCmd {
             .map_err(|_| CaliptraError::RUNTIME_IDEV_CERT_POPULATION_FAILED)?;
         drivers.cert_chain = tmp_chain;
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }

--- a/runtime/src/reallocate_dpe_context_limits.rs
+++ b/runtime/src/reallocate_dpe_context_limits.rs
@@ -18,7 +18,7 @@ use crate::{
     PL0_DPE_ACTIVE_CONTEXT_THRESHOLD_MIN, PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
 use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, ReallocateDpeContextLimitsReq, ReallocateDpeContextLimitsResp,
+    MailboxRespHeader, ReallocateDpeContextLimitsReq, ReallocateDpeContextLimitsResp,
 };
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 
@@ -27,7 +27,7 @@ use zerocopy::{FromZeros, IntoBytes};
 pub struct ReallocateDpeContextLimitsCmd;
 impl ReallocateDpeContextLimitsCmd {
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = ReallocateDpeContextLimitsReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -64,12 +64,12 @@ impl ReallocateDpeContextLimitsCmd {
         drivers.persistent_data.get_mut().dpe_pl1_context_limit =
             TOTAL_DPE_CONTEXT_LIMIT as u8 - cmd.pl0_context_limit as u8;
 
-        let resp = ReallocateDpeContextLimitsResp {
+        let mut resp = ReallocateDpeContextLimitsResp {
             hdr: MailboxRespHeader::default(),
             new_pl0_context_limit: drivers.persistent_data.get().dpe_pl0_context_limit as u32,
             new_pl1_context_limit: drivers.persistent_data.get().dpe_pl1_context_limit as u32,
         };
 
-        Ok(MailboxResp::ReallocateDpeContextLimits(resp))
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -7,9 +7,7 @@ use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 
-use caliptra_common::mailbox_api::{
-    MailboxResp, RevokeExportedCdiHandleReq, RevokeExportedCdiHandleResp,
-};
+use caliptra_common::mailbox_api::{RevokeExportedCdiHandleReq, RevokeExportedCdiHandleResp};
 use caliptra_drivers::ExportedCdiEntry;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
@@ -22,7 +20,7 @@ pub struct RevokeExportedCdiHandleCmd;
 impl RevokeExportedCdiHandleCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = RevokeExportedCdiHandleReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -54,9 +52,8 @@ impl RevokeExportedCdiHandleCmd {
                     *active = U8Bool::new(false);
                     slot.zeroize();
 
-                    return Ok(MailboxResp::RevokeExportedCdiHandle(
-                        RevokeExportedCdiHandleResp::default(),
-                    ));
+                    let mut resp = RevokeExportedCdiHandleResp::default();
+                    return crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes());
                 }
                 _ => (),
             }

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -23,7 +23,7 @@ use caliptra_auth_man_types::{
 };
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
-use caliptra_common::mailbox_api::{MailboxResp, SetAuthManifestReq};
+use caliptra_common::mailbox_api::{MailboxRespHeader, SetAuthManifestReq};
 use caliptra_drivers::{
     Array4x12, Array4xN, CaliptraError, CaliptraResult, Ecc384, Ecc384PubKey, Ecc384Signature,
     HashValue, Lms, RomVerifyConfig, Sha256, Sha384, SocIfc,
@@ -444,7 +444,7 @@ impl SetAuthManifestCmd {
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut req = SetAuthManifestReq::new_zeroed();
         copy_from_mbox(drivers, req.as_mut_bytes())?;
 
@@ -511,7 +511,7 @@ impl SetAuthManifestCmd {
 
         persistent_data.auth_manifest_digest = drivers.sha384.digest(manifest_buf)?.0;
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -5,9 +5,7 @@ use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 
-use caliptra_common::mailbox_api::{
-    MailboxResp, SignWithExportedEcdsaReq, SignWithExportedEcdsaResp,
-};
+use caliptra_common::mailbox_api::{SignWithExportedEcdsaReq, SignWithExportedEcdsaResp};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
@@ -61,7 +59,7 @@ impl SignWithExportedEcdsaCmd {
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = SignWithExportedEcdsaReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -128,6 +126,10 @@ impl SignWithExportedEcdsaCmd {
         } else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }
-        Ok(MailboxResp::SignWithExportedEcdsa(resp))
+
+        // Explicitely drop crypto and pdata so the multable borrow to drivers also ends.
+        drop(crypto);
+        let _ = pdata;
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -127,7 +127,7 @@ impl SignWithExportedEcdsaCmd {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         }
 
-        // Explicitely drop crypto and pdata so the multable borrow to drivers also ends.
+        // Explicitely drop crypto and pdata so the mutable borrow to drivers also ends.
         drop(crypto);
         let _ = pdata;
         crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -12,16 +12,17 @@ Abstract:
 
 --*/
 
+use caliptra_dpe_response_buffer::SliceResponseBuffer;
+
 use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{
-    MailboxResp, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
-};
+use caliptra_common::mailbox_api::{MailboxRespHeader, StashMeasurementReq, StashMeasurementResp};
 use caliptra_drivers::{pcr_log::PCR_ID_STASH_MEASUREMENT, CaliptraError, CaliptraResult};
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
-    response::{DeriveContextExportedCdiResp, DpeErrorCode},
+    error::DpeErrorCode,
+    response::DeriveContextExportedCdiResp,
     tci::TciMeasurement,
 };
 use zerocopy::{FromZeros, IntoBytes};
@@ -66,16 +67,15 @@ impl StashMeasurementCmd {
             let command = Command::from(&cmd);
             let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
             let mut buf = [0u8; size_of::<DeriveContextExportedCdiResp>()];
+            let mut out = SliceResponseBuffer::new(&mut buf);
             let derive_context_resp =
-                invoke_dpe_cmd(drivers, &command, None, ueid, Some(locality), &mut buf);
+                invoke_dpe_cmd(drivers, &command, None, ueid, Some(locality), &mut out);
 
             match derive_context_resp {
                 Ok(_) => DpeErrorCode::NoError,
                 Err(e) => {
                     // If there is extended error info, populate CPTRA_FW_EXTENDED_ERROR_INFO
-                    if let Some(ext_err) = e.get_error_detail() {
-                        drivers.soc_ifc.set_fw_extended_error(ext_err);
-                    }
+                    drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
                     e
                 }
             }
@@ -93,16 +93,17 @@ impl StashMeasurementCmd {
         Ok(dpe_result)
     }
 
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = StashMeasurementReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
         let dpe_result =
             Self::stash_measurement(drivers, &cmd.metadata, &cmd.measurement, cmd.svn)?;
 
-        Ok(MailboxResp::StashMeasurement(StashMeasurementResp {
+        let mut resp = StashMeasurementResp {
             hdr: MailboxRespHeader::default(),
             dpe_result: dpe_result.get_error_code(),
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/subject_alt_name.rs
+++ b/runtime/src/subject_alt_name.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use arrayvec::ArrayVec;
-use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxResp};
+use caliptra_common::mailbox_api::{AddSubjectAltNameReq, MailboxRespHeader};
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::{FromZeros, IntoBytes};
 
@@ -26,7 +26,7 @@ impl AddSubjectAltNameCmd {
         &[0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0x1C, 0x82, 0x12, 0x01];
 
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = AddSubjectAltNameReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -43,7 +43,7 @@ impl AddSubjectAltNameCmd {
             .map_err(|_| CaliptraError::RUNTIME_STORE_DMTF_DEVICE_INFO_FAILED)?;
         drivers.dmtf_device_info = Some(dmtf_device_info);
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 
     /// Verifies that `dmtf_device_info` only contains ascii characters and contains exactly 2 ':'

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::packet::copy_from_mbox;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{
-    GetTaggedTciReq, GetTaggedTciResp, MailboxResp, MailboxRespHeader, TagTciReq,
+    GetTaggedTciReq, GetTaggedTciResp, MailboxRespHeader, TagTciReq,
 };
 use caliptra_error::{CaliptraError, CaliptraResult};
 use dpe::{context::ContextHandle, U8Bool, MAX_HANDLES};
@@ -27,7 +27,7 @@ pub struct TagTciCmd;
 impl TagTciCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = TagTciReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
         let pdata_mut = drivers.persistent_data.get_mut();
@@ -58,7 +58,7 @@ impl TagTciCmd {
         context_has_tag[idx] = U8Bool::new(true);
         context_tags[idx] = cmd.tag;
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 
@@ -66,7 +66,7 @@ pub struct GetTaggedTciCmd;
 impl GetTaggedTciCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = GetTaggedTciReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
         let persistent_data = drivers.persistent_data.get();
@@ -85,10 +85,11 @@ impl GetTaggedTciCmd {
         }
         let context = persistent_data.dpe.contexts[idx];
 
-        Ok(MailboxResp::GetTaggedTci(GetTaggedTciResp {
+        let mut resp = GetTaggedTciResp {
             hdr: MailboxRespHeader::default(),
             tci_cumulative: context.tci.tci_cumulative.0,
             tci_current: context.tci.tci_current.0,
-        }))
+        };
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -17,7 +17,7 @@ use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(feature = "mldsa_attestation")]
 use caliptra_common::mailbox_api::Mldsa87VerifyReq;
-use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxResp};
+use caliptra_common::mailbox_api::{EcdsaVerifyReq, LmsVerifyReq, MailboxRespHeader};
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Ecc384PubKey, Ecc384Result, Ecc384Scalar,
     Ecc384Signature, LmsResult,
@@ -33,7 +33,7 @@ pub struct EcdsaVerifyCmd;
 impl EcdsaVerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = EcdsaVerifyReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -59,7 +59,7 @@ impl EcdsaVerifyCmd {
             return Err(CaliptraError::RUNTIME_ECDSA_VERIFY_FAILED);
         }
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 
@@ -67,7 +67,7 @@ pub struct LmsVerifyCmd;
 impl LmsVerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = LmsVerifyReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -134,7 +134,7 @@ impl LmsVerifyCmd {
             return Err(CaliptraError::RUNTIME_LMS_VERIFY_FAILED);
         }
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }
 
@@ -144,7 +144,7 @@ pub struct Mldsa87VerifyCmd;
 impl Mldsa87VerifyCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = Mldsa87VerifyReq::new_zeroed();
         copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
@@ -167,6 +167,6 @@ impl Mldsa87VerifyCmd {
             return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED);
         }
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -23,7 +23,8 @@ use caliptra_hw_model::{
 use caliptra_image_types::ImageBundle;
 use dpe::{
     commands::{Command, CommandHdr},
-    response::{DpeErrorCode, Response, ResponseHdr},
+    error::DpeErrorCode,
+    response::{Response, ResponseHdr},
     DpeProfile,
 };
 use openssl::{

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -111,9 +111,10 @@ fn test_dmtf_other_name_extension_present() {
         panic!("Wrong response type!");
     };
 
-    let (_, cert) =
-        X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
-            .unwrap();
+    let (_, cert) = X509Certificate::from_der(
+        &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize],
+    )
+    .unwrap();
     let ext = cert.subject_alternative_name().unwrap().unwrap();
     assert!(!ext.critical);
     let san = ext.value;
@@ -169,9 +170,10 @@ fn test_dmtf_other_name_extension_not_present() {
     let Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)) = resp else {
         panic!("Wrong response type!");
     };
-    let (_, cert) =
-        X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
-            .unwrap();
+    let (_, cert) = X509Certificate::from_der(
+        &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize],
+    )
+    .unwrap();
     assert!(cert.subject_alternative_name().unwrap().is_none());
 
     // populate DMTF otherName
@@ -219,8 +221,9 @@ fn test_dmtf_other_name_extension_not_present() {
     let Response::CertifyKey(CertifyKeyResp::P384(certify_key_resp)) = resp else {
         panic!("Wrong response type!");
     };
-    let (_, cert) =
-        X509Certificate::from_der(&certify_key_resp.cert[..certify_key_resp.cert_size as usize])
-            .unwrap();
+    let (_, cert) = X509Certificate::from_der(
+        &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize],
+    )
+    .unwrap();
     assert!(cert.subject_alternative_name().unwrap().is_none());
 }

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -90,8 +90,8 @@ fn test_disable_attestation_cmd() {
     .unwrap();
     let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
         &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
-        &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
-        &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
+        &BigNum::from_slice(&certify_key_resp.header.derived_pubkey_x).unwrap(),
+        &BigNum::from_slice(&certify_key_resp.header.derived_pubkey_y).unwrap(),
     )
     .unwrap();
     // check that signature is unable to be verified by the pub key

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -28,7 +28,8 @@ use dpe::{
         RotateCtxFlags, SignFlags, SignP384Cmd,
     },
     context::ContextHandle,
-    response::{CertifyKeyResp, DpeErrorCode, Response, SignResp},
+    error::DpeErrorCode,
+    response::{CertifyKeyResp, Response, SignResp},
     tci::TciMeasurement,
     DpeProfile, TCI_SIZE,
 };
@@ -145,8 +146,8 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
 
             let ecc_pub_key = EcKey::from_public_key_affine_coordinates(
                 &EcGroup::from_curve_name(Nid::SECP384R1).unwrap(),
-                &BigNum::from_slice(&certify_key_resp.derived_pubkey_x).unwrap(),
-                &BigNum::from_slice(&certify_key_resp.derived_pubkey_y).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.header.derived_pubkey_x).unwrap(),
+                &BigNum::from_slice(&certify_key_resp.header.derived_pubkey_y).unwrap(),
             )
             .unwrap();
             assert!(sig.verify(TEST_DIGEST.as_slice(), &ecc_pub_key).unwrap());
@@ -374,7 +375,7 @@ fn test_invoke_dpe_export_cdi_with_non_critical_dice_extensions() {
         panic!("expected derive context resp!");
     };
     check_dice_extension_criticality(
-        &resp.new_certificate[..resp.certificate_size.try_into().unwrap()],
+        &resp.new_certificate[..resp.header.certificate_size.try_into().unwrap()],
         false,
     );
 }

--- a/runtime/tests/runtime_integration_tests/test_measurements_common.rs
+++ b/runtime/tests/runtime_integration_tests/test_measurements_common.rs
@@ -282,7 +282,7 @@ pub fn run_command_suite(
             &mut Command::DeriveContext(&export_cdi_cmd),
             DpeResult::Success,
         ) {
-            Some(Response::DeriveContextExportedCdi(resp)) => resp.exported_cdi,
+            Some(Response::DeriveContextExportedCdi(resp)) => resp.header.exported_cdi,
             _ => panic!("expected an exported-CDI derive-context response"),
         };
 

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle.rs
@@ -41,7 +41,7 @@ fn test_revoke_exported_cdi_handle() {
 
     let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        exported_cdi_handle: original_cdi_resp.header.exported_cdi,
     });
     cmd.populate_chksum().unwrap();
 
@@ -79,7 +79,7 @@ fn test_revoke_already_revoked_exported_cdi_handle() {
 
     let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        exported_cdi_handle: original_cdi_resp.header.exported_cdi,
     });
     cmd.populate_chksum().unwrap();
 
@@ -169,7 +169,7 @@ fn test_export_cdi_after_revoke() {
 
     let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: resp.exported_cdi,
+        exported_cdi_handle: resp.header.exported_cdi,
     });
     cmd.populate_chksum().unwrap();
 

--- a/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_export_ecdsa.rs
@@ -18,9 +18,8 @@ use crypto::{CryptoError, MAX_EXPORTED_CDI_SIZE};
 use dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags, RotateCtxCmd, RotateCtxFlags},
     context::ContextHandle,
-    response::{
-        DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, NewHandleResp, Response,
-    },
+    error::DpeErrorCode,
+    response::{DeriveContextExportedCdiResp, DeriveContextResp, NewHandleResp, Response},
     tci::TciMeasurement,
     TCI_SIZE,
 };
@@ -49,8 +48,11 @@ fn check_certificate_signature(
 
     // Verify that the certificate from DeriveContext can verify the signature.
     let x509 = X509::from_der(
-        &exported_cdi_resp.new_certificate
-            [..exported_cdi_resp.certificate_size.try_into().unwrap()],
+        &exported_cdi_resp.new_certificate[..exported_cdi_resp
+            .header
+            .certificate_size
+            .try_into()
+            .unwrap()],
     )
     .unwrap();
     let ec_pub_key = x509.public_key().unwrap().ec_key().unwrap();
@@ -101,7 +103,7 @@ fn test_sign_with_exported_cdi() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: derive_resp.exported_cdi,
+        exported_cdi_handle: derive_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -223,7 +225,7 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        exported_cdi_handle: original_cdi_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -264,7 +266,7 @@ fn test_sign_with_exported_cdi_measurement_update_duplicate_cdi() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        exported_cdi_handle: original_cdi_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -329,7 +331,7 @@ fn test_sign_with_exported_cdi_measurement_update() {
 
     let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: original_cdi_resp.exported_cdi,
+        exported_cdi_handle: original_cdi_resp.header.exported_cdi,
     });
     cmd.populate_chksum().unwrap();
 
@@ -351,7 +353,7 @@ fn test_sign_with_exported_cdi_measurement_update() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: updated_cdi_resp.exported_cdi,
+        exported_cdi_handle: updated_cdi_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -369,8 +371,8 @@ fn test_sign_with_exported_cdi_measurement_update() {
     assert!(check_certificate_signature(sign_resp, &updated_cdi_resp));
     assert_ne!(original_cdi_resp, updated_cdi_resp);
     assert_ne!(
-        original_cdi_resp.exported_cdi,
-        updated_cdi_resp.exported_cdi
+        original_cdi_resp.header.exported_cdi,
+        updated_cdi_resp.header.exported_cdi
     );
     assert_ne!(
         original_cdi_resp.new_certificate,
@@ -410,7 +412,7 @@ fn test_sign_with_revoked_exported_cdi() {
 
     let mut sign_cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: cdi_resp.exported_cdi,
+        exported_cdi_handle: cdi_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     sign_cmd.populate_chksum().unwrap();
@@ -427,7 +429,7 @@ fn test_sign_with_revoked_exported_cdi() {
 
     let mut revoke_cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: cdi_resp.exported_cdi,
+        exported_cdi_handle: cdi_resp.header.exported_cdi,
     });
     revoke_cmd.populate_chksum().unwrap();
 
@@ -484,7 +486,7 @@ fn test_sign_with_disabled_attestation() {
 
     let mut sign_cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: cdi_resp.exported_cdi,
+        exported_cdi_handle: cdi_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     sign_cmd.populate_chksum().unwrap();
@@ -565,7 +567,7 @@ fn test_sign_with_exported_cdi_warm_reset() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: derive_resp.exported_cdi,
+        exported_cdi_handle: derive_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -600,7 +602,7 @@ fn test_sign_with_exported_cdi_warm_reset() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: derive_resp.exported_cdi,
+        exported_cdi_handle: derive_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -685,7 +687,7 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: derive_resp.exported_cdi,
+        exported_cdi_handle: derive_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();
@@ -720,7 +722,7 @@ fn test_sign_with_exported_cdi_warm_reset_parent() {
 
     let mut cmd = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: derive_resp.exported_cdi,
+        exported_cdi_handle: derive_resp.header.exported_cdi,
         tbs: TEST_DIGEST,
     });
     cmd.populate_chksum().unwrap();

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -16,7 +16,7 @@ use caliptra_hw_model::{BootParams, DefaultHwModel, HwModel, InitParams};
 use caliptra_runtime::{ContextState, RtBootStatus, PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD};
 use dpe::{
     context::{Context, ContextHandle, ContextType},
-    response::DpeErrorCode,
+    error::DpeErrorCode,
     tci::TciMeasurement,
     validation::ValidationError,
     U8Bool, MAX_HANDLES, TCI_SIZE,

--- a/test/dpe_verification/go.mod
+++ b/test/dpe_verification/go.mod
@@ -3,8 +3,8 @@ module dpe
 go 1.24.0
 
 require (
-	github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260529004809-a174f3379983
-	github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260529004809-a174f3379983
+	github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260625202335-ce921a0a1fb9
+	github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260625202335-ce921a0a1fb9
 )
 
 require (

--- a/test/dpe_verification/go.sum
+++ b/test/dpe_verification/go.sum
@@ -4,6 +4,8 @@ github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7N
 github.com/certifi/gocertifi v0.0.0-20180118203423-deb3ae2ef261/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260529004809-a174f3379983 h1:vi0sqIg5CDKkfuDNwHp/jHqEnLt044vzr1a6W8uSTtk=
 github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260529004809-a174f3379983/go.mod h1:6wRR/2VE9+SSX7bdiSbgBoUL0WpGPU0F8Roe+1taPj0=
+github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260625202335-ce921a0a1fb9 h1:u0pHWSjodPtpEk5GSOvnn1zQSmTt298+maP2Sjpq7zU=
+github.com/chipsalliance/caliptra-dpe/verification/client v0.0.0-20260625202335-ce921a0a1fb9/go.mod h1:6wRR/2VE9+SSX7bdiSbgBoUL0WpGPU0F8Roe+1taPj0=
 github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20240305022518-f4e3dd792a5c h1:AU8lHtgX1iZCjO/UZiaW226dc7mMl4zBhwjQqefB9ps=
 github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20240305022518-f4e3dd792a5c/go.mod h1:tCF7Q+jyiox85doSbjd2pFsdlFbzhdYQngIAJa85iHU=
 github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20260529004809-a174f3379983 h1:LgwiTCg3KUaiiSL32xQhlwtKv5h4zAGq9FW3TVMoGnM=
@@ -11,6 +13,8 @@ github.com/chipsalliance/caliptra-dpe/verification/sim v0.0.0-20260529004809-a17
 github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20240227181801-29d5ca397c66/go.mod h1:uRrz57lTSma4a7MnKBB/Poc1yjt5aZfcxBGJmql/7JQ=
 github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260529004809-a174f3379983 h1:Qpf0a3aWG8/BsjxqXkiBo3Mg69H5JdIHlxITtU1tPes=
 github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260529004809-a174f3379983/go.mod h1:KTs671NV0uvqBbTIGE82u4MbooZsqbTJ+EBlGxeBOF8=
+github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260625202335-ce921a0a1fb9 h1:R0zxyFdu/gekTwGJkNUgwGGmXjZ+MAbr84cV+KV4NjE=
+github.com/chipsalliance/caliptra-dpe/verification/testing v0.0.0-20260625202335-ce921a0a1fb9/go.mod h1:KTs671NV0uvqBbTIGE82u4MbooZsqbTJ+EBlGxeBOF8=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=

--- a/test/tests/fips_test_suite/services.rs
+++ b/test/tests/fips_test_suite/services.rs
@@ -519,12 +519,16 @@ pub fn exec_dpe_certify_key<T: HwModel>(hw: &mut T) {
     };
 
     assert_eq!(
-        certify_key_resp.new_context_handle.0,
+        certify_key_resp.header.new_context_handle.0,
         [0u8; ContextHandle::SIZE]
     );
-    assert!(contains_some_data(&certify_key_resp.derived_pubkey_x));
-    assert!(contains_some_data(&certify_key_resp.derived_pubkey_y));
-    assert_ne!(0, certify_key_resp.cert_size);
+    assert!(contains_some_data(
+        &certify_key_resp.header.derived_pubkey_x
+    ));
+    assert!(contains_some_data(
+        &certify_key_resp.header.derived_pubkey_y
+    ));
+    assert_ne!(0, certify_key_resp.header.cert_size);
     assert!(contains_some_data(&certify_key_resp.cert));
 }
 
@@ -906,7 +910,7 @@ pub fn exec_cmd_sign_with_exported_ecdsa<T: HwModel>(hw: &mut T) -> DeriveContex
 
     let mut payload = MailboxReq::SignWithExportedEcdsa(SignWithExportedEcdsaReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: exported_cdi_resp.exported_cdi,
+        exported_cdi_handle: exported_cdi_resp.header.exported_cdi,
         tbs,
     });
     payload.populate_chksum().unwrap();
@@ -932,7 +936,7 @@ pub fn exec_cmd_revoke_exported_cdi_handle<T: HwModel>(
 ) {
     let mut payload = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
         hdr: MailboxReqHeader { chksum: 0 },
-        exported_cdi_handle: exported_cdi_resp.exported_cdi,
+        exported_cdi_handle: exported_cdi_resp.header.exported_cdi,
     });
     payload.populate_chksum().unwrap();
 


### PR DESCRIPTION
Alter the runtime to allow responses to be written directly to the mailbox.  This allow greatly reduced stack space for commands with large responses.  Particularly this includes DPE commands which will be required to integrate with MLDSA functionality for the 1.x PQC retrofit.

This also includes the optimization of having responses be published from individual command arms, reducing stack optimizations for commands which previously allocated the union of responses on to the stack.

The overal statistics are as follows:

## Caliptra FW Size

### Component Sizes (no-PQC baseline, image build)

| Component | Baseline text+data | Branch text+data | Δ bytes | Budget | Baseline Used | Branch Used |
|-----------|-------------------|-----------------|---------|--------|---------------|-------------|
| ROM       | 42,536            | 42,536          | 0       | 49,152 B (48 KiB) | 86.5% | 86.5% |
| FMC       | 20,300            | 20,300          | 0       | 24,576 B (24 KiB) | 82.6% | 82.6% |
| Runtime¹  | 83,228            | 84,716          | **+1,488** | 98,304 B (96 KiB) | 84.7% | 86.2% |

| Image Bundle | Baseline | Branch | Δ bytes | Budget | Baseline Used | Branch Used |
|---|---|---|---|---|---|---|
| image-bundle.bin | 109,412 B (106.85 KiB) | 110,900 B (108.30 KiB) | **+1,488** | 131,072 B (128 KiB) | 83.5% | 84.6% |

> ¹ Image build uses `APP_WITH_UART` feature set (`emu`, `fips_self_test`, `cfi`)
> — `mldsa_attestation` not included.

ROM and FMC are unaffected. The Runtime grows by **+1,488 bytes** (+1.5 pp of
the 96 KiB ICCM budget), primarily from `MboxResponseWriter`,
`finalize_mbox_buffer`, and the per-command direct-write logic.

### mldsa_attestation Feature Impact (Runtime, standalone builds)

| Runtime build             | Baseline text+data | Branch text+data | Budget Used |
|---------------------------|--------------------|-----------------|-------------|
| without mldsa_attestation | 83,228 B           | 82,764 B        | 84.2%       |
| with mldsa_attestation    | 83,228 B²          | 95,460 B        | 97.1%       |
| **Δ (feature cost)**      | —                  | **+12,696 B**   | **+12.9 pp** |


## Stack Usage

Runtime stack = **87,040 bytes** (both branches)

| Command | Baseline bytes | Branch bytes | Δ bytes | Δ % |
|---|---|---|---|---|
| INVOKE_DPE(CertifyKey/X509)  | 44,672 (51.3%) | 11,088 (12.7%) | **-33,584** | **-75%** |
| INVOKE_DPE(GetProfile)       | 36,976 (42.5%) |  6,640  (7.6%) | **-30,336** | **-82%** |
| CERTIFY_KEY_EXTENDED         | 34,256 (39.4%) |  6,592  (7.6%) | **-27,664** | **-81%** |
| SET_AUTH_MANIFEST            | 35,232 (40.5%) | 20,048 (23.0%) | **-15,184** | **-43%** |
| STASH_MEASUREMENT            | 33,680 (38.7%) | 13,184 (15.1%) | **-20,496** | **-61%** |
| AUTHORIZE_AND_STASH          | 33,216 (38.2%) | 12,704 (14.6%) | **-20,512** | **-62%** |
| LMS_VERIFY                   | 26,928 (30.9%) | 11,776 (13.5%) | **-15,152** | **-56%** |
| QUOTE_PCRS                   | 26,432 (30.4%) | 11,536 (13.3%) | **-14,896** | **-56%** |
| POPULATE_IDEV_CERT           | 25,056 (28.8%) |  9,888 (11.4%) | **-15,168** | **-61%** |
| SELF_TEST_GET_RESULTS(+KATs) | 23,936 (27.5%) |  8,768 (10.1%) | **-15,168** | **-63%** |
| SIGN_WITH_EXPORTED_ECDSA     | 22,880 (26.3%) |  7,888  (9.1%) | **-14,992** | **-66%** |
| GET_IDEV_CERT                | 22,128 (25.4%) |  6,976  (8.0%) | **-15,152** | **-68%** |
| GET_LDEV_CERT                | 21,520 (24.7%) |  6,352  (7.3%) | **-15,168** | **-71%** |
| GET_FMC_ALIAS_CERT           | 21,520 (24.7%) |  6,352  (7.3%) | **-15,168** | **-71%** |
| GET_RT_ALIAS_CERT            | 21,264 (24.4%) |  6,096  (7.0%) | **-15,168** | **-71%** |
| DISABLE_ATTESTATION          | 21,024 (24.2%) |  5,840  (6.7%) | **-15,184** | **-72%** |
| GET_PCR_LOG                  | 20,752 (23.8%) |  5,584  (6.4%) | **-15,168** | **-73%** |
| GET_FMC_ALIAS_CSR            | 20,656 (23.7%) |  5,504  (6.3%) | **-15,152** | **-73%** |
| ECDSA384_VERIFY              | 20,576 (23.6%) |  5,392  (6.2%) | **-15,184** | **-74%** |
| FW_INFO                      | 19,872 (22.8%) |  5,248  (6.0%) | **-14,624** | **-74%** |
| GET_IDEV_INFO                | 19,872 (22.8%) |  4,864  (5.6%) | **-15,008** | **-76%** |
| EXTEND_PCR                   | 20,256 (23.3%) |  5,088  (5.8%) | **-15,168** | **-75%** |
| ADD_SUBJECT_ALT_NAME         | 20,160 (23.2%) |  4,992  (5.7%) | **-15,168** | **-75%** |
| DPE_GET_TAGGED_TCI           | 19,904 (22.9%) |  4,928  (5.7%) | **-14,976** | **-75%** |
| DPE_TAG_TCI                  | 19,936 (22.9%) |  4,752  (5.5%) | **-15,184** | **-76%** |
| REVOKE_EXPORTED_CDI_HANDLE   | 19,936 (22.9%) |  4,768  (5.5%) | **-15,168** | **-76%** |
| REALLOCATE_DPE_CONTEXT_LIMITS| 19,904 (22.9%) |  4,736  (5.4%) | **-15,168** | **-76%** |
| INCREMENT_PCR_RESET_COUNTER  | 19,888 (22.8%) |  4,736  (5.4%) | **-15,152** | **-76%** |
| VERSION                      | 19,872 (22.8%) |  4,704  (5.4%) | **-15,168** | **-76%** |
| CAPABILITIES                 | 19,872 (22.8%) |  4,704  (5.4%) | **-15,168** | **-76%** |
| SELF_TEST_START              | 19,872 (22.8%) |  4,704  (5.4%) | **-15,168** | **-76%** |
| SHUTDOWN                     | 19,872 (22.8%) |  4,704  (5.4%) | **-15,168** | **-76%** |
| **Peak (worst case)**        | **44,672 (51.3%)** | **20,048 (23.0%)** | **-24,624** | **-55%** |
