### PR TITLE
runtime: hook SET_PQ_SEED to the command loop

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1273,11 +1273,6 @@ impl CaliptraError {
             0x000E0064,
             "Runtime Error: SET_PQ_SEED already enabled PQC mode"
         ),
-        (
-            RUNTIME_INVALID_PQ_SEED,
-            0x000E0065,
-            "Runtime Error: Invalid PQ seed"
-        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1273,6 +1273,11 @@ impl CaliptraError {
             0x000E0064,
             "Runtime Error: SET_PQ_SEED already enabled PQC mode"
         ),
+        (
+            RUNTIME_INVALID_PQ_SEED,
+            0x000E0065,
+            "Runtime Error: Invalid PQ seed"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -41,7 +41,6 @@ mod reallocate_dpe_context_limits;
 mod revoke_exported_cdi_handle;
 mod set_auth_manifest;
 #[cfg(feature = "mldsa_attestation")]
-#[allow(dead_code)]
 mod set_pq_seed;
 mod sign_with_exported_ecdsa;
 mod stash_measurement;
@@ -97,6 +96,8 @@ pub use mbox_response_writer::MboxResponseWriter;
 pub use pcr::{GetPcrLogCmd, IncrementPcrResetCounterCmd};
 pub use reallocate_dpe_context_limits::ReallocateDpeContextLimitsCmd;
 pub use set_auth_manifest::SetAuthManifestCmd;
+#[cfg(feature = "mldsa_attestation")]
+pub use set_pq_seed::SetPqSeedCmd;
 pub use stash_measurement::StashMeasurementCmd;
 #[cfg(feature = "mldsa_attestation")]
 pub use verify::Mldsa87VerifyCmd;
@@ -275,7 +276,7 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         }
         CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
-        CommandId::SET_PQ_SEED => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
+        CommandId::SET_PQ_SEED => SetPqSeedCmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
         CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeMldsa87Cmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -35,10 +35,6 @@ impl SetPqSeedCmd {
         let mut cmd = SetPqSeedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
-        if cmd.seed == [0; SET_PQ_SEED_SEED_SIZE] {
-            return Err(CaliptraError::RUNTIME_INVALID_PQ_SEED);
-        }
-
         let mut out = Array4x12::default();
         Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)?;
 

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::{Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{MailboxResp, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE};
+use caliptra_common::mailbox_api::{MailboxRespHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE};
 use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult};
 use zerocopy::{FromZeros, IntoBytes};
 
@@ -23,17 +23,21 @@ pub struct SetPqSeedCmd;
 impl SetPqSeedCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<MailboxResp> {
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-            Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?;
+            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
         }
 
         if drivers.persistent_data.get().pqc_mode_enabled() {
-            Err(CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET)?;
+            return Err(CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET);
         }
 
         let mut cmd = SetPqSeedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
+        if cmd.seed == [0; SET_PQ_SEED_SEED_SIZE] {
+            return Err(CaliptraError::RUNTIME_INVALID_PQ_SEED);
+        }
 
         let mut out = Array4x12::default();
         Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)?;
@@ -41,7 +45,7 @@ impl SetPqSeedCmd {
         drivers.persistent_data.get_mut().pq_devid_cdi = out.into();
         drivers.persistent_data.get_mut().set_pqc_mode_enabled();
 
-        Ok(MailboxResp::default())
+        crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]

--- a/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
@@ -12,7 +12,7 @@ use caliptra_runtime::RtBootStatus;
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 
 #[test]
-fn test_set_pq_seed_rejected_from_runtime_command_loop() {
+fn test_set_pq_seed() {
     let mut model = run_rt_test(RuntimeTestArgs {
         test_fwid: Some(&APP_MLDSA_ATTESTATION),
         ..Default::default()
@@ -28,12 +28,58 @@ fn test_set_pq_seed_rejected_from_runtime_command_loop() {
     });
     cmd.populate_chksum().unwrap();
 
+    let resp = model.mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap());
+    assert!(resp.is_ok());
+}
+
+#[test]
+fn test_repeated_set_pq_seed_rejected() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model.mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap());
+    assert!(resp.is_ok());
     let resp = model
         .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
         .unwrap_err();
     assert_error(
         &mut model,
-        CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+        CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET,
         resp,
     );
+}
+
+#[test]
+fn test_zero_pq_seed_rejected() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0u8; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_INVALID_PQ_SEED, resp);
 }

--- a/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
@@ -60,26 +60,3 @@ fn test_repeated_set_pq_seed_rejected() {
         resp,
     );
 }
-
-#[test]
-fn test_zero_pq_seed_rejected() {
-    let mut model = run_rt_test(RuntimeTestArgs {
-        test_fwid: Some(&APP_MLDSA_ATTESTATION),
-        ..Default::default()
-    });
-
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
-
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: [0u8; SET_PQ_SEED_SEED_SIZE],
-    });
-    cmd.populate_chksum().unwrap();
-
-    let resp = model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .unwrap_err();
-    assert_error(&mut model, CaliptraError::RUNTIME_INVALID_PQ_SEED, resp);
-}


### PR DESCRIPTION
Handle `SET_PQ_SEED` in the normal command loop, but reject it once a seed is successfully set and a `PQ.DevID.CDI` is successfully derived. Also reject an all-zero seed, and update corresponding unit tests.

Issue: #3743

Although I'm referencing the ticket, the ticket itself doesn't really reflect the new design that `SET_PQ_SEED` is regarded as a normal mailbox command. For DPE initialization, we follow the way that 2.x uses - using an ECDSA-based environment, because the initialization is algorithm-agnostic and only creates the context tree. In the follow-up PRs that implement the DPE commands like `INVOKE_DPE`, when such an command is executed, we create an algorithm-dependent DPE environment.