### PR TITLE
dpe: enable hybrid feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe", features = ["p384", "arbitrary_max_handles"] }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe", features = ["hybrid", "arbitrary_max_handles"] }
 crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe-crypto", default-features = false }
 platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", package = "caliptra-dpe-platform", default-features = false }
 caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "cf3224c41b64789aa556e4f0c78e7395c6528a43", default-features = false }

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -730,7 +730,7 @@ pub struct CertifyKeyExtendedResp {
     pub certify_key_resp: [u8; CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE],
 }
 impl CertifyKeyExtendedResp {
-    pub const CERTIFY_KEY_RESP_SIZE: usize = 12672;
+    pub const CERTIFY_KEY_RESP_SIZE: usize = 25152;
 }
 impl Response for CertifyKeyExtendedResp {}
 
@@ -820,7 +820,7 @@ pub struct InvokeDpeResp {
     pub data: [u8; InvokeDpeResp::DATA_MAX_SIZE], // variable length
 }
 impl InvokeDpeResp {
-    pub const DATA_MAX_SIZE: usize = 15168;
+    pub const DATA_MAX_SIZE: usize = 25152;
 }
 impl ResponseVarSize for InvokeDpeResp {}
 


### PR DESCRIPTION
Enable the "hybrid" feature of caliptra-dpe, and bump the size of receive buffers for INVOKE_DPE and CERTIFY_KEY commands to match caliptra-sw 2.0. This will be the last step of upgrading caliptra-dpe to the version with ML-DSA support.

Issue: #3741