### PR TITLE
mldsa: Enable mldsa verify libcaliptra test

### DIFF
--- a/builder/bin/image_gen.rs
+++ b/builder/bin/image_gen.rs
@@ -45,6 +45,7 @@ fn main() {
                 .value_parser(value_parser!(PathBuf))
         )
         .arg(arg!(--"zeros" "Build an image bundle with zero'd FMC and RT. This will NMI immediately."))
+        .arg(arg!(--"mldsa-attestation" "Build the RT app with the mldsa_attestation feature (compiles in MLDSA87_SIGNATURE_VERIFY)"))
         .arg(arg!(--"owner-sig-override" [FILE] "Manually overwrite the owner_sigs of the FW bundle image with the contents of binary [FILE]. The signature should be an ECC signature concatenated with an LMS signature").value_parser(value_parser!(PathBuf)))
         .arg(arg!(--"vendor-sig-override" [FILE] "Manually overwrite the vendor_sigs of the FW bundle image with the contents of binary [FILE]. The signature should be an ECC signature concatenated with an LMS signature").value_parser(value_parser!(PathBuf)))
         .arg(arg!(--"image-options" [FILE] "Override the `ImageOptions` struct for the image bundle with the given toml file").value_parser(value_parser!(PathBuf)))
@@ -95,6 +96,8 @@ fn main() {
         // Get image types (zeros or actual firmware)
         let (fmc_type, app_type) = if args.contains_id("zeros") {
             (firmware::FMC_ZEROS, firmware::APP_ZEROS)
+        } else if args.contains_id("mldsa-attestation") {
+            (firmware::FMC_WITH_UART, firmware::APP_MLDSA_ATTESTATION)
         } else {
             (firmware::FMC_WITH_UART, firmware::APP_WITH_UART)
         };

--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -664,18 +664,6 @@ int rt_test_all_commands(const test_info* info)
     }
 
     // MLDSA87_SIGNATURE_VERIFY
-    //
-    // TODO(https://github.com/chipsalliance/caliptra-sw/issues/3835): re-enable once both
-    //   1. caliptra-mldsa::verify_internal stack-budget reduction (per-Scalar
-    //      rewrite so verify fits the runtime's ~85 KiB stack), and
-    //   2. caliptra-mldsa / caliptra-shake panic-freedom audit (so
-    //      test_panic_missing keeps passing once mldsa_attestation is
-    //      enabled in APP_WITH_UART)
-    // both land in caliptra-1.x. Until then, MDSV is not compiled into the
-    // upstream firmware image used by this hwmodel test (the mldsa_attestation
-    // cargo feature on caliptra-runtime is off by default), so calling MDSV
-    // here would return RUNTIME_UNIMPLEMENTED_COMMAND (0xE0002).
-#if 0
     struct caliptra_mldsa87_signature_verify_req mldsa_req = {};
 
     status = caliptra_mldsa87_signature_verify(&mldsa_req, false);
@@ -694,7 +682,6 @@ int rt_test_all_commands(const test_info* info)
     } else {
         printf("MLDSA87 Signature Verify: OK\n");
     }
-#endif
 
     // STASH_MEASUREMENT
     struct caliptra_stash_measurement_req stash_req = {};
@@ -1004,13 +991,21 @@ int rt_test_all_commands(const test_info* info)
         printf("FIPS Self Test Start: OK\n");
     }
 
-    // Give self test time to run
-    for (int i = 0; i < 4000000; i++){
-        caliptra_wait();
+    // Give the self test time to run. The runtime self test holds the mailbox
+    // lock while it runs; with mldsa_attestation enabled it also executes the
+    // software ML-DSA-87 KAT (key-gen + sign + verify), which is much slower
+    // than the hardware-accelerated KATs, so a fixed wait is fragile. Poll
+    // SELF_TEST_GET_RESULTS (which returns MBX_BUSY while the lock is held)
+    // until the self test releases the mailbox.
+    for (int i = 0; i < 64; i++) {
+        for (int j = 0; j < 1000000; j++) {
+            caliptra_wait();
+        }
+        status = caliptra_self_test_get_results(false);
+        if (status != MBX_BUSY) {
+            break;
+        }
     }
-
-    // SELF_TEST_GET_RESULTS
-    status = caliptra_self_test_get_results(false);
 
     if (status) {
         printf("FIPS Self Test Get Results failed: 0x%x\n", status);

--- a/libcaliptra/examples/hwmodel/Makefile
+++ b/libcaliptra/examples/hwmodel/Makefile
@@ -53,7 +53,7 @@ $(ROM_FILE) $(FW_FILE):
 	@echo [IMAGE] caliptra_rom.bin image_bundle.bin
 	$(Q)make -C ../../../rom/dev
 	$(Q)cd ../../../runtime && ./build.sh
-	$(Q)cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom-with-log $(ROM_FW_DIR)/caliptra_rom.bin --fw $(ROM_FW_DIR)/image_bundle.bin
+	$(Q)cargo --config="$(EXTRA_CARGO_CONFIG)" run --manifest-path=$(BUILDER_PATH)/Cargo.toml --bin image -- --rom-with-log $(ROM_FW_DIR)/caliptra_rom.bin --fw $(ROM_FW_DIR)/image_bundle.bin --mldsa-attestation
 
 $(HWMODEL_BINDING_LIB_OBJ):
 	@echo "[CARGO] c-binding"


### PR DESCRIPTION
Now that mldsa verify patches have landed enable the libcaliptra test. This also required utilizing the mldsa runtime to run the libcaliptra tests, and exposed the need for an increased timeout on the KAT tests, since the MLDSA tests can take significant amounts of time.