### PR TITLE
ML-DSA firmware implementation optimizations

### DIFF
--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -79,23 +79,31 @@ pub struct Vector7 {
 
 /* Complex types. */
 
-pub struct PublicKey {
-    pub rho: [u8; K_RHO_BYTES],
-    pub t1: Vector8,
-}
-
 pub struct PrivateKey {
     pub rho: [u8; K_RHO_BYTES],
     pub k: [u8; K_K_BYTES],
-    pub s1_ntt: Vector7,
-    pub s2_ntt: Vector8,
+    pub sigma: [u8; K_SIGMA_BYTES],
     pub t0_ntt: Vector8,
 }
 
-pub struct Signature {
-    pub c_tilde: [u8; 2 * LAMBDA_BYTES],
-    pub z: Vector7,
-    pub h: Vector8,
+#[derive(Clone, Copy)]
+pub struct HintEnt {
+    pub v: [u8; OMEGA],
+    pub num_hints: usize,
+}
+
+impl Default for HintEnt {
+    fn default() -> Self {
+        HintEnt {
+            v: [0u8; OMEGA],
+            num_hints: 0,
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct Hint {
+    pub v: [HintEnt; 8],
 }
 
 /* Arithmetic. */
@@ -264,12 +272,6 @@ fn vector8_mul_scalar(out: &mut Vector8, lhs: &Vector8, rhs: &Scalar) {
     }
 }
 
-fn vector7_mul_scalar(out: &mut Vector7, lhs: &Vector7, rhs: &Scalar) {
-    for i in 0..7 {
-        scalar_mul(&mut out.v[i], &lhs.v[i], rhs);
-    }
-}
-
 fn vector8_ntt(a: &mut Vector8) {
     for i in 0..8 {
         scalar_ntt(&mut a.v[i]);
@@ -284,12 +286,6 @@ fn vector7_ntt(a: &mut Vector7) {
 
 fn vector8_inverse_ntt(a: &mut Vector8) {
     for i in 0..8 {
-        scalar_inverse_ntt(&mut a.v[i]);
-    }
-}
-
-fn vector7_inverse_ntt(a: &mut Vector7) {
-    for i in 0..7 {
         scalar_inverse_ntt(&mut a.v[i]);
     }
 }
@@ -387,9 +383,15 @@ fn scalar_max_signed(max: &mut u32, s: &Scalar) {
     }
 }
 
-fn scalar_use_hint(out: &mut Scalar, h: &Scalar, r: &Scalar) {
-    for i in 0..K_DEGREE {
-        out.c[i] = use_hint(h.c[i], r.c[i]);
+fn scalar_use_hint_sparse(out: &mut Scalar, h_ent: &HintEnt, r: &Scalar) {
+    let active_hints = &h_ent.v[..h_ent.num_hints];
+    for (i, (out_c, &r_c)) in out.c.iter_mut().zip(r.c.iter()).enumerate() {
+        let hint = if active_hints.contains(&(i as u8)) {
+            1
+        } else {
+            0
+        };
+        *out_c = use_hint(hint, r_c);
     }
 }
 
@@ -650,6 +652,38 @@ fn vectors78_expand_short(s1: &mut Vector7, s2: &mut Vector8, sigma: &[u8; K_SIG
     }
 }
 
+fn expand_s1_ntt_mul_scalar(
+    out: &mut Scalar,
+    i: usize,
+    sigma: &[u8; K_SIGMA_BYTES],
+    rhs: &Scalar,
+) {
+    let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
+    derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
+    derived_seed[K_SIGMA_BYTES] = i as u8;
+    derived_seed[K_SIGMA_BYTES + 1] = 0;
+    scalar_uniform_2(out, &derived_seed);
+    scalar_ntt(out);
+    let out_copy = *out;
+    scalar_mul(out, &out_copy, rhs);
+}
+
+fn expand_s2_ntt_mul_scalar(
+    out: &mut Scalar,
+    i: usize,
+    sigma: &[u8; K_SIGMA_BYTES],
+    rhs: &Scalar,
+) {
+    let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
+    derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
+    derived_seed[K_SIGMA_BYTES] = (i + 7) as u8;
+    derived_seed[K_SIGMA_BYTES + 1] = 0;
+    scalar_uniform_2(out, &derived_seed);
+    scalar_ntt(out);
+    let out_copy = *out;
+    scalar_mul(out, &out_copy, rhs);
+}
+
 fn vector7_expand_mask(out: &mut Vector7, seed: &[u8; K_RHO_PRIME_BYTES], kappa: usize) {
     let mut derived_seed = [0u8; K_RHO_PRIME_BYTES + 2];
     derived_seed[..K_RHO_PRIME_BYTES].copy_from_slice(seed);
@@ -716,8 +750,8 @@ fn hint_bit_pack(out: &mut [u8; OMEGA + 8], h: &Vector8) {
     }
 }
 
-fn hint_bit_unpack(h: &mut Vector8, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
-    vector8_zero(h);
+fn hint_bit_unpack(h: &mut Hint, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
+    *h = Hint::default();
     let mut index = 0;
     for i in 0..8 {
         let limit = in_val[OMEGA + i] as usize;
@@ -732,7 +766,8 @@ fn hint_bit_unpack(h: &mut Vector8, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
                 return Mldsa87Result::SigVerifyFailed;
             }
             last = byte as i32;
-            h.v[i].c[byte] = 1;
+            h.v[i].v[h.v[i].num_hints] = byte as u8;
+            h.v[i].num_hints += 1;
         }
     }
     for val in in_val.iter().take(OMEGA).skip(index) {
@@ -743,36 +778,36 @@ fn hint_bit_unpack(h: &mut Vector8, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
     Mldsa87Result::Success
 }
 
-fn encode_public_key(out: &mut [u8; MLDSA87_PUBLIC_KEY_BYTES], pub_key: &PublicKey) {
-    out[..K_RHO_BYTES].copy_from_slice(&pub_key.rho);
-    vector8_encode_10(&mut out[K_RHO_BYTES..], &pub_key.t1);
-}
-
-fn decode_public_key(pub_key: &mut PublicKey, in_val: &[u8; MLDSA87_PUBLIC_KEY_BYTES]) {
-    pub_key.rho.copy_from_slice(&in_val[..K_RHO_BYTES]);
-    vector8_decode_10(&mut pub_key.t1, &in_val[K_RHO_BYTES..]);
-}
-
-fn encode_signature(out: &mut [u8; MLDSA87_SIGNATURE_BYTES], sign: &Signature) {
-    out[..2 * LAMBDA_BYTES].copy_from_slice(&sign.c_tilde);
-    vector7_encode_signed_20_19(&mut out[2 * LAMBDA_BYTES..], &sign.z);
+fn encode_signature(
+    out: &mut [u8; MLDSA87_SIGNATURE_BYTES],
+    c_tilde: &[u8; 2 * LAMBDA_BYTES],
+    z: &Vector7,
+    h: &Vector8,
+) {
+    out[..2 * LAMBDA_BYTES].copy_from_slice(c_tilde);
+    vector7_encode_signed_20_19(&mut out[2 * LAMBDA_BYTES..], z);
 
     let hint_out: &mut [u8; OMEGA + 8] = (&mut out
         [2 * LAMBDA_BYTES + 640 * 7..2 * LAMBDA_BYTES + 640 * 7 + OMEGA + 8])
         .try_into()
         .unwrap();
-    hint_bit_pack(hint_out, &sign.h);
+    hint_bit_pack(hint_out, h);
 }
 
-fn decode_signature(sign: &mut Signature, in_val: &[u8; MLDSA87_SIGNATURE_BYTES]) -> Mldsa87Result {
-    sign.c_tilde.copy_from_slice(&in_val[..2 * LAMBDA_BYTES]);
-    vector7_decode_signed_20_19(&mut sign.z, &in_val[2 * LAMBDA_BYTES..]);
+fn decode_signature(
+    c_tilde: &mut [u8; 2 * LAMBDA_BYTES],
+    z: &mut Vector7,
+    h: &mut Hint,
+    in_val: &[u8; MLDSA87_SIGNATURE_BYTES],
+) -> Mldsa87Result {
+    c_tilde.copy_from_slice(&in_val[..2 * LAMBDA_BYTES]);
+    vector7_decode_signed_20_19(z, &in_val[2 * LAMBDA_BYTES..]);
 
     let hint_in: &[u8; OMEGA + 8] = (&in_val
         [2 * LAMBDA_BYTES + 640 * 7..2 * LAMBDA_BYTES + 640 * 7 + OMEGA + 8])
         .try_into()
         .unwrap();
-    hint_bit_unpack(&mut sign.h, hint_in)
+    hint_bit_unpack(h, hint_in)
 }
 
 /* Main algorithms. */
@@ -817,44 +852,43 @@ fn generate_key_internal(
 
     priv_key.rho.copy_from_slice(rho);
     priv_key.k.copy_from_slice(k);
+    priv_key.sigma.copy_from_slice(sigma);
 
     if let Some(sk) = out_encoded_private_key.as_mut() {
         sk[SK_RHO_OFF..SK_RHO_OFF + K_RHO_BYTES].copy_from_slice(rho);
         sk[SK_K_OFF..SK_K_OFF + K_K_BYTES].copy_from_slice(k);
     }
 
+    let mut s1_ntt = Vector7::default();
+    let mut s2_ntt = Vector8::default();
     vectors78_expand_short(
-        &mut priv_key.s1_ntt,
-        &mut priv_key.s2_ntt,
+        &mut s1_ntt,
+        &mut s2_ntt,
         sigma.try_into().unwrap(),
     );
 
     // s1 is in normal domain here (before its NTT for the matrix multiply).
     if let Some(sk) = out_encoded_private_key.as_mut() {
-        for (i, scalar) in priv_key.s1_ntt.v.iter().enumerate() {
+        for (i, scalar) in s1_ntt.v.iter().enumerate() {
             let off = SK_S1_OFF + i * SK_S_PACK_BYTES;
             pack_scalar_bits(&mut sk[off..off + SK_S_PACK_BYTES], scalar, 3, 2);
         }
     }
 
-    vector7_ntt(&mut priv_key.s1_ntt);
+    vector7_ntt(&mut s1_ntt);
 
     let mut t = Vector8::default();
-    matrix87_expand_mul(&mut t, rho.try_into().unwrap(), &priv_key.s1_ntt);
+    matrix87_expand_mul(&mut t, rho.try_into().unwrap(), &s1_ntt);
     vector8_inverse_ntt(&mut t);
     let t_copy = t;
-    vector8_add(&mut t, &t_copy, &priv_key.s2_ntt);
+    vector8_add(&mut t, &t_copy, &s2_ntt);
 
-    let rho_bytes: [u8; K_RHO_BYTES] = rho.try_into().unwrap();
-    let mut pub_key = PublicKey {
-        rho: rho_bytes,
-        t1: Vector8::default(),
-    };
-    vector8_power2_round(&mut pub_key.t1, &mut priv_key.t0_ntt, &t);
+    let mut t1 = Vector8::default();
+    vector8_power2_round(&mut t1, &mut priv_key.t0_ntt, &t);
 
     // s2 and t0 are in normal domain here (before their NTTs for signing).
     if let Some(sk) = out_encoded_private_key.as_mut() {
-        for (i, scalar) in priv_key.s2_ntt.v.iter().enumerate() {
+        for (i, scalar) in s2_ntt.v.iter().enumerate() {
             let off = SK_S2_OFF + i * SK_S_PACK_BYTES;
             pack_scalar_bits(&mut sk[off..off + SK_S_PACK_BYTES], scalar, 3, 2);
         }
@@ -864,10 +898,10 @@ fn generate_key_internal(
         }
     }
 
-    vector8_ntt(&mut priv_key.s2_ntt);
     vector8_ntt(&mut priv_key.t0_ntt);
 
-    encode_public_key(out_encoded_public_key, &pub_key);
+    out_encoded_public_key[..K_RHO_BYTES].copy_from_slice(rho);
+    vector8_encode_10(&mut out_encoded_public_key[K_RHO_BYTES..], &t1);
 
     if out_encoded_private_key.is_some() || out_public_key_hash.is_some() {
         let mut tr = [0u8; K_TR_BYTES];
@@ -911,8 +945,7 @@ pub fn mldsa87_key_pair_from_seed(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     generate_key_internal(
@@ -953,11 +986,9 @@ fn sign_internal_with_mu(
     shake256.absorb(mu);
     shake256.squeeze(&mut rho_prime);
 
-    let mut sign = Signature {
-        c_tilde: [0u8; 2 * LAMBDA_BYTES],
-        z: Vector7::default(),
-        h: Vector8::default(),
-    };
+    let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];
+    let mut z = Vector7::default();
+    let mut h = Vector8::default();
     let mut w1 = Vector8::default();
 
     #[allow(clippy::large_enum_variant)]
@@ -976,32 +1007,34 @@ fn sign_internal_with_mu(
             _ => unreachable!(),
         };
 
-        vector7_expand_mask(&mut sign.z, &rho_prime, kappa);
-        vector7_ntt(&mut sign.z);
+        vector7_expand_mask(&mut z, &rho_prime, kappa);
+        vector7_ntt(&mut z);
 
-        matrix87_expand_mul(&mut sign.h, &priv_key.rho, &sign.z);
-        vector8_inverse_ntt(&mut sign.h);
+        matrix87_expand_mul(&mut h, &priv_key.rho, &z);
+        vector8_inverse_ntt(&mut h);
 
-        vector8_high_bits(&mut w1, &sign.h);
+        vector8_high_bits(&mut w1, &h);
         let mut w1_encoded = [0u8; 128 * 8];
         w1_encode(&mut w1_encoded, &w1);
 
         let mut shake256 = Shake256::new();
         shake256.absorb(mu);
         shake256.absorb(&w1_encoded);
-        shake256.squeeze(&mut sign.c_tilde);
+        shake256.squeeze(&mut c_tilde);
 
         let mut c_ntt = Scalar::default();
-        scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde, sign.c_tilde.len());
+        scalar_sample_in_ball_vartime(&mut c_ntt, &c_tilde, c_tilde.len());
         scalar_ntt(&mut c_ntt);
 
-        vector7_mul_scalar(cs1, &priv_key.s1_ntt, &c_ntt);
-        vector7_inverse_ntt(cs1);
+        for (i, cs_i) in cs1.v.iter_mut().enumerate() {
+            expand_s1_ntt_mul_scalar(cs_i, i, &priv_key.sigma, &c_ntt);
+            scalar_inverse_ntt(cs_i);
+        }
 
-        vector7_expand_mask(&mut sign.z, &rho_prime, kappa);
+        vector7_expand_mask(&mut z, &rho_prime, kappa);
 
         // Inline implementation of vector7_add to prevent creating a copy to save stack space
-        for (lhs, rhs) in sign.z.v.iter_mut().zip(cs1.v.iter()) {
+        for (lhs, rhs) in z.v.iter_mut().zip(cs1.v.iter()) {
             // Inline implementaiton of scalar_add
             for (lhs, rhs) in lhs.c.iter_mut().zip(rhs.c.iter()) {
                 *lhs = reduce_once(lhs.wrapping_add(*rhs));
@@ -1014,11 +1047,13 @@ fn sign_internal_with_mu(
             _ => unreachable!(),
         };
 
-        vector8_mul_scalar(cs2, &priv_key.s2_ntt, &c_ntt);
-        vector8_inverse_ntt(cs2);
+        for (i, cs_i) in cs2.v.iter_mut().enumerate() {
+            expand_s2_ntt_mul_scalar(cs_i, i, &priv_key.sigma, &c_ntt);
+            scalar_inverse_ntt(cs_i);
+        }
 
         let r0 = &mut w1;
-        vector8_sub(r0, &sign.h, cs2);
+        vector8_sub(r0, &h, cs2);
 
         // Inline implementation of vector8_low_bits to prevent creating a copy to save stack space
         for s in r0.v.iter_mut() {
@@ -1028,7 +1063,7 @@ fn sign_internal_with_mu(
             }
         }
 
-        let z_max = vector7_max(&sign.z);
+        let z_max = vector7_max(&z);
         let r0_max = vector8_max_signed(r0);
 
         if (ct_ge(z_max, GAMMA1.wrapping_sub(BETA)) | ct_ge(r0_max, K_GAMMA_2.wrapping_sub(BETA)))
@@ -1043,7 +1078,7 @@ fn sign_internal_with_mu(
         vector8_inverse_ntt(ct0);
 
         // Inline implementation of vector8_make_hint to prevent creating a copy to save stack space
-        for (sign_s, (ct0_s, cs2_s)) in sign.h.v.iter_mut().zip(ct0.v.iter().zip(cs2.v.iter())) {
+        for (sign_s, (ct0_s, cs2_s)) in h.v.iter_mut().zip(ct0.v.iter().zip(cs2.v.iter())) {
             // Inline implementation of scalar_make_hint
             for (sign_c, (ct0_c, cs2_c)) in
                 sign_s.c.iter_mut().zip(ct0_s.c.iter().zip(cs2_s.c.iter()))
@@ -1053,44 +1088,45 @@ fn sign_internal_with_mu(
         }
 
         let ct0_max = vector8_max(ct0);
-        let h_ones = vector8_count_ones(&sign.h);
+        let h_ones = vector8_count_ones(&h);
 
         if (ct_ge(ct0_max, K_GAMMA_2) | ct_lt(OMEGA as u32, h_ones as u32)) != 0 {
             kappa += 7;
             continue;
         }
 
-        encode_signature(out_encoded_signature, &sign);
+        encode_signature(out_encoded_signature, &c_tilde, &z, &h);
         return;
     }
 }
 
 fn verify_internal_with_mu(
-    pub_key: &PublicKey,
+    encoded_public_key: &[u8; MLDSA87_PUBLIC_KEY_BYTES],
     encoded_signature: &[u8; MLDSA87_SIGNATURE_BYTES],
     mu: &[u8; K_MU_BYTES],
 ) -> Mldsa87Result {
-    let mut sign = Signature {
-        c_tilde: [0u8; 2 * LAMBDA_BYTES],
-        z: Vector7::default(),
-        h: Vector8::default(),
-    };
-    if decode_signature(&mut sign, encoded_signature) != Mldsa87Result::Success {
+    let mut sig_c_tilde = [0u8; 2 * LAMBDA_BYTES];
+    let mut z = Vector7::default();
+    let mut h = Hint::default();
+    if decode_signature(&mut sig_c_tilde, &mut z, &mut h, encoded_signature) != Mldsa87Result::Success {
         return Mldsa87Result::SigVerifyFailed;
     }
 
-    let z_max = vector7_max(&sign.z);
-    vector7_ntt(&mut sign.z);
+    let z_max = vector7_max(&z);
+    vector7_ntt(&mut z);
 
     let mut c_ntt = Scalar::default();
-    scalar_sample_in_ball_vartime(&mut c_ntt, &sign.c_tilde, sign.c_tilde.len());
+    scalar_sample_in_ball_vartime(&mut c_ntt, &sig_c_tilde, sig_c_tilde.len());
     scalar_ntt(&mut c_ntt);
 
+    let pub_rho: &[u8; K_RHO_BYTES] = (&encoded_public_key[..K_RHO_BYTES]).try_into().unwrap();
     let mut az_ntt = Vector8::default();
-    matrix87_expand_mul(&mut az_ntt, &pub_key.rho, &sign.z);
+    matrix87_expand_mul(&mut az_ntt, pub_rho, &z);
 
     let mut ct1_ntt = Vector8::default();
-    vector8_scale_power2_round(&mut ct1_ntt, &pub_key.t1);
+    vector8_decode_10(&mut ct1_ntt, &encoded_public_key[K_RHO_BYTES..]);
+    let ct1_copy = ct1_ntt;
+    vector8_scale_power2_round(&mut ct1_ntt, &ct1_copy);
     vector8_ntt(&mut ct1_ntt);
     // Multiply each Scalar by c_ntt in place. Avoids the 8 KiB Vector8 copy
     // that vector8_mul_scalar would require: on stack-constrained targets pushes verify over budget
@@ -1107,7 +1143,7 @@ fn verify_internal_with_mu(
     // reason as above (avoids an 8 KiB Vector8 copy of w1).
     for i in 0..8 {
         let r = w1.v[i];
-        scalar_use_hint(&mut w1.v[i], &sign.h.v[i], &r);
+        scalar_use_hint_sparse(&mut w1.v[i], &h.v[i], &r);
     }
     let mut w1_encoded = [0u8; 128 * 8];
     w1_encode(&mut w1_encoded, &w1);
@@ -1118,7 +1154,7 @@ fn verify_internal_with_mu(
     shake256.absorb(&w1_encoded);
     shake256.squeeze(&mut c_tilde);
 
-    if z_max < (GAMMA1 - BETA) && c_tilde == sign.c_tilde {
+    if z_max < (GAMMA1 - BETA) && c_tilde == sig_c_tilde {
         Mldsa87Result::Success
     } else {
         Mldsa87Result::SigVerifyFailed
@@ -1157,8 +1193,7 @@ pub fn mldsa87_pub_from_seed(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     generate_key_internal(
@@ -1179,8 +1214,7 @@ pub fn mldsa87_sign(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     let mut tr = [0u8; K_TR_BYTES];
@@ -1215,8 +1249,7 @@ pub fn mldsa87_sign_mu(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     generate_priv_internal(&mut priv_key, private_key_seed, None);
@@ -1245,12 +1278,7 @@ pub fn mldsa87_verify_mu(
     encoded_signature: &[u8; MLDSA87_SIGNATURE_BYTES],
     mu: &[u8; K_MU_BYTES],
 ) -> Mldsa87Result {
-    let mut pub_key = PublicKey {
-        rho: [0u8; K_RHO_BYTES],
-        t1: Vector8::default(),
-    };
-    decode_public_key(&mut pub_key, encoded_public_key);
-    verify_internal_with_mu(&pub_key, encoded_signature, mu)
+    verify_internal_with_mu(encoded_public_key, encoded_signature, mu)
 }
 
 /// Verification entry point that accepts a signing `context`.
@@ -1356,8 +1384,7 @@ pub fn mldsa87_sign_with_context_from_sk(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     let tr = decode_private_key_internal(&mut priv_key, sk);
@@ -1401,8 +1428,7 @@ pub fn mldsa87_sign_mu_from_sk(
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
-        s1_ntt: Vector7::default(),
-        s2_ntt: Vector8::default(),
+        sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
     decode_private_key_internal(&mut priv_key, sk);

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -351,11 +351,6 @@ fn use_hint(h: u32, r: u32) -> u32 {
     r1
 }
 
-fn scalar_power2_round(s1: &mut Scalar, s0: &mut Scalar, s: &Scalar) {
-    for i in 0..K_DEGREE {
-        power2_round(&mut s1.c[i], &mut s0.c[i], s.c[i]);
-    }
-}
 
 fn scalar_scale_power2_round(out: &mut Scalar, in_val: &Scalar) {
     for i in 0..K_DEGREE {
@@ -395,9 +390,12 @@ fn scalar_use_hint_sparse(out: &mut Scalar, h_ent: &HintEnt, r: &Scalar) {
     }
 }
 
-fn vector8_power2_round(t1: &mut Vector8, t0: &mut Vector8, t: &Vector8) {
-    for i in 0..8 {
-        scalar_power2_round(&mut t1.v[i], &mut t0.v[i], &t.v[i]);
+fn vector8_power2_round_in_place(t1: &mut Vector8, t0: &mut Vector8) {
+    for (t1_scalar, t0_scalar) in t1.v.iter_mut().zip(t0.v.iter_mut()) {
+        for (t1_c, t0_c) in t1_scalar.c.iter_mut().zip(t0_scalar.c.iter_mut()) {
+            let r = *t0_c;
+            power2_round(t1_c, t0_c, r);
+        }
     }
 }
 
@@ -637,7 +635,7 @@ fn matrix87_expand_mul(out: &mut Vector8, rho: &[u8; K_RHO_BYTES], a: &Vector7) 
     }
 }
 
-fn vectors78_expand_short(s1: &mut Vector7, s2: &mut Vector8, sigma: &[u8; K_SIGMA_BYTES]) {
+fn expand_s1_short(s1: &mut Vector7, sigma: &[u8; K_SIGMA_BYTES]) {
     let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
     derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
     derived_seed[K_SIGMA_BYTES] = 0;
@@ -646,6 +644,13 @@ fn vectors78_expand_short(s1: &mut Vector7, s2: &mut Vector8, sigma: &[u8; K_SIG
         scalar_uniform_2(&mut s1.v[i], &derived_seed);
         derived_seed[K_SIGMA_BYTES] = derived_seed[K_SIGMA_BYTES].wrapping_add(1);
     }
+}
+
+fn expand_s2_short(s2: &mut Vector8, sigma: &[u8; K_SIGMA_BYTES]) {
+    let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
+    derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
+    derived_seed[K_SIGMA_BYTES] = 7;
+    derived_seed[K_SIGMA_BYTES + 1] = 0;
     for i in 0..8 {
         scalar_uniform_2(&mut s2.v[i], &derived_seed);
         derived_seed[K_SIGMA_BYTES] = derived_seed[K_SIGMA_BYTES].wrapping_add(1);
@@ -656,13 +661,19 @@ fn expand_s1_ntt_mul_scalar(
     out: &mut Scalar,
     i: usize,
     sigma: &[u8; K_SIGMA_BYTES],
+    sk_opt: Option<&[u8; MLDSA87_PRIVATE_KEY_BYTES]>,
     rhs: &Scalar,
 ) {
-    let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
-    derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
-    derived_seed[K_SIGMA_BYTES] = i as u8;
-    derived_seed[K_SIGMA_BYTES + 1] = 0;
-    scalar_uniform_2(out, &derived_seed);
+    if let Some(sk) = sk_opt {
+        let off = SK_S1_OFF + i * SK_S_PACK_BYTES;
+        unpack_scalar_bits(out, &sk[off..off + SK_S_PACK_BYTES], 3, 2);
+    } else {
+        let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
+        derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
+        derived_seed[K_SIGMA_BYTES] = i as u8;
+        derived_seed[K_SIGMA_BYTES + 1] = 0;
+        scalar_uniform_2(out, &derived_seed);
+    }
     scalar_ntt(out);
     let out_copy = *out;
     scalar_mul(out, &out_copy, rhs);
@@ -672,13 +683,19 @@ fn expand_s2_ntt_mul_scalar(
     out: &mut Scalar,
     i: usize,
     sigma: &[u8; K_SIGMA_BYTES],
+    sk_opt: Option<&[u8; MLDSA87_PRIVATE_KEY_BYTES]>,
     rhs: &Scalar,
 ) {
-    let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
-    derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
-    derived_seed[K_SIGMA_BYTES] = (i + 7) as u8;
-    derived_seed[K_SIGMA_BYTES + 1] = 0;
-    scalar_uniform_2(out, &derived_seed);
+    if let Some(sk) = sk_opt {
+        let off = SK_S2_OFF + i * SK_S_PACK_BYTES;
+        unpack_scalar_bits(out, &sk[off..off + SK_S_PACK_BYTES], 3, 2);
+    } else {
+        let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
+        derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
+        derived_seed[K_SIGMA_BYTES] = (i + 7) as u8;
+        derived_seed[K_SIGMA_BYTES + 1] = 0;
+        scalar_uniform_2(out, &derived_seed);
+    }
     scalar_ntt(out);
     let out_copy = *out;
     scalar_mul(out, &out_copy, rhs);
@@ -859,13 +876,18 @@ fn generate_key_internal(
         sk[SK_K_OFF..SK_K_OFF + K_K_BYTES].copy_from_slice(k);
     }
 
-    let mut s1_ntt = Vector7::default();
-    let mut s2_ntt = Vector8::default();
-    vectors78_expand_short(
-        &mut s1_ntt,
-        &mut s2_ntt,
-        sigma.try_into().unwrap(),
-    );
+    #[allow(clippy::large_enum_variant)]
+    enum KeygenState {
+        V7(Vector7),
+        V8(Vector8),
+    }
+
+    let mut state = KeygenState::V7(Vector7::default());
+    let s1_ntt = match &mut state {
+        KeygenState::V7(v) => v,
+        _ => unreachable!(),
+    };
+    expand_s1_short(s1_ntt, sigma.try_into().unwrap());
 
     // s1 is in normal domain here (before its NTT for the matrix multiply).
     if let Some(sk) = out_encoded_private_key.as_mut() {
@@ -875,23 +897,37 @@ fn generate_key_internal(
         }
     }
 
-    vector7_ntt(&mut s1_ntt);
+    vector7_ntt(s1_ntt);
 
-    let mut t = Vector8::default();
-    matrix87_expand_mul(&mut t, rho.try_into().unwrap(), &s1_ntt);
-    vector8_inverse_ntt(&mut t);
-    let t_copy = t;
-    vector8_add(&mut t, &t_copy, &s2_ntt);
+    matrix87_expand_mul(&mut priv_key.t0_ntt, rho.try_into().unwrap(), s1_ntt);
+    vector8_inverse_ntt(&mut priv_key.t0_ntt);
 
-    let mut t1 = Vector8::default();
-    vector8_power2_round(&mut t1, &mut priv_key.t0_ntt, &t);
+    state = KeygenState::V8(Vector8::default());
+    let s2_ntt = match &mut state {
+        KeygenState::V8(v) => v,
+        _ => unreachable!(),
+    };
+    expand_s2_short(s2_ntt, sigma.try_into().unwrap());
 
-    // s2 and t0 are in normal domain here (before their NTTs for signing).
     if let Some(sk) = out_encoded_private_key.as_mut() {
         for (i, scalar) in s2_ntt.v.iter().enumerate() {
             let off = SK_S2_OFF + i * SK_S_PACK_BYTES;
             pack_scalar_bits(&mut sk[off..off + SK_S_PACK_BYTES], scalar, 3, 2);
         }
+    }
+
+    let t0_copy = priv_key.t0_ntt;
+    vector8_add(&mut priv_key.t0_ntt, &t0_copy, s2_ntt);
+
+    state = KeygenState::V8(Vector8::default());
+    let t1 = match &mut state {
+        KeygenState::V8(v) => v,
+        _ => unreachable!(),
+    };
+    vector8_power2_round_in_place(t1, &mut priv_key.t0_ntt);
+
+    // s2 and t0 are in normal domain here (before their NTTs for signing).
+    if let Some(sk) = out_encoded_private_key.as_mut() {
         for (i, scalar) in priv_key.t0_ntt.v.iter().enumerate() {
             let off = SK_T0_OFF + i * SK_T0_PACK_BYTES;
             pack_scalar_bits(&mut sk[off..off + SK_T0_PACK_BYTES], scalar, 13, 1 << 12);
@@ -901,7 +937,7 @@ fn generate_key_internal(
     vector8_ntt(&mut priv_key.t0_ntt);
 
     out_encoded_public_key[..K_RHO_BYTES].copy_from_slice(rho);
-    vector8_encode_10(&mut out_encoded_public_key[K_RHO_BYTES..], &t1);
+    vector8_encode_10(&mut out_encoded_public_key[K_RHO_BYTES..], t1);
 
     if out_encoded_private_key.is_some() || out_public_key_hash.is_some() {
         let mut tr = [0u8; K_TR_BYTES];
@@ -978,6 +1014,7 @@ fn sign_internal_with_mu(
     priv_key: &PrivateKey,
     mu: &[u8; K_MU_BYTES],
     randomizer: &[u8; MLDSA87_RANDOMIZER_BYTES],
+    sk_opt: Option<&[u8; MLDSA87_PRIVATE_KEY_BYTES]>,
 ) {
     let mut rho_prime = [0u8; K_RHO_PRIME_BYTES];
     let mut shake256 = Shake256::new();
@@ -988,7 +1025,7 @@ fn sign_internal_with_mu(
 
     let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];
     let mut z = Vector7::default();
-    let mut h = Vector8::default();
+    let mut tmp = Vector8::default();
     let mut w1 = Vector8::default();
 
     #[allow(clippy::large_enum_variant)]
@@ -1010,10 +1047,10 @@ fn sign_internal_with_mu(
         vector7_expand_mask(&mut z, &rho_prime, kappa);
         vector7_ntt(&mut z);
 
-        matrix87_expand_mul(&mut h, &priv_key.rho, &z);
-        vector8_inverse_ntt(&mut h);
+        matrix87_expand_mul(&mut tmp, &priv_key.rho, &z);
+        vector8_inverse_ntt(&mut tmp);
 
-        vector8_high_bits(&mut w1, &h);
+        vector8_high_bits(&mut w1, &tmp);
         let mut w1_encoded = [0u8; 128 * 8];
         w1_encode(&mut w1_encoded, &w1);
 
@@ -1027,7 +1064,7 @@ fn sign_internal_with_mu(
         scalar_ntt(&mut c_ntt);
 
         for (i, cs_i) in cs1.v.iter_mut().enumerate() {
-            expand_s1_ntt_mul_scalar(cs_i, i, &priv_key.sigma, &c_ntt);
+            expand_s1_ntt_mul_scalar(cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
             scalar_inverse_ntt(cs_i);
         }
 
@@ -1048,12 +1085,12 @@ fn sign_internal_with_mu(
         };
 
         for (i, cs_i) in cs2.v.iter_mut().enumerate() {
-            expand_s2_ntt_mul_scalar(cs_i, i, &priv_key.sigma, &c_ntt);
+            expand_s2_ntt_mul_scalar(cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
             scalar_inverse_ntt(cs_i);
         }
 
         let r0 = &mut w1;
-        vector8_sub(r0, &h, cs2);
+        vector8_sub(r0, &tmp, cs2);
 
         // Inline implementation of vector8_low_bits to prevent creating a copy to save stack space
         for s in r0.v.iter_mut() {
@@ -1078,24 +1115,23 @@ fn sign_internal_with_mu(
         vector8_inverse_ntt(ct0);
 
         // Inline implementation of vector8_make_hint to prevent creating a copy to save stack space
-        for (sign_s, (ct0_s, cs2_s)) in h.v.iter_mut().zip(ct0.v.iter().zip(cs2.v.iter())) {
-            // Inline implementation of scalar_make_hint
-            for (sign_c, (ct0_c, cs2_c)) in
-                sign_s.c.iter_mut().zip(ct0_s.c.iter().zip(cs2_s.c.iter()))
+        for (tmp_s, (ct0_s, cs2_s)) in tmp.v.iter_mut().zip(ct0.v.iter().zip(cs2.v.iter())) {
+            for (tmp_c, (ct0_c, cs2_c)) in
+                tmp_s.c.iter_mut().zip(ct0_s.c.iter().zip(cs2_s.c.iter()))
             {
-                *sign_c = make_hint(*ct0_c, *cs2_c, *sign_c) as u32;
+                *tmp_c = make_hint(*ct0_c, *cs2_c, *tmp_c) as u32;
             }
         }
 
         let ct0_max = vector8_max(ct0);
-        let h_ones = vector8_count_ones(&h);
+        let h_ones = vector8_count_ones(&tmp);
 
         if (ct_ge(ct0_max, K_GAMMA_2) | ct_lt(OMEGA as u32, h_ones as u32)) != 0 {
             kappa += 7;
             continue;
         }
 
-        encode_signature(out_encoded_signature, &c_tilde, &z, &h);
+        encode_signature(out_encoded_signature, &c_tilde, &z, &tmp);
         return;
     }
 }
@@ -1106,14 +1142,25 @@ fn verify_internal_with_mu(
     mu: &[u8; K_MU_BYTES],
 ) -> Mldsa87Result {
     let mut sig_c_tilde = [0u8; 2 * LAMBDA_BYTES];
-    let mut z = Vector7::default();
     let mut h = Hint::default();
-    if decode_signature(&mut sig_c_tilde, &mut z, &mut h, encoded_signature) != Mldsa87Result::Success {
+
+    #[allow(clippy::large_enum_variant)]
+    enum VerifyState {
+        V7(Vector7),
+        V8(Vector8),
+    }
+
+    let mut state = VerifyState::V7(Vector7::default());
+    let z = match &mut state {
+        VerifyState::V7(v) => v,
+        _ => unreachable!(),
+    };
+    if decode_signature(&mut sig_c_tilde, z, &mut h, encoded_signature) != Mldsa87Result::Success {
         return Mldsa87Result::SigVerifyFailed;
     }
 
-    let z_max = vector7_max(&z);
-    vector7_ntt(&mut z);
+    let z_max = vector7_max(z);
+    vector7_ntt(z);
 
     let mut c_ntt = Scalar::default();
     scalar_sample_in_ball_vartime(&mut c_ntt, &sig_c_tilde, sig_c_tilde.len());
@@ -1121,13 +1168,17 @@ fn verify_internal_with_mu(
 
     let pub_rho: &[u8; K_RHO_BYTES] = (&encoded_public_key[..K_RHO_BYTES]).try_into().unwrap();
     let mut az_ntt = Vector8::default();
-    matrix87_expand_mul(&mut az_ntt, pub_rho, &z);
+    matrix87_expand_mul(&mut az_ntt, pub_rho, z);
 
-    let mut ct1_ntt = Vector8::default();
-    vector8_decode_10(&mut ct1_ntt, &encoded_public_key[K_RHO_BYTES..]);
-    let ct1_copy = ct1_ntt;
-    vector8_scale_power2_round(&mut ct1_ntt, &ct1_copy);
-    vector8_ntt(&mut ct1_ntt);
+    state = VerifyState::V8(Vector8::default());
+    let ct1_ntt = match &mut state {
+        VerifyState::V8(v) => v,
+        _ => unreachable!(),
+    };
+    vector8_decode_10(ct1_ntt, &encoded_public_key[K_RHO_BYTES..]);
+    let ct1_copy = *ct1_ntt;
+    vector8_scale_power2_round(ct1_ntt, &ct1_copy);
+    vector8_ntt(ct1_ntt);
     // Multiply each Scalar by c_ntt in place. Avoids the 8 KiB Vector8 copy
     // that vector8_mul_scalar would require: on stack-constrained targets pushes verify over budget
     for i in 0..8 {
@@ -1167,21 +1218,20 @@ fn verify_with_mu_context(
     msg: &[u8],
     context: &[u8],
 ) -> Mldsa87Result {
-    let mut tr = [0u8; K_TR_BYTES];
+    let mut tr_mu = [0u8; K_TR_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(encoded_public_key);
-    shake256.squeeze(&mut tr);
+    shake256.squeeze(&mut tr_mu);
 
-    let mut mu = [0u8; K_MU_BYTES];
     let mut shake256 = Shake256::new();
-    shake256.absorb(&tr);
+    shake256.absorb(&tr_mu);
     let context_prefix = [0u8, context.len() as u8];
     shake256.absorb(&context_prefix);
     shake256.absorb(context);
     shake256.absorb(msg);
-    shake256.squeeze(&mut mu);
+    shake256.squeeze(&mut tr_mu);
 
-    mldsa87_verify_mu(encoded_public_key, encoded_signature, &mu)
+    mldsa87_verify_mu(encoded_public_key, encoded_signature, &tr_mu)
 }
 
 /* Public API. */
@@ -1217,18 +1267,17 @@ pub fn mldsa87_sign(
         sigma: [0u8; K_SIGMA_BYTES],
         t0_ntt: Vector8::default(),
     };
-    let mut tr = [0u8; K_TR_BYTES];
-    generate_priv_internal(&mut priv_key, private_key_seed, Some(&mut tr));
+    let mut tr_mu = [0u8; K_TR_BYTES];
+    generate_priv_internal(&mut priv_key, private_key_seed, Some(&mut tr_mu));
 
-    let mut mu = [0u8; K_MU_BYTES];
     let mut shake256 = Shake256::new();
-    shake256.absorb(&tr);
+    shake256.absorb(&tr_mu);
     let context_prefix = [0u8, 0];
     shake256.absorb(&context_prefix);
     shake256.absorb(msg);
-    shake256.squeeze(&mut mu);
+    shake256.squeeze(&mut tr_mu);
 
-    sign_internal_with_mu(out_encoded_signature, &priv_key, &mu, randomizer);
+    sign_internal_with_mu(out_encoded_signature, &priv_key, &tr_mu, randomizer, None);
 }
 
 pub fn mldsa87_sign_deterministic(
@@ -1253,7 +1302,7 @@ pub fn mldsa87_sign_mu(
         t0_ntt: Vector8::default(),
     };
     generate_priv_internal(&mut priv_key, private_key_seed, None);
-    sign_internal_with_mu(out_encoded_signature, &priv_key, mu, randomizer);
+    sign_internal_with_mu(out_encoded_signature, &priv_key, mu, randomizer, None);
 }
 
 pub fn mldsa87_sign_mu_deterministic(
@@ -1298,7 +1347,6 @@ pub fn mldsa87_verify_with_context(
 
 /// Inverse of [`pack_scalar_bits`]: recover each coefficient from its packed
 /// form via `mod_sub(sub, packed)`.  Only used by the ACVP sigGen harness.
-#[cfg(test)]
 fn unpack_scalar_bits(s: &mut Scalar, data: &[u8], bits: u32, sub: u32) {
     for (out_chunk, in_chunk) in
         s.c.chunks_exact_mut(8)
@@ -1331,28 +1379,6 @@ fn decode_private_key_internal(
         .k
         .copy_from_slice(&sk[SK_K_OFF..SK_K_OFF + K_K_BYTES]);
     let tr: [u8; K_TR_BYTES] = sk[SK_TR_OFF..SK_TR_OFF + K_TR_BYTES].try_into().unwrap();
-
-    for i in 0..7 {
-        let off = SK_S1_OFF + i * SK_S_PACK_BYTES;
-        unpack_scalar_bits(
-            &mut priv_key.s1_ntt.v[i],
-            &sk[off..off + SK_S_PACK_BYTES],
-            3,
-            2,
-        );
-    }
-    vector7_ntt(&mut priv_key.s1_ntt);
-
-    for i in 0..8 {
-        let off = SK_S2_OFF + i * SK_S_PACK_BYTES;
-        unpack_scalar_bits(
-            &mut priv_key.s2_ntt.v[i],
-            &sk[off..off + SK_S_PACK_BYTES],
-            3,
-            2,
-        );
-    }
-    vector8_ntt(&mut priv_key.s2_ntt);
 
     for i in 0..8 {
         let off = SK_T0_OFF + i * SK_T0_PACK_BYTES;
@@ -1398,7 +1424,7 @@ pub fn mldsa87_sign_with_context_from_sk(
     shake256.absorb(msg);
     shake256.squeeze(&mut mu);
 
-    sign_internal_with_mu(out_encoded_signature, &priv_key, &mu, randomizer);
+    sign_internal_with_mu(out_encoded_signature, &priv_key, &mu, randomizer, Some(sk));
 }
 
 /// Deterministic variant of [`mldsa87_sign_with_context_from_sk`].
@@ -1432,7 +1458,7 @@ pub fn mldsa87_sign_mu_from_sk(
         t0_ntt: Vector8::default(),
     };
     decode_private_key_internal(&mut priv_key, sk);
-    sign_internal_with_mu(out_encoded_signature, &priv_key, mu, randomizer);
+    sign_internal_with_mu(out_encoded_signature, &priv_key, mu, randomizer, Some(sk));
 }
 
 /// Compute `mu` (the 64-byte message representative) from a private key seed

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -266,12 +266,6 @@ fn vector8_sub(out: &mut Vector8, lhs: &Vector8, rhs: &Vector8) {
     }
 }
 
-fn vector8_mul_scalar(out: &mut Vector8, lhs: &Vector8, rhs: &Scalar) {
-    for i in 0..8 {
-        scalar_mul(&mut out.v[i], &lhs.v[i], rhs);
-    }
-}
-
 fn vector8_ntt(a: &mut Vector8) {
     for i in 0..8 {
         scalar_ntt(&mut a.v[i]);
@@ -336,6 +330,16 @@ fn make_hint(ct0: u32, cs2: u32, w: u32) -> i32 {
     (high_bits(r) != high_bits(r_plus_z)) as i32
 }
 
+fn scalar_low_bits(out: &mut Scalar, in_val: &Scalar) {
+    for (out_c, in_c) in out.c.iter_mut().zip(in_val.c.iter()) {
+        *out_c = low_bits(*in_c) as u32;
+    }
+}
+
+fn scalar_count_ones(s: &Scalar) -> usize {
+    s.c.iter().map(|&c| c as usize).sum()
+}
+
 fn use_hint(h: u32, r: u32) -> u32 {
     let mut r1 = 0;
     let mut r0 = 0;
@@ -350,7 +354,6 @@ fn use_hint(h: u32, r: u32) -> u32 {
     }
     r1
 }
-
 
 fn scalar_scale_power2_round(out: &mut Scalar, in_val: &Scalar) {
     for i in 0..K_DEGREE {
@@ -379,9 +382,13 @@ fn scalar_max_signed(max: &mut u32, s: &Scalar) {
 }
 
 fn scalar_use_hint_sparse(out: &mut Scalar, h_ent: &HintEnt, r: &Scalar) {
-    let active_hints = &h_ent.v[..h_ent.num_hints];
     for (i, (out_c, &r_c)) in out.c.iter_mut().zip(r.c.iter()).enumerate() {
-        let hint = if active_hints.contains(&(i as u8)) {
+        let hint = if h_ent
+            .v
+            .iter()
+            .take(h_ent.num_hints)
+            .any(|&idx| idx as usize == i)
+        {
             1
         } else {
             0
@@ -405,44 +412,12 @@ fn vector8_scale_power2_round(out: &mut Vector8, in_val: &Vector8) {
     }
 }
 
-fn vector8_high_bits(out: &mut Vector8, in_val: &Vector8) {
-    for i in 0..8 {
-        scalar_high_bits(&mut out.v[i], &in_val.v[i]);
-    }
-}
-
-fn vector8_max(a: &Vector8) -> u32 {
-    let mut max = 0;
-    for i in 0..8 {
-        scalar_max(&mut max, &a.v[i]);
-    }
-    max
-}
-
 fn vector7_max(a: &Vector7) -> u32 {
     let mut max = 0;
     for i in 0..7 {
         scalar_max(&mut max, &a.v[i]);
     }
     max
-}
-
-fn vector8_max_signed(a: &Vector8) -> u32 {
-    let mut max = 0;
-    for i in 0..8 {
-        scalar_max_signed(&mut max, &a.v[i]);
-    }
-    max
-}
-
-fn vector8_count_ones(a: &Vector8) -> usize {
-    let mut count = 0;
-    for i in 0..8 {
-        for j in 0..K_DEGREE {
-            count += a.v[i].c[j] as usize;
-        }
-    }
-    count
 }
 
 /* Bit packing. */
@@ -701,24 +676,38 @@ fn expand_s2_ntt_mul_scalar(
     scalar_mul(out, &out_copy, rhs);
 }
 
-fn vector7_expand_mask(out: &mut Vector7, seed: &[u8; K_RHO_PRIME_BYTES], kappa: usize) {
-    let mut derived_seed = [0u8; K_RHO_PRIME_BYTES + 2];
-    derived_seed[..K_RHO_PRIME_BYTES].copy_from_slice(seed);
-    for i in 0..7 {
-        let index = kappa + i;
-        derived_seed[K_RHO_PRIME_BYTES] = (index & 0xFF) as u8;
-        derived_seed[K_RHO_PRIME_BYTES + 1] = ((index >> 8) & 0xFF) as u8;
-        scalar_sample_mask(&mut out.v[i], &derived_seed);
+fn matrix87_expand_mul_mask(
+    out: &mut Vector8,
+    rho: &[u8; K_RHO_BYTES],
+    rho_prime: &[u8; K_RHO_PRIME_BYTES],
+    kappa: usize,
+) {
+    vector8_zero(out);
+    let mut derived_seed = [0u8; K_RHO_BYTES + 2];
+    derived_seed[..K_RHO_BYTES].copy_from_slice(rho);
+    let mut mask_seed = [0u8; K_RHO_PRIME_BYTES + 2];
+    mask_seed[..K_RHO_PRIME_BYTES].copy_from_slice(rho_prime);
+
+    for j in 0..7 {
+        let mut y_j = Scalar::default();
+        let index = kappa + j;
+        mask_seed[K_RHO_PRIME_BYTES] = (index & 0xFF) as u8;
+        mask_seed[K_RHO_PRIME_BYTES + 1] = ((index >> 8) & 0xFF) as u8;
+        scalar_sample_mask(&mut y_j, &mask_seed);
+        scalar_ntt(&mut y_j);
+
+        for (i, out_scalar) in out.v.iter_mut().enumerate() {
+            let mut m_ij = Scalar::default();
+            derived_seed[K_RHO_BYTES + 1] = i as u8;
+            derived_seed[K_RHO_BYTES] = j as u8;
+            scalar_from_keccak_vartime(&mut m_ij, &derived_seed);
+            let out_copy = *out_scalar;
+            scalar_mul_add(out_scalar, &out_copy, &m_ij, &y_j);
+        }
     }
 }
 
 /* Encoding. */
-
-fn vector8_encode_4(out: &mut [u8], a: &Vector8) {
-    for i in 0..8 {
-        scalar_encode_4(&mut out[i * 4 * K_DEGREE / 8..], &a.v[i]);
-    }
-}
 
 fn vector8_encode_10(out: &mut [u8], a: &Vector8) {
     for i in 0..8 {
@@ -732,20 +721,10 @@ fn vector8_decode_10(out: &mut Vector8, in_val: &[u8]) {
     }
 }
 
-fn vector7_encode_signed_20_19(out: &mut [u8], a: &Vector7) {
-    for i in 0..7 {
-        scalar_encode_signed_20_19(&mut out[i * 20 * K_DEGREE / 8..], &a.v[i]);
-    }
-}
-
 fn vector7_decode_signed_20_19(out: &mut Vector7, in_val: &[u8]) {
     for i in 0..7 {
         scalar_decode_signed_20_19(&mut out.v[i], &in_val[i * 20 * K_DEGREE / 8..]);
     }
-}
-
-fn w1_encode(out: &mut [u8; 128 * 8], w1: &Vector8) {
-    vector8_encode_4(out, w1);
 }
 
 fn hint_bit_pack(out: &mut [u8; OMEGA + 8], h: &Vector8) {
@@ -775,17 +754,18 @@ fn hint_bit_unpack(h: &mut Hint, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
         if limit < index || limit > OMEGA {
             return Mldsa87Result::SigVerifyFailed;
         }
+        let slice = &in_val[index..limit];
         let mut last: i32 = -1;
-        while index < limit {
-            let byte = in_val[index] as usize;
-            index += 1;
+        for (&byte_u8, out_slot) in slice.iter().zip(h.v[i].v.iter_mut()) {
+            let byte = byte_u8 as usize;
             if last >= 0 && byte <= last as usize {
                 return Mldsa87Result::SigVerifyFailed;
             }
             last = byte as i32;
-            h.v[i].v[h.v[i].num_hints] = byte as u8;
-            h.v[i].num_hints += 1;
+            *out_slot = byte_u8;
         }
+        h.v[i].num_hints = slice.len();
+        index = limit;
     }
     for val in in_val.iter().take(OMEGA).skip(index) {
         if *val != 0 {
@@ -793,22 +773,6 @@ fn hint_bit_unpack(h: &mut Hint, in_val: &[u8; OMEGA + 8]) -> Mldsa87Result {
         }
     }
     Mldsa87Result::Success
-}
-
-fn encode_signature(
-    out: &mut [u8; MLDSA87_SIGNATURE_BYTES],
-    c_tilde: &[u8; 2 * LAMBDA_BYTES],
-    z: &Vector7,
-    h: &Vector8,
-) {
-    out[..2 * LAMBDA_BYTES].copy_from_slice(c_tilde);
-    vector7_encode_signed_20_19(&mut out[2 * LAMBDA_BYTES..], z);
-
-    let hint_out: &mut [u8; OMEGA + 8] = (&mut out
-        [2 * LAMBDA_BYTES + 640 * 7..2 * LAMBDA_BYTES + 640 * 7 + OMEGA + 8])
-        .try_into()
-        .unwrap();
-    hint_bit_pack(hint_out, h);
 }
 
 fn decode_signature(
@@ -1023,115 +987,100 @@ fn sign_internal_with_mu(
     shake256.absorb(mu);
     shake256.squeeze(&mut rho_prime);
 
-    let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];
-    let mut z = Vector7::default();
-    let mut tmp = Vector8::default();
-    let mut w1 = Vector8::default();
-
-    #[allow(clippy::large_enum_variant)]
-    enum CsVector {
-        V7(Vector7),
-        V8(Vector8),
-    }
-
-    let mut cs;
-
     let mut kappa = 0;
     loop {
-        cs = CsVector::V7(Vector7::default());
-        let cs1 = match &mut cs {
-            CsVector::V7(v) => v,
-            _ => unreachable!(),
-        };
-
-        vector7_expand_mask(&mut z, &rho_prime, kappa);
-        vector7_ntt(&mut z);
-
-        matrix87_expand_mul(&mut tmp, &priv_key.rho, &z);
+        let mut tmp = Vector8::default();
+        matrix87_expand_mul_mask(&mut tmp, &priv_key.rho, &rho_prime, kappa);
         vector8_inverse_ntt(&mut tmp);
 
-        vector8_high_bits(&mut w1, &tmp);
-        let mut w1_encoded = [0u8; 128 * 8];
-        w1_encode(&mut w1_encoded, &w1);
-
+        let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];
         let mut shake256 = Shake256::new();
         shake256.absorb(mu);
-        shake256.absorb(&w1_encoded);
+        for i in 0..8 {
+            let mut w1_encoded_part = [0u8; 128];
+            let mut temp = Scalar::default();
+            scalar_high_bits(&mut temp, &tmp.v[i]);
+            scalar_encode_4(&mut w1_encoded_part, &temp);
+            shake256.absorb(&w1_encoded_part);
+        }
         shake256.squeeze(&mut c_tilde);
 
         let mut c_ntt = Scalar::default();
         scalar_sample_in_ball_vartime(&mut c_ntt, &c_tilde, c_tilde.len());
         scalar_ntt(&mut c_ntt);
 
-        for (i, cs_i) in cs1.v.iter_mut().enumerate() {
-            expand_s1_ntt_mul_scalar(cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
-            scalar_inverse_ntt(cs_i);
+        out_encoded_signature[..2 * LAMBDA_BYTES].copy_from_slice(&c_tilde);
+
+        let mut z_max = 0u32;
+        let mut mask_seed = [0u8; K_RHO_PRIME_BYTES + 2];
+        mask_seed[..K_RHO_PRIME_BYTES].copy_from_slice(&rho_prime);
+
+        for i in 0..7 {
+            let mut cs_i = Scalar::default();
+            expand_s1_ntt_mul_scalar(&mut cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
+            scalar_inverse_ntt(&mut cs_i);
+
+            let mut z_i = Scalar::default();
+            let index = kappa + i;
+            mask_seed[K_RHO_PRIME_BYTES] = (index & 0xFF) as u8;
+            mask_seed[K_RHO_PRIME_BYTES + 1] = ((index >> 8) & 0xFF) as u8;
+            scalar_sample_mask(&mut z_i, &mask_seed);
+            let z_copy = z_i;
+            scalar_add(&mut z_i, &z_copy, &cs_i);
+
+            scalar_max(&mut z_max, &z_i);
+
+            let out_slice = &mut out_encoded_signature
+                [2 * LAMBDA_BYTES + i * 640..2 * LAMBDA_BYTES + (i + 1) * 640];
+            scalar_encode_signed_20_19(out_slice, &z_i);
         }
 
-        vector7_expand_mask(&mut z, &rho_prime, kappa);
+        let mut r0_max = 0u32;
+        let mut ct0_max = 0u32;
+        let mut h_ones = 0usize;
 
-        // Inline implementation of vector7_add to prevent creating a copy to save stack space
-        for (lhs, rhs) in z.v.iter_mut().zip(cs1.v.iter()) {
-            // Inline implementaiton of scalar_add
-            for (lhs, rhs) in lhs.c.iter_mut().zip(rhs.c.iter()) {
-                *lhs = reduce_once(lhs.wrapping_add(*rhs));
+        for i in 0..8 {
+            let mut cs_i = Scalar::default();
+            expand_s2_ntt_mul_scalar(&mut cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
+            scalar_inverse_ntt(&mut cs_i);
+
+            let mut r0_i = Scalar::default();
+            scalar_sub(&mut r0_i, &tmp.v[i], &cs_i);
+            let r0_copy = r0_i;
+            scalar_low_bits(&mut r0_i, &r0_copy);
+
+            scalar_max_signed(&mut r0_max, &r0_i);
+
+            let ct0_i = &mut r0_i;
+            scalar_mul(ct0_i, &priv_key.t0_ntt.v[i], &c_ntt);
+            scalar_inverse_ntt(ct0_i);
+
+            // Inline implementation of vector8_make_hint to prevent creating a copy to save stack space
+            for (tmp_c, (ct0_c, cs2_c)) in
+                tmp.v[i].c.iter_mut().zip(ct0_i.c.iter().zip(cs_i.c.iter()))
+            {
+                *tmp_c = make_hint(*ct0_c, *cs2_c, *tmp_c) as u32;
             }
+
+            scalar_max(&mut ct0_max, ct0_i);
+            h_ones += scalar_count_ones(&tmp.v[i]);
         }
 
-        cs = CsVector::V8(Vector8::default());
-        let cs2 = match &mut cs {
-            CsVector::V8(v) => v,
-            _ => unreachable!(),
-        };
-
-        for (i, cs_i) in cs2.v.iter_mut().enumerate() {
-            expand_s2_ntt_mul_scalar(cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
-            scalar_inverse_ntt(cs_i);
-        }
-
-        let r0 = &mut w1;
-        vector8_sub(r0, &tmp, cs2);
-
-        // Inline implementation of vector8_low_bits to prevent creating a copy to save stack space
-        for s in r0.v.iter_mut() {
-            // Inline implementation of scalar_low_bits
-            for c in s.c.iter_mut() {
-                *c = low_bits(*c) as u32;
-            }
-        }
-
-        let z_max = vector7_max(&z);
-        let r0_max = vector8_max_signed(r0);
-
-        if (ct_ge(z_max, GAMMA1.wrapping_sub(BETA)) | ct_ge(r0_max, K_GAMMA_2.wrapping_sub(BETA)))
+        if (ct_ge(z_max, GAMMA1.wrapping_sub(BETA))
+            | ct_ge(r0_max, K_GAMMA_2.wrapping_sub(BETA))
+            | ct_ge(ct0_max, K_GAMMA_2)
+            | ct_lt(OMEGA as u32, h_ones as u32))
             != 0
         {
             kappa += 7;
             continue;
         }
 
-        let ct0 = &mut w1;
-        vector8_mul_scalar(ct0, &priv_key.t0_ntt, &c_ntt);
-        vector8_inverse_ntt(ct0);
-
-        // Inline implementation of vector8_make_hint to prevent creating a copy to save stack space
-        for (tmp_s, (ct0_s, cs2_s)) in tmp.v.iter_mut().zip(ct0.v.iter().zip(cs2.v.iter())) {
-            for (tmp_c, (ct0_c, cs2_c)) in
-                tmp_s.c.iter_mut().zip(ct0_s.c.iter().zip(cs2_s.c.iter()))
-            {
-                *tmp_c = make_hint(*ct0_c, *cs2_c, *tmp_c) as u32;
-            }
-        }
-
-        let ct0_max = vector8_max(ct0);
-        let h_ones = vector8_count_ones(&tmp);
-
-        if (ct_ge(ct0_max, K_GAMMA_2) | ct_lt(OMEGA as u32, h_ones as u32)) != 0 {
-            kappa += 7;
-            continue;
-        }
-
-        encode_signature(out_encoded_signature, &c_tilde, &z, &tmp);
+        let hint_out: &mut [u8; OMEGA + 8] = (&mut out_encoded_signature
+            [2 * LAMBDA_BYTES + 640 * 7..2 * LAMBDA_BYTES + 640 * 7 + OMEGA + 8])
+            .try_into()
+            .unwrap();
+        hint_bit_pack(hint_out, &tmp);
         return;
     }
 }
@@ -1187,7 +1136,7 @@ fn verify_internal_with_mu(
     }
 
     let mut w1 = Vector8::default();
-    vector8_sub(&mut w1, &az_ntt, &ct1_ntt);
+    vector8_sub(&mut w1, &az_ntt, ct1_ntt);
     vector8_inverse_ntt(&mut w1);
 
     // Apply the verifier hint in place, per-Scalar, for the same stack-budget
@@ -1196,13 +1145,14 @@ fn verify_internal_with_mu(
         let r = w1.v[i];
         scalar_use_hint_sparse(&mut w1.v[i], &h.v[i], &r);
     }
-    let mut w1_encoded = [0u8; 128 * 8];
-    w1_encode(&mut w1_encoded, &w1);
-
     let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(mu);
-    shake256.absorb(&w1_encoded);
+    for i in 0..8 {
+        let mut w1_encoded_part = [0u8; 128];
+        scalar_encode_4(&mut w1_encoded_part, &w1.v[i]);
+        shake256.absorb(&w1_encoded_part);
+    }
     shake256.squeeze(&mut c_tilde);
 
     if z_max < (GAMMA1 - BETA) && c_tilde == sig_c_tilde {


### PR DESCRIPTION
  1. (Persistent State Compression):  s1_ntt  and  s2_ntt  removed;  sigma  stored instead. 
  2. (Hint Data Structure Reduction): Dense bitmasks replaced with sparse struct.
  3. (Key Generation Memory Aliasing):  s1_ntt ,  s2 , and  t1  unionized; accumulator t computed in-place over output buffer  priv_key.t0_ntt .
  4. (Streaming Matrix Multiplication): Evaluate column-by-column, eliminating the 7 KB full mask vector allocation during signing. 
  5. (Streaming Digest Absorption): Eliminated 8 KB  w1  vector and 1,024-byte  w1_encoded  buffer; scalars encoded directly into SHAKE-256 per iteration. 
  6. (Component-by-Component Signature Generation): Eliminated 47+ KB of dynamic intermediate vectors ( s1_ntt ,  cs1 ,  y / z ,  s2_ntt ,  cs2 ,  r0 ,  ct0 ) in favor of 1 KB loop-local scalars.
  7. Section 7 (Buffer Sharing): Reused  tr_mu  across API wrappers and shared  tmp  and  VerifyState  stack storage.