### PR TITLE
drivers: chunk DMA image hashing to support images > 1 MiB

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-178f7a10b43275c68ae4698569b720678eb349c4d1deb3c8e3faf7a27ecce072e52874b186cb96a8a46a3f2b7bc4fb1d  caliptra-rom-no-log.bin
-5ee14fc648c2fec43556f03ec1422d77b28d1981368217fb6853f1d2feaefc59eca38a587db54cb3e1df8b7ca14f6a55  caliptra-rom-with-log.bin
+e0d451a546c8f89bdbdef551515ac584d5518e2a2290413beaef6708e2fe80af40855602b1be12cf144283ebcccba50d  caliptra-rom-no-log.bin
+0dc3b980366dae111ccfde78a7222597a5bf101e79c45671b3a045bb0b804c51cf9d4435e6bdf6929260b882b6c2cb37  caliptra-rom-with-log.bin

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -507,6 +507,10 @@ pub struct DmaRecovery<'a> {
 impl<'a> DmaRecovery<'a> {
     const RECOVERY_REGISTER_OFFSET: usize = 0x100;
     const INDIRECT_FIFO_DATA_OFFSET: u32 = 0x68;
+
+    /// Max bytes per DMA transfer; mirrors `DMA_MAX_XFER_SIZE` in
+    /// `axi_dma_ctrl.sv`. A larger `byte_count` is rejected by the HW.
+    const DMA_MAX_XFER_SIZE: u32 = 0x10_0000; // 1 MiB
     const PROT_CAP2_DEVICE_ID_SUPPORT: u32 = 0x1; // Bit 0 in agent_caps
     const PROT_CAP2_DEVICE_STATUS_SUPPORT: u32 = 0x10; // Bit 4 in agent_caps
     const PROT_CAP2_RECOVERY_MEMORY_ACCESS_SUPPORT: u32 = 0x20; // Bit 5 in agent_caps
@@ -1174,6 +1178,36 @@ impl<'a> DmaRecovery<'a> {
         self.sha512_image(sha_acc, source, length, aes_mode)
     }
 
+    /// Feed `length` bytes from `source` into the SHA accelerator's `datain`
+    /// (`write_addr`) in <= [`DMA_MAX_XFER_SIZE`] chunks; the digest matches a
+    /// single transfer. AES is rejected: its cipher context is per-DMA-command,
+    /// so it cannot be split into multiple transfers like the caller expects.
+    fn chunked_sha_datain(
+        &self,
+        source: AxiAddr,
+        length: u32,
+        write_addr: AxiAddr,
+        aes_mode: AesDmaMode,
+    ) -> CaliptraResult<()> {
+        if aes_mode.aes() {
+            return Err(CaliptraError::DRIVER_DMA_INVALID_DMA_TARGET);
+        }
+
+        for offset in (0..length).step_by(Self::DMA_MAX_XFER_SIZE as usize) {
+            let chunk = (length - offset).min(Self::DMA_MAX_XFER_SIZE);
+            // `source` advances per chunk; `write_addr` (datain) stays fixed.
+            self.transfer_payload_to_axi(
+                source + offset,
+                chunk,
+                write_addr,
+                false,
+                true,
+                AesDmaMode::None,
+            )?;
+        }
+        Ok(())
+    }
+
     pub fn sha384_image(
         &self,
         sha_acc: &'a mut Sha2_512_384Acc,
@@ -1216,8 +1250,9 @@ impl<'a> DmaRecovery<'a> {
             // Safety: the dma_sha is relative to 0, so we can use it to get the offset of the data in register.
             let write_addr = self.caliptra_base + (dma_sha.datain().ptr as u32 as u64);
 
-            // stream the data in to the SHA accelerator
-            self.transfer_payload_to_axi(source, length, write_addr, false, true, aes_mode)?;
+            // feed the data into the SHA accelerator (split into <= 1 MiB
+            // DMA transfers; dlen/execute cover the full length).
+            self.chunked_sha_datain(source, length, write_addr, aes_mode)?;
 
             dma_sha.execute().write(|w| w.execute(true));
 
@@ -1287,8 +1322,9 @@ impl<'a> DmaRecovery<'a> {
                 length
             );
 
-            // stream the data in to the SHA accelerator
-            self.transfer_payload_to_axi(source, length, write_addr, false, true, aes_mode)?;
+            // feed the data into the SHA accelerator (split into <= 1 MiB
+            // DMA transfers; dlen/execute cover the full length).
+            self.chunked_sha_datain(source, length, write_addr, aes_mode)?;
 
             dma_sha.execute().write(|w| w.execute(true));
 

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -1180,8 +1180,10 @@ impl<'a> DmaRecovery<'a> {
 
     /// Feed `length` bytes from `source` into the SHA accelerator's `datain`
     /// (`write_addr`) in <= [`DMA_MAX_XFER_SIZE`] chunks; the digest matches a
-    /// single transfer. AES is rejected: its cipher context is per-DMA-command,
-    /// so it cannot be split into multiple transfers like the caller expects.
+    /// single transfer. AES cannot be chunked (its cipher context is
+    /// per-DMA-command), so an AES payload is sent as a single transfer and is
+    /// therefore limited to [`DMA_MAX_XFER_SIZE`]; a larger AES payload is
+    /// rejected.
     fn chunked_sha_datain(
         &self,
         source: AxiAddr,
@@ -1190,7 +1192,10 @@ impl<'a> DmaRecovery<'a> {
         aes_mode: AesDmaMode,
     ) -> CaliptraResult<()> {
         if aes_mode.aes() {
-            return Err(CaliptraError::DRIVER_DMA_AES_CHUNKING_UNSUPPORTED);
+            if length > Self::DMA_MAX_XFER_SIZE {
+                return Err(CaliptraError::DRIVER_DMA_AES_CHUNKING_UNSUPPORTED);
+            }
+            return self.transfer_payload_to_axi(source, length, write_addr, false, true, aes_mode);
         }
 
         for offset in (0..length).step_by(Self::DMA_MAX_XFER_SIZE as usize) {

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -1190,7 +1190,7 @@ impl<'a> DmaRecovery<'a> {
         aes_mode: AesDmaMode,
     ) -> CaliptraResult<()> {
         if aes_mode.aes() {
-            return Err(CaliptraError::DRIVER_DMA_INVALID_DMA_TARGET);
+            return Err(CaliptraError::DRIVER_DMA_AES_CHUNKING_UNSUPPORTED);
         }
 
         for offset in (0..length).step_by(Self::DMA_MAX_XFER_SIZE as usize) {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1106,6 +1106,11 @@ impl CaliptraError {
             "DMA driver Error: Invalid target"
         ),
         (
+            DRIVER_DMA_AES_CHUNKING_UNSUPPORTED,
+            0x0000f007,
+            "DMA driver Error: AES cannot be split across multiple transfers"
+        ),
+        (
             DRIVER_SHA3_INVALID_STATE_ERR,
             0x0001f000,
             "SHA3 driver Error: Invalid op state"

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1247,6 +1247,76 @@ fn test_authorize_from_load_address() {
     assert_eq!(tagged_tci.tci_current, fw_digest);
 }
 
+// Exercises an image larger than the DMA engine's 1 MiB per-transfer limit
+// (see caliptra-rtl axi_dma_ctrl.sv DMA_MAX_XFER_SIZE). The driver must split
+// the hash into multiple <= 1 MiB DMA transfers; this checks the resulting
+// digest matches a single-shot SHA384 over the whole image.
+// Ignored on FPGA: needs > 1 MiB of staging SRAM.
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
+#[test]
+fn test_authorize_from_load_address_larger_than_1mib() {
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_ignore_auth_check(false);
+    flags.set_image_source(ImageHashSource::LoadAddress as u32);
+
+    // 2 MiB + 3 KiB: spans three DMA transfers (1 MiB, 1 MiB, remainder).
+    let mut load_memory_contents = vec![0u8; 2 * 1024 * 1024 + 3 * 1024];
+    for (i, b) in load_memory_contents.iter_mut().enumerate() {
+        *b = i as u8;
+    }
+
+    let mut hasher = Sha384::new();
+    hasher.update(&load_memory_contents);
+    let fw_digest: [u8; 48] = hasher.finalize().into();
+
+    let image_metadata = AuthManifestImageMetadata {
+        fw_id: u32::from_le_bytes(FW_ID_1),
+        flags: flags.0,
+        digest: fw_digest,
+        image_load_address: Addr64 {
+            lo: TEST_SRAM_BASE.lo,
+            hi: TEST_SRAM_BASE.hi,
+        },
+        ..Default::default()
+    };
+    let mcu_image = [0xAAu8; 256];
+    let mcu_image_metadata = get_mcu_image_metadata(&mcu_image);
+    let auth_manifest =
+        create_auth_manifest_with_metadata([mcu_image_metadata, image_metadata].to_vec());
+    let mut model =
+        set_auth_manifest_with_test_sram(Some(auth_manifest), &load_memory_contents, &mcu_image);
+
+    write_to_test_sram(
+        &mut model,
+        image_metadata.image_load_address,
+        &load_memory_contents,
+    );
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: FW_ID_1,
+        measurement: [0; 48],
+        source: ImageHashSource::LoadAddress as u32,
+        flags: 0, // Don't skip stash
+        image_size: load_memory_contents.len() as u32,
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            authorize_and_stash_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
+
+    let tagged_tci = tag_and_get_default_tci(&mut model);
+    assert_eq!(tagged_tci.tci_current, fw_digest);
+}
+
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_authorize_from_load_address_incorrect_digest() {

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -30,7 +30,9 @@ use std::{rc::Rc, sync::mpsc};
 
 pub type AxiAddr = u64;
 
-const TEST_SRAM_SIZE: usize = 64 * 1024;
+// Large enough to stage firmware images bigger than the DMA's 1 MiB
+// per-transfer limit, so tests can exercise multi-transfer image hashing.
+const TEST_SRAM_SIZE: usize = 4 * 1024 * 1024;
 const EXTERNAL_TEST_SRAM_SIZE: usize = 1024 * 1024;
 const MCU_SRAM_SIZE: usize = 384 * 1024;
 
@@ -117,9 +119,11 @@ impl AxiRootBus {
             if test_sram_content.len() > TEST_SRAM_SIZE {
                 panic!("test_sram_content length exceeds TEST_SRAM_SIZE");
             }
-            let mut sram_data = [0u8; TEST_SRAM_SIZE];
-            sram_data[..test_sram_content.len()].copy_from_slice(test_sram_content);
-            Some(ReadWriteMemory::new_with_data(sram_data))
+            // Allocate zeroed (heap-backed, so a large TEST_SRAM_SIZE does not
+            // overflow the stack) and copy the caller's content into the front.
+            let mut sram = ReadWriteMemory::new();
+            sram.data_mut()[..test_sram_content.len()].copy_from_slice(test_sram_content);
+            Some(sram)
         } else {
             None
         };


### PR DESCRIPTION
## Summary

Fixes #3458 — `authorize_and_stash` (and the ROM/RT image verifier) fails to
hash images larger than 1 MiB.

The AXI DMA engine rejects any single transfer larger than `DMA_MAX_XFER_SIZE`
(1 MiB) — an oversized `byte_count` asserts `cmd_inv_byte_count`, which the DMA
reports as a Command Decode Error and moves no data. `sha384_image()` /
`sha512_image()` programmed the full image length as one transfer, so
`ImageHashSource::LoadAddress` / `StagingAddress` on an image > 1 MiB failed to
hash and hung waiting for bytes that never streamed.

## Change

- Split the DMA feed into ≤ 1 MiB transfers in a new `stream_to_sha_datain`
  helper. The SHA accelerator's `dlen` is still programmed once and finalized
  with a single `execute`, so it accumulates across the transfers and the
  resulting digest is identical to a single transfer. Chunk arithmetic is
  factored into `dma_chunk_len` for unit testing.
- AES modes are **not** chunked: the AES cipher context (CTR/IV and GCM
  GHASH/byte-count) is per-DMA-command, so an AES stream must stay one
  continuous transfer.
- Both `sha384_image` and `sha512_image` route through the helper, covering
  `authorize_and_stash`, the ROM/RT image verifier, and the crypto mailbox.
