### PR TITLE
runtime: mark certain functions never inline

### DIFF
--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -276,6 +276,7 @@ impl Drivers {
     }
 
     /// Validate DPE and disable attestation if validation fails
+    #[inline(never)]
     fn validate_dpe_structure(drivers: &mut Drivers) -> CaliptraResult<()> {
         let dpe = &mut drivers.persistent_data.get_mut().dpe;
         let dpe_validator = DpeValidator { dpe };
@@ -440,6 +441,7 @@ impl Drivers {
     }
 
     /// Check that inactive DPE contexts do not have context tags set
+    #[inline(never)]
     fn validate_context_tags(drivers: &mut Drivers) -> CaliptraResult<()> {
         let pdata = drivers.persistent_data.get();
         let context_has_tag = &pdata.context_has_tag;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -180,6 +180,7 @@ fn enter_idle(drivers: &mut Drivers) {
 /// # Returns
 ///
 /// * `MboxStatusE` - the mailbox status (DataReady when we send a response)
+#[inline(never)]
 fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
     // Drop all commands for invalid PAUSER
     if drivers.mbox.user() == RESERVED_PAUSER {


### PR DESCRIPTION
Mark a few functions never inline, reducing the code size by roughly 400 bytes.

Before (caliptra-1.x):
```
   text    data     bss     dec     hex filename
  96636     128   89088  185852   2d5fc target/riscv32imc-unknown-none-elf/firmware/caliptra-runtime
```

After (this branch):
```
   text    data     bss     dec     hex filename
  96284     128   89088  185500   2d49c target/riscv32imc-unknown-none-elf/firmware/caliptra-runtime
```