### PR TITLE
link.x: specify program headers

### DIFF
--- a/cpu/build.rs
+++ b/cpu/build.rs
@@ -10,109 +10,117 @@ fn main() {
     // Put the linker script somewhere the linker can find it.
     fs::write(
         out_dir.join("link.x"),
-        r#"SECTIONS 
+        r#"PHDRS
+    {
+        text   PT_LOAD FLAGS(5);
+        rodata PT_LOAD FLAGS(4);
+        data   PT_LOAD FLAGS(6);
+        stack  PT_LOAD FLAGS(6);
+        estack PT_LOAD FLAGS(6);
+        nstack PT_LOAD FLAGS(6);
+    }
+
+    SECTIONS
     {
         .text : ALIGN(4)
         {
             _stext = .;
-    
+
             KEEP(*(.init .init.*));
             *(.text .text.*);
             KEEP(*(.vectors))
-    
+
             . = ALIGN(4);
             _etext = .;
-        } > REGION_TEXT
-    
+        } > REGION_TEXT :text
+
         .rodata : ALIGN(4)
         {
             _srodata = .;
-            
+
             *(.srodata .srodata.*);
             *(.rodata .rodata.*);
-    
+
             . = ALIGN(4);
             _erodata = .;
-        } > REGION_RODATA
-    
-        .data : AT (_erodata) ALIGN(4) 
+        } > REGION_RODATA :rodata
+
+        .data : AT (_erodata) ALIGN(4)
         {
             _sidata = LOADADDR(.data);
             _sdata = .;
-            
+
             /* Must be called __global_pointer$ for linker relaxations to work. */
             PROVIDE(__global_pointer$ = . + 0x800);
-       
+
             *(.sdata .sdata.* .sdata2 .sdata2.*);
             *(.data .data.*);
-            
+
             . = ALIGN(4);
             _edata = .;
-        } > REGION_DATA 
-    
-     
-        .bss (NOLOAD) : ALIGN(4) 
+        } > REGION_DATA :data
+
+        .bss (NOLOAD) : ALIGN(4)
         {
             _sbss = .;
-    
+
             *(.bss*)
             *(.sbss*)
             *(COMMON)
             . = ALIGN(4);
-            
+
             _ebss = .;
-        } > REGION_BSS
-    
+        } > REGION_BSS :data
+
         .stack (NOLOAD): ALIGN(4)
         {
             _estack = .;
-            
+
             . = . + STACK_SIZE;
-    
+
             . = ALIGN(4);
             _sstack = .;
-        } > REGION_STACK
-    
+        } > REGION_STACK :stack
+
         .estack (NOLOAD): ALIGN(4)
         {
             _eestack = .;
-            
+
             . = . + ESTACK_SIZE;
-    
+
             . = ALIGN(4);
             _sestack = .;
-        } > REGION_ESTACK
-    
+        } > REGION_ESTACK :estack
+
         .nstack (NOLOAD): ALIGN(4)
         {
             _enstack = .;
-            
+
             . = . + NSTACK_SIZE;
-    
+
             . = ALIGN(4);
             _snstack = .;
-        } > REGION_NSTACK
-    
-    
+        } > REGION_NSTACK :nstack
+
         .got (INFO) :
         {
             KEEP(*(.got .got.*));
         }
-    
-        .eh_frame (INFO) : 
-        { 
+
+        .eh_frame (INFO) :
+        {
             KEEP(*(.eh_frame))
         }
-        
+
         .eh_frame_hdr (INFO) :
         {
-            *(.eh_frame_hdr) 
+            *(.eh_frame_hdr)
         }
     }
-    
+
     _bss_len  = SIZEOF(.bss);
     _data_len = SIZEOF(.data);
-    
+
     ASSERT(SIZEOF(.got) == 0, ".got section detected");
     ASSERT(SIZEOF(.bss) == 0, ".bss section detected");
     ASSERT(SIZEOF(.stack) == STACK_SIZE, ".stack section overflow");


### PR DESCRIPTION
Currently with the FMC and runtime budget, the generated runtime binary contains segments:

```
Program Headers:
    Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
    PHDR           0x000034 0x40005034 0x40005034 0x00140 0x00140 R   0x4
    LOAD           0x000000 0x40005000 0x40005000 0x00174 0x00174 R   0x1000
    LOAD           0x000800 0x40005800 0x40005800 0x16b5c 0x16b5c R E 0x1000
    LOAD           0x017360 0x4001c360 0x4001c360 0x0162c 0x0162c R   0x1000
    LOAD           0x018c00 0x50009c00 0x4001d98c 0x00080 0x00080 RW  0x1000
    LOAD           0x019400 0x5000a400 0x5000a400 0x00000 0x15400 RW  0x1000
    LOAD           0x019800 0x5001f800 0x5001f800 0x00000 0x00400 RW  0x1000
    LOAD           0x019c00 0x5001fc00 0x5001fc00 0x00000 0x00400 RW  0x1000
    GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0
    RISCV_ATTRIBUT 0x019d5b 0x00000000 0x00000000 0x0003d 0x0003d R   0x1

Section to Segment mapping:
    Segment Sections...
     00
     01
     02     .text
     03     .rodata
     04     .data
     05     .stack
     06     .estack
     07     .nstack
     08
     09     .riscv.attributes
```

The first `LOAD` segment covers the ELF header and the program header table, both are not interesting to the firmware image. However it will still be included in the resulting firmware image, as the image builder considers all `LOAD` segments. This would affect the calculation of the base load address and the length of the firmware image.

This commit specify program headers in link.x as we need to prevent the linker from injecting anything accidentally.

With this change the same runtime binary has the following segments:
```
$ cargo build --locked --target riscv32imc-unknown-none-elf --profile=firmware --no-default-features --features=fips_self_test,cfi,riscv,mldsa_attestation -p caliptra-runtime --bin=caliptra-runtime && riscv32-unknown-elf-readelf -Wl target/riscv32imc-unknown-none-elf/firmw
are/caliptra-runtime
...
Elf file type is EXEC (Executable file)
Entry point 0x40005940
There are 7 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000800 0x40005800 0x40005800 0x1655c 0x1655c R E 0x1000
  LOAD           0x016d60 0x4001bd60 0x4001bd60 0x01454 0x01454 R   0x1000
  LOAD           0x018c00 0x50009c00 0x4001d1b4 0x00080 0x00080 RW  0x1000
  LOAD           0x019400 0x5000a400 0x5000a400 0x00000 0x15400 RW  0x1000
  LOAD           0x019800 0x5001f800 0x5001f800 0x00000 0x00400 RW  0x1000
  LOAD           0x019c00 0x5001fc00 0x5001fc00 0x00000 0x00400 RW  0x1000
  RISCV_ATTRIBUT 0x019d5b 0x00000000 0x00000000 0x0003d 0x0003d R   0x1

 Section to Segment mapping:
  Segment Sections...
   00     .text
   01     .rodata
   02     .data
   03     .stack
   04     .estack
   05     .nstack
   06     .riscv.attributes
```