### PR TITLE
mldsa-dpe: Add skeleton for mldsa87 DPE Commands

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -42,6 +42,12 @@ impl CommandId {
     pub const EXTEND_PCR: Self = Self(0x50435245); // "PCRE"
     pub const ADD_SUBJECT_ALT_NAME: Self = Self(0x414C544E); // "ALTN"
     pub const CERTIFY_KEY_EXTENDED: Self = Self(0x434B4558); // "CKEX"
+    #[cfg(feature = "mldsa_attestation")]
+    pub const INVOKE_DPE_MLDSA87: Self = Self(0x4D4C4450); // "MLDP"
+    #[cfg(feature = "mldsa_attestation")]
+    pub const GET_PQ_CSR: Self = Self(0x50514353); // "PQCS"
+    #[cfg(feature = "mldsa_attestation")]
+    pub const CERTIFY_KEY_EXTENDED_MLDSA87: Self = Self(0x434B454D); // "CKEM"
 
     /// FIPS module commands.
     /// The status command.
@@ -176,6 +182,12 @@ pub enum MailboxResp {
     GetRtAliasCert(GetRtAliasCertResp),
     QuotePcrs(QuotePcrsResp),
     CertifyKeyExtended(CertifyKeyExtendedResp),
+    #[cfg(feature = "mldsa_attestation")]
+    InvokeDpeMldsa87Command(InvokeDpeMldsa87Resp),
+    #[cfg(feature = "mldsa_attestation")]
+    GetPqCsr(GetPqCsrResp),
+    #[cfg(feature = "mldsa_attestation")]
+    CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Resp),
     AuthorizeAndStash(AuthorizeAndStashResp),
     GetIdevCsr(GetIdevCsrResp),
     GetFmcAliasCsr(GetFmcAliasCsrResp),
@@ -202,6 +214,12 @@ impl MailboxResp {
             MailboxResp::GetRtAliasCert(resp) => resp.as_bytes_partial(),
             MailboxResp::QuotePcrs(resp) => Ok(resp.as_bytes()),
             MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::InvokeDpeMldsa87Command(resp) => resp.as_bytes_partial(),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::GetPqCsr(resp) => Ok(resp.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::CertifyKeyExtendedMldsa87(resp) => Ok(resp.as_bytes()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_bytes()),
@@ -228,6 +246,12 @@ impl MailboxResp {
             MailboxResp::GetRtAliasCert(resp) => resp.as_bytes_partial_mut(),
             MailboxResp::QuotePcrs(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CertifyKeyExtended(resp) => Ok(resp.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::InvokeDpeMldsa87Command(resp) => resp.as_bytes_partial_mut(),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::GetPqCsr(resp) => Ok(resp.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::CertifyKeyExtendedMldsa87(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_mut_bytes()),
@@ -291,6 +315,10 @@ pub enum MailboxReq {
     QuotePcrs(QuotePcrsReq),
     #[cfg(feature = "mldsa_attestation")]
     SetPqSeed(SetPqSeedReq),
+    #[cfg(feature = "mldsa_attestation")]
+    InvokeDpeMldsa87Command(InvokeDpeMldsa87Req),
+    #[cfg(feature = "mldsa_attestation")]
+    CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req),
     ExtendPcr(ExtendPcrReq),
     AddSubjectAltName(AddSubjectAltNameReq),
     CertifyKeyExtended(CertifyKeyExtendedReq),
@@ -323,6 +351,10 @@ impl MailboxReq {
             MailboxReq::QuotePcrs(req) => Ok(req.as_bytes()),
             #[cfg(feature = "mldsa_attestation")]
             MailboxReq::SetPqSeed(req) => Ok(req.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::InvokeDpeMldsa87Command(req) => req.as_bytes_partial(),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::CertifyKeyExtendedMldsa87(req) => Ok(req.as_bytes()),
             MailboxReq::ExtendPcr(req) => Ok(req.as_bytes()),
             MailboxReq::AddSubjectAltName(req) => req.as_bytes_partial(),
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_bytes()),
@@ -355,6 +387,10 @@ impl MailboxReq {
             MailboxReq::QuotePcrs(req) => Ok(req.as_mut_bytes()),
             #[cfg(feature = "mldsa_attestation")]
             MailboxReq::SetPqSeed(req) => Ok(req.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::InvokeDpeMldsa87Command(req) => req.as_bytes_partial_mut(),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::CertifyKeyExtendedMldsa87(req) => Ok(req.as_mut_bytes()),
             MailboxReq::ExtendPcr(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AddSubjectAltName(req) => req.as_bytes_partial_mut(),
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_mut_bytes()),
@@ -387,6 +423,10 @@ impl MailboxReq {
             MailboxReq::QuotePcrs(_) => CommandId::QUOTE_PCRS,
             #[cfg(feature = "mldsa_attestation")]
             MailboxReq::SetPqSeed(_) => CommandId::SET_PQ_SEED,
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::InvokeDpeMldsa87Command(_) => CommandId::INVOKE_DPE_MLDSA87,
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::CertifyKeyExtendedMldsa87(_) => CommandId::CERTIFY_KEY_EXTENDED_MLDSA87,
             MailboxReq::ExtendPcr(_) => CommandId::EXTEND_PCR,
             MailboxReq::AddSubjectAltName(_) => CommandId::ADD_SUBJECT_ALT_NAME,
             MailboxReq::CertifyKeyExtended(_) => CommandId::CERTIFY_KEY_EXTENDED,
@@ -1077,6 +1117,163 @@ const _: () =
 impl Request for SetPqSeedReq {
     const ID: CommandId = CommandId::SET_PQ_SEED;
     type Resp = MailboxRespHeader;
+}
+
+// INVOKE_DPE_MLDSA87
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeMldsa87Req {
+    pub hdr: MailboxReqHeader,
+    pub data_size: u32,
+    pub data: [u8; InvokeDpeMldsa87Req::DATA_MAX_SIZE], // variable length
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl InvokeDpeMldsa87Req {
+    pub const DATA_MAX_SIZE: usize = 512;
+
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.data_size as usize > Self::DATA_MAX_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+
+    pub fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if self.data_size as usize > Self::DATA_MAX_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::DATA_MAX_SIZE - self.data_size as usize;
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+#[cfg(feature = "mldsa_attestation")]
+impl Default for InvokeDpeMldsa87Req {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            data_size: 0,
+            data: [0u8; InvokeDpeMldsa87Req::DATA_MAX_SIZE],
+        }
+    }
+}
+#[cfg(feature = "mldsa_attestation")]
+impl Request for InvokeDpeMldsa87Req {
+    const ID: CommandId = CommandId::INVOKE_DPE_MLDSA87;
+    type Resp = InvokeDpeMldsa87Resp;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct InvokeDpeMldsa87Resp {
+    pub hdr: MailboxRespHeader,
+    pub data_size: u32,
+    pub data: [u8; InvokeDpeMldsa87Resp::DATA_MAX_SIZE], // variable length
+}
+#[cfg(feature = "mldsa_attestation")]
+impl InvokeDpeMldsa87Resp {
+    pub const DATA_MAX_SIZE: usize = 25168;
+}
+#[cfg(feature = "mldsa_attestation")]
+impl ResponseVarSize for InvokeDpeMldsa87Resp {}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for InvokeDpeMldsa87Resp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            data_size: 0,
+            data: [0u8; InvokeDpeMldsa87Resp::DATA_MAX_SIZE],
+        }
+    }
+}
+
+// GET_PQ_CSR
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Default, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetPqCsrReq {
+    pub hdr: MailboxReqHeader,
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Request for GetPqCsrReq {
+    const ID: CommandId = CommandId::GET_PQ_CSR;
+    type Resp = GetPqCsrResp;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetPqCsrResp {
+    pub hdr: MailboxRespHeader,
+    pub data_size: u32,
+    pub data: [u8; Self::DATA_MAX_SIZE],
+}
+#[cfg(feature = "mldsa_attestation")]
+impl GetPqCsrResp {
+    pub const DATA_MAX_SIZE: usize = 12800;
+}
+#[cfg(feature = "mldsa_attestation")]
+impl ResponseVarSize for GetPqCsrResp {}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for GetPqCsrResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            data_size: 0,
+            data: [0u8; Self::DATA_MAX_SIZE],
+        }
+    }
+}
+
+// CERTIFY_KEY_EXTENDED_MLDSA87
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyExtendedMldsa87Req {
+    pub hdr: MailboxReqHeader,
+    pub flags: CertifyKeyExtendedFlags,
+    pub certify_key_req: [u8; CertifyKeyExtendedMldsa87Req::CERTIFY_KEY_REQ_SIZE],
+}
+#[cfg(feature = "mldsa_attestation")]
+impl CertifyKeyExtendedMldsa87Req {
+    pub const CERTIFY_KEY_REQ_SIZE: usize = 72;
+}
+#[cfg(feature = "mldsa_attestation")]
+impl Request for CertifyKeyExtendedMldsa87Req {
+    const ID: CommandId = CommandId::CERTIFY_KEY_EXTENDED_MLDSA87;
+    type Resp = CertifyKeyExtendedMldsa87Resp;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct CertifyKeyExtendedMldsa87Resp {
+    pub hdr: MailboxRespHeader,
+    pub size: u32,
+    pub certify_key_resp: [u8; CertifyKeyExtendedMldsa87Resp::CERTIFY_KEY_RESP_SIZE],
+}
+#[cfg(feature = "mldsa_attestation")]
+impl CertifyKeyExtendedMldsa87Resp {
+    pub const CERTIFY_KEY_RESP_SIZE: usize = 25152;
+}
+#[cfg(feature = "mldsa_attestation")]
+impl Response for CertifyKeyExtendedMldsa87Resp {}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for CertifyKeyExtendedMldsa87Resp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            size: 0,
+            certify_key_resp: [0u8; CertifyKeyExtendedMldsa87Resp::CERTIFY_KEY_RESP_SIZE],
+        }
+    }
 }
 
 // SET_AUTH_MANIFEST

--- a/runtime/src/certify_key_extended_mldsa.rs
+++ b/runtime/src/certify_key_extended_mldsa.rs
@@ -1,0 +1,31 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    certify_key_extended_mldsa.rs
+
+Abstract:
+
+    File contains the CERTIFY_KEY_EXTENDED_MLDSA87 mailbox command, the ML-DSA-87
+    (PQ) identity variant of CERTIFY_KEY_EXTENDED.
+
+--*/
+
+use crate::Drivers;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+
+pub struct CertifyKeyExtendedMldsa87Cmd;
+
+impl CertifyKeyExtendedMldsa87Cmd {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(_drivers: &mut Drivers) -> CaliptraResult<()> {
+        // TODO(PQC): certify the requested key under the ML-DSA-87 identity and
+        // return the certificate via CertifyKeyExtendedMldsa87Resp. Return
+        // RUNTIME_PQC_NOT_INITIALIZED when pqc_mode is disabled.
+        Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND)
+    }
+}

--- a/runtime/src/get_pq_csr.rs
+++ b/runtime/src/get_pq_csr.rs
@@ -1,0 +1,31 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    get_pq_csr.rs
+
+Abstract:
+
+    File contains the GET_PQ_CSR mailbox command, which returns the PQ.DevID
+    ML-DSA-87 self-signed Certificate Signing Request.
+
+--*/
+
+use crate::Drivers;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+
+pub struct GetPqCsrCmd;
+
+impl GetPqCsrCmd {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(_drivers: &mut Drivers) -> CaliptraResult<()> {
+        // TODO(PQC): regenerate the ML-DSA-87 keypair from the PQ seed, build
+        // and sign the CSR TBS, and return it via GetPqCsrResp. Return
+        // RUNTIME_PQC_NOT_INITIALIZED when pqc_mode is disabled.
+        Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND)
+    }
+}

--- a/runtime/src/invoke_dpe_mldsa.rs
+++ b/runtime/src/invoke_dpe_mldsa.rs
@@ -1,0 +1,31 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    invoke_dpe_mldsa.rs
+
+Abstract:
+
+    File contains the INVOKE_DPE_MLDSA87 mailbox command, which executes a DPE
+    command using the ML-DSA-87 (PQ) identity.
+
+--*/
+
+use crate::Drivers;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_drivers::{CaliptraError, CaliptraResult};
+
+pub struct InvokeDpeMldsa87Cmd;
+
+impl InvokeDpeMldsa87Cmd {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(_drivers: &mut Drivers) -> CaliptraResult<()> {
+        // TODO(PQC): create the ML-DSA DPE environment and execute the DPE
+        // command (CertifyKey, Sign, DeriveContext). Return
+        // RUNTIME_PQC_NOT_INITIALIZED when pqc_mode is disabled.
+        Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND)
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,6 +16,8 @@ Abstract:
 mod authorize_and_stash;
 mod capabilities;
 mod certify_key_extended;
+#[cfg(feature = "mldsa_attestation")]
+mod certify_key_extended_mldsa;
 pub mod dice;
 mod disable;
 mod dpe_crypto;
@@ -24,10 +26,14 @@ mod drivers;
 pub mod fips;
 mod get_fmc_alias_csr;
 mod get_idev_csr;
+#[cfg(feature = "mldsa_attestation")]
+mod get_pq_csr;
 pub mod handoff;
 mod hmac;
 pub mod info;
 mod invoke_dpe;
+#[cfg(feature = "mldsa_attestation")]
+mod invoke_dpe_mldsa;
 pub mod mbox_response_writer;
 mod pcr;
 mod populate_idev;
@@ -55,8 +61,14 @@ use mailbox::Mailbox;
 
 use crate::capabilities::CapabilitiesCmd;
 pub use crate::certify_key_extended::CertifyKeyExtendedCmd;
+#[cfg(feature = "mldsa_attestation")]
+pub use crate::certify_key_extended_mldsa::CertifyKeyExtendedMldsa87Cmd;
+#[cfg(feature = "mldsa_attestation")]
+pub use crate::get_pq_csr::GetPqCsrCmd;
 pub use crate::hmac::Hmac;
 pub use crate::invoke_dpe::CaliptraDpeProfile;
+#[cfg(feature = "mldsa_attestation")]
+pub use crate::invoke_dpe_mldsa::InvokeDpeMldsa87Cmd;
 use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
@@ -264,6 +276,12 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
         CommandId::SET_PQ_SEED => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeMldsa87Cmd::execute(drivers),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::GET_PQ_CSR => GetPqCsrCmd::execute(drivers),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::CERTIFY_KEY_EXTENDED_MLDSA87 => CertifyKeyExtendedMldsa87Cmd::execute(drivers),
         CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers),
         CommandId::GET_IDEV_CSR => GetIdevCsrCmd::execute(drivers),
         CommandId::GET_FMC_ALIAS_CSR => GetFmcAliasCsrCmd::execute(drivers),

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -73,6 +73,25 @@ pub fn run_rt_test_return_fw(args: RuntimeTestArgs) -> (DefaultHwModel, ImageBun
     run_rt_test_base(args, false)
 }
 
+// Boot the ML-DSA attestation runtime image and wait until it is ready for
+// commands. Shared by the per-command PQC DPE integration tests.
+#[cfg(feature = "mldsa_attestation")]
+pub fn run_pqc_rt_test() -> DefaultHwModel {
+    use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+    use caliptra_runtime::RtBootStatus;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    model
+}
+
 pub fn run_rt_test_base(args: RuntimeTestArgs, lms_verify: bool) -> (DefaultHwModel, ImageBundle) {
     let default_rt_fwid = if cfg!(feature = "fpga_realtime") {
         &APP_WITH_UART_FPGA

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -4,6 +4,8 @@ mod common;
 mod test_authorize_and_stash;
 mod test_boot;
 mod test_certify_key_extended;
+#[cfg(feature = "mldsa_attestation")]
+mod test_certify_key_extended_mldsa;
 mod test_certs;
 mod test_command_timing;
 mod test_disable;
@@ -11,8 +13,12 @@ mod test_ecdsa;
 mod test_fips;
 mod test_get_fmc_alias_csr;
 mod test_get_idev_csr;
+#[cfg(feature = "mldsa_attestation")]
+mod test_get_pq_csr;
 mod test_info;
 mod test_invoke_dpe;
+#[cfg(feature = "mldsa_attestation")]
+mod test_invoke_dpe_mldsa;
 mod test_lms;
 mod test_mailbox;
 mod test_measurements_common;

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_common::mailbox_api::{
+    CertifyKeyExtendedFlags, CertifyKeyExtendedMldsa87Req, CommandId, MailboxReq, MailboxReqHeader,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+
+use crate::common::{assert_error, run_pqc_rt_test};
+
+#[test]
+fn test_certify_key_extended_mldsa87_unimplemented() {
+    let mut model = run_pqc_rt_test();
+
+    let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        flags: CertifyKeyExtendedFlags::empty(),
+        certify_key_req: [0u8; CertifyKeyExtendedMldsa87Req::CERTIFY_KEY_REQ_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+        resp,
+    );
+}

--- a/runtime/tests/runtime_integration_tests/test_get_pq_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_pq_csr.rs
@@ -1,0 +1,26 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+use zerocopy::IntoBytes;
+
+use crate::common::{assert_error, run_pqc_rt_test};
+
+#[test]
+fn test_get_pq_csr_unimplemented() {
+    let mut model = run_pqc_rt_test();
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_CSR), &[]),
+    };
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_CSR), payload.as_bytes())
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+        resp,
+    );
+}

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_common::mailbox_api::{CommandId, InvokeDpeMldsa87Req, MailboxReq};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+
+use crate::common::{assert_error, run_pqc_rt_test};
+
+#[test]
+fn test_invoke_dpe_mldsa87_unimplemented() {
+    let mut model = run_pqc_rt_test();
+
+    let mut cmd = MailboxReq::InvokeDpeMldsa87Command(InvokeDpeMldsa87Req::default());
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::INVOKE_DPE_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+        resp,
+    );
+}


### PR DESCRIPTION
Add the skeletons for the MLDSA related DPE commands.  These currently return unimplemented and have tests verifying the plumbing works as expected. 