### PR TITLE
mldsa: sign exported cmd

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -3,7 +3,7 @@
 use bitflags::bitflags;
 use caliptra_error::{CaliptraError, CaliptraResult};
 #[cfg(feature = "mldsa_attestation")]
-use caliptra_mldsa::MLDSA87_PRIVATE_SEED_BYTES;
+use caliptra_mldsa::{MLDSA87_MU_BYTES, MLDSA87_PRIVATE_SEED_BYTES};
 use caliptra_mldsa::{MLDSA87_PUBLIC_KEY_BYTES, MLDSA87_SIGNATURE_BYTES};
 #[cfg(feature = "mldsa_attestation")]
 use core::mem::size_of;
@@ -84,6 +84,10 @@ impl CommandId {
 
     // The revoke exported CDI handle command.
     pub const REVOKE_EXPORTED_CDI_HANDLE: Self = Self(0x5256_4348); // "RVCH"
+
+    // The sign with exported MLDSA command.
+    #[cfg(feature = "mldsa_attestation")]
+    pub const SIGN_WITH_EXPORTED_MLDSA: Self = Self(0x5357_4D4C); // "SWML"
 
     // Get PCR log command.
     pub const GET_PCR_LOG: Self = Self(0x504C_4F47); // "PLOG"
@@ -198,6 +202,8 @@ pub enum MailboxResp {
     GetFmcAliasCsr(GetFmcAliasCsrResp),
     SignWithExportedEcdsa(SignWithExportedEcdsaResp),
     RevokeExportedCdiHandle(RevokeExportedCdiHandleResp),
+    #[cfg(feature = "mldsa_attestation")]
+    SignWithExportedMldsa(SignWithExportedMldsaResp),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsResp),
     GetPcrLog(GetPcrLogResp),
 }
@@ -230,6 +236,8 @@ impl MailboxResp {
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_bytes()),
             MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_bytes()),
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::SignWithExportedMldsa(resp) => Ok(resp.as_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_bytes()),
         }
