### PR TITLE
runtime: fix source of PQ.DevID.CDI

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -100,13 +100,13 @@ pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCd
 
 #[cfg(all(feature = "mldsa_attestation", feature = "runtime"))]
 pub use persistent::MldsaExportedCdiEntry;
-#[cfg(feature = "mldsa_attestation")]
-pub use persistent::PQ_DEVID_CDI_SIZE;
 pub use persistent::{
     FuseLogArray, IdevIdCsr, PcrLogArray, PersistentData, PersistentDataAccessor,
     StashMeasurementArray, FUSE_LOG_MAX_COUNT, MAX_FMC_ALIAS_CSR_SIZE, MAX_IDEVID_CSR_SIZE,
     MEASUREMENT_MAX_COUNT, MLDSA_EXPORTED_CDI_HANDLES_SIZE, PCR_LOG_MAX_COUNT,
 };
+#[cfg(feature = "mldsa_attestation")]
+pub use persistent::{PqDevIdCdi, PQ_DEVID_CDI_SIZE};
 pub use pic::{IntSource, Pic};
 pub use sha1::{Sha1, Sha1Digest, Sha1DigestOp};
 pub use sha256::{Sha256, Sha256Alg, Sha256DigestOp};

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -143,6 +143,8 @@ pub type AuthManifestImageMetadataList =
 const _: () = assert!(MAX_IDEVID_CSR_SIZE < IDEVID_CSR_SIZE as usize);
 const _: () = assert!(MAX_FMC_ALIAS_CSR_SIZE < FMC_ALIAS_CSR_SIZE as usize);
 
+pub type PqDevIdCdi = [u8; PQ_DEVID_CDI_SIZE as usize];
+
 #[derive(Clone, FromZeros, IntoBytes, Zeroize)]
 #[repr(C)]
 pub struct IdevIdCsr {
@@ -351,9 +353,9 @@ pub struct PersistentData {
     pub dpe_pl1_context_limit: u8,
 
     #[cfg(feature = "mldsa_attestation")]
-    pub pq_devid_cdi: [u8; PQ_DEVID_CDI_SIZE as usize],
+    pub pq_devid_cdi: PqDevIdCdi,
     #[cfg(not(feature = "mldsa_attestation"))]
-    pq_devid_cdi: [u8; PQ_DEVID_CDI_SIZE as usize],
+    pq_devid_cdi: PqDevIdCdi,
 
     #[cfg(feature = "mldsa_attestation")]
     pub pqc_status_flags: u8,

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -36,7 +36,7 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 #[cfg(feature = "mldsa_attestation")]
 use {
     caliptra_drivers::{
-        Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature,
+        Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature, PqDevIdCdi,
         MLDSA87_PRIVATE_SEED_BYTES,
     },
     crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
@@ -52,7 +52,7 @@ pub struct DpeCrypto<'a> {
     hasher: DpeHasher<'a>,
     cdi: Option<KeyId>,
     derived_key: Option<DerivedKey>,
-    key_id_rt_cdi: KeyId,
+    rt_cdi: RtCdi,
     exported_cdi_slots: &'a mut ExportedCdiHandles,
 }
 
@@ -81,7 +81,7 @@ impl<'a> DpeCrypto<'a> {
             hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
-            key_id_rt_cdi,
+            rt_cdi: RtCdi::Ec(key_id_rt_cdi),
             exported_cdi_slots,
         })
     }
@@ -94,7 +94,7 @@ impl<'a> DpeCrypto<'a> {
         trng: &'a mut Trng,
         hmac384: &'a mut Hmac384,
         key_vault: &'a mut KeyVault,
-        key_id_rt_cdi: KeyId,
+        pq_devid_cdi: &'a PqDevIdCdi,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
     ) -> CaliptraResult<Self> {
         Ok(Self {
@@ -105,7 +105,7 @@ impl<'a> DpeCrypto<'a> {
             hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
-            key_id_rt_cdi,
+            rt_cdi: RtCdi::Mldsa(*pq_devid_cdi),
             exported_cdi_slots,
         })
     }
@@ -117,10 +117,20 @@ impl<'a> DpeCrypto<'a> {
         key_id: KeyId,
     ) -> Result<KeyId, CryptoError> {
         let context = self.hash_all(&[&measurement.as_slice(), &info])?;
+        #[cfg(feature = "mldsa_attestation")]
+        let array: Array4x12;
+        let key = match self.rt_cdi {
+            RtCdi::Ec(key_id) => KeyReadArgs::new(key_id).into(),
+            #[cfg(feature = "mldsa_attestation")]
+            RtCdi::Mldsa(pq_devid_cdi) => {
+                array = Array4x12::from(pq_devid_cdi);
+                (&array).into()
+            }
+        };
 
         hmac384_kdf(
             self.hmac384,
-            KeyReadArgs::new(self.key_id_rt_cdi).into(),
+            key,
             b"derive_cdi",
             Some(context.as_slice()),
             self.trng,
@@ -556,4 +566,10 @@ enum DerivedKey {
     Ec((KeyId, PubKey)),
     #[cfg(feature = "mldsa_attestation")]
     Mldsa(Mldsa87Seed),
+}
+
+enum RtCdi {
+    Ec(KeyId),
+    #[cfg(feature = "mldsa_attestation")]
+    Mldsa(PqDevIdCdi),
 }


### PR DESCRIPTION
When passing the CDI to the HMAC KDF, fetch it from the persistent data instead of the key vault.