### PR TITLE
runtime: implement sign_with_alias for ML-DSA

### DIFF
--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -30,6 +30,13 @@ use caliptra_drivers::{
 use caliptra_x509::MlDsa87CertBuilder;
 use caliptra_x509::{Ecdsa384CertBuilder, Ecdsa384Signature};
 use zerocopy::{FromZeros, IntoBytes};
+#[cfg(feature = "mldsa_attestation")]
+use {
+    caliptra_drivers::{
+        hmac384_kdf, Array4x12, Hmac384, Mldsa87Seed, PqDevIdCdi, Trng, MLDSA87_PRIVATE_SEED_BYTES,
+    },
+    zeroize::Zeroizing,
+};
 
 pub struct IDevIdCertCmd;
 impl IDevIdCertCmd {
@@ -395,4 +402,34 @@ fn cert_from_tbs_and_sig(
     };
 
     Ok(size)
+}
+
+/// Derive the PQ.DevID ML-DSA-87 seed from the PQ.DevID CDI stored in
+/// persistent data.
+///
+/// This mirrors the ROM DICE convention of deriving the DevID key pair from
+/// the DevID CDI, so the CSR here matches the PQ.DevID identity used
+/// elsewhere in the runtime. The CDI is provisioned by SET_PQ_SEED and lives
+/// in persistent data.
+#[cfg(feature = "mldsa_attestation")]
+pub fn derive_devid_seed(
+    cdi: &PqDevIdCdi,
+    seed: &mut Mldsa87Seed,
+    hmac384: &mut Hmac384,
+    trng: &mut Trng,
+) -> CaliptraResult<()> {
+    let cdi = Zeroizing::new(Array4x12::from(cdi));
+    let mut output = Zeroizing::new(Array4x12::default());
+    hmac384_kdf(
+        hmac384,
+        (&*cdi).into(),
+        b"pq_devid_keygen",
+        None,
+        trng,
+        (&mut *output).into(),
+    )?;
+
+    let bytes = Zeroizing::new(<[u8; core::mem::size_of::<Array4x12>()]>::from(*output));
+    seed.copy_from_slice(&bytes[..MLDSA87_PRIVATE_SEED_BYTES]);
+    Ok(())
 }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -35,6 +35,7 @@ use crypto::{
 use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 #[cfg(feature = "mldsa_attestation")]
 use {
+    crate::dice,
     caliptra_drivers::{
         Hmac384Key, Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature,
         MldsaExportedCdiEntry, PqDevIdCdi, MLDSA87_PRIVATE_SEED_BYTES,
@@ -486,24 +487,13 @@ impl Crypto for DpeCrypto<'_> {
 
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa => {
-                let cdi_array = match self.rt_cdi {
-                    RtCdi::Mldsa(pq_devid_cdi) => Array4x12::from(pq_devid_cdi),
+                let cdi = match self.rt_cdi {
+                    RtCdi::Mldsa(ref pq_devid_cdi) => pq_devid_cdi,
                     _ => return Err(CryptoError::MismatchedAlgorithm),
                 };
-                let mut seed_array = Zeroizing::new(Array4x12::default());
-                hmac384_kdf(
-                    self.hmac384,
-                    (&cdi_array).into(),
-                    b"pq_devid_keygen",
-                    None,
-                    self.trng,
-                    (&mut *seed_array).into(),
-                )
-                .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                let seed_bytes =
-                    Zeroizing::new(<[u8; core::mem::size_of::<Array4x12>()]>::from(*seed_array));
                 let mut seed = Mldsa87Seed::default();
-                seed.copy_from_slice(&seed_bytes[..MLDSA87_PRIVATE_SEED_BYTES]);
+                dice::derive_devid_seed(cdi, &mut seed, self.hmac384, self.trng)
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
                 Self::sign_helper_mldsa(data, &seed)
             }
         }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -485,7 +485,27 @@ impl Crypto for DpeCrypto<'_> {
             }
 
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => Err(CryptoError::MismatchedAlgorithm),
+            Signer::Mldsa => {
+                let cdi_array = match self.rt_cdi {
+                    RtCdi::Mldsa(pq_devid_cdi) => Array4x12::from(pq_devid_cdi),
+                    _ => return Err(CryptoError::MismatchedAlgorithm),
+                };
+                let mut seed_array = Zeroizing::new(Array4x12::default());
+                hmac384_kdf(
+                    self.hmac384,
+                    (&cdi_array).into(),
+                    b"pq_devid_keygen",
+                    None,
+                    self.trng,
+                    (&mut *seed_array).into(),
+                )
+                .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                let seed_bytes =
+                    Zeroizing::new(<[u8; core::mem::size_of::<Array4x12>()]>::from(*seed_array));
+                let mut seed = Mldsa87Seed::default();
+                seed.copy_from_slice(&seed_bytes[..MLDSA87_PRIVATE_SEED_BYTES]);
+                Self::sign_helper_mldsa(data, &seed)
+            }
         }
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -26,10 +26,7 @@ use crate::{
 #[cfg(feature = "mldsa_attestation")]
 use {
     crate::MAX_MLDSA_CERT_CHAIN_SIZE,
-    caliptra_drivers::{
-        hmac384_kdf, Mldsa87, Mldsa87PubKey, Mldsa87Seed, MLDSA87_PRIVATE_SEED_BYTES,
-    },
-    zeroize::Zeroizing,
+    caliptra_drivers::{Mldsa87, Mldsa87PubKey, Mldsa87Seed},
 };
 
 use arrayvec::ArrayVec;
@@ -909,30 +906,15 @@ impl Drivers {
         Ok(initialization_values_hash)
     }
 
-    /// Derive the PQ.DevID ML-DSA-87 seed from the PQ.DevID CDI stored in
-    /// persistent data.
-    ///
-    /// This mirrors the ROM DICE convention of deriving the DevID key pair from
-    /// the DevID CDI, so the CSR here matches the PQ.DevID identity used
-    /// elsewhere in the runtime. The CDI is provisioned by SET_PQ_SEED and lives
-    /// in persistent data.
     #[cfg(feature = "mldsa_attestation")]
     #[inline(never)]
     fn derive_devid_seed(&mut self, seed: &mut Mldsa87Seed) -> CaliptraResult<()> {
-        let cdi = Zeroizing::new(Array4x12::from(&self.persistent_data.get().pq_devid_cdi));
-        let mut output = Zeroizing::new(Array4x12::default());
-        hmac384_kdf(
+        dice::derive_devid_seed(
+            &self.persistent_data.get().pq_devid_cdi,
+            seed,
             &mut self.hmac384,
-            (&*cdi).into(),
-            b"pq_devid_keygen",
-            None,
             &mut self.trng,
-            (&mut *output).into(),
-        )?;
-
-        let bytes = Zeroizing::new(<[u8; core::mem::size_of::<Array4x12>()]>::from(*output));
-        seed.copy_from_slice(&bytes[..MLDSA87_PRIVATE_SEED_BYTES]);
-        Ok(())
+        )
     }
 
     #[cfg(feature = "mldsa_attestation")]


### PR DESCRIPTION
Add the missing implementation of `DpeCrypto::sign_with_alias` for the ML-DSA call path.

Tests exercising this interface will be added along with the upcoming PR for `INVOKE_DPE` implementation.