@@ -262,6 +270,8 @@ impl MailboxResp {
             MailboxResp::GetFmcAliasCsr(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::SignWithExportedEcdsa(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::SignWithExportedMldsa(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::ReallocateDpeContextLimits(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetPcrLog(resp) => Ok(resp.as_mut_bytes()),
         }
@@ -335,6 +345,8 @@ pub enum MailboxReq {
     AuthorizeAndStash(AuthorizeAndStashReq),
     SignWithExportedEcdsa(SignWithExportedEcdsaReq),
     RevokeExportedCdiHandle(RevokeExportedCdiHandleReq),
+    #[cfg(feature = "mldsa_attestation")]
+    SignWithExportedMldsa(SignWithExportedMldsaReq),
     ReallocateDpeContextLimits(ReallocateDpeContextLimitsReq),
     GetPcrLog(MailboxReqHeader),
 }
@@ -375,6 +387,8 @@ impl MailboxReq {
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::SignWithExportedMldsa(req) => req.as_bytes_partial(),
             MailboxReq::ReallocateDpeContextLimits(req) => Ok(req.as_bytes()),
             MailboxReq::GetPcrLog(req) => Ok(req.as_bytes()),
         }
@@ -415,6 +429,8 @@ impl MailboxReq {
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_mut_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::SignWithExportedMldsa(req) => req.as_bytes_partial_mut(),
             MailboxReq::ReallocateDpeContextLimits(req) => Ok(req.as_mut_bytes()),
             MailboxReq::GetPcrLog(req) => Ok(req.as_mut_bytes()),
         }
@@ -455,6 +471,8 @@ impl MailboxReq {
             MailboxReq::AuthorizeAndStash(_) => CommandId::AUTHORIZE_AND_STASH,
             MailboxReq::SignWithExportedEcdsa(_) => CommandId::SIGN_WITH_EXPORTED_ECDSA,
             MailboxReq::RevokeExportedCdiHandle(_) => CommandId::REVOKE_EXPORTED_CDI_HANDLE,
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxReq::SignWithExportedMldsa(_) => CommandId::SIGN_WITH_EXPORTED_MLDSA,
             MailboxReq::ReallocateDpeContextLimits(_) => CommandId::REALLOCATE_DPE_CONTEXT_LIMITS,
             MailboxReq::GetPcrLog(_) => CommandId::GET_PCR_LOG,
         }
@@ -1604,6 +1622,108 @@ impl Response for RevokeExportedCdiHandleResp {}
 #[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
 pub struct RevokeExportedCdiHandleResp {
     pub hdr: MailboxRespHeader,
+}
+
+// SIGN_WITH_EXPORTED_MLDSA
+//
+// Signs with an ML-DSA-87 key pair derived from a previously exported CDI
+// handle. Two signing modes are selected by `sign_mode`:
+//   * `SIGN_MODE_DATA`        - `message[..message_size]` is the raw message to
+//                               sign; the device computes mu internally.
+//   * `SIGN_MODE_EXTERNAL_MU` - `message[..MU_SIZE]` is a caller-supplied
+//                               external mu (`message_size` must equal MU_SIZE).
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct SignWithExportedMldsaReq {
+    pub hdr: MailboxReqHeader,
+    pub exported_cdi_handle: [u8; Self::EXPORTED_CDI_MAX_SIZE],
+    pub sign_mode: u32,
+    pub message_size: u32,
+    pub message: [u8; Self::MAX_DATA_SIZE],
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for SignWithExportedMldsaReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            exported_cdi_handle: [0u8; Self::EXPORTED_CDI_MAX_SIZE],
+            sign_mode: Self::SIGN_MODE_DATA,
+            message_size: 0,
+            message: [0u8; Self::MAX_DATA_SIZE],
+        }
+    }
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl SignWithExportedMldsaReq {
+    pub const EXPORTED_CDI_MAX_SIZE: usize = 32;
+    pub const MAX_DATA_SIZE: usize = 1024;
+    /// Size of an external mu, occupying the first bytes of `message`.
+    pub const MU_SIZE: usize = MLDSA87_MU_BYTES;
+
+    /// `message[..message_size]` is the raw message to sign.
+    pub const SIGN_MODE_DATA: u32 = 0;
+    /// `message[..MU_SIZE]` is a caller-supplied external mu.
+    pub const SIGN_MODE_EXTERNAL_MU: u32 = 1;
+
+    /// Serialize only the populated prefix of the request (trailing unused
+    /// `message` bytes are trimmed based on `message_size`).
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.message_size as usize > Self::MAX_DATA_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::MAX_DATA_SIZE - self.message_size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+
+    pub fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if self.message_size as usize > Self::MAX_DATA_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::MAX_DATA_SIZE - self.message_size as usize;
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Request for SignWithExportedMldsaReq {
+    const ID: CommandId = CommandId::SIGN_WITH_EXPORTED_MLDSA;
+    type Resp = SignWithExportedMldsaResp;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct SignWithExportedMldsaResp {
+    pub hdr: MailboxRespHeader,
+    pub derived_pubkey: [u8; Self::PUBKEY_SIZE],
+    pub signature: [u8; Self::SIG_SIZE],
+    // Pads the struct to a 4-byte multiple so `IntoBytes`/`FromBytes` can be
+    // derived (SIG_SIZE is odd). Always zero.
+    pub reserved: [u8; 1],
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl SignWithExportedMldsaResp {
+    pub const PUBKEY_SIZE: usize = MLDSA87_PUBLIC_KEY_BYTES;
+    pub const SIG_SIZE: usize = MLDSA87_SIGNATURE_BYTES;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl ResponseVarSize for SignWithExportedMldsaResp {}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for SignWithExportedMldsaResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            derived_pubkey: [0u8; Self::PUBKEY_SIZE],
+            signature: [0u8; Self::SIG_SIZE],
+            reserved: [0u8; 1],
+        }
+    }
 }
 
 #[repr(u32)]

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1305,8 +1305,28 @@ impl CaliptraError {
         ),
         (
             RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_SUPPORTED,
-            0x000E006A,
+            0x000E006B,
             "Runtime Error: Sign with Exported MLDSA Not Supported"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND,
+            0x000E006C,
+            "Runtime Error: Sign with Exported MLDSA Handle Not Found"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED,
+            0x000E006D,
+            "Runtime Error: Sign with Exported MLDSA Key Derivation Failed"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED,
+            0x000E006E,
+            "Runtime Error: Sign with Exported MLDSA Signature Failed"
+        ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS,
+            0x000E006F,
+            "Runtime Error: Sign with Exported MLDSA Invalid Parameters"
         ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1303,6 +1303,11 @@ impl CaliptraError {
             0x000E006A,
             "Runtime Error: Get PQ Cert Failed"
         ),
+        (
+            RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_SUPPORTED,
+            0x000E006A,
+            "Runtime Error: Sign with Exported MLDSA Not Supported"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -36,8 +36,8 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 #[cfg(feature = "mldsa_attestation")]
 use {
     caliptra_drivers::{
-        Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature, PqDevIdCdi,
-        MLDSA87_PRIVATE_SEED_BYTES,
+        Hmac384Key, Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature,
+        MldsaExportedCdiEntry, PqDevIdCdi, MLDSA87_PRIVATE_SEED_BYTES,
     },
     crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
     zerocopy::FromBytes,
@@ -54,6 +54,11 @@ pub struct DpeCrypto<'a> {
     derived_key: Option<DerivedKey>,
     rt_cdi: RtCdi,
     exported_cdi_slots: &'a mut ExportedCdiHandles,
+    /// Single ML-DSA exported-CDI slot (raw CDI bytes in persistent data). Only
+    /// populated for the ML-DSA signer; the ECDSA exported CDIs live in
+    /// `exported_cdi_slots`.
+    #[cfg(feature = "mldsa_attestation")]
+    mldsa_exported_cdi_slot: Option<&'a MldsaExportedCdiEntry>,
 }
 
 impl<'a> DpeCrypto<'a> {
@@ -83,11 +88,12 @@ impl<'a> DpeCrypto<'a> {
             derived_key: None,
             rt_cdi: RtCdi::Ec(key_id_rt_cdi),
             exported_cdi_slots,
+            #[cfg(feature = "mldsa_attestation")]
+            mldsa_exported_cdi_slot: None,
         })
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
     #[cfg(feature = "mldsa_attestation")]
     pub fn new_mldsa87(
         sha384: &'a mut Sha384,
@@ -96,6 +102,7 @@ impl<'a> DpeCrypto<'a> {
         key_vault: &'a mut KeyVault,
         pq_devid_cdi: &'a PqDevIdCdi,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
+        mldsa_exported_cdi_slot: &'a MldsaExportedCdiEntry,
     ) -> CaliptraResult<Self> {
         Ok(Self {
             trng,
@@ -107,6 +114,7 @@ impl<'a> DpeCrypto<'a> {
             derived_key: None,
             rt_cdi: RtCdi::Mldsa(*pq_devid_cdi),
             exported_cdi_slots,
+            mldsa_exported_cdi_slot: Some(mldsa_exported_cdi_slot),
         })
     }
 
@@ -146,19 +154,21 @@ impl<'a> DpeCrypto<'a> {
         Ok(key_id)
     }
 
+    /// Derive an ML-DSA-87 key pair from a CDI. The CDI is supplied as an
+    /// already-resolved HMAC key so the same derivation serves both the DPE CDI
+    /// (a key-vault slot) and an exported CDI (raw bytes in persistent data).
     #[cfg(feature = "mldsa_attestation")]
     fn derive_key_pair_mldsa(
         &mut self,
-        cdi: &KeyId,
+        cdi_key: Hmac384Key,
         label: &[u8],
         info: &[u8],
         seed: &mut Mldsa87Seed,
-        pub_key: &mut Mldsa87PubKey,
     ) -> Result<(), CryptoError> {
         let mut output = Zeroizing::new(Array4x12::default());
         hmac384_kdf(
             self.hmac384,
-            KeyReadArgs::new(*cdi).into(),
+            cdi_key,
             label,
             Some(info),
             self.trng,
@@ -169,8 +179,7 @@ impl<'a> DpeCrypto<'a> {
         let bytes = Zeroizing::new(<[u8; core::mem::size_of::<Array4x12>()]>::from(*output));
         seed.copy_from_slice(&bytes[..MLDSA87_PRIVATE_SEED_BYTES]);
 
-        Mldsa87::pub_from_seed(seed, pub_key, None)
-            .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
+        Ok(())
     }
 
     fn derive_key_pair_ec(
@@ -423,35 +432,45 @@ impl Crypto for DpeCrypto<'_> {
         label: &[u8],
         info: &[u8],
     ) -> Result<&mut dyn crypto::Signer, CryptoError> {
-        let cdi = {
-            let mut cdi = None;
-            for cdi_slot in self.exported_cdi_slots.entries.iter() {
-                match cdi_slot {
-                    ExportedCdiEntry {
-                        key,
-                        handle,
-                        active,
-                    } if active.get() && constant_time_eq(handle, exported_handle) => {
-                        cdi = Some(*key);
-                        break;
-                    }
-                    _ => (),
-                }
-            }
-            cdi.ok_or(CryptoError::InvalidExportedCdiHandle)
-        }?;
-
         match self.signer {
             Signer::Ec { .. } => {
+                // ECDSA exported CDIs are key-vault slots referenced by KeyId.
+                let cdi = {
+                    let mut cdi = None;
+                    for cdi_slot in self.exported_cdi_slots.entries.iter() {
+                        match cdi_slot {
+                            ExportedCdiEntry {
+                                key,
+                                handle,
+                                active,
+                            } if active.get() && constant_time_eq(handle, exported_handle) => {
+                                cdi = Some(*key);
+                                break;
+                            }
+                            _ => (),
+                        }
+                    }
+                    cdi.ok_or(CryptoError::InvalidExportedCdiHandle)?
+                };
                 self.derived_key = Some(DerivedKey::Ec(
                     self.derive_key_pair_ec(&cdi, label, info, KEY_ID_TMP)?,
                 ));
             }
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa => {
+                // The ML-DSA exported CDI is held as raw bytes in a single
+                // persistent-data slot; derive directly from those bytes.
+                let cdi = {
+                    let slot = self
+                        .mldsa_exported_cdi_slot
+                        .ok_or(CryptoError::InvalidExportedCdiHandle)?;
+                    if !(slot.active.get() && constant_time_eq(&slot.handle, exported_handle)) {
+                        return Err(CryptoError::InvalidExportedCdiHandle);
+                    }
+                    Zeroizing::new(Array4x12::from(&slot.cdi))
+                };
                 let mut seed = Mldsa87Seed::default();
-                let mut pub_key = Mldsa87PubKey::default();
-                self.derive_key_pair_mldsa(&cdi, label, info, &mut seed, &mut pub_key)?;
+                self.derive_key_pair_mldsa((&*cdi).into(), label, info, &mut seed)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
         }
@@ -493,8 +512,7 @@ impl CdiManager for DpeCrypto<'_> {
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa => {
                 let mut seed = Mldsa87Seed::default();
-                let mut pub_key = Mldsa87PubKey::default();
-                self.derive_key_pair_mldsa(&cdi, label, info, &mut seed, &mut pub_key)?;
+                self.derive_key_pair_mldsa(KeyReadArgs::new(cdi).into(), label, info, &mut seed)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,6 +45,8 @@ mod set_auth_manifest;
 #[cfg(feature = "mldsa_attestation")]
 mod set_pq_seed;
 mod sign_with_exported_ecdsa;
+#[cfg(feature = "mldsa_attestation")]
+mod sign_with_exported_mldsa;
 mod stash_measurement;
 mod subject_alt_name;
 mod update;
@@ -72,6 +74,8 @@ pub use crate::invoke_dpe::CaliptraDpeProfile;
 pub use crate::invoke_dpe_mldsa::InvokeDpeMldsa87Cmd;
 use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
+#[cfg(feature = "mldsa_attestation")]
+use crate::sign_with_exported_mldsa::SignWithExportedMldsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
 pub use caliptra_common::fips::FipsVersionCmd;
@@ -308,6 +312,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         }
         CommandId::SIGN_WITH_EXPORTED_ECDSA => SignWithExportedEcdsaCmd::execute(drivers),
         CommandId::REVOKE_EXPORTED_CDI_HANDLE => RevokeExportedCdiHandleCmd::execute(drivers),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::SIGN_WITH_EXPORTED_MLDSA => SignWithExportedMldsaCmd::execute(drivers),
         CommandId::REALLOCATE_DPE_CONTEXT_LIMITS => ReallocateDpeContextLimitsCmd::execute(drivers),
         _ => return Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     }?;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -517,6 +517,7 @@ fn mldsa_dpe_env(
         &mut drivers.key_vault,
         &pdata.pq_devid_cdi,
         &mut pdata.exported_cdi_slots,
+        &pdata.mldsa_exported_cdi_slots,
     )?;
     let pl0_pauser = pdata.manifest1.header.pl0_pauser;
     let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -3,6 +3,8 @@
 use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
 
 use caliptra_cfi_derive::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_mod_fn;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
 
 use caliptra_common::mailbox_api::{SignWithExportedEcdsaReq, SignWithExportedEcdsaResp};
@@ -13,50 +15,13 @@ use crypto::{
         curve_384::{EcdsaPub384, EcdsaSignature384},
         EcdsaPubKey, EcdsaSignature,
     },
-    Crypto, Digest, PubKey, SignData, Signature,
+    Crypto, CryptoError, Digest, PubKey, SignData, Signature,
 };
 use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SignWithExportedEcdsaCmd;
 impl SignWithExportedEcdsaCmd {
-    /// SignWithExported signs a `digest` using an ECDSA keypair derived from a exported_cdi
-    /// handle and the CDI stored in DPE.
-    ///
-    /// # Arguments
-    ///
-    /// * `env` - DPE environment containing Crypto and Platform implementations
-    /// * `digest` - The data to be signed
-    /// * `exported_cdi_handle` - A handle from DPE that is exchanged for a CDI.
-    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
-    fn ecdsa_sign(
-        env: &mut DpeCrypto,
-        data: &SignData,
-        exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
-    ) -> CaliptraResult<(Signature, PubKey)> {
-        let key_pair =
-            env.derive_key_pair_exported(exported_cdi_handle, b"Exported ECC", b"Exported ECC");
-
-        if cfi_launder(key_pair.is_ok()) {
-            #[cfg(feature = "cfi")]
-            cfi_assert!(key_pair.is_ok());
-        } else {
-            #[cfg(feature = "cfi")]
-            cfi_assert!(key_pair.is_err());
-        }
-        let signer = key_pair
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
-
-        let pub_key: PubKey = signer
-            .public_key()
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED)?;
-        let sig: Signature = signer
-            .sign(data)
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED)?;
-
-        Ok((sig, pub_key))
-    }
-
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
@@ -96,7 +61,18 @@ impl SignWithExportedEcdsaCmd {
         let (
             Signature::Ecdsa(EcdsaSignature::Ecdsa384(EcdsaSignature384 { r, s })),
             PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })),
-        ) = Self::ecdsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle)?
+        ) = sign_exported(
+            &mut crypto,
+            &data,
+            &cmd.exported_cdi_handle,
+            b"Exported ECC",
+        )
+        .map_err(|e| match e {
+            ExportedSignError::Signature => {
+                CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED
+            }
+            _ => CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED,
+        })?
         else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         };
@@ -132,4 +108,45 @@ impl SignWithExportedEcdsaCmd {
         let _ = pdata;
         crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
+}
+
+/// Which step of an exported-CDI sign failed, so each command (ECDSA/ML-DSA) can
+/// map it to its own algorithm-specific error code.
+pub(crate) enum ExportedSignError {
+    /// No active exported-CDI slot matched the handle.
+    NotFound,
+    KeyDerivation,
+    Signature,
+}
+
+/// Derive the key pair bound to `exported_cdi_handle` (using `label`) and sign
+/// `data`, returning the signature and the derived public key. Shared by the
+/// SIGN_WITH_EXPORTED_{ECDSA,MLDSA} commands.
+#[cfg_attr(feature = "cfi", cfi_mod_fn)]
+pub(crate) fn sign_exported(
+    env: &mut DpeCrypto,
+    data: &SignData,
+    exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
+    label: &[u8],
+) -> Result<(Signature, PubKey), ExportedSignError> {
+    let key_pair = env.derive_key_pair_exported(exported_cdi_handle, label, label);
+    if cfi_launder(key_pair.is_ok()) {
+        #[cfg(feature = "cfi")]
+        cfi_assert!(key_pair.is_ok());
+    } else {
+        #[cfg(feature = "cfi")]
+        cfi_assert!(key_pair.is_err());
+    }
+
+    let signer = key_pair.map_err(|e| match e {
+        CryptoError::InvalidExportedCdiHandle => ExportedSignError::NotFound,
+        _ => ExportedSignError::KeyDerivation,
+    })?;
+    let pub_key = signer
+        .public_key()
+        .map_err(|_| ExportedSignError::KeyDerivation)?;
+    let sig = signer
+        .sign(data)
+        .map_err(|_| ExportedSignError::Signature)?;
+    Ok((sig, pub_key))
 }

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use crate::sign_with_exported_ecdsa::{sign_exported, ExportedSignError};
 use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
 
 #[cfg(feature = "cfi")]
@@ -11,45 +12,12 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
     ml_dsa::{MldsaPublicKey, MldsaSignature},
-    Crypto, CryptoError, Mu, PubKey, SignData, Signature,
+    Mu, PubKey, SignData, Signature,
 };
-use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SignWithExportedMldsaCmd;
 impl SignWithExportedMldsaCmd {
-    /// Sign `data` with an ML-DSA-87 key pair derived from an exported CDI
-    /// handle, returning the signature and the derived public key.
-    ///
-    /// This mirrors the ECDSA variant: the exported-CDI lookup and key
-    /// derivation live in [`DpeCrypto::derive_key_pair_exported`], which for the
-    /// ML-DSA signer reads the raw CDI from `mldsa_exported_cdi_slots`.
-    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
-    fn mldsa_sign(
-        env: &mut DpeCrypto,
-        data: &SignData,
-        exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
-    ) -> CaliptraResult<(Signature, PubKey)> {
-        let signer = env
-            .derive_key_pair_exported(exported_cdi_handle, b"Exported ML-DSA", b"Exported ML-DSA")
-            .map_err(|e| match e {
-                // No active slot matched the handle.
-                CryptoError::InvalidExportedCdiHandle => {
-                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND
-                }
-                _ => CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED,
-            })?;
-
-        let pub_key = signer
-            .public_key()
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED)?;
-        let sig = signer
-            .sign(data)
-            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED)?;
-
-        Ok((sig, pub_key))
-    }
-
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
@@ -98,7 +66,23 @@ impl SignWithExportedMldsaCmd {
         )?;
 
         let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pub_key))) =
