### PR TITLE
[dpe] Make SVN in `DeriveContext` optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,9 +455,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "caliptra-cfi-derive-git"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "caliptra-cfi-lib"
 version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=72c75dc70cde4120a9ce149d4f5cb21621399958#72c75dc70cde4120a9ce149d4f5cb21621399958"
+
+[[package]]
+name = "caliptra-cfi-lib-git"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
 name = "caliptra-coverage"
@@ -1035,6 +1051,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cms",
  "constant_time_eq",
+ "dpe",
  "memoffset 0.8.0",
  "openssl",
  "sha2",
@@ -1499,6 +1516,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=e63241cebad7c96ff954ec7d33207fc96b3323ef#e63241cebad7c96ff954ec7d33207fc96b3323ef"
+dependencies = [
+ "arrayvec",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib-git",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1712,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "dpe"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=e63241cebad7c96ff954ec7d33207fc96b3323ef#e63241cebad7c96ff954ec7d33207fc96b3323ef"
+dependencies = [
+ "bitflags 2.13.0",
+ "caliptra-cfi-derive-git",
+ "caliptra-cfi-lib-git",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+ "crypto",
+ "platform",
+ "ufmt",
+ "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -3031,6 +3076,16 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platform"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=e63241cebad7c96ff954ec7d33207fc96b3323ef#e63241cebad7c96ff954ec7d33207fc96b3323ef"
+dependencies = [
+ "arrayvec",
+ "cfg-if 1.0.0",
+ "ufmt",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,8 @@ dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a
 crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", package = "caliptra-dpe-crypto", default-features = false }
 platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", package = "caliptra-dpe-platform", default-features = false }
 caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", default-features = false }
+# Older version for backwards compatibility logic
+dpe-runtime-1-2 = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "e63241cebad7c96ff954ec7d33207fc96b3323ef", package = "dpe", default-features = false, features = ["dpe_profile_p384_sha384", "arbitrary_max_handles"] }
 elf = "0.7.2"
 fips204 = "0.2.1"
 gdbstub = "0.6.3"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,6 +21,7 @@ caliptra-registers.workspace = true
 caliptra-shake.workspace = true
 caliptra-x509 = { workspace = true, default-features = false }
 dpe           = { workspace = true, features = ["arbitrary_max_handles"] }
+dpe-runtime-1-2.workspace = true
 constant_time_eq.workspace = true
 crypto.workspace = true
 platform.workspace = true

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -20,7 +20,10 @@ use caliptra_cfi_derive::{cfi_impl_fn, cfi_mod_fn};
 use caliptra_common::mailbox_api::{InvokeDpeReq, MailboxRespHeader, MailboxRespHeaderVarSize};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
 use dpe::{
-    commands::{CertifyKeyCommand, Command, CommandExecution, InitCtxCmd},
+    commands::{
+        CertifyKeyCommand, Command, CommandExecution, CommandHdr, DeriveContextCmd,
+        DeriveContextCmdV1, InitCtxCmd,
+    },
     context::ContextState,
     error::DpeErrorCode,
     response::ResponseHdr,
@@ -28,7 +31,7 @@ use dpe::{
 };
 use platform::MAX_OTHER_NAME_SIZE;
 use ufmt::derive::uDebug;
-use zerocopy::{FromZeros, IntoBytes};
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
 #[cfg(feature = "mldsa_attestation")]
 use {crate::mldsa_dpe_env, caliptra_common::mailbox_api::InvokeDpeMldsa87Req};
 
@@ -59,7 +62,7 @@ impl InvokeDpeCmd {
         execute(
             drivers,
             CaliptraDpeProfile::Ecc384,
-            &cmd.data,
+            &mut cmd.data,
             cmd.data_size as usize,
         )
     }
@@ -111,7 +114,7 @@ impl InvokeDpeMldsa87Cmd {
         execute(
             drivers,
             CaliptraDpeProfile::Mldsa,
-            &cmd.data,
+            &mut cmd.data,
             cmd.data_size as usize,
         )
     }
@@ -121,15 +124,42 @@ impl InvokeDpeMldsa87Cmd {
 /// and execute it. Non-generic over the request type so both entry points share
 /// one copy, and takes the raw payload (rather than a deserialized `Command`) so
 /// the large `Command` enum never crosses a call boundary by value.
+///
+/// Note: This function will also append a zeroed SVN to the command if it is a
+/// DeriveContext command and the SVN is missing. This is to support older
+/// versions of DPE that do not include the SVN in the DeriveContext command.
 fn execute(
     drivers: &mut Drivers,
     profile: CaliptraDpeProfile,
-    data: &[u8],
-    data_size: usize,
+    data: &mut [u8; InvokeDpeReq::DATA_MAX_SIZE],
+    mut data_size: usize,
 ) -> CaliptraResult<()> {
     if data_size > data.len() {
         return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
     }
+
+    // Append a zeroed SVN to the command if it is a DeriveContext command and the SVN is
+    // missing. This is to support older versions of DPE that do not include the SVN in the
+    // DeriveContext command.
+    if let Ok((hdr, _)) = CommandHdr::read_from_prefix(&data[..data_size]) {
+        let expected_no_svn_len = size_of::<CommandHdr>() + size_of::<DeriveContextCmdV1>();
+
+        let is_derive_context_cmd = hdr.cmd_id == Command::DERIVE_CONTEXT;
+        let is_missing_svn = data_size == expected_no_svn_len;
+
+        if is_derive_context_cmd && is_missing_svn {
+            let cmd_start = size_of::<CommandHdr>();
+            let (derive_context_v1, _) =
+                DeriveContextCmdV1::read_from_prefix(&data[cmd_start..data_size])
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+
+            data_size = size_of::<CommandHdr>() + size_of::<DeriveContextCmd>();
+            let (cmd, _) = DeriveContextCmd::mut_from_prefix(&mut data[cmd_start..data_size])
+                .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
+            *cmd = derive_context_v1.into();
+        }
+    }
+
     let command = Command::deserialize(profile.into(), &data[..data_size])
         .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
     let caller_privilege_level = drivers.caller_privilege_level();
@@ -245,3 +275,8 @@ fn clear_tags_for_inactive_contexts(
         }
     });
 }
+
+const _: () = assert!(
+    size_of::<DeriveContextCmdV1>() == size_of::<DeriveContextCmd>() - size_of::<u32>(),
+    "DeriveContextCmd size changed, check if SVN compatibility logic needs updating"
+);

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -22,13 +22,15 @@ use caliptra_drivers::{CaliptraError, CaliptraResult};
 use dpe::{
     commands::{
         CertifyKeyCommand, Command, CommandExecution, CommandHdr, DeriveContextCmd,
-        DeriveContextCmdV1, InitCtxCmd,
+        DeriveContextFlags, InitCtxCmd,
     },
-    context::ContextState,
+    context::{ContextHandle, ContextState},
     error::DpeErrorCode,
     response::ResponseHdr,
+    tci::TciMeasurement,
     DpeInstance, DpeProfile, State, U8Bool, MAX_HANDLES,
 };
+use dpe_runtime_1_2::commands::DeriveContextCmd as DeriveContextCmdV1;
 use platform::MAX_OTHER_NAME_SIZE;
 use ufmt::derive::uDebug;
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
@@ -156,7 +158,7 @@ fn execute(
             data_size = size_of::<CommandHdr>() + size_of::<DeriveContextCmd>();
             let (cmd, _) = DeriveContextCmd::mut_from_prefix(&mut data[cmd_start..data_size])
                 .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-            *cmd = derive_context_v1.into();
+            *cmd = derive_context_cmd_v1_to_v2(&derive_context_v1);
         }
     }
 
@@ -274,6 +276,17 @@ fn clear_tags_for_inactive_contexts(
             context_tags[i] = 0;
         }
     });
