### PR TITLE
fmc: Reduce FMC instruction budget

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,9 +38,9 @@ pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 
 pub const FMC_ORG: u32 = 0x40000000;
-pub const FMC_SIZE: u32 = 24 * 1024;
+pub const FMC_SIZE: u32 = 22 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 96 * 1024;
+pub const RUNTIME_SIZE: u32 = 98 * 1024;
 
 // Max size of runtime code should be 120K to allow 8k for the manifest
 #[allow(clippy::assertions_on_constants)]


### PR DESCRIPTION
While optimizing instruction memory for 1.3 some of these changes also reduced FMC instruction requirements.  However the improvements were never translated to increased runtime space as the FMC budget kept the FMC consuming 24Kb.

Reduce the FMC budget to be 22Kb, leaving 2Kb (10%) of the overall space remaining for any bug patches etc.