-            Self::mldsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle)?
+            sign_exported(
+                &mut crypto,
+                &data,
+                &cmd.exported_cdi_handle,
+                b"Exported ML-DSA",
+            )
+            .map_err(|e| match e {
+                ExportedSignError::NotFound => {
+                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND
+                }
+                ExportedSignError::KeyDerivation => {
+                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED
+                }
+                ExportedSignError::Signature => {
+                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED
+                }
+            })?
         else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED);
         };

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,0 +1,40 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{Drivers, PauserPrivileges};
+
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+
+use caliptra_common::mailbox_api::SignWithExportedMldsaReq;
+use caliptra_error::{CaliptraError, CaliptraResult};
+
+use zerocopy::{FromZeros, IntoBytes};
+
+pub struct SignWithExportedMldsaCmd;
+impl SignWithExportedMldsaCmd {
+    /// Sign a message with an ML-DSA-87 key pair derived from a previously
+    /// exported CDI handle.
+    ///
+    /// The exported CDI is looked up in `mldsa_exported_cdi_slots`; the ML-DSA-87
+    /// seed is re-derived from the stored CDI, and the request is signed either
+    /// from a raw message (`SIGN_MODE_DATA`) or a caller-supplied external mu
+    /// (`SIGN_MODE_EXTERNAL_MU`). The derived public key and signature are
+    /// returned so the caller can verify the result.
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
+        let mut cmd = SignWithExportedMldsaReq::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
+        match drivers.caller_privilege_level() {
+            // SIGN_WITH_EXPORTED_MLDSA MUST only be called from PL0
+            PauserPrivileges::PL0 => (),
+            PauserPrivileges::PL1 => {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
+        }
+
+        // TODO: implement key derivation and signing.
+        Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_SUPPORTED)
+    }
+}

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,25 +1,55 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{Drivers, PauserPrivileges};
+use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
 
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 
-use caliptra_common::mailbox_api::SignWithExportedMldsaReq;
+use caliptra_common::mailbox_api::{SignWithExportedMldsaReq, SignWithExportedMldsaResp};
+use caliptra_drivers::MLDSA87_MU_BYTES;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
+use crypto::{
+    ml_dsa::{MldsaPublicKey, MldsaSignature},
+    Crypto, CryptoError, Mu, PubKey, SignData, Signature,
+};
+use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SignWithExportedMldsaCmd;
 impl SignWithExportedMldsaCmd {
-    /// Sign a message with an ML-DSA-87 key pair derived from a previously
-    /// exported CDI handle.
+    /// Sign `data` with an ML-DSA-87 key pair derived from an exported CDI
+    /// handle, returning the signature and the derived public key.
     ///
-    /// The exported CDI is looked up in `mldsa_exported_cdi_slots`; the ML-DSA-87
-    /// seed is re-derived from the stored CDI, and the request is signed either
-    /// from a raw message (`SIGN_MODE_DATA`) or a caller-supplied external mu
-    /// (`SIGN_MODE_EXTERNAL_MU`). The derived public key and signature are
-    /// returned so the caller can verify the result.
+    /// This mirrors the ECDSA variant: the exported-CDI lookup and key
+    /// derivation live in [`DpeCrypto::derive_key_pair_exported`], which for the
+    /// ML-DSA signer reads the raw CDI from `mldsa_exported_cdi_slots`.
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    fn mldsa_sign(
+        env: &mut DpeCrypto,
+        data: &SignData,
+        exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
+    ) -> CaliptraResult<(Signature, PubKey)> {
+        let signer = env
+            .derive_key_pair_exported(exported_cdi_handle, b"Exported ML-DSA", b"Exported ML-DSA")
+            .map_err(|e| match e {
+                // No active slot matched the handle.
+                CryptoError::InvalidExportedCdiHandle => {
+                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND
+                }
+                _ => CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED,
+            })?;
+
+        let pub_key = signer
+            .public_key()
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED)?;
+        let sig = signer
+            .sign(data)
+            .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED)?;
+
+        Ok((sig, pub_key))
+    }
+
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
@@ -34,7 +64,59 @@ impl SignWithExportedMldsaCmd {
             }
         }
 
