### PR TITLE
mldsa: revoke mldsa cdi

### DIFF
--- a/runtime/src/revoke_exported_cdi_handle.rs
+++ b/runtime/src/revoke_exported_cdi_handle.rs
@@ -58,6 +58,25 @@ impl RevokeExportedCdiHandleCmd {
                 _ => (),
             }
         }
+
+        // An exported CDI handle may instead refer to an ML-DSA exported CDI,
+        // which is held in its own single-entry slot in persistent data.
+        #[cfg(feature = "mldsa_attestation")]
+        {
+            let slot = &mut drivers.persistent_data.get_mut().mldsa_exported_cdi_slots;
+            if constant_time_eq(&slot.handle, &cmd.exported_cdi_handle) && slot.active.get() {
+                #[cfg(feature = "cfi")]
+                cfi_assert!(constant_time_eq(&slot.handle, &cmd.exported_cdi_handle));
+
+                // Setting to false is redundant with zeroize but included for clarity.
+                slot.active = U8Bool::new(false);
+                slot.zeroize();
+
+                let mut resp = RevokeExportedCdiHandleResp::default();
+                return crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes());
+            }
+        }
+
         Err(CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND)
     }
 }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -30,6 +30,8 @@ mod test_pcr;
 mod test_populate_idev;
 mod test_reallocate_dpe_context_limits;
 mod test_revoke_exported_cdi_handle;
+#[cfg(feature = "mldsa_attestation")]
+mod test_revoke_exported_cdi_handle_mldsa;
 mod test_set_auth_manifest;
 #[cfg(feature = "mldsa_attestation")]
 mod test_set_pq_seed;

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
@@ -1,0 +1,86 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::SocManager;
+use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, RevokeExportedCdiHandleReq,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::RtBootStatus;
+
+use crate::common::{assert_error, run_pqc_rt_test, run_rt_test, RuntimeTestArgs};
+
+#[test]
+fn test_revoke_exported_cdi_handle_mldsa_not_found() {
+    // Exercises the unified REVOKE_EXPORTED_CDI_HANDLE command on the ML-DSA
+    // attestation build, where it also checks the ML-DSA exported-CDI slot.
+    let mut model = run_pqc_rt_test();
+
+    // Revoking a non-existent handle should return NOT_FOUND.
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0xFFu8; RevokeExportedCdiHandleReq::EXPORTED_CDI_MAX_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.unwrap_err(),
+    );
+
+    // Zero handle should also return NOT_FOUND.
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0u8; RevokeExportedCdiHandleReq::EXPORTED_CDI_MAX_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_revoke_exported_cdi_handle_mldsa_pl1_rejected() {
+    use caliptra_builder::ImageOptions;
+
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0u8; RevokeExportedCdiHandleReq::EXPORTED_CDI_MAX_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        result.unwrap_err(),
+    );
+}


### PR DESCRIPTION
Add the command to revoke an exported MLDSA cdi, in a similar fashion to the ecdsa cdi.  Also add unit tests validating the same functionality.

Note: Additional tests will be added once the export mldsa cdi infrastructure is implemented.