### PR TITLE
fmc: Reduce budget

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,9 +38,9 @@ pub use fuse::{FuseLogEntry, FuseLogEntryId};
 pub use pcr::{PcrLogEntry, PcrLogEntryId, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR};
 
 pub const FMC_ORG: u32 = 0x40000000;
-pub const FMC_SIZE: u32 = 22 * 1024;
+pub const FMC_SIZE: u32 = 21 * 1024;
 pub const RUNTIME_ORG: u32 = FMC_ORG + FMC_SIZE;
-pub const RUNTIME_SIZE: u32 = 98 * 1024;
+pub const RUNTIME_SIZE: u32 = 99 * 1024;
 
 // Max size of runtime code should be 120K to allow 8k for the manifest
 #[allow(clippy::assertions_on_constants)]


### PR DESCRIPTION
Further reduce the FMC budget.  This provides the Runtime with 1 more Kb of instruction space and brings the FMC to 95% utilization.