-        // TODO: implement key derivation and signing.
-        Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_SUPPORTED)
+        if cmd.message_size as usize > SignWithExportedMldsaReq::MAX_DATA_SIZE {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS);
+        }
+
+        // Build the data to sign. In data mode `message[..message_size]` is the
+        // raw message; in external-mu mode the first MLDSA87_MU_BYTES hold the
+        // caller-supplied mu.
+        let data = match cmd.sign_mode {
+            SignWithExportedMldsaReq::SIGN_MODE_DATA => {
+                SignData::Raw(&cmd.message[..cmd.message_size as usize])
+            }
+            SignWithExportedMldsaReq::SIGN_MODE_EXTERNAL_MU => {
+                if cmd.message_size as usize != MLDSA87_MU_BYTES {
+                    return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS);
+                }
+                let mut mu = [0u8; MLDSA87_MU_BYTES];
+                mu.copy_from_slice(&cmd.message[..MLDSA87_MU_BYTES]);
+                SignData::Mu(Mu(mu))
+            }
+            _ => return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS),
+        };
+
+        let pdata = drivers.persistent_data.get_mut();
+        let mut crypto = DpeCrypto::new_mldsa87(
+            &mut drivers.sha384,
+            &mut drivers.trng,
+            &mut drivers.hmac384,
+            &mut drivers.key_vault,
+            &pdata.pq_devid_cdi,
+            &mut pdata.exported_cdi_slots,
+            &pdata.mldsa_exported_cdi_slots,
+        )?;
+
+        let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pub_key))) =
+            Self::mldsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle)?
+        else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED);
+        };
+
+        // Explicitly drop crypto and pdata so the mutable borrow to drivers also ends.
+        drop(crypto);
+        let _ = pdata;
+        Self::send_response(drivers, &pub_key, &sig)
+    }
+
+    /// Assemble the response from `pub_key`/`sig` and send it. Kept in its own
+    /// (inline-never) frame so the large response buffer does not coexist on the
+    /// stack with the ML-DSA keygen/sign frames.
+    #[inline(never)]
+    fn send_response(drivers: &mut Drivers, pub_key: &[u8], sig: &[u8]) -> CaliptraResult<()> {
+        let mut resp = SignWithExportedMldsaResp::new_zeroed();
+        resp.derived_pubkey.copy_from_slice(pub_key);
+        resp.signature.copy_from_slice(sig);
+        crate::packet::copy_to_mbox(drivers, resp.as_mut_bytes())
     }
 }

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -40,6 +40,8 @@ mod test_set_auth_manifest;
 #[cfg(feature = "mldsa_attestation")]
 mod test_set_pq_seed;
 mod test_sign_with_export_ecdsa;
