### PR TITLE
runtime: derive PQ.DevID.CDI during SET_PQ_SEED handling

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -98,8 +98,6 @@ pub use persistent::fmc_alias_csr::FmcAliasCsr;
 #[cfg(feature = "runtime")]
 pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
 
-#[cfg(feature = "mldsa_attestation")]
-pub use persistent::PQ_DEVID_SEED_SIZE;
 pub use persistent::{
     FuseLogArray, IdevIdCsr, PcrLogArray, PersistentData, PersistentDataAccessor,
     StashMeasurementArray, FUSE_LOG_MAX_COUNT, MAX_FMC_ALIAS_CSR_SIZE, MAX_IDEVID_CSR_SIZE,

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -46,11 +46,10 @@ pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
 pub const IDEVID_CSR_SIZE: u32 = 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 1024;
 pub const DPE_PL_CONTEXT_LIMITS_SIZE: u32 = 2;
-pub const PQ_DEVID_SEED_SIZE: u32 = 32;
 pub const PQC_STATUS_FLAGS_SIZE: u32 = 1;
 #[cfg(feature = "mldsa_attestation")]
 pub const PQC_MODE_ENABLED_FLAG: u8 = 1;
-pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2 - PQ_DEVID_SEED_SIZE - PQC_STATUS_FLAGS_SIZE;
+pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024) - 2 - PQC_STATUS_FLAGS_SIZE;
 
 pub const PCR_LOG_MAX_COUNT: usize = 17;
 pub const FUSE_LOG_MAX_COUNT: usize = 62;
@@ -321,11 +320,6 @@ pub struct PersistentData {
     pub dpe_pl1_context_limit: u8,
 
     #[cfg(feature = "mldsa_attestation")]
-    pub pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
-    #[cfg(not(feature = "mldsa_attestation"))]
-    pq_devid_seed: [u8; PQ_DEVID_SEED_SIZE as usize],
-
-    #[cfg(feature = "mldsa_attestation")]
     pub pqc_status_flags: u8,
     #[cfg(not(feature = "mldsa_attestation"))]
     pqc_status_flags: u8,
@@ -448,12 +442,6 @@ impl PersistentData {
             );
 
             persistent_data_offset += DPE_PL_CONTEXT_LIMITS_SIZE;
-            assert_eq!(
-                addr_of!((*P).pq_devid_seed) as u32,
-                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
-            );
-
-            persistent_data_offset += PQ_DEVID_SEED_SIZE;
             assert_eq!(
                 addr_of!((*P).pqc_status_flags) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -60,11 +60,6 @@ use dpe::{
     response::DeriveContextResp,
 };
 use dpe::{DpeFlags, DpeProfile, State};
-#[cfg(feature = "mldsa_attestation")]
-use {
-    caliptra_common::keyids::KEY_ID_PQ_DEVID_CDI,
-    caliptra_drivers::{hmac384_kdf, KeyUsage, KeyWriteArgs, PQ_DEVID_SEED_SIZE},
-};
 
 use core::cmp::Ordering::{Equal, Greater};
 use crypto::{
@@ -493,10 +488,6 @@ impl Drivers {
         // Create a hash of critical initialization values
         let initialization_values_hash = Self::compute_initialization_values_hash(drivers)?;
 
-        // Derive the PQ DevID CDI when ML-DSA is enabled.
-        #[cfg(feature = "mldsa_attestation")]
-        Self::derive_pq_devid_cdi(drivers)?;
-
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         let key_id_rt_priv_key = Drivers::get_key_id_rt_priv_key(drivers)?;
         let pdata = drivers.persistent_data.get_mut();
@@ -630,23 +621,6 @@ impl Drivers {
         // Write DPE to persistent data.
         pdata.dpe = state;
         Ok(())
-    }
-
-    #[cfg(feature = "mldsa_attestation")]
-    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
-    fn derive_pq_devid_cdi(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let mut buf = [0u8; core::mem::size_of::<Array4x12>()];
-        buf.get_mut(..PQ_DEVID_SEED_SIZE as usize)
-            .ok_or(CaliptraError::RUNTIME_MLDSA87_DEVID_SEED_TOO_LARGE)?
-            .copy_from_slice(&drivers.persistent_data.get().pq_devid_seed);
-        hmac384_kdf(
-            &mut drivers.hmac384,
-            (&Array4x12::from(&buf)).into(),
-            b"pq_devid_cdi",
-            None,
-            &mut drivers.trng,
-            KeyWriteArgs::new(KEY_ID_PQ_DEVID_CDI, KeyUsage::default().set_hmac_key_en()).into(),
-        )
     }
 
     /// Create certificate chain and store in Drivers

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -14,8 +14,13 @@ Abstract:
 
 use crate::{Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{MailboxResp, SetPqSeedReq};
-use caliptra_drivers::{CaliptraError, CaliptraResult};
+use caliptra_common::{
+    keyids::KEY_ID_PQ_DEVID_CDI,
+    mailbox_api::{MailboxResp, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE},
+};
+use caliptra_drivers::{
+    hmac384_kdf, Array4x12, CaliptraError, CaliptraResult, KeyUsage, KeyWriteArgs,
+};
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SetPqSeedCmd;
@@ -35,9 +40,29 @@ impl SetPqSeedCmd {
         let mut cmd = SetPqSeedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
-        drivers.persistent_data.get_mut().pq_devid_seed = cmd.seed;
+        Self::derive_pq_devid_cdi(drivers, &cmd.seed)?;
+
         drivers.persistent_data.get_mut().set_pqc_mode_enabled();
 
         Ok(MailboxResp::default())
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    fn derive_pq_devid_cdi(
+        drivers: &mut Drivers,
+        seed: &[u8; SET_PQ_SEED_SEED_SIZE],
+    ) -> CaliptraResult<()> {
+        let mut buf = [0u8; core::mem::size_of::<Array4x12>()];
+        buf.get_mut(..SET_PQ_SEED_SEED_SIZE as usize)
+            .ok_or(CaliptraError::RUNTIME_MLDSA87_DEVID_SEED_TOO_LARGE)?
+            .copy_from_slice(seed);
+        hmac384_kdf(
+            &mut drivers.hmac384,
+            (&Array4x12::from(&buf)).into(),
+            b"pq_devid_cdi",
+            None,
+            &mut drivers.trng,
+            KeyWriteArgs::new(KEY_ID_PQ_DEVID_CDI, KeyUsage::default().set_hmac_key_en()).into(),
+        )
     }
 }


### PR DESCRIPTION
Remove the PQ seed storage from persistent data since it is only used to derive the CDI. The CDI is now derived immediately during the handling of SET_PQ_SEED command, and stored in the key vault.