### PR TITLE
dpe: Extend DPE signing to mldsa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
 name = "caliptra-mldsa"
 version = "0.1.0"
 dependencies = [
+ "caliptra-dpe-response-buffer",
  "caliptra-shake",
  "hex",
  "serde_json",

--- a/common/crypto/mldsa/Cargo.toml
+++ b/common/crypto/mldsa/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+caliptra-dpe-response-buffer.workspace = true
 caliptra-shake.workspace = true
 zerocopy.workspace = true
 

--- a/common/crypto/mldsa/src/lib.rs
+++ b/common/crypto/mldsa/src/lib.rs
@@ -3,9 +3,9 @@
 #![cfg_attr(not(test), no_std)]
 
 use crate::mldsa87::{
-    mldsa87_key_pair_from_seed, mldsa87_pub_from_seed, mldsa87_sign, mldsa87_sign_deterministic,
-    mldsa87_sign_mu, mldsa87_sign_mu_deterministic, mldsa87_verify, mldsa87_verify_mu,
-    mldsa87_verify_with_context,
+    mldsa87_generate_mu, mldsa87_key_pair_from_seed, mldsa87_pub_from_seed, mldsa87_sign,
+    mldsa87_sign_deterministic, mldsa87_sign_mu, mldsa87_sign_mu_deterministic, mldsa87_verify,
+    mldsa87_verify_mu, mldsa87_verify_with_context,
 };
 #[cfg(test)]
 use crate::mldsa87::{
@@ -16,6 +16,7 @@ pub use crate::mldsa87::{
     Mldsa87Result, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
     MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
 };
+pub use caliptra_dpe_response_buffer::{ResponseBufError, ResponseBuffer};
 
 mod ct;
 mod mldsa87;
@@ -139,6 +140,16 @@ impl Mldsa87 {
         sig: &mut [u8; MLDSA87_SIGNATURE_BYTES],
     ) {
         mldsa87_sign_mu_deterministic_from_sk(sig, sk, mu);
+    }
+
+    /// Generate the mu for an MLDSA operation based on the given response buffer and public key.
+    pub fn generate_mu(
+        seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
+        msg: &dyn ResponseBuffer,
+        msg_range: core::ops::Range<usize>,
+        out_mu: &mut [u8; MLDSA87_MU_BYTES],
+    ) -> Result<(), ResponseBufError> {
+        mldsa87_generate_mu(seed, msg, msg_range, out_mu)
     }
 
     /// Verify a signature using an explicit signing `context`.

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::ct::{ct_ge, ct_if, ct_lt};
+use caliptra_dpe_response_buffer::{ResponseBufError, ResponseBuffer};
 use caliptra_shake::{Shake128, Shake256};
 use core::convert::TryInto;
 
@@ -1406,6 +1407,37 @@ pub fn mldsa87_sign_mu_from_sk(
     };
     decode_private_key_internal(&mut priv_key, sk);
     sign_internal_with_mu(out_encoded_signature, &priv_key, mu, randomizer);
+}
+
+/// Compute `mu` (the 64-byte message representative) from a private key seed
+/// and a message supplied via a [`ResponseBuffer`].
+///
+/// Implements FIPS 204 HashML-DSA with an empty (zero-length) context:
+/// `mu = SHAKE256(tr || 0x00 || 0x00 || M)` where `tr = SHAKE256(pk)` and
+/// `pk` is derived from `seed`.
+pub fn mldsa87_generate_mu(
+    private_key_seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
+    msg: &dyn ResponseBuffer,
+    msg_range: core::ops::Range<usize>,
+    out_mu: &mut [u8; MLDSA87_MU_BYTES],
+) -> Result<(), ResponseBufError> {
+    let mut pub_key = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+    mldsa87_pub_from_seed(&mut pub_key, private_key_seed);
+
+    let mut tr = [0u8; K_TR_BYTES];
+    let mut shake256 = Shake256::new();
+    shake256.absorb(&pub_key);
+    shake256.squeeze(&mut tr);
+
+    let mut shake256 = Shake256::new();
+    shake256.absorb(&tr);
+    shake256.absorb(&[0u8, 0u8]);
+    msg.read_range(msg_range, &mut |d| {
+        shake256.absorb(d);
+        Ok(())
+    })?;
+    shake256.squeeze(out_mu);
+    Ok(())
 }
 
 /// Deterministic variant of [`mldsa87_sign_mu_from_sk`].

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -21,8 +21,9 @@ use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 
 pub use caliptra_mldsa::{
-    Mldsa87Result, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
-    MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_RANDOMIZER_BYTES, MLDSA87_SIGNATURE_BYTES,
+    Mldsa87Result, ResponseBufError, ResponseBuffer, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_KEY_BYTES,
+    MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_RANDOMIZER_BYTES,
+    MLDSA87_SIGNATURE_BYTES,
 };
 
 /// ML-DSA-87 deterministic key-generation / signing seed (32 bytes).
@@ -74,6 +75,17 @@ impl Mldsa87 {
             None => Mldsa87Sw::pub_from_seed(seed, pub_key),
         }
         Ok(())
+    }
+
+    /// Compute `mu` from a seed and a message in a [`ResponseBuffer`].
+    #[inline(never)]
+    pub fn generate_mu(
+        seed: &Mldsa87Seed,
+        msg: &dyn ResponseBuffer,
+        msg_range: core::ops::Range<usize>,
+        out_mu: &mut Mldsa87Mu,
+    ) -> Result<(), ResponseBufError> {
+        Mldsa87Sw::generate_mu(seed, msg, msg_range, out_mu)
     }
 
     /// Deterministically sign `mu` with the key derived from `seed`.

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -36,9 +36,10 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 #[cfg(feature = "mldsa_attestation")]
 use {
     caliptra_drivers::{
-        Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES,
+        Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_MU_BYTES, MLDSA87_PRIVATE_SEED_BYTES,
+        MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
     },
-    crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey},
+    crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
     zeroize::Zeroizing,
 };
 
@@ -279,9 +280,24 @@ impl<'a> DpeCrypto<'a> {
     }
 
     #[cfg(feature = "mldsa_attestation")]
-    fn sign_helper_mldsa(_data: &SignData, _seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
-        // TODO: Issue #3936 - Implement MLDSA DPE Hash.
-        Err(CryptoError::MismatchedAlgorithm)
+    fn sign_helper_mldsa(data: &SignData, seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
+        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+        match data {
+            SignData::ResponseBuffer(buf, range) => {
+                let mut mu = [0u8; MLDSA87_MU_BYTES];
+                Mldsa87::generate_mu(seed, *buf, range.clone(), &mut mu)
+                    .map_err(|_| CryptoError::HashError(0))?;
+                Mldsa87::sign_mu_deterministic(seed, &mu, &mut sig)
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
+            }
+            SignData::Raw(msg) => Mldsa87::sign_deterministic(seed, msg, &mut sig)
+                .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),
+            SignData::Mu(mu) => Mldsa87::sign_mu_deterministic(seed, &mu.0, &mut sig)
+                .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        }?;
+
+        Ok(Signature::Mldsa(MldsaSignature(sig)))
     }
 }
 


### PR DESCRIPTION
Complete the todo left by the stack optimization to implement the signing logic required by the mldsa dpe instance.  This utilizes a newly provided utility to generate the mu value for response buffers which cannot be passed over to the normal sign operations.