### PR TITLE
[tests] Make ML-DSA the default for firmware verification

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1646,7 +1646,7 @@ impl ModelFpgaSubsystem {
 
             let vendor_pqc_type =
                 FwVerificationPqcKeyType::from_u8(self.fuses.fuse_pqc_key_type as u8)
-                    .unwrap_or(FwVerificationPqcKeyType::LMS);
+                    .unwrap_or(FwVerificationPqcKeyType::MLDSA);
             println!(
                 "Setting vendor public key pqc type to {:x?}",
                 vendor_pqc_type

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -182,7 +182,7 @@ impl CertifyKeyExtendedCmd {
                 let len = size_of::<CertifyKeyExtendedResp>()
                     - CertifyKeyExtendedResp::CERTIFY_KEY_RESP_SIZE
                     + dpe_resp_len;
-                resp.size = len as u32;
+                resp.size = dpe_resp_len as u32;
                 Ok(len)
             }
             Err(e) => {

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -358,8 +358,7 @@ pub fn run_rt_test(args: RuntimeTestArgs) -> DefaultHwModel {
 }
 
 pub fn run_rt_test_return_fw(args: RuntimeTestArgs) -> (DefaultHwModel, ImageBundle) {
-    // TODO(clundin): Do we want to use MLDSA by default in 2.1?
-    let key_type = args.key_type.unwrap_or(FwVerificationPqcKeyType::LMS);
+    let key_type = args.key_type.unwrap_or(FwVerificationPqcKeyType::MLDSA);
     run_rt_test_pqc_return_fw(args, key_type)
 }
 
@@ -474,7 +473,7 @@ pub fn execute_dpe_cmd(
         _ => false,
     };
     let external_response_info = if external_response {
-        let addr = model.staging_physical_address().unwrap();
+        let addr = model.staging_physical_address().unwrap() + 1024;
         Some(AxiResponseInfo {
             addr_lo: addr as u32,
             addr_hi: (addr >> 32) as u32,
@@ -563,7 +562,7 @@ pub fn execute_dpe_cmd_raw(
         resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
     } else {
         let resp = model
-            .read_payload_from_ss_staging_area(size_of::<InvokeDpeResp>(), 0)
+            .read_payload_from_ss_staging_area(size_of::<InvokeDpeResp>(), 1024)
             .unwrap();
         resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
         check_header_checksum(resp_hdr.as_bytes_partial().unwrap()).unwrap();

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -101,10 +101,7 @@ fn load_and_authorize_fw(images: &[Image]) -> DefaultHwModel {
     let auth_manifest = create_auth_manifest_with_metadata(image_metadata);
     let runtime_args = RuntimeTestArgs {
         subsystem_mode: true,
-        test_image_options: Some(caliptra_builder::ImageOptions {
-            pqc_key_type: caliptra_image_types::FwVerificationPqcKeyType::LMS,
-            ..Default::default()
-        }),
+        test_image_options: Some(caliptra_builder::ImageOptions::default()),
         soc_manifest: Some(auth_manifest.as_bytes()),
         mcu_fw_image: Some(&images[0].contents),
         ..Default::default()

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -59,10 +59,7 @@ pub const TEST_SRAM_BASE: Addr64 = Addr64 {
 
 pub fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> DefaultHwModel {
     let runtime_args = RuntimeTestArgs {
-        test_image_options: Some(ImageOptions {
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
-            ..Default::default()
-        }),
+        test_image_options: Some(ImageOptions::default()),
         ..Default::default()
     };
 
@@ -74,7 +71,7 @@ pub fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> Defaul
     } else {
         create_auth_manifest(&AuthManifestBuilderCfg {
             manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            pqc_key_type: FwVerificationPqcKeyType::MLDSA,
             svn: 1,
         })
     };
@@ -107,10 +104,7 @@ pub fn set_auth_manifest_with_test_sram(
     mcu_image: &[u8],
 ) -> DefaultHwModel {
     let runtime_args = RuntimeTestArgs {
-        test_image_options: Some(ImageOptions {
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
-            ..Default::default()
-        }),
+        test_image_options: Some(ImageOptions::default()),
         test_sram: Some(test_sram),
         soc_manifest: Some(
             auth_manifest
@@ -131,7 +125,7 @@ pub fn set_auth_manifest_with_test_sram(
     } else {
         create_auth_manifest(&AuthManifestBuilderCfg {
             manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            pqc_key_type: FwVerificationPqcKeyType::MLDSA,
             svn: 1,
         })
     };
@@ -189,10 +183,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     );
 
     // create a new fw image with the runtime replaced by the mbox responder
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
         crate::test_update_reset::mbox_test_image(),
@@ -255,10 +246,7 @@ fn test_authorize_and_stash_cmd_success() {
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 
     // create a new fw image with the runtime replaced by the mbox responder
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let updated_fw_image = caliptra_builder::build_and_sign_image(
         &FMC_WITH_UART,
         crate::test_update_reset::mbox_test_image(),
@@ -632,10 +620,7 @@ fn test_authorize_and_stash_after_update_reset() {
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 
     // Trigger an update reset.
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     update_fw(&mut model, &APP_WITH_UART, image_options);
 
     // Re-authorize the image.
@@ -703,10 +688,7 @@ fn test_authorize_and_stash_after_update_reset_unauthorized_fw_id() {
     );
 
     // Trigger an update reset.
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     update_fw(&mut model, &APP_WITH_UART, image_options);
 
     // Attempt Authorization with a unauthorized fw id.
@@ -777,10 +759,7 @@ fn test_authorize_and_stash_after_update_reset_bad_hash() {
     );
 
     // Trigger an update reset.
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     update_fw(&mut model, &APP_WITH_UART, image_options);
 
     // Attempt Authorization with a bad image hash.
@@ -835,10 +814,7 @@ fn test_authorize_and_stash_after_update_reset_skip_auth() {
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 
     // Trigger an update reset.
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     update_fw(&mut model, &APP_WITH_UART, image_options);
 
     let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
@@ -929,10 +905,7 @@ fn test_authorize_and_stash_after_update_reset_multiple_set_manifest() {
     );
 
     // Trigger an update reset.
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     update_fw(&mut model, &APP_WITH_UART, image_options);
 
     //
@@ -1416,13 +1389,7 @@ fn test_authorize_from_staging_address_incorrect_digest() {
 #[test]
 fn test_verify_valid_manifest() {
     // Create the model
-    let runtime_args = RuntimeTestArgs {
-        test_image_options: Some(ImageOptions {
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
+    let runtime_args = RuntimeTestArgs::default();
 
     let mut model = run_rt_test(runtime_args);
 
@@ -1431,7 +1398,7 @@ fn test_verify_valid_manifest() {
     // Create a valid auth manifest
     let valid_auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
         manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        pqc_key_type: FwVerificationPqcKeyType::MLDSA,
         svn: 1,
     });
 
@@ -1539,7 +1506,7 @@ fn test_verify_invalid_manifest() {
     // Create the model
     let runtime_args = RuntimeTestArgs {
         test_image_options: Some(ImageOptions {
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            pqc_key_type: FwVerificationPqcKeyType::MLDSA,
             ..Default::default()
         }),
         ..Default::default()
@@ -1552,7 +1519,6 @@ fn test_verify_invalid_manifest() {
     // Create an invalid auth manifest
     let valid_auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
         manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     });
 

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -8,7 +8,6 @@ use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxReqHeader, Stas
 use caliptra_hw_model::{
     BootParams, Fuses, HwModel, InitParams, SecurityState, SubsystemInitParams,
 };
-use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
 use zerocopy::IntoBytes;
@@ -80,7 +79,6 @@ fn test_update() {
     let image_options = ImageOptions {
         fmc_version: DEFAULT_FMC_VERSION,
         app_version: 0xaabbccdd,
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     };
     // Make image to update to. On the FPGA this needs to be done before executing the test,
@@ -118,12 +116,10 @@ fn test_stress_update() {
     let app_versions = [0xaaabbbbc, 0xaaabbbbd];
     let image_options_0 = ImageOptions {
         app_version: app_versions[0],
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     };
     let image_options_1 = ImageOptions {
         app_version: app_versions[1],
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     };
 
@@ -289,7 +285,7 @@ fn test_boot_encrypted_firmware_rri() {
     use crate::common::{default_soc_manifest_bytes, start_rt_test_pqc_model, DEFAULT_MCU_FW};
     use caliptra_image_types::FwVerificationPqcKeyType;
 
-    let pqc_key_type = FwVerificationPqcKeyType::LMS;
+    let pqc_key_type = FwVerificationPqcKeyType::MLDSA;
 
     // Create args with stop_at_rom and subsystem_mode enabled
     let args = RuntimeTestArgs {

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -103,7 +103,7 @@ fn execute_certify_key_extended_cmd_helper(
     let mut certify_key_extended_resp = CertifyKeyExtendedResp::default();
     if external_response {
         let resp = model
-            .read_payload_from_ss_staging_area(size_of::<CertifyKeyExtendedResp>(), 0)
+            .read_payload_from_ss_staging_area(size_of::<CertifyKeyExtendedResp>(), 1024)
             .unwrap();
         certify_key_extended_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
         check_header_checksum(certify_key_extended_resp.as_bytes_partial().unwrap())?;
@@ -129,7 +129,7 @@ fn execute_certify_key_extended_cmd(
     flags: CertifyKeyExtendedFlags,
 ) -> anyhow::Result<CertifyKeyResp> {
     let (flags, axi_info) = if model.subsystem_mode() && profile == CaliptraDpeProfile::Mldsa87 {
-        let addr = model.staging_physical_address().unwrap();
+        let addr = model.staging_physical_address().unwrap() + 1024;
         (
             flags | CertifyKeyExtendedFlags::EXTERNAL_AXI_RESPONSE,
             Some(AxiResponseInfo {

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -11,7 +11,6 @@ use caliptra_dpe::{
     response::{CertifyKeyResp, Response, SignResp},
 };
 use caliptra_hw_model::HwModel;
-use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::CaliptraDpeProfile;
 use openssl::{
     bn::BigNum,
@@ -114,10 +113,7 @@ fn test_attestation_disabled_flag_after_update_reset() {
     );
 
     // trigger update reset to same firmware
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let updated_fw_image =
         caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_options)
             .unwrap()

--- a/runtime/tests/runtime_integration_tests/test_fips.rs
+++ b/runtime/tests/runtime_integration_tests/test_fips.rs
@@ -7,7 +7,6 @@ use caliptra_common::mailbox_api::{
     CommandId, FipsVersionResp, MailboxReqHeader, MailboxRespHeader,
 };
 use caliptra_hw_model::HwModel;
-use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::FipsVersionCmd;
 use zerocopy::{FromBytes, IntoBytes};
 
@@ -19,7 +18,6 @@ fn test_fips_version() {
         test_image_options: Some(ImageOptions {
             fmc_version: version::get_fmc_version(),
             app_version: version::get_runtime_version(),
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
             ..Default::default()
         }),
         ..Default::default()

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -715,7 +715,7 @@ fn test_invoke_dpe_external_addr() {
     let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
 
     let external_response_info = {
-        let addr = model.staging_physical_address().unwrap();
+        let addr = model.staging_physical_address().unwrap() + 1024;
         Some(AxiResponseInfo {
             addr_lo: addr as u32,
             addr_hi: (addr >> 32) as u32,

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -447,7 +447,6 @@ fn test_set_auth_manifest_cannot_be_called_from_pl1() {
 fn test_sign_with_exported_ecdsa_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -479,7 +478,6 @@ fn test_sign_with_exported_ecdsa_cannot_be_called_from_pl1() {
 fn test_revoke_export_cdi_handle_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -511,7 +509,6 @@ fn test_revoke_export_cdi_handle_cannot_be_called_from_pl1() {
 fn test_export_cdi_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -836,10 +833,7 @@ fn test_measurement_log_pl_context_threshold() {
 
 #[test]
 fn test_pl0_unset_in_header() {
-    let fuses = Fuses {
-        fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
-        ..Default::default()
-    };
+    let fuses = Fuses::default();
     let rom = crate::common::rom_for_fw_integration_tests().unwrap();
     let life_cycle = fuses.life_cycle;
     let mut model = caliptra_hw_model::new(
@@ -853,10 +847,7 @@ fn test_pl0_unset_in_header() {
     )
     .unwrap();
 
-    let mut opts = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let mut opts = ImageOptions::default();
     opts.vendor_config.pl0_pauser = None;
     let mut image_bundle =
         caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, opts).unwrap();
@@ -865,19 +856,16 @@ fn test_pl0_unset_in_header() {
     // flag bit to make it valid. Also need to re-generate and re-sign the image.
     image_bundle.manifest.header.pl0_pauser = 1;
 
-    let opts = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let opts = ImageOptions::default();
     let ecc_index = opts.vendor_config.ecc_key_idx;
-    let lms_index = opts.vendor_config.pqc_key_idx;
+    let pqc_index = opts.vendor_config.pqc_key_idx;
     let gen = ImageGenerator::new(Crypto::default());
     let vendor_header_digest_384 = gen
         .vendor_header_digest_384(&image_bundle.manifest.header)
         .unwrap();
     let vendor_header_digest_holder = ImageSignData {
         digest_384: &vendor_header_digest_384,
-        mldsa_msg: None,
+        mldsa_msg: Some(gen.vendor_header_bytes(&image_bundle.manifest.header)),
     };
 
     let owner_header_digest_384 = gen
@@ -885,7 +873,7 @@ fn test_pl0_unset_in_header() {
         .unwrap();
     let owner_header_digest_holder = ImageSignData {
         digest_384: &owner_header_digest_384,
-        mldsa_msg: None,
+        mldsa_msg: Some(image_bundle.manifest.header.as_bytes()),
     };
 
     let fmc_elf = build_firmware_elf(&FMC_WITH_UART).unwrap();
@@ -904,10 +892,10 @@ fn test_pl0_unset_in_header() {
                 fw_svn: opts.fw_svn,
                 vendor_config: opts.vendor_config,
                 owner_config: opts.owner_config,
-                pqc_key_type: FwVerificationPqcKeyType::LMS,
+                pqc_key_type: FwVerificationPqcKeyType::MLDSA,
             },
             ecc_index,
-            lms_index,
+            pqc_index,
             &vendor_header_digest_holder,
             &owner_header_digest_holder,
         )
@@ -917,7 +905,7 @@ fn test_pl0_unset_in_header() {
     crate::common::test_upload_firmware(
         &mut model,
         &image_bundle.to_bytes().unwrap(),
-        FwVerificationPqcKeyType::LMS,
+        FwVerificationPqcKeyType::MLDSA,
     );
 
     model.step_until(|m| {
@@ -1000,7 +988,6 @@ fn test_user_not_pl0() {
 fn test_ocp_lock_commands_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -1051,7 +1038,6 @@ fn test_ocp_lock_commands_cannot_be_called_from_pl1() {
 fn test_external_dpe_responses_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -1094,7 +1080,6 @@ fn test_external_dpe_responses_cannot_be_called_from_pl1() {
 fn test_external_command_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),
@@ -1129,7 +1114,6 @@ fn test_external_command_cannot_be_called_from_pl1() {
 fn test_aes_gcm_decrypt_dma_cannot_be_called_from_pl1() {
     let mut image_opts = ImageOptions::default();
     image_opts.vendor_config.pl0_pauser = None;
-    image_opts.pqc_key_type = FwVerificationPqcKeyType::LMS;
 
     let args = RuntimeTestArgs {
         test_image_options: Some(image_opts),

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -87,7 +87,7 @@ pub fn create_auth_manifest_with_metadata(
 ) -> AuthorizationManifest {
     create_auth_manifest_with_metadata_with_svn(
         image_metadata_list,
-        FwVerificationPqcKeyType::LMS,
+        FwVerificationPqcKeyType::MLDSA,
         1,
     )
 }
@@ -134,7 +134,6 @@ fn create_auth_manifest_of_metadata_size(
 fn test_set_auth_manifest_cmd_external() {
     let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
         manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     });
     let buf = auth_manifest.as_bytes();
@@ -166,7 +165,7 @@ fn test_set_auth_manifest_cmd_external() {
             test_sram: Some(&test_sram),
             ..Default::default()
         },
-        FwVerificationPqcKeyType::LMS,
+        FwVerificationPqcKeyType::MLDSA,
     );
 
     model.step_until(|m| {

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -9,7 +9,6 @@ use caliptra_common::mailbox_api::{
     CommandId, MailboxReq, MailboxReqHeader, StashMeasurementReq, StashMeasurementResp,
 };
 use caliptra_hw_model::HwModel;
-use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use caliptra_test::DEFAULT_MCU_FW;
 use sha2::{Digest, Sha384};
@@ -19,10 +18,7 @@ use crate::common::{calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeT
 
 #[test]
 fn test_stash_measurement() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         ..Default::default()
@@ -97,10 +93,7 @@ fn test_stash_measurement() {
 
 #[test]
 fn test_pcr31_extended_upon_stash_measurement() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_fwid: Some(crate::test_update_reset::mbox_test_image()),
         test_image_options: Some(image_options.clone()),

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -64,10 +64,7 @@ pub fn mbox_test_image_without_uart() -> &'static FwId<'static> {
 
 #[test]
 fn test_rt_pcr_updated_in_dpe() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         ..Default::default()
@@ -98,10 +95,7 @@ fn test_rt_pcr_updated_in_dpe() {
 
 #[test]
 fn test_rt_journey_pcr_updated_with_good_fw() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         test_fwid: Some(mbox_test_image()),
@@ -127,10 +121,7 @@ fn test_rt_journey_pcr_updated_with_good_fw() {
 
 #[test]
 fn test_rt_journey_pcr_not_updated_with_bad_fw() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         test_fwid: Some(mbox_test_image()),
@@ -170,10 +161,7 @@ fn test_rt_journey_pcr_not_updated_with_bad_fw() {
 
 #[test]
 fn test_tags_persistence() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         ..Default::default()
@@ -216,10 +204,7 @@ fn test_tags_persistence() {
 
 #[test]
 fn test_context_tags_validation() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_fwid: Some(mbox_test_image()),
         test_image_options: Some(image_options.clone()),
@@ -252,10 +237,7 @@ fn test_context_tags_validation() {
 
 #[test]
 fn test_context_has_tag_validation() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let args = RuntimeTestArgs {
         test_fwid: Some(mbox_test_image()),
         test_image_options: Some(image_options.clone()),
@@ -283,10 +265,7 @@ fn test_context_has_tag_validation() {
 
 #[test]
 fn test_dpe_validation_deformed_structure() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let args = RuntimeTestArgs {
         test_fwid: Some(mbox_test_image()),
         test_image_options: Some(image_options.clone()),
@@ -338,10 +317,7 @@ fn test_dpe_validation_deformed_structure() {
 
 #[test]
 fn test_dpe_validation_illegal_state() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let args = RuntimeTestArgs {
         test_fwid: Some(mbox_test_image()),
         test_image_options: Some(image_options.clone()),
@@ -391,10 +367,7 @@ fn test_dpe_validation_illegal_state() {
 
 #[test]
 fn test_dpe_validation_used_context_threshold_exceeded() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let args = RuntimeTestArgs {
         test_fwid: Some(mbox_test_image()),
         test_image_options: Some(image_options.clone()),
@@ -477,10 +450,7 @@ fn test_dpe_validation_used_context_threshold_exceeded() {
 
 #[test]
 fn test_pcr_reset_counter_persistence() {
-    let image_options = ImageOptions {
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
-        ..Default::default()
-    };
+    let image_options = ImageOptions::default();
     let runtime_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
         ..Default::default()
@@ -526,7 +496,6 @@ fn test_pcr_reset_counter_persistence() {
 fn get_image_opts(svn: u32) -> ImageOptions {
     ImageOptions {
         fw_svn: svn,
-        pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     }
 }

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -1377,7 +1377,7 @@ fn smoke_test_flash_boot() {
     use caliptra_hw_model::flash_image::build_flash_image_bytes;
     use caliptra_hw_model::SubsystemInitParams;
 
-    let pqc_key_type = FwVerificationPqcKeyType::LMS;
+    let pqc_key_type = FwVerificationPqcKeyType::MLDSA;
     let fw_svn = 1;
 
     let rom = caliptra_builder::rom_for_fw_integration_tests_fpga(true).unwrap();

--- a/test/tests/caliptra_integration_tests/warm_reset.rs
+++ b/test/tests/caliptra_integration_tests/warm_reset.rs
@@ -16,7 +16,7 @@ use caliptra_test::{default_soc_manifest_bytes, image_pk_desc_hash};
 
 #[test]
 fn warm_reset_basic() {
-    let pqc_key_type = FwVerificationPqcKeyType::LMS; // Default for test
+    let pqc_key_type = FwVerificationPqcKeyType::MLDSA;
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);
@@ -82,7 +82,7 @@ fn warm_reset_basic() {
 
 #[test]
 fn warm_reset_during_fw_load() {
-    let pqc_key_type = FwVerificationPqcKeyType::LMS; // Default for test
+    let pqc_key_type = FwVerificationPqcKeyType::MLDSA;
     let security_state = *SecurityState::default()
         .set_debug_locked(true)
         .set_device_lifecycle(DeviceLifecycle::Production);


### PR DESCRIPTION
Previously LMS was used as the default. It is assumed ML-DSA will be used in most integrations. This switches the default to use LMS. There are still a lot of tests that loop through both options to ensure LMS continues to work.

Also adds an offset to DPE external response buffers to avoid clashing with the MCU runtime image and fixes a bug in the CertifyKeyExtended response logic that was setting the wrong length value.