### PR TITLE
drivers: add trait impls and APIs to ML-DSA types

### DIFF
--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -48,6 +48,10 @@ pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 #[derive(KnownLayout, Immutable, FromBytes)]
 pub struct Mldsa87Signature([u8; MLDSA87_SIGNATURE_BYTES]);
 
+#[repr(transparent)]
+#[derive(KnownLayout, Immutable, FromBytes)]
+pub struct Mldsa87Mu([u8; MLDSA87_MU_BYTES]);
+
 macro_rules! impl_helper_traits {
     ($name:ty) => {
         impl $name {
@@ -85,8 +89,7 @@ impl_helper_traits!(Mldsa87Seed);
 impl_helper_traits!(Mldsa87PubKey);
 impl_helper_traits!(Mldsa87PrivKey);
 impl_helper_traits!(Mldsa87Signature);
-
-pub type Mldsa87Mu = [u8; MLDSA87_MU_BYTES];
+impl_helper_traits!(Mldsa87Mu);
 
 /// Software ML-DSA-87 engine.
 ///

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -19,6 +19,8 @@ Abstract:
 
 use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
+use core::ops::{Deref, DerefMut};
+use zeroize::Zeroize;
 
 pub use caliptra_mldsa::{
     Mldsa87Result, ResponseBufError, ResponseBuffer, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES,
@@ -27,16 +29,65 @@ pub use caliptra_mldsa::{
 };
 
 /// ML-DSA-87 deterministic key-generation / signing seed (32 bytes).
-pub type Mldsa87Seed = [u8; MLDSA87_PRIVATE_SEED_BYTES];
+#[repr(transparent)]
+#[derive(Zeroize)]
+pub struct Mldsa87Seed([u8; MLDSA87_PRIVATE_SEED_BYTES]);
 
 /// ML-DSA-87 encoded public key (2,592 bytes).
-pub type Mldsa87PubKey = [u8; MLDSA87_PUBLIC_KEY_BYTES];
+#[repr(transparent)]
+pub struct Mldsa87PubKey([u8; MLDSA87_PUBLIC_KEY_BYTES]);
 
 /// ML-DSA-87 FIPS 204 encoded private key (4,896 bytes).
-pub type Mldsa87PrivKey = [u8; MLDSA87_PRIVATE_KEY_BYTES];
+#[repr(transparent)]
+#[derive(Zeroize)]
+pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 
 /// ML-DSA-87 encoded signature (4,627 bytes).
-pub type Mldsa87Signature = [u8; MLDSA87_SIGNATURE_BYTES];
+#[repr(transparent)]
+pub struct Mldsa87Signature([u8; MLDSA87_SIGNATURE_BYTES]);
+
+macro_rules! impl_helper_traits {
+    ($name:ty) => {
+        impl $name {
+            pub const fn new(data: [u8; core::mem::size_of::<$name>()]) -> Self {
+                Self(data)
+            }
+
+            pub fn from_ref(data: &[u8; core::mem::size_of::<$name>()]) -> &Self {
+                // SAFETY: Self is transparent over u8 array.
+                unsafe { &*(data.as_ptr() as *const Self) }
+            }
+
+            pub fn as_slice(&self) -> &[u8] {
+                &self.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = [u8; core::mem::size_of::<$name>()];
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self([0u8; core::mem::size_of::<$name>()])
+            }
+        }
+    };
+}
+
+impl_helper_traits!(Mldsa87Seed);
+impl_helper_traits!(Mldsa87PubKey);
+impl_helper_traits!(Mldsa87PrivKey);
+impl_helper_traits!(Mldsa87Signature);
 
 pub type Mldsa87Mu = [u8; MLDSA87_MU_BYTES];
 

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -21,7 +21,7 @@ use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 use core::ops::{Deref, DerefMut};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
-use zeroize::Zeroize;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use caliptra_mldsa::{
     Mldsa87Result, ResponseBufError, ResponseBuffer, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES,
@@ -31,7 +31,7 @@ pub use caliptra_mldsa::{
 
 /// ML-DSA-87 deterministic key-generation / signing seed (32 bytes).
 #[repr(transparent)]
-#[derive(Zeroize)]
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct Mldsa87Seed([u8; MLDSA87_PRIVATE_SEED_BYTES]);
 
 /// ML-DSA-87 encoded public key (2,592 bytes).
@@ -41,6 +41,7 @@ pub struct Mldsa87PubKey([u8; MLDSA87_PUBLIC_KEY_BYTES]);
 
 /// ML-DSA-87 FIPS 204 encoded private key (4,896 bytes).
 #[repr(transparent)]
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 
 /// ML-DSA-87 encoded signature (4,627 bytes).

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -41,7 +41,6 @@ pub struct Mldsa87PubKey([u8; MLDSA87_PUBLIC_KEY_BYTES]);
 
 /// ML-DSA-87 FIPS 204 encoded private key (4,896 bytes).
 #[repr(transparent)]
-#[derive(Zeroize)]
 pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 
 /// ML-DSA-87 encoded signature (4,627 bytes).

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -20,6 +20,7 @@ Abstract:
 use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 use core::ops::{Deref, DerefMut};
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 use zeroize::Zeroize;
 
 pub use caliptra_mldsa::{
@@ -35,6 +36,7 @@ pub struct Mldsa87Seed([u8; MLDSA87_PRIVATE_SEED_BYTES]);
 
 /// ML-DSA-87 encoded public key (2,592 bytes).
 #[repr(transparent)]
+#[derive(KnownLayout, Immutable, FromBytes)]
 pub struct Mldsa87PubKey([u8; MLDSA87_PUBLIC_KEY_BYTES]);
 
 /// ML-DSA-87 FIPS 204 encoded private key (4,896 bytes).
@@ -44,6 +46,7 @@ pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 
 /// ML-DSA-87 encoded signature (4,627 bytes).
 #[repr(transparent)]
+#[derive(KnownLayout, Immutable, FromBytes)]
 pub struct Mldsa87Signature([u8; MLDSA87_SIGNATURE_BYTES]);
 
 macro_rules! impl_helper_traits {
@@ -51,11 +54,6 @@ macro_rules! impl_helper_traits {
         impl $name {
             pub const fn new(data: [u8; core::mem::size_of::<$name>()]) -> Self {
                 Self(data)
-            }
-
-            pub fn from_ref(data: &[u8; core::mem::size_of::<$name>()]) -> &Self {
-                // SAFETY: Self is transparent over u8 array.
-                unsafe { &*(data.as_ptr() as *const Self) }
             }
 
             pub fn as_slice(&self) -> &[u8] {

--- a/kat/src/mldsa87_kat.rs
+++ b/kat/src/mldsa87_kat.rs
@@ -14,8 +14,7 @@ Abstract:
 
 use caliptra_drivers::{
     Array4x12, CaliptraError, CaliptraResult, Mldsa87, Mldsa87PrivKey, Mldsa87PubKey,
-    Mldsa87Result, Mldsa87Seed, Mldsa87Signature, Sha384, MLDSA87_PRIVATE_KEY_BYTES,
-    MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
+    Mldsa87Result, Mldsa87Seed, Mldsa87Signature, Sha384,
 };
 
 // Digest-based KAT, mirroring the Caliptra 2.x / `main` ML-DSA KAT format and
@@ -30,10 +29,10 @@ use caliptra_drivers::{
 // vector's `sk` byte-for-byte). See common/crypto/mldsa/src/acvp. The signature
 // is the FIPS 204 deterministic signature over `MESSAGE` with an empty context.
 
-const SEED: Mldsa87Seed = [
+const SEED: Mldsa87Seed = Mldsa87Seed::new([
     0xf7, 0x05, 0x2f, 0xbb, 0x92, 0x17, 0x59, 0xcd, 0x87, 0x16, 0x77, 0x3b, 0xa6, 0x35, 0x56, 0x30,
     0x12, 0x1d, 0x69, 0x27, 0x89, 0x9f, 0xdd, 0xa5, 0x76, 0x8e, 0x2b, 0xc2, 0x40, 0xfc, 0xcb, 0x7b,
-];
+]);
 
 const MESSAGE: [u8; 64] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -88,16 +87,16 @@ impl Mldsa87Kat {
     fn kat_keygen(sha384: &mut Sha384) -> CaliptraResult<Mldsa87PubKey> {
         // A single key generation produces both the public key and the encoded
         // private key (the optional sk buffer is supplied).
-        let mut public_key: Mldsa87PubKey = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
-        let mut private_key: Mldsa87PrivKey = [0u8; MLDSA87_PRIVATE_KEY_BYTES];
+        let mut public_key = Mldsa87PubKey::default();
+        let mut private_key = Mldsa87PrivKey::default();
         Mldsa87::pub_from_seed(&SEED, &mut public_key, Some(&mut private_key))
             .map_err(|_| CaliptraError::KAT_MLDSA87_KEY_PAIR_GENERATE_FAILURE)?;
 
         let pub_key_digest = sha384
-            .digest(&public_key)
+            .digest(public_key.as_slice())
             .map_err(|_| CaliptraError::KAT_SHA384_DIGEST_FAILURE)?;
         let priv_key_digest = sha384
-            .digest(&private_key)
+            .digest(private_key.as_slice())
             .map_err(|_| CaliptraError::KAT_SHA384_DIGEST_FAILURE)?;
 
         if pub_key_digest != PUB_KEY_DIGEST || priv_key_digest != PRIV_KEY_DIGEST {
@@ -112,12 +111,12 @@ impl Mldsa87Kat {
     /// against `SIGNATURE_DIGEST`.
     #[inline(never)]
     fn kat_sign(sha384: &mut Sha384) -> CaliptraResult<Mldsa87Signature> {
-        let mut signature: Mldsa87Signature = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut signature = Mldsa87Signature::default();
         Mldsa87::sign_deterministic(&SEED, &MESSAGE, &mut signature)
             .map_err(|_| CaliptraError::KAT_MLDSA87_SIGNATURE_GENERATE_FAILURE)?;
 
         let signature_digest = sha384
-            .digest(&signature)
+            .digest(signature.as_slice())
             .map_err(|_| CaliptraError::KAT_SHA384_DIGEST_FAILURE)?;
         if signature_digest != SIGNATURE_DIGEST {
             Err(CaliptraError::KAT_MLDSA87_SIGNATURE_MISMATCH)?;

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -37,7 +37,7 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 use {
     caliptra_drivers::{
         Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
-        MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
+        MLDSA87_SIGNATURE_BYTES,
     },
     crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
     zeroize::Zeroizing,
@@ -435,8 +435,8 @@ impl Crypto for DpeCrypto<'_> {
             }
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa => {
-                let mut seed = Zeroizing::new([0u8; MLDSA87_PRIVATE_SEED_BYTES]);
-                let mut pub_key = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+                let mut seed = Mldsa87Seed::default();
+                let mut pub_key = Mldsa87PubKey::default();
                 self.derive_key_pair_mldsa(&cdi, label, info, &mut seed, &mut pub_key)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
@@ -478,8 +478,8 @@ impl CdiManager for DpeCrypto<'_> {
 
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa => {
-                let mut seed = Zeroizing::new([0u8; MLDSA87_PRIVATE_SEED_BYTES]);
-                let mut pub_key = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+                let mut seed = Mldsa87Seed::default();
+                let mut pub_key = Mldsa87PubKey::default();
                 self.derive_key_pair_mldsa(&cdi, label, info, &mut seed, &mut pub_key)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
@@ -524,10 +524,10 @@ impl crypto::Signer for DpeCrypto<'_> {
             Some(DerivedKey::Ec((_, pub_key))) => Ok(pub_key.clone()),
             #[cfg(feature = "mldsa_attestation")]
             Some(DerivedKey::Mldsa(seed)) => {
-                let mut pub_key = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+                let mut pub_key = Mldsa87PubKey::default();
                 Mldsa87::pub_from_seed(seed, &mut pub_key, None)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                Ok(PubKey::Mldsa(MldsaPublicKey(pub_key)))
+                Ok(PubKey::Mldsa(MldsaPublicKey(*pub_key)))
             }
             _ => Err(CryptoError::CryptoLibError(4)),
         }
@@ -547,5 +547,5 @@ enum Signer<'a> {
 enum DerivedKey {
     Ec((KeyId, PubKey)),
     #[cfg(feature = "mldsa_attestation")]
-    Mldsa(Zeroizing<Mldsa87Seed>),
+    Mldsa(Mldsa87Seed),
 }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -36,10 +36,11 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 #[cfg(feature = "mldsa_attestation")]
 use {
     caliptra_drivers::{
-        Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
-        MLDSA87_SIGNATURE_BYTES,
+        Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature,
+        MLDSA87_PRIVATE_SEED_BYTES,
     },
     crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
+    zerocopy::FromBytes,
     zeroize::Zeroizing,
 };
 
@@ -281,10 +282,10 @@ impl<'a> DpeCrypto<'a> {
 
     #[cfg(feature = "mldsa_attestation")]
     fn sign_helper_mldsa(data: &SignData, seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
-        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut sig = Mldsa87Signature::default();
         match data {
             SignData::ResponseBuffer(buf, range) => {
-                let mut mu = [0u8; MLDSA87_MU_BYTES];
+                let mut mu = Mldsa87Mu::default();
                 Mldsa87::generate_mu(seed, *buf, range.clone(), &mut mu)
                     .map_err(|_| CryptoError::HashError(0))?;
                 Mldsa87::sign_mu_deterministic(seed, &mu, &mut sig)
@@ -292,12 +293,15 @@ impl<'a> DpeCrypto<'a> {
             }
             SignData::Raw(msg) => Mldsa87::sign_deterministic(seed, msg, &mut sig)
                 .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),
-            SignData::Mu(mu) => Mldsa87::sign_mu_deterministic(seed, &mu.0, &mut sig)
-                .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),
+            SignData::Mu(mu) => {
+                let mu = Mldsa87Mu::ref_from_bytes(&mu.0).map_err(|_| CryptoError::Size)?;
+                Mldsa87::sign_mu_deterministic(seed, mu, &mut sig)
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
+            }
             _ => return Err(CryptoError::MismatchedAlgorithm),
         }?;
 
-        Ok(Signature::Mldsa(MldsaSignature(sig)))
+        Ok(Signature::Mldsa(MldsaSignature(*sig)))
     }
 }
 

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -23,7 +23,7 @@ use caliptra_drivers::{
     Ecc384Signature, LmsResult,
 };
 #[cfg(feature = "mldsa_attestation")]
-use caliptra_drivers::{Mldsa87, Mldsa87Result};
+use caliptra_drivers::{Mldsa87, Mldsa87PubKey, Mldsa87Result, Mldsa87Signature};
 use caliptra_lms_types::{
     LmotsAlgorithmType, LmotsSignature, LmsAlgorithmType, LmsPublicKey, LmsSignature,
 };
@@ -162,7 +162,11 @@ impl Mldsa87VerifyCmd {
             msg_digest[i * 4..][..4].copy_from_slice(&src_word.to_be_bytes());
         }
 
-        let result = Mldsa87::verify(&cmd.pub_key, &cmd.signature, &msg_digest)?;
+        let result = Mldsa87::verify(
+            Mldsa87PubKey::from_ref(&cmd.pub_key),
+            Mldsa87Signature::from_ref(&cmd.signature),
+            &msg_digest,
+        )?;
         if result != Mldsa87Result::Success {
             return Err(CaliptraError::RUNTIME_MLDSA87_VERIFY_FAILED);
         }

--- a/runtime/src/verify.rs
+++ b/runtime/src/verify.rs
@@ -163,8 +163,10 @@ impl Mldsa87VerifyCmd {
         }
 
         let result = Mldsa87::verify(
-            Mldsa87PubKey::from_ref(&cmd.pub_key),
-            Mldsa87Signature::from_ref(&cmd.signature),
+            Mldsa87PubKey::ref_from_bytes(&cmd.pub_key)
+                .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
+            Mldsa87Signature::ref_from_bytes(&cmd.signature)
+                .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?,
             &msg_digest,
         )?;
         if result != Mldsa87Result::Success {


### PR DESCRIPTION
Add useful trait impls like `Default` and `Zeroize`, together with helper APIs to ML-DSA types to enable code simplification on user side.