### PR TITLE
[docs] Rename DICE diagram HKDF labels to KBKDF

### DIFF
--- a/rom/dev/doc/svg/dice-diagram.svg
+++ b/rom/dev/doc/svg/dice-diagram.svg
@@ -470,7 +470,7 @@
 			<text x="71.33" y="1181.18" class="st25" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>SIGN</text>		</g>
 		<g id="shape1040-156" v:mID="1040" v:groupContext="shape" v:layerMember="2" transform="translate(310.62,-798.307)">
 			<title>Custom 2.1006</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -498,7 +498,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1041-160" v:mID="1041" v:groupContext="shape" v:layerMember="0" transform="translate(351.12,-798.307)">
 			<title>Dynamic connector.1008</title>
@@ -529,7 +529,7 @@
 			<text x="7.51" y="1123.1" class="st28" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>“idevid_cdi”</text>		</g>
 		<g id="shape1044-178" v:mID="1044" v:groupContext="shape" v:layerMember="2" transform="translate(274.62,-647.558)">
 			<title>Custom 2.1011</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -557,11 +557,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1045-182" v:mID="1045" v:groupContext="shape" v:layerMember="2" transform="translate(346.62,-647.558)">
 			<title>Custom 2.1012</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -589,7 +589,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1046-186" v:mID="1046" v:groupContext="shape" v:layerMember="0" transform="translate(342.12,-715.8)">
 			<title>Dynamic connector.1014</title>
@@ -873,7 +873,7 @@
 			<text x="5.63" y="1117.37" class="st16" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>PRIVKEY</text>		</g>
 		<g id="shape1071-321" v:mID="1071" v:groupContext="shape" v:layerMember="2" transform="translate(472.62,-647.858)">
 			<title>Custom 2.1039</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -901,11 +901,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1072-325" v:mID="1072" v:groupContext="shape" v:layerMember="2" transform="translate(544.62,-647.858)">
 			<title>Custom 2.1040</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -933,7 +933,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1073-329" v:mID="1073" v:groupContext="shape" v:layerMember="0" transform="translate(538.995,-715.794)">
 			<title>Dynamic connector.1041</title>
@@ -1078,7 +1078,7 @@
 			<text x="-27.77" y="1140.58" class="st22" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>key</text>		</g>
 		<g id="shape1088-413" v:mID="1088" v:groupContext="shape" v:layerMember="2" transform="translate(705.382,-798.307)">
 			<title>Custom 2.1057</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1106,7 +1106,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1089-417" v:mID="1089" v:groupContext="shape" v:layerMember="0" transform="translate(727.939,-798.307)">
 			<title>Dynamic connector.1058</title>
@@ -1157,7 +1157,7 @@
 						dy="-0.289em" class="st8" v:baseFontSize="9">FMC</tspan></text>		</g>
 		<g id="shape1094-447" v:mID="1094" v:groupContext="shape" v:layerMember="2" transform="translate(670.62,-648.058)">
 			<title>Custom 2.1066</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1185,11 +1185,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1095-451" v:mID="1095" v:groupContext="shape" v:layerMember="2" transform="translate(742.62,-648.058)">
 			<title>Custom 2.1067</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1217,7 +1217,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1096-455" v:mID="1096" v:groupContext="shape" v:layerMember="0" transform="translate(736.995,-715.994)">
 			<title>Dynamic connector.1068</title>
@@ -1653,7 +1653,7 @@
 		</g>
 		<g id="shape1157-684" v:mID="1157" v:groupContext="shape" v:layerMember="2" transform="translate(955.695,-797.679)">
 			<title>Custom 2.1175</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1681,7 +1681,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1158-688" v:mID="1158" v:groupContext="shape" v:layerMember="0" transform="translate(978.251,-797.679)">
 			<title>Dynamic connector.1158</title>
@@ -1732,7 +1732,7 @@
 						dy="-0.289em" class="st8" v:baseFontSize="9">RT</tspan></text>		</g>
 		<g id="shape1163-718" v:mID="1163" v:groupContext="shape" v:layerMember="2" transform="translate(920.932,-647.429)">
 			<title>Custom 2.1181</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1760,11 +1760,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1164-722" v:mID="1164" v:groupContext="shape" v:layerMember="2" transform="translate(992.932,-647.429)">
 			<title>Custom 2.1182</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1792,7 +1792,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1165-726" v:mID="1165" v:groupContext="shape" v:layerMember="0" transform="translate(987.307,-715.365)">
 			<title>Dynamic connector.1183</title>


### PR DESCRIPTION
Update the ROM DICE SVG to label SP 800-108 HMAC-KDF derivations as KBKDF 512 instead of HKDF 512.