### PR TITLE
[fpga-image]: Create stable mac address by hashing boot SD serial number

### DIFF
--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -38,6 +38,7 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c 'echo auto end0 > /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo allow-hotplug end0 >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo iface end0 inet dhcp >> /etc/network/interfaces'
+  chroot out/rootfs bash -c 'echo "    pre-up /usr/sbin/set-mac-address.sh end0" >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo iface end0 inet6 auto >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf'
   chroot out/rootfs bash -c 'echo nameserver 2001:4860:4860::6464 > /etc/resolv.conf'
@@ -137,6 +138,8 @@ popd
 mv out/aarch64-unknown-linux-gnu/release/cargo-nextest out/rootfs/usr/bin/
 
 chroot out/rootfs bash -c 'echo ::1 caliptra-fpga >> /etc/hosts'
+cp set-mac-address.sh out/rootfs/usr/sbin/
+chmod 755 out/rootfs/usr/sbin/set-mac-address.sh
 cp overlay-mount.sh out/rootfs/usr/sbin/
 chmod 755 out/rootfs/usr/sbin/overlay-mount.sh
 cp startup-script.sh out/rootfs/usr/bin/

--- a/ci-tools/fpga-image/set-mac-address.sh
+++ b/ci-tools/fpga-image/set-mac-address.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+# Generate and apply a deterministic, board-unique MAC address for network interfaces.
+# This prevents MAC address collisions on the local network between multiple FPGA boards
+# while ensuring the MAC address remains stable across reboots of the same board.
+
+set -e
+
+IFACE="${1:-end0}"
+
+get_hardware_seed() {
+    # SD Card CID (128-bit unique hardware card identification register on the boot SD card)
+    if [ -f /sys/block/mmcblk0/device/cid ]; then
+        local cid
+        cid=$(tr -d '\n\r\0' < /sys/block/mmcblk0/device/cid 2>/dev/null | xargs)
+        if [ -n "$cid" ]; then
+            echo "$cid"
+            return 0
+        fi
+    fi
+
+    # Fallback seed if SD card CID is unavailable (e.g. QEMU or container)
+    echo "caliptra-fpga-default-seed"
+}
+
+SEED=$(get_hardware_seed)
+HASH=$(echo -n "$SEED" | sha256sum | awk '{print $1}')
+
+# Construct locally administered unicast MAC address (02:xx:xx:xx:xx:xx)
+MAC="02:${HASH:0:2}:${HASH:2:2}:${HASH:4:2}:${HASH:6:2}:${HASH:8:2}"
+
+if [ "$1" = "--print" ]; then
+    echo "$MAC"
+    exit 0
+fi
+
+if ip link show "$IFACE" >/dev/null 2>&1; then
+    CURRENT_MAC=$(ip link show "$IFACE" | grep -oE 'link/ether [0-9a-fA-F:]+' | awk '{print $2}')
+    if [ "$CURRENT_MAC" != "$MAC" ]; then
+        echo "Setting MAC address for $IFACE to $MAC (seed: $SEED)"
+        ip link set dev "$IFACE" down 2>/dev/null || true
+        ip link set dev "$IFACE" address "$MAC"
+        ip link set dev "$IFACE" up 2>/dev/null || true
+    fi
+fi

--- a/ci-tools/fpga-image/startup-script.sh
+++ b/ci-tools/fpga-image/startup-script.sh
@@ -5,11 +5,6 @@
 # Startup script that is executed against the zcu104 UART. fpga-boss will
 # connect to this UART (via on-board FTDI chip) and send commands.
 
-# The VCK-190 image currently always has the same MAC. Do this for now until 
-# a better option is found.
-ip link set dev end0 down
-macchanger -r end0 || true
-ip link set dev end0 up
 
 # Load the IO module if it exists
 if [[ -f "/home/runner/io-module.ko" ]]; then


### PR DESCRIPTION
* This assumes the SD serial numbers are unique
* This resolves a longstanding problem, where the FPGAs all have the same MAC address

This should provide a stable and unique MAC solving some longstanding problems and inconveniences with the FPGAs.