+#[cfg(feature = "mldsa_attestation")]
+mod test_sign_with_exported_mldsa;
 mod test_stack_usage;
 mod test_stash_measurement;
 mod test_tagging;

--- a/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
@@ -1,0 +1,176 @@
+// Licensed under the Apache-2.0 license
+
+//! Integration tests for the SIGN_WITH_EXPORTED_MLDSA mailbox command.
+//!
+//! The exported ML-DSA CDI slot is normally populated by a DPE export command
+//! that does not exist yet, and there is no test backdoor to seed it. Until one
+//! exists the successful-sign path is deferred, but every request-validation
+//! path (privilege, malformed request, handle-not-found) runs before the CDI
+//! lookup and so is covered here.
+
+use caliptra_api::SocManager;
+use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+use caliptra_common::checksum::calc_checksum;
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, SignWithExportedMldsaReq,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::{HwModel, ModelError};
+use caliptra_runtime::RtBootStatus;
+use zerocopy::IntoBytes;
+
+use crate::common::{assert_error, run_pqc_rt_test, run_rt_test, RuntimeTestArgs};
+
+/// Issue SIGN_WITH_EXPORTED_MLDSA and return the raw response bytes.
+fn sign(
+    model: &mut caliptra_hw_model::DefaultHwModel,
+    handle: [u8; 32],
+    sign_mode: u32,
+    message: &[u8],
+) -> Result<Vec<u8>, ModelError> {
+    let mut req = SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: handle,
+        sign_mode,
+        message_size: message.len() as u32,
+        message: [0u8; SignWithExportedMldsaReq::MAX_DATA_SIZE],
+    };
+    req.message[..message.len()].copy_from_slice(message);
+
+    let mut cmd = MailboxReq::SignWithExportedMldsa(req);
+    cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            CommandId::SIGN_WITH_EXPORTED_MLDSA.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .map(|resp| resp.expect("expected a SIGN_WITH_EXPORTED_MLDSA response"))
+}
+
+/// Issue SIGN_WITH_EXPORTED_MLDSA encoded as the full fixed-size struct (rather
+/// than the `message_size`-trimmed form). This lets a `message_size` larger than
+/// the request buffer be sent, which the checksum-aware `MailboxReq` encoder
+/// would otherwise reject client-side.
+fn sign_full(
+    model: &mut caliptra_hw_model::DefaultHwModel,
+    sign_mode: u32,
+    message_size: u32,
+) -> Result<Vec<u8>, ModelError> {
+    let mut req = SignWithExportedMldsaReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: [0u8; 32],
+        sign_mode,
+        message_size,
+        message: [0u8; SignWithExportedMldsaReq::MAX_DATA_SIZE],
+    };
+    let cmd_id = u32::from(CommandId::SIGN_WITH_EXPORTED_MLDSA);
+    // Checksum covers the request payload after the chksum field itself.
+    req.hdr.chksum = calc_checksum(cmd_id, &req.as_bytes()[4..]);
+
+    model
+        .mailbox_execute(cmd_id, req.as_bytes())
+        .map(|resp| resp.expect("expected a SIGN_WITH_EXPORTED_MLDSA response"))
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_invalid_sign_mode() {
+    let mut model = run_pqc_rt_test();
+
+    // sign_mode is neither SIGN_MODE_DATA nor SIGN_MODE_EXTERNAL_MU.
+    let result = sign(&mut model, [0u8; 32], 0xDEAD_BEEF, b"message");
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_external_mu_wrong_size() {
+    let mut model = run_pqc_rt_test();
+
+    // External-mu mode requires exactly MLDSA87_MU_BYTES (64) of message; any
+    // other length is rejected before the CDI lookup.
+    for len in [0usize, 32, 63, 65] {
+        let msg = vec![0u8; len];
+        let result = sign(
+            &mut model,
+            [0u8; 32],
+            SignWithExportedMldsaReq::SIGN_MODE_EXTERNAL_MU,
+            &msg,
+        );
+        assert_error(
+            &mut model,
+            CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS,
+            result.unwrap_err(),
+        );
+    }
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_message_too_large() {
+    let mut model = run_pqc_rt_test();
+
+    // A message_size larger than the buffer must be rejected as invalid params
+    // (and must not be used to index the message buffer).
+    let result = sign_full(
+        &mut model,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        SignWithExportedMldsaReq::MAX_DATA_SIZE as u32 + 1,
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_handle_not_found() {
+    let mut model = run_pqc_rt_test();
+
+    // No CDI has been exported, so any handle must be rejected as not found.
+    let result = sign(
+        &mut model,
+        [0xFFu8; 32],
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_pl1_rejected() {
+    use caliptra_builder::ImageOptions;
+
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // The privilege check runs before the CDI lookup, so this is rejected
+    // regardless of whether a CDI has been exported.
+    let result = sign(
+        &mut model,
+        [0u8; 32],
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        result.unwrap_err(),
+    );
+}


### PR DESCRIPTION
Add the sign exported cdi command variant for mldsa.  This implements the request/response, command, and basic negative tests following the same scope as the implementation for the sign mldsa on main, with support for both an external mu and an up to 1024 byte buffer of raw data to sign.

Note: Full testing requires the CDI to be populated and will occur when the invoke_dpe command is implemented for the mldsa variant. 