### PR TITLE
tests: enable mldsa ci

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -50,6 +50,12 @@ mkdir -p target-ci
 
 export CARGO_TARGET_DIR="${PWD}/target-ci"
 
+# Packages that define the `mldsa_attestation` (PQC ML-DSA) feature and carry
+# feature-gated code and tests. The feature is not a default and cannot be
+# enabled at the virtual-workspace level, so these packages are built, linted,
+# and tested with the feature in separate, package-scoped invocations below.
+MLDSA_PKGS="-p caliptra-runtime -p caliptra-x509 -p caliptra-drivers -p caliptra-kat"
+
 function build_rom_images() {
     rm -rf "${CARGO_TARGET_DIR}/riscv32imc-unknown-none-elf"
     CALIPTRA_IMAGE_NO_GIT_REVISION=1 cargo --config "${EXTRA_CARGO_CONFIG}" run -p caliptra-builder -- \
@@ -80,6 +86,9 @@ fi
 if task_enabled "check_lint"; then
   echo Clippy lint check
   RUSTFLAGS="-Dwarnings" cargo clippy --locked --all-targets -- -D warnings
+  echo Clippy lint check "(mldsa_attestation)"
+  RUSTFLAGS="-Dwarnings" cargo clippy --locked --all-targets \
+    ${MLDSA_PKGS} --features mldsa_attestation -- -D warnings
 fi
 
 if task_enabled "check_license"; then
@@ -90,6 +99,9 @@ fi
 if task_enabled "build"; then
   echo Build
   cargo --config "${EXTRA_CARGO_CONFIG}" build --locked
+  echo Build "(mldsa_attestation)"
+  cargo --config "${EXTRA_CARGO_CONFIG}" build --locked \
+    ${MLDSA_PKGS} --features mldsa_attestation
 fi
 
 if task_enabled "build_fw"; then
@@ -101,8 +113,14 @@ if task_enabled "test"; then
   echo Run tests
   if cargo nextest help > /dev/null 2>/dev/null; then
     CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked
+    echo Run tests "(mldsa_attestation)"
+    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo nextest run --config "${EXTRA_CARGO_CONFIG}" --locked \
+      ${MLDSA_PKGS} --features mldsa_attestation
   else
     CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked
+    echo Run tests "(mldsa_attestation)"
+    CPTRA_COVERAGE_PATH="${cov_dir}" CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" test --locked \
+      ${MLDSA_PKGS} --features mldsa_attestation
   fi
   CALIPTRA_PREBUILT_FW_DIR="${fw_dir}" CPTRA_COVERAGE_PATH="${cov_dir}" cargo --config "${EXTRA_CARGO_CONFIG}" run --manifest-path ./coverage/Cargo.toml
 fi

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -235,24 +235,24 @@ impl Mldsa87 {
 mod tests {
     use super::*;
 
-    const SEED: Mldsa87Seed = [0x42; MLDSA87_PRIVATE_SEED_BYTES];
+    const SEED: Mldsa87Seed = Mldsa87Seed::new([0x42; MLDSA87_PRIVATE_SEED_BYTES]);
 
     #[test]
     fn test_keygen_deterministic() {
-        let mut pk1 = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
-        let mut pk2 = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+        let mut pk1 = Mldsa87PubKey::default();
+        let mut pk2 = Mldsa87PubKey::default();
         Mldsa87::pub_from_seed(&SEED, &mut pk1, None).unwrap();
         Mldsa87::pub_from_seed(&SEED, &mut pk2, None).unwrap();
-        assert_eq!(pk1, pk2);
+        assert_eq!(pk1.as_slice(), pk2.as_slice());
     }
 
     #[test]
     fn test_sign_verify_roundtrip() {
-        let mut pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+        let mut pk = Mldsa87PubKey::default();
         Mldsa87::pub_from_seed(&SEED, &mut pk, None).unwrap();
 
         let msg = b"caliptra pqc mldsa-87 driver round-trip";
-        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut sig = Mldsa87Signature::default();
         Mldsa87::sign_deterministic(&SEED, msg, &mut sig).unwrap();
 
         assert_eq!(
@@ -264,20 +264,20 @@ mod tests {
     #[test]
     fn test_sign_is_deterministic() {
         let msg = b"deterministic signing";
-        let mut sig1 = [0u8; MLDSA87_SIGNATURE_BYTES];
-        let mut sig2 = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut sig1 = Mldsa87Signature::default();
+        let mut sig2 = Mldsa87Signature::default();
         Mldsa87::sign_deterministic(&SEED, msg, &mut sig1).unwrap();
         Mldsa87::sign_deterministic(&SEED, msg, &mut sig2).unwrap();
-        assert_eq!(sig1, sig2);
+        assert_eq!(sig1.as_slice(), sig2.as_slice());
     }
 
     #[test]
     fn test_verify_rejects_tampered_signature() {
-        let mut pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+        let mut pk = Mldsa87PubKey::default();
         Mldsa87::pub_from_seed(&SEED, &mut pk, None).unwrap();
 
         let msg = b"tamper detection";
-        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut sig = Mldsa87Signature::default();
         Mldsa87::sign_deterministic(&SEED, msg, &mut sig).unwrap();
         sig[0] ^= 0xFF;
 
@@ -289,10 +289,10 @@ mod tests {
 
     #[test]
     fn test_verify_rejects_wrong_message() {
-        let mut pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
+        let mut pk = Mldsa87PubKey::default();
         Mldsa87::pub_from_seed(&SEED, &mut pk, None).unwrap();
 
-        let mut sig = [0u8; MLDSA87_SIGNATURE_BYTES];
+        let mut sig = Mldsa87Signature::default();
         Mldsa87::sign_deterministic(&SEED, b"message one", &mut sig).unwrap();
 
         assert_eq!(

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -538,6 +538,8 @@ impl crypto::Signer for DpeCrypto<'_> {
     }
 }
 
+// The mldsa key is significantly larger than ecdsa.  Allow a large enum variant to support it.
+#[allow(clippy::large_enum_variant)]
 enum Signer<'a> {
     Ec {
         ecc384: &'a mut Ecc384,
@@ -548,6 +550,8 @@ enum Signer<'a> {
     Mldsa,
 }
 
+// The mldsa key is significantly larger than ecdsa.  Allow a large enum variant to support it.
+#[allow(clippy::large_enum_variant)]
 enum DerivedKey {
     Ec((KeyId, PubKey)),
     #[cfg(feature = "mldsa_attestation")]

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -52,7 +52,7 @@ impl SetPqSeedCmd {
     ) -> CaliptraResult<()> {
         let mut buf = [0u8; core::mem::size_of::<Array4x12>()];
 
-        buf.get_mut(..SET_PQ_SEED_SEED_SIZE as usize)
+        buf.get_mut(..SET_PQ_SEED_SEED_SIZE)
             .ok_or(CaliptraError::RUNTIME_MLDSA87_DEVID_SEED_TOO_LARGE)?
             .copy_from_slice(seed);
 

--- a/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_verify.rs
@@ -20,10 +20,9 @@
 //!   malformed inputs.
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
+use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 use caliptra_common::checksum::calc_checksum;
-use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, Mldsa87VerifyReq,
-};
+use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxRespHeader, Mldsa87VerifyReq};
 use caliptra_hw_model::{HwModel, ShaAccMode};
 use caliptra_mldsa::{
     Mldsa87, MLDSA87_PRIVATE_SEED_BYTES, MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES,
@@ -122,7 +121,10 @@ fn boot_ready<T: HwModel>(model: &mut T) {
 /// path.
 #[test]
 fn test_mldsa87_verify_cmd() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     for seed in [&SEED_A, &SEED_B] {
@@ -143,7 +145,10 @@ fn test_mldsa87_verify_cmd() {
 /// with `RUNTIME_MLDSA87_VERIFY_FAILED` rather than crash or pass.
 #[test]
 fn test_mldsa87_verify_failure_tampered_signature() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     let (pk, mut sig) = keygen_and_sign(&SEED_A, MSG_1);
@@ -169,7 +174,10 @@ fn test_mldsa87_verify_failure_tampered_signature() {
 /// SHA-384 digest streamed into the accelerator) must fail.
 #[test]
 fn test_mldsa87_verify_failure_wrong_message() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     let (pk, sig) = keygen_and_sign(&SEED_A, MSG_1);
@@ -195,7 +203,10 @@ fn test_mldsa87_verify_failure_wrong_message() {
 /// fail.
 #[test]
 fn test_mldsa87_verify_failure_wrong_pub_key() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     let (_, sig_a) = keygen_and_sign(&SEED_A, MSG_1);
@@ -222,7 +233,10 @@ fn test_mldsa87_verify_failure_wrong_pub_key() {
 /// cryptographically meaningless" path.
 #[test]
 fn test_mldsa87_verify_failure_all_zero() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     let pk = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
@@ -252,7 +266,10 @@ fn test_mldsa87_verify_failure_all_zero() {
 /// first; skipping that step must surface as `RUNTIME_INVALID_CHECKSUM`.
 #[test]
 fn test_mldsa87_verify_bad_chksum() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
     let (pk, sig) = keygen_and_sign(&SEED_A, MSG_1);
@@ -277,19 +294,26 @@ fn test_mldsa87_verify_bad_chksum() {
     );
 }
 
-/// Sending a payload that's shorter than `Mldsa87VerifyReq` (but with a
-/// valid checksum over the truncated bytes, so the dispatcher's chksum
-/// gate passes) must be rejected by the handler's `ref_from_bytes` parse
-/// with `RUNTIME_INSUFFICIENT_MEMORY`.
+/// Sending a payload larger than `Mldsa87VerifyReq` must be rejected by the
+/// mailbox length guard with `RUNTIME_INSUFFICIENT_MEMORY` (the request does
+/// not fit the handler's fixed-size request buffer).
+///
+/// Note: an under-sized (truncated) request is *not* rejected here — the
+/// mailbox zero-pads it into the request buffer, so it degenerates to an
+/// all-zero key/signature and fails closed with `RUNTIME_MLDSA87_VERIFY_FAILED`
+/// (see `test_mldsa87_verify_failure_all_zero`).
 #[test]
-fn test_mldsa87_verify_truncated_request() {
-    let mut model = run_rt_test(RuntimeTestArgs::default());
+fn test_mldsa87_verify_oversized_request() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
     boot_ready(&mut model);
 
-    // Build a payload that contains the mailbox header plus a few extra
-    // bytes — well short of the full request size.
-    let mut payload = vec![0u8; core::mem::size_of::<MailboxReqHeader>() + 32];
-    // Compute a valid checksum over everything after the chksum field.
+    // One word larger than the request buffer trips the mailbox size guard.
+    let mut payload = vec![0u8; core::mem::size_of::<Mldsa87VerifyReq>() + 4];
+    // A valid checksum is not required to reach the guard (the size check runs
+    // first), but stamp one so the payload is otherwise well-formed.
     let chksum_size = core::mem::size_of::<u32>();
     let chksum = calc_checksum(
         u32::from(CommandId::MLDSA87_SIGNATURE_VERIFY),


### PR DESCRIPTION
The mldsa attestation feature was previously not being linted and a number of mldsa specific tests skipped.  This PR corrects the small amount of issues which crept in and enables the lints and tests by default. 