+}
+
+fn derive_context_cmd_v1_to_v2(cmd: &DeriveContextCmdV1) -> DeriveContextCmd {
+    DeriveContextCmd {
+        handle: ContextHandle(cmd.handle.0),
+        data: TciMeasurement(cmd.data),
+        flags: DeriveContextFlags(cmd.flags.bits()),
+        tci_type: cmd.tci_type,
+        target_locality: cmd.target_locality,
+        svn: 0,
+    }
 }
 
 const _: () = assert!(

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -12,7 +12,7 @@ use caliptra_builder::{
     firmware::{APP_WITH_UART, FMC_WITH_UART},
     ImageOptions,
 };
-use caliptra_common::mailbox_api::{InvokeDpeReq, MailboxReq, MailboxReqHeader};
+use caliptra_common::mailbox_api::{InvokeDpeReq, InvokeDpeResp, MailboxReq, MailboxReqHeader};
 use caliptra_drivers::CaliptraError;
 use caliptra_hw_model::{HwModel, ModelError};
 use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus, DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
@@ -23,9 +23,9 @@ use cms::{
 };
 use dpe::{
     commands::{
-        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, DeriveContextCmd,
-        DeriveContextFlags, GetCertificateChainCmd, GetProfileCmd, InitCtxCmd, RotateCtxCmd,
-        RotateCtxFlags, SignFlags, SignP384Cmd,
+        CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, CommandHdr,
+        DeriveContextCmd, DeriveContextCmdV1, DeriveContextFlags, GetCertificateChainCmd,
+        GetProfileCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd,
     },
     context::ContextHandle,
     error::DpeErrorCode,
@@ -548,4 +548,59 @@ fn test_certify_key_with_max_contexts() {
             DpeResult::Success,
         );
     }
+}
+
+#[test]
+fn test_invoke_dpe_derive_context_without_svn() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let derive_ctx_cmd = DeriveContextCmdV1 {
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        ..Default::default()
+    };
+
+    let mut cmd_data = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
+    let cmd_hdr = CommandHdr::new(PROFILE.into(), Command::DERIVE_CONTEXT);
+    let cmd_hdr_buf = cmd_hdr.as_bytes();
+    cmd_data[..cmd_hdr_buf.len()].copy_from_slice(cmd_hdr_buf);
+    let dpe_cmd_buf = derive_ctx_cmd.as_bytes();
+    // Strip the last 4 bytes (svn u32 field) to simulate caller without SVN
+    let dpe_cmd_buf_no_svn = &dpe_cmd_buf[..dpe_cmd_buf.len()];
+    cmd_data[cmd_hdr_buf.len()..cmd_hdr_buf.len() + dpe_cmd_buf_no_svn.len()]
+        .copy_from_slice(dpe_cmd_buf_no_svn);
+    let mut mbox_cmd = MailboxReq::InvokeDpeCommand(InvokeDpeReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        data: cmd_data,
+        data_size: (cmd_hdr_buf.len() + dpe_cmd_buf_no_svn.len()) as u32,
+    });
+    mbox_cmd.populate_chksum().unwrap();
+
+    let resp = model.mailbox_execute(
+        u32::from(CommandId::INVOKE_DPE),
+        mbox_cmd.as_bytes().unwrap(),
+    );
+    let resp = resp.unwrap().expect("We should have received a response");
+
+    assert!(resp.len() <= std::mem::size_of::<InvokeDpeResp>());
+    let mut resp_hdr = InvokeDpeResp::default();
+    resp_hdr.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+
+    assert!(caliptra_common::checksum::verify_checksum(
+        resp_hdr.hdr.chksum,
+        0x0,
+        &resp[core::mem::size_of_val(&resp_hdr.hdr.chksum)..],
+    ));
+
+    let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
+    let parsed_resp =
+        Response::try_read_from_bytes(&Command::DeriveContext(&derive_ctx_cmd.into()), resp_bytes)
+            .unwrap();
+
+    let Response::DeriveContextExportedCdi(_) = parsed_resp else {
+        panic!("expected derive context exported cdi resp!");
+    };
 }

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -24,8 +24,8 @@ use cms::{
 use dpe::{
     commands::{
         CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, CommandHdr,
-        DeriveContextCmd, DeriveContextCmdV1, DeriveContextFlags, GetCertificateChainCmd,
-        GetProfileCmd, InitCtxCmd, RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd,
+        DeriveContextCmd, DeriveContextFlags, GetCertificateChainCmd, GetProfileCmd, InitCtxCmd,
+        RotateCtxCmd, RotateCtxFlags, SignFlags, SignP384Cmd,
     },
     context::ContextHandle,
     error::DpeErrorCode,
@@ -33,6 +33,10 @@ use dpe::{
     tci::TciMeasurement,
     TCI_SIZE,
 };
+use dpe_runtime_1_2::commands::{
+    DeriveContextCmd as DeriveContextCmdV1, DeriveContextFlags as DeriveContextFlagsV1,
+};
+use dpe_runtime_1_2::context::ContextHandle as ContextHandleV1;
 use openssl::{
     bn::BigNum,
     ec::{EcGroup, EcKey},
@@ -559,8 +563,11 @@ fn test_invoke_dpe_derive_context_without_svn() {
     });
 
     let derive_ctx_cmd = DeriveContextCmdV1 {
-        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        ..Default::default()
+        flags: DeriveContextFlagsV1::EXPORT_CDI | DeriveContextFlagsV1::CREATE_CERTIFICATE,
+        handle: ContextHandleV1::default(),
+        data: [0; TCI_SIZE],
+        tci_type: 0,
+        target_locality: 0,
     };
 
     let mut cmd_data = [0u8; InvokeDpeReq::DATA_MAX_SIZE];
@@ -596,9 +603,16 @@ fn test_invoke_dpe_derive_context_without_svn() {
     ));
 
     let resp_bytes = &resp_hdr.data[..resp_hdr.data_size as usize];
+    let v2_cmd = DeriveContextCmd {
+        handle: ContextHandle(derive_ctx_cmd.handle.0),
+        data: TciMeasurement(derive_ctx_cmd.data),
+        flags: DeriveContextFlags(derive_ctx_cmd.flags.bits()),
+        tci_type: derive_ctx_cmd.tci_type,
+        target_locality: derive_ctx_cmd.target_locality,
+        svn: 0,
+    };
     let parsed_resp =
-        Response::try_read_from_bytes(&Command::DeriveContext(&derive_ctx_cmd.into()), resp_bytes)
-            .unwrap();
+        Response::try_read_from_bytes(&Command::DeriveContext(&v2_cmd), resp_bytes).unwrap();
 
     let Response::DeriveContextExportedCdi(_) = parsed_resp else {
         panic!("expected derive context exported cdi resp!");


### PR DESCRIPTION
DPE added an SVN field to `DeriveContext`. To avoid making a breaking change to Caliptra integrators, this will append a default SVN value (`0`) to the command if it is not present.

This also adds a test to make sure it is handled correctly.