### PR TITLE
mldsa: pqc certify cmd

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -938,7 +938,7 @@ pub trait HwModel: SocManager {
     /// Wait for the response to a previous call to `start_mailbox_execute()`.
     fn finish_mailbox_execute(&mut self) -> std::result::Result<Option<Vec<u8>>, ModelError> {
         // Wait for the microcontroller to finish executing
-        let mut timeout_cycles = 40000000; // 100ms @400MHz
+        let mut timeout_cycles = 400000000; // 1s @400MHz
         while self.soc_mbox().status().read().status().cmd_busy() {
             self.step();
             timeout_cycles -= 1;

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -935,10 +935,23 @@ pub trait HwModel: SocManager {
         Ok(())
     }
 
+    /// Number of `step()` iterations to wait for a mailbox command to complete
+    /// before declaring a `MailboxTimeout`.
+    ///
+    /// On the emulator each `step()` advances a single emulated core cycle, so a
+    /// large count is needed to accommodate long-running commands (e.g. ML-DSA).
+    /// On real hardware (FPGA) the core runs in real time and each `step()` is a
+    /// real-time MMIO poll, so this count acts as a busy-wait bound and must stay
+    /// small. Backends override this as appropriate; the default matches the
+    /// original Caliptra 1.x value (100ms @400MHz).
+    fn mailbox_timeout_cycles(&self) -> u32 {
+        40000000 // 100ms @400MHz
+    }
+
     /// Wait for the response to a previous call to `start_mailbox_execute()`.
     fn finish_mailbox_execute(&mut self) -> std::result::Result<Option<Vec<u8>>, ModelError> {
         // Wait for the microcontroller to finish executing
-        let mut timeout_cycles = 400000000; // 1s @400MHz
+        let mut timeout_cycles = self.mailbox_timeout_cycles();
         while self.soc_mbox().status().read().status().cmd_busy() {
             self.step();
             timeout_cycles -= 1;

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -945,7 +945,7 @@ pub trait HwModel: SocManager {
     /// small. Backends override this as appropriate; the default matches the
     /// original Caliptra 1.x value (100ms @400MHz).
     fn mailbox_timeout_cycles(&self) -> u32 {
-        40000000 // 100ms @400MHz
+        40_000_000 // 100ms @400MHz
     }
 
     /// Wait for the response to a previous call to `start_mailbox_execute()`.

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -262,6 +262,12 @@ impl HwModel for ModelEmulated {
         }
     }
 
+    fn mailbox_timeout_cycles(&self) -> u32 {
+        // Each step() advances a single emulated core cycle, so allow extra
+        // cycles to accommodate long-running commands (e.g. ML-DSA). 1s @400MHz.
+        400000000
+    }
+
     fn output(&mut self) -> &mut Output {
         // In case the caller wants to log something, make sure the log has the
         // correct time.env::

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -265,7 +265,7 @@ impl HwModel for ModelEmulated {
     fn mailbox_timeout_cycles(&self) -> u32 {
         // Each step() advances a single emulated core cycle, so allow extra
         // cycles to accommodate long-running commands (e.g. ML-DSA). 1s @400MHz.
-        400000000
+        400_000_000
     }
 
     fn output(&mut self) -> &mut Output {

--- a/hw-model/src/model_verilated.rs
+++ b/hw-model/src/model_verilated.rs
@@ -144,6 +144,12 @@ impl HwModel for ModelVerilated {
         self.process_trng_end();
     }
 
+    fn mailbox_timeout_cycles(&self) -> u32 {
+        // Each step() advances a single RTL core cycle, so allow extra cycles to
+        // accommodate long-running commands (e.g. ML-DSA). 1s @400MHz.
+        400000000
+    }
+
     fn new_unbooted(params: crate::InitParams) -> Result<Self, Box<dyn std::error::Error>>
     where
         Self: Sized,

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -12,13 +12,17 @@ Abstract:
 
 --*/
 
-use crate::{invoke_dpe::invoke_dpe_cmd, Drivers, MboxResponseWriter, PauserPrivileges};
+use crate::{
+    invoke_dpe::invoke_dpe_cmd, CaliptraDpeProfile, Drivers, MboxResponseWriter, PauserPrivileges,
+};
 use arrayvec::ArrayVec;
 use caliptra_common::mailbox_api::{
     CertifyKeyExtendedFlags, CertifyKeyExtendedReq, MailboxRespHeader, MailboxRespHeaderVarSize,
 };
 use caliptra_dpe_response_buffer::{OffsetResponseBuffer, ResponseBuffer};
 use caliptra_drivers::{CaliptraError, CaliptraResult};
+#[cfg(feature = "mldsa_attestation")]
+use dpe::commands::CertifyKeyMldsa87Cmd;
 use dpe::commands::{CertifyKeyP384Cmd, Command};
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
@@ -28,7 +32,21 @@ impl CertifyKeyExtendedCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         let mut cmd = CertifyKeyExtendedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        Self::certify_key(
+            drivers,
+            cmd.flags,
+            &cmd.certify_key_req[..],
+            CaliptraDpeProfile::Ecc384,
+        )
+    }
 
+    /// CERTIFY_KEY_EXTENDED logic generic to the cryptographic algorithm in use.
+    pub(crate) fn certify_key(
+        drivers: &mut Drivers,
+        flags: CertifyKeyExtendedFlags,
+        certify_key_req: &[u8],
+        profile: CaliptraDpeProfile,
+    ) -> CaliptraResult<()> {
         match drivers.caller_privilege_level() {
             // CERTIFY_KEY_EXTENDED MUST only be called from PL0
             PauserPrivileges::PL0 => (),
@@ -38,7 +56,7 @@ impl CertifyKeyExtendedCmd {
         }
 
         // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
-        let dmtf_device_info = if cmd.flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
+        let dmtf_device_info = if flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {
             drivers.dmtf_device_info.as_ref().and_then(|info| {
                 let mut dmtf_device_info = ArrayVec::new();
                 dmtf_device_info.try_extend_from_slice(info).ok()?;
@@ -47,21 +65,38 @@ impl CertifyKeyExtendedCmd {
         } else {
             None
         };
-        let certify_key_cmd = CertifyKeyP384Cmd::ref_from_bytes(&cmd.certify_key_req[..])
-            .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-        let command = Command::from(certify_key_cmd);
+
+        let command = match profile {
+            CaliptraDpeProfile::Ecc384 => Command::from(
+                CertifyKeyP384Cmd::ref_from_bytes(certify_key_req)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?,
+            ),
+            #[cfg(feature = "mldsa_attestation")]
+            CaliptraDpeProfile::Mldsa => Command::from(
+                CertifyKeyMldsa87Cmd::ref_from_bytes(certify_key_req)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?,
+            ),
+        };
 
         let mut writer = MboxResponseWriter::from_mbox_base();
         let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
 
-        let resp_size = invoke_dpe_cmd(drivers, &command, dmtf_device_info, None, None, &mut w)
-            .map_err(|e| {
-                drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
-                // The Mbox writer cannot encounter an error during clear, and the Certify Key
-                // extended error is more important.
-                let _ = writer.clear();
-                CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
-            })?;
+        let resp_size = invoke_dpe_cmd(
+            profile,
+            drivers,
+            &command,
+            dmtf_device_info,
+            None,
+            None,
+            &mut w,
+        )
+        .map_err(|e| {
+            drivers.soc_ifc.set_fw_extended_error(e.get_error_code());
+            // The Mbox writer cannot encounter an error during clear, and the Certify Key
+            // extended error is more important.
+            let _ = writer.clear();
+            CaliptraError::RUNTIME_CERTIFY_KEY_EXTENDED_FAILED
+        })?;
 
         let header = MailboxRespHeaderVarSize {
             hdr: MailboxRespHeader::default(),

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -35,7 +35,7 @@ impl CertifyKeyExtendedCmd {
         Self::certify_key(
             drivers,
             cmd.flags,
-            &cmd.certify_key_req[..],
+            &cmd.certify_key_req,
             CaliptraDpeProfile::Ecc384,
         )
     }

--- a/runtime/src/certify_key_extended_mldsa.rs
+++ b/runtime/src/certify_key_extended_mldsa.rs
@@ -13,19 +13,41 @@ Abstract:
 
 --*/
 
-use crate::Drivers;
+use crate::{CaliptraDpeProfile, CertifyKeyExtendedCmd, Drivers};
 use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_common::mailbox_api::CertifyKeyExtendedMldsa87Req;
 use caliptra_drivers::{CaliptraError, CaliptraResult};
+use zerocopy::{FromZeros, IntoBytes};
 
 pub struct CertifyKeyExtendedMldsa87Cmd;
 
 impl CertifyKeyExtendedMldsa87Cmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    pub(crate) fn execute(_drivers: &mut Drivers) -> CaliptraResult<()> {
-        // TODO(PQC): certify the requested key under the ML-DSA-87 identity and
-        // return the certificate via CertifyKeyExtendedMldsa87Resp. Return
-        // RUNTIME_PQC_NOT_INITIALIZED when pqc_mode is disabled.
-        Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND)
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
+        let mut cmd = CertifyKeyExtendedMldsa87Req::new_zeroed();
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
+        // The ML-DSA DPE identity is the PQ.DevID, which only exists once a seed
+        // has been provisioned via SET_PQ_SEED.
+        if !drivers.persistent_data.get().pqc_mode_enabled() {
+            return Err(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED);
+        }
+
+        // The mldsa variant of the certify key extended can be quite long, the current longest
+        // measurement over 400_000_000 cycles. As such support 800_000_000 cycles prior to timeout.
+        caliptra_common::wdt::start_wdt(
+            &mut drivers.soc_ifc,
+            caliptra_common::WdtTimeout::new_const(800_000_000),
+        );
+
+        // The certify-key logic is shared with the ECDSA variant; only the DPE
+        // profile (and thus identity / signature algorithm) differs.
+        CertifyKeyExtendedCmd::certify_key(
+            drivers,
+            cmd.flags,
+            &cmd.certify_key_req[..],
+            CaliptraDpeProfile::Mldsa,
+        )
     }
 }

--- a/runtime/src/certify_key_extended_mldsa.rs
+++ b/runtime/src/certify_key_extended_mldsa.rs
@@ -46,7 +46,7 @@ impl CertifyKeyExtendedMldsa87Cmd {
         CertifyKeyExtendedCmd::certify_key(
             drivers,
             cmd.flags,
-            &cmd.certify_key_req[..],
+            &cmd.certify_key_req,
             CaliptraDpeProfile::Mldsa,
         )
     }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -181,15 +181,15 @@ impl<'a> DpeCrypto<'a> {
         info: &[u8],
     ) -> Result<Zeroizing<Array4x12>, CryptoError> {
         // Copy root CDI to the stack before borrowing self.hmac384/trng.
-        let root_copy: Array4x12 = match &self.rt_cdi {
-            Cdi::Mldsa(root) => **root,
+        let root_copy = match &self.rt_cdi {
+            Cdi::Mldsa(root) => root.clone(),
             _ => return Err(CryptoError::MismatchedAlgorithm),
         };
         let mut output = Zeroizing::new(Array4x12::default());
         self.derive_cdi_kdf(
             measurement,
             info,
-            (&root_copy).into(),
+            (&*root_copy).into(),
             (&mut *output).into(),
         )?;
         Ok(output)
@@ -564,12 +564,12 @@ impl Crypto for DpeCrypto<'_> {
 
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa { .. } => {
-                let cdi: Array4x12 = match self.rt_cdi {
-                    Cdi::Mldsa(ref pq_devid_cdi) => **pq_devid_cdi,
+                let cdi = match &self.rt_cdi {
+                    Cdi::Mldsa(pq_devid_cdi) => pq_devid_cdi.clone(),
                     _ => return Err(CryptoError::MismatchedAlgorithm),
                 };
                 let mut seed = Mldsa87Seed::default();
-                dice::derive_devid_seed(&(cdi.into()), &mut seed, self.hmac384, self.trng)
+                dice::derive_devid_seed(&((*cdi).into()), &mut seed, self.hmac384, self.trng)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
                 Self::sign_helper_mldsa(data, &seed)
             }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -19,8 +19,8 @@ use caliptra_common::keyids::{
 use caliptra_dpe_response_buffer::ResponseBufError;
 use caliptra_drivers::{
     hmac384_kdf, sha384::DpeHasher, Array4x12, Ecc384, Ecc384PrivKeyIn, Ecc384PubKey, Ecc384Scalar,
-    Ecc384Seed, ExportedCdiEntry, ExportedCdiHandles, Hmac384, KeyId, KeyReadArgs, KeyUsage,
-    KeyVault, KeyWriteArgs, Sha384, Trng,
+    Ecc384Seed, ExportedCdiEntry, ExportedCdiHandles, Hmac384, Hmac384Key, Hmac384Tag, KeyId,
+    KeyReadArgs, KeyUsage, KeyVault, KeyWriteArgs, Sha384, Trng,
 };
 use caliptra_error::CaliptraResult;
 use constant_time_eq::constant_time_eq;
@@ -37,13 +37,24 @@ use dpe::{EcdsaAlgorithm, ExportedCdiHandle, U8Bool, MAX_EXPORTED_CDI_SIZE};
 use {
     crate::dice,
     caliptra_drivers::{
-        Hmac384Key, Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature,
-        MldsaExportedCdiEntry, PqDevIdCdi, MLDSA87_PRIVATE_SEED_BYTES,
+        Mldsa87, Mldsa87Mu, Mldsa87PubKey, Mldsa87Seed, Mldsa87Signature, MldsaExportedCdiEntry,
+        MLDSA87_PRIVATE_SEED_BYTES, PQ_DEVID_CDI_SIZE,
     },
     crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
     zerocopy::FromBytes,
     zeroize::Zeroizing,
 };
+
+// A CDI, held either as a key-vault slot (ECDSA) or in memory (ML-DSA). Used for
+// both the root RT CDI and the derived DPE CDI. ML-DSA cannot keep a CDI in a
+// key-vault slot: the hardware zeroes any CPU read of an HMAC tag derived from a
+// key-vault-sourced key (key_from_kv=true), so it must derive in and from memory.
+#[allow(clippy::large_enum_variant)]
+enum Cdi {
+    Ec(KeyId),
+    #[cfg(feature = "mldsa_attestation")]
+    Mldsa(Zeroizing<Array4x12>),
+}
 
 pub struct DpeCrypto<'a> {
     trng: &'a mut Trng,
@@ -51,15 +62,10 @@ pub struct DpeCrypto<'a> {
     key_vault: &'a mut KeyVault,
     signer: Signer<'a>,
     hasher: DpeHasher<'a>,
-    cdi: Option<KeyId>,
+    cdi: Option<Cdi>,
     derived_key: Option<DerivedKey>,
-    rt_cdi: RtCdi,
+    rt_cdi: Cdi,
     exported_cdi_slots: &'a mut ExportedCdiHandles,
-    /// Single ML-DSA exported-CDI slot (raw CDI bytes in persistent data). Only
-    /// populated for the ML-DSA signer; the ECDSA exported CDIs live in
-    /// `exported_cdi_slots`.
-    #[cfg(feature = "mldsa_attestation")]
-    mldsa_exported_cdi_slot: Option<&'a MldsaExportedCdiEntry>,
 }
 
 impl<'a> DpeCrypto<'a> {
@@ -87,10 +93,8 @@ impl<'a> DpeCrypto<'a> {
             hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
-            rt_cdi: RtCdi::Ec(key_id_rt_cdi),
+            rt_cdi: Cdi::Ec(key_id_rt_cdi),
             exported_cdi_slots,
-            #[cfg(feature = "mldsa_attestation")]
-            mldsa_exported_cdi_slot: None,
         })
     }
 
@@ -101,48 +105,62 @@ impl<'a> DpeCrypto<'a> {
         trng: &'a mut Trng,
         hmac384: &'a mut Hmac384,
         key_vault: &'a mut KeyVault,
-        pq_devid_cdi: &'a PqDevIdCdi,
+        root_cdi: Array4x12,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
-        mldsa_exported_cdi_slot: &'a MldsaExportedCdiEntry,
+        exported_cdi_slot: &'a mut MldsaExportedCdiEntry,
     ) -> CaliptraResult<Self> {
         Ok(Self {
             trng,
             hmac384,
             key_vault,
-            signer: Signer::Mldsa,
+            signer: Signer::Mldsa { exported_cdi_slot },
             hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
-            rt_cdi: RtCdi::Mldsa(*pq_devid_cdi),
+            rt_cdi: Cdi::Mldsa(Zeroizing::new(root_cdi)),
             exported_cdi_slots,
-            mldsa_exported_cdi_slot: Some(mldsa_exported_cdi_slot),
         })
     }
 
-    fn derive_cdi_inner(
+    // Shared CDI-derivation KDF: HMAC(key, "derive_cdi", measurement || info) → output.
+    // The `key` (RT CDI) and `output` (derived CDI) enums abstract over key-vault
+    // slots (ECDSA) versus in-memory buffers (ML-DSA), which is the only difference
+    // between the two algorithms' derivations.
+    fn derive_cdi_kdf(
         &mut self,
         measurement: &Digest,
         info: &[u8],
-        key_id: KeyId,
-    ) -> Result<KeyId, CryptoError> {
+        key: Hmac384Key,
+        output: Hmac384Tag,
+    ) -> Result<(), CryptoError> {
         let context = self.hash_all(&[&measurement.as_slice(), &info])?;
-        #[cfg(feature = "mldsa_attestation")]
-        let array: Array4x12;
-        let key = match self.rt_cdi {
-            RtCdi::Ec(key_id) => KeyReadArgs::new(key_id).into(),
-            #[cfg(feature = "mldsa_attestation")]
-            RtCdi::Mldsa(pq_devid_cdi) => {
-                array = Array4x12::from(pq_devid_cdi);
-                (&array).into()
-            }
-        };
-
         hmac384_kdf(
             self.hmac384,
             key,
             b"derive_cdi",
             Some(context.as_slice()),
             self.trng,
+            output,
+        )
+        .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
+    }
+
+    // EC-only: HMAC from key-vault RT CDI → key-vault output slot.
+    fn derive_cdi_inner_ec(
+        &mut self,
+        measurement: &Digest,
+        info: &[u8],
+        key_id: KeyId,
+    ) -> Result<KeyId, CryptoError> {
+        let key_id_rt_cdi = match &self.rt_cdi {
+            Cdi::Ec(k) => *k,
+            #[cfg(feature = "mldsa_attestation")]
+            _ => return Err(CryptoError::CryptoLibError(0x100)),
+        };
+        self.derive_cdi_kdf(
+            measurement,
+            info,
+            KeyReadArgs::new(key_id_rt_cdi).into(),
             KeyWriteArgs::new(
                 key_id,
                 KeyUsage::default()
@@ -150,14 +168,34 @@ impl<'a> DpeCrypto<'a> {
                     .set_ecc_key_gen_seed_en(),
             )
             .into(),
-        )
-        .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+        )?;
         Ok(key_id)
     }
 
-    /// Derive an ML-DSA-87 key pair from a CDI. The CDI is supplied as an
-    /// already-resolved HMAC key so the same derivation serves both the DPE CDI
-    /// (a key-vault slot) and an exported CDI (raw bytes in persistent data).
+    // ML-DSA: HMAC from in-memory root CDI → in-memory output. key_from_kv stays
+    // false so the hardware security model does not zero the HMAC tag on CPU reads.
+    #[cfg(feature = "mldsa_attestation")]
+    fn derive_cdi_inner_mldsa(
+        &mut self,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Zeroizing<Array4x12>, CryptoError> {
+        // Copy root CDI to the stack before borrowing self.hmac384/trng.
+        let root_copy: Array4x12 = match &self.rt_cdi {
+            Cdi::Mldsa(root) => **root,
+            _ => return Err(CryptoError::MismatchedAlgorithm),
+        };
+        let mut output = Zeroizing::new(Array4x12::default());
+        self.derive_cdi_kdf(
+            measurement,
+            info,
+            (&root_copy).into(),
+            (&mut *output).into(),
+        )?;
+        Ok(output)
+    }
+
+    // Derive only the ML-DSA seed from an in-memory CDI.
     #[cfg(feature = "mldsa_attestation")]
     fn derive_key_pair_mldsa(
         &mut self,
@@ -332,7 +370,7 @@ impl SignatureType for DpeCrypto<'_> {
         match self.signer {
             Signer::Ec { .. } => SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384),
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => SignatureAlgorithm::Mldsa(MldsaAlgorithm::Mldsa87),
+            Signer::Mldsa { .. } => SignatureAlgorithm::Mldsa(MldsaAlgorithm::Mldsa87),
         }
     }
 }
@@ -377,43 +415,70 @@ impl Crypto for DpeCrypto<'_> {
         let mut exported_cdi_handle = [0; MAX_EXPORTED_CDI_SIZE];
         self.rand_bytes(&mut exported_cdi_handle)?;
 
-        // Currently we only use one slot for export CDIs.
-        let cdi_slot = KEY_ID_EXPORTED_DPE_CDI;
-        // Copy the CDI slots to work around the borrow checker.
-        let mut slots_clone = self.exported_cdi_slots.clone();
+        match self.signer {
+            Signer::Ec { .. } => {
+                // Currently we only use one slot for export CDIs.
+                let cdi_slot = KEY_ID_EXPORTED_DPE_CDI;
+                // Copy the CDI slots to work around the borrow checker.
+                let mut slots_clone = self.exported_cdi_slots.clone();
 
-        for slot in slots_clone.entries.iter_mut() {
-            match slot {
-                // Matching existing slot
-                ExportedCdiEntry {
-                    key,
-                    handle: _,
-                    active,
-                } if active.get() && *key == cdi_slot => {
-                    Err(CryptoError::ExportedCdiHandleDuplicateCdi)?
+                for slot in slots_clone.entries.iter_mut() {
+                    match slot {
+                        // Matching existing slot
+                        ExportedCdiEntry {
+                            key,
+                            handle: _,
+                            active,
+                        } if active.get() && *key == cdi_slot => {
+                            return Err(CryptoError::ExportedCdiHandleDuplicateCdi);
+                        }
+                        ExportedCdiEntry {
+                            key: _,
+                            handle: _,
+                            active,
+                        } if !active.get() => {
+                            // Empty slot
+                            let cdi = self.derive_cdi_inner_ec(measurement, info, cdi_slot)?;
+                            *slot = ExportedCdiEntry {
+                                key: cdi,
+                                handle: exported_cdi_handle,
+                                active: U8Bool::new(true),
+                            };
+                            // We need to update `self.exported_cdi_slots` with our mutation.
+                            *self.exported_cdi_slots = slots_clone;
+                            return Ok(exported_cdi_handle);
+                        }
+                        // Used slot for a different CDI.
+                        _ => (),
+                    }
                 }
-                ExportedCdiEntry {
-                    key: _,
-                    handle: _,
-                    active,
-                } if !active.get() => {
-                    // Empty slot
-                    let cdi = self.derive_cdi_inner(measurement, info, cdi_slot)?;
-                    *slot = ExportedCdiEntry {
-                        key: cdi,
-                        handle: exported_cdi_handle,
-                        active: U8Bool::new(true),
-                    };
-                    // We need to update `self.exported_cdi_slots` with our mutation.
-                    *self.exported_cdi_slots = slots_clone;
-                    return Ok(exported_cdi_handle);
+                // Never found an available slot.
+                Err(CryptoError::ExportedCdiHandleLimitExceeded)
+            }
+            // ML-DSA: CDI cannot live in a key-vault slot, so use the dedicated
+            // in-memory persistent-data slot held in the ML-DSA signer variant.
+            #[cfg(feature = "mldsa_attestation")]
+            Signer::Mldsa { .. } => {
+                // Only one ML-DSA exported CDI slot exists; reject if it is in use.
+                // Scope the borrow so it ends before derive_cdi_inner_mldsa (&mut self).
+                // The borrow will be trivially true since we entered this branch of the match.
+                if let Signer::Mldsa { exported_cdi_slot } = &self.signer {
+                    if exported_cdi_slot.active.get() {
+                        return Err(CryptoError::ExportedCdiHandleLimitExceeded);
+                    }
                 }
-                // Used slot for a different CDI.
-                _ => (),
+
+                let mldsa_cdi = self.derive_cdi_inner_mldsa(measurement, info)?;
+                let cdi_bytes = <[u8; PQ_DEVID_CDI_SIZE as usize]>::from(*mldsa_cdi);
+                // The borrow will be trivially true since we entered this branch of the match.
+                if let Signer::Mldsa { exported_cdi_slot } = &mut self.signer {
+                    exported_cdi_slot.cdi = cdi_bytes;
+                    exported_cdi_slot.handle = exported_cdi_handle;
+                    exported_cdi_slot.active = U8Bool::new(true);
+                }
+                Ok(exported_cdi_handle)
             }
         }
-        // Never found an available slot.
-        Err(CryptoError::ExportedCdiHandleLimitExceeded)
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
@@ -422,7 +487,17 @@ impl Crypto for DpeCrypto<'_> {
         measurement: &Digest,
         info: &[u8],
     ) -> Result<&mut dyn CdiManager, CryptoError> {
-        self.cdi = Some(self.derive_cdi_inner(measurement, info, KEY_ID_DPE_CDI)?);
+        self.cdi = match &self.signer {
+            Signer::Ec { .. } => Some(Cdi::Ec(self.derive_cdi_inner_ec(
+                measurement,
+                info,
+                KEY_ID_DPE_CDI,
+            )?)),
+            #[cfg(feature = "mldsa_attestation")]
+            Signer::Mldsa { .. } => {
+                Some(Cdi::Mldsa(self.derive_cdi_inner_mldsa(measurement, info)?))
+            }
+        };
         Ok(self)
     }
 
@@ -458,17 +533,19 @@ impl Crypto for DpeCrypto<'_> {
                 ));
             }
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => {
+            Signer::Mldsa { .. } => {
                 // The ML-DSA exported CDI is held as raw bytes in a single
                 // persistent-data slot; derive directly from those bytes.
                 let cdi = {
-                    let slot = self
-                        .mldsa_exported_cdi_slot
-                        .ok_or(CryptoError::InvalidExportedCdiHandle)?;
-                    if !(slot.active.get() && constant_time_eq(&slot.handle, exported_handle)) {
+                    let Signer::Mldsa { exported_cdi_slot } = &self.signer else {
+                        return Err(CryptoError::InvalidExportedCdiHandle);
+                    };
+                    if !(exported_cdi_slot.active.get()
+                        && constant_time_eq(&exported_cdi_slot.handle, exported_handle))
+                    {
                         return Err(CryptoError::InvalidExportedCdiHandle);
                     }
-                    Zeroizing::new(Array4x12::from(&slot.cdi))
+                    Zeroizing::new(Array4x12::from(&exported_cdi_slot.cdi))
                 };
                 let mut seed = Mldsa87Seed::default();
                 self.derive_key_pair_mldsa((&*cdi).into(), label, info, &mut seed)?;
@@ -486,13 +563,13 @@ impl Crypto for DpeCrypto<'_> {
             }
 
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => {
-                let cdi = match self.rt_cdi {
-                    RtCdi::Mldsa(ref pq_devid_cdi) => pq_devid_cdi,
+            Signer::Mldsa { .. } => {
+                let cdi: Array4x12 = match self.rt_cdi {
+                    Cdi::Mldsa(ref pq_devid_cdi) => **pq_devid_cdi,
                     _ => return Err(CryptoError::MismatchedAlgorithm),
                 };
                 let mut seed = Mldsa87Seed::default();
-                dice::derive_devid_seed(cdi, &mut seed, self.hmac384, self.trng)
+                dice::derive_devid_seed(&(cdi.into()), &mut seed, self.hmac384, self.trng)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
                 Self::sign_helper_mldsa(data, &seed)
             }
@@ -507,10 +584,12 @@ impl CdiManager for DpeCrypto<'_> {
         label: &[u8],
         info: &[u8],
     ) -> Result<&mut dyn crypto::Signer, CryptoError> {
-        let cdi: KeyId = self.cdi.ok_or(CryptoError::CryptoLibError(1))?;
-
-        match self.signer {
+        match &self.signer {
             Signer::Ec { .. } => {
+                let cdi = match &self.cdi {
+                    Some(Cdi::Ec(k)) => *k,
+                    _ => return Err(CryptoError::CryptoLibError(1)),
+                };
                 self.derived_key = Some(DerivedKey::Ec(self.derive_key_pair_ec(
                     &cdi,
                     label,
@@ -518,14 +597,20 @@ impl CdiManager for DpeCrypto<'_> {
                     KEY_ID_DPE_PRIV_KEY,
                 )?));
             }
-
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => {
+            Signer::Mldsa { .. } => {
+                // Copy CDI bytes to the stack so we can release the borrow on self.cdi
+                // before calling derive_key_pair_mldsa which needs &mut self.
+                let cdi_bytes = match &self.cdi {
+                    Some(Cdi::Mldsa(b)) => **b,
+                    _ => return Err(CryptoError::CryptoLibError(1)),
+                };
                 let mut seed = Mldsa87Seed::default();
-                self.derive_key_pair_mldsa(KeyReadArgs::new(cdi).into(), label, info, &mut seed)?;
+                self.derive_key_pair_mldsa((&cdi_bytes).into(), label, info, &mut seed)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
-        }
+        };
+
         Ok(self)
     }
 
@@ -552,7 +637,7 @@ impl crypto::Signer for DpeCrypto<'_> {
             }
 
             #[cfg(feature = "mldsa_attestation")]
-            Signer::Mldsa => {
+            Signer::Mldsa { .. } => {
                 let Some(DerivedKey::Mldsa(seed)) = &self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
@@ -585,7 +670,11 @@ enum Signer<'a> {
         rt_priv_key: KeyId,
     },
     #[cfg(feature = "mldsa_attestation")]
-    Mldsa,
+    Mldsa {
+        /// Single ML-DSA exported-CDI slot (raw CDI bytes in persistent data).
+        /// ECDSA exported CDIs instead live in `exported_cdi_slots`.
+        exported_cdi_slot: &'a mut MldsaExportedCdiEntry,
+    },
 }
 
 // The mldsa key is significantly larger than ecdsa.  Allow a large enum variant to support it.
@@ -594,10 +683,4 @@ enum DerivedKey {
     Ec((KeyId, PubKey)),
     #[cfg(feature = "mldsa_attestation")]
     Mldsa(Mldsa87Seed),
-}
-
-enum RtCdi {
-    Ec(KeyId),
-    #[cfg(feature = "mldsa_attestation")]
-    Mldsa(PqDevIdCdi),
 }

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -117,7 +117,15 @@ impl InvokeDpeCmd {
         let mut writer = MboxResponseWriter::from_mbox_base();
         let mut w = OffsetResponseBuffer::new(&mut writer, size_of::<MailboxRespHeaderVarSize>());
 
-        let result = invoke_dpe_cmd(drivers, &command, None, ueid, None, &mut w);
+        let result = invoke_dpe_cmd(
+            CaliptraDpeProfile::Ecc384,
+            drivers,
+            &command,
+            None,
+            ueid,
+            None,
+            &mut w,
+        );
 
         if let Command::DestroyCtx(_) = command {
             // clear tags for destroyed contexts
@@ -180,6 +188,7 @@ impl InvokeDpeCmd {
 }
 
 pub fn invoke_dpe_cmd(
+    profile: CaliptraDpeProfile,
     drivers: &mut Drivers,
     command: &Command<'_>,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
@@ -188,7 +197,13 @@ pub fn invoke_dpe_cmd(
     out: &mut dyn ResponseBuffer,
 ) -> Result<usize, DpeErrorCode> {
     let locality = locality.unwrap_or(drivers.mbox.user());
-    let mut env = ec_dpe_env(drivers, dmtf_device_info, ueid);
+    // The DPE environment differs by identity (ECDSA RT alias vs ML-DSA
+    // PQ.DevID), but the state and command execution are shared.
+    let mut env = match profile {
+        CaliptraDpeProfile::Ecc384 => ec_dpe_env(drivers, dmtf_device_info, ueid),
+        #[cfg(feature = "mldsa_attestation")]
+        CaliptraDpeProfile::Mldsa => crate::mldsa_dpe_env(drivers, dmtf_device_info, ueid),
+    };
     let env = match env.as_mut() {
         Ok(r) => r,
         Err(_) => {
@@ -197,6 +212,6 @@ pub fn invoke_dpe_cmd(
             ))
         }
     };
-    let dpe = &mut DpeInstance::initialized(DpeProfile::P384Sha384);
+    let dpe = &mut DpeInstance::initialized(profile.into());
     command.execute_serialized(dpe, env, locality, out)
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -460,6 +460,7 @@ impl DpeEnv for CaliptraDpeEnv<'_> {
     }
 }
 
+#[inline(never)]
 fn ec_dpe_env(
     drivers: &mut Drivers,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
@@ -503,8 +504,8 @@ fn ec_dpe_env(
     })
 }
 
-#[allow(dead_code)]
 #[cfg(feature = "mldsa_attestation")]
+#[inline(never)]
 fn mldsa_dpe_env(
     drivers: &mut Drivers,
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,6 +59,8 @@ use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter,
 };
+#[cfg(feature = "mldsa_attestation")]
+use caliptra_drivers::Array4x12;
 pub use drivers::{Drivers, PauserPrivileges};
 use mailbox::Mailbox;
 
@@ -515,9 +517,9 @@ fn mldsa_dpe_env(
         &mut drivers.trng,
         &mut drivers.hmac384,
         &mut drivers.key_vault,
-        &pdata.pq_devid_cdi,
+        Array4x12::from(&pdata.pq_devid_cdi),
         &mut pdata.exported_cdi_slots,
-        &pdata.mldsa_exported_cdi_slots,
+        &mut pdata.mldsa_exported_cdi_slots,
     )?;
     let pl0_pauser = pdata.manifest1.header.pl0_pauser;
     let (nb, nf) = Drivers::get_cert_validity_info(&pdata.manifest1);

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -7,7 +7,7 @@ use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_common::mailbox_api::{SignWithExportedMldsaReq, SignWithExportedMldsaResp};
-use caliptra_drivers::MLDSA87_MU_BYTES;
+use caliptra_drivers::{Array4x12, MLDSA87_MU_BYTES};
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
@@ -55,14 +55,15 @@ impl SignWithExportedMldsaCmd {
         };
 
         let pdata = drivers.persistent_data.get_mut();
+        let root_cdi = Array4x12::from(&pdata.pq_devid_cdi);
         let mut crypto = DpeCrypto::new_mldsa87(
             &mut drivers.sha384,
             &mut drivers.trng,
             &mut drivers.hmac384,
             &mut drivers.key_vault,
-            &pdata.pq_devid_cdi,
+            root_cdi,
             &mut pdata.exported_cdi_slots,
-            &pdata.mldsa_exported_cdi_slots,
+            &mut pdata.mldsa_exported_cdi_slots,
         )?;
 
         let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pub_key))) =

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -68,8 +68,15 @@ impl StashMeasurementCmd {
             let ueid = Some(drivers.soc_ifc.fuse_bank().ueid());
             let mut buf = [0u8; size_of::<DeriveContextExportedCdiResp>()];
             let mut out = SliceResponseBuffer::new(&mut buf);
-            let derive_context_resp =
-                invoke_dpe_cmd(drivers, &command, None, ueid, Some(locality), &mut out);
+            let derive_context_resp = invoke_dpe_cmd(
+                crate::CaliptraDpeProfile::Ecc384,
+                drivers,
+                &command,
+                None,
+                ueid,
+                Some(locality),
+                &mut out,
+            );
 
             match derive_context_resp {
                 Ok(_) => DpeErrorCode::NoError,

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -92,6 +92,83 @@ pub fn run_pqc_rt_test() -> DefaultHwModel {
     model
 }
 
+// Boot the ML-DSA attestation runtime image **debug-locked** (Production
+// lifecycle) so the firmware actually arms the per-command watchdog. The
+// runtime's `start_wdt` (runtime/src/lib.rs) is a no-op unless the device is
+// debug-locked, so the default (unlocked) test boots never enforce the WDT.
+// This helper enables realistic WDT-constrained tests for the PQC commands.
+//
+// WDT budget: `WdtTimeout::default()` = 20M cycles (WDT1), cascading to WDT2
+// (1 cycle) -> NMI -> `RUNTIME_GLOBAL_WDT_EXPIRED` fatal error.
+#[cfg(feature = "mldsa_attestation")]
+pub fn run_pqc_rt_test_wdt() -> DefaultHwModel {
+    use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+    use caliptra_hw_model::{DeviceLifecycle, SecurityState};
+    use openssl::sha::sha384;
+
+    let security_state = *SecurityState::default()
+        .set_debug_locked(true)
+        .set_device_lifecycle(DeviceLifecycle::Production);
+
+    let mut image_options = ImageOptions::default();
+    image_options.vendor_config.pl0_pauser = Some(0x1);
+    image_options.fmc_version = DEFAULT_FMC_VERSION;
+    image_options.app_version = DEFAULT_APP_VERSION;
+
+    let image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_MLDSA_ATTESTATION,
+        image_options,
+    )
+    .unwrap();
+
+    // Debug-locked (Production) boot verifies the image signature, so the fuses
+    // must carry the vendor/owner public-key hashes of the signed image.
+    let vendor_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.vendor_pub_keys.as_bytes()));
+    let owner_pk_hash =
+        bytes_to_be_words_48(&sha384(image.manifest.preamble.owner_pub_keys.as_bytes()));
+
+    let image_info = vec![
+        ImageInfo::new(
+            StackRange::new(ROM_STACK_ORG + ROM_STACK_SIZE, ROM_STACK_ORG),
+            CodeRange::new(ROM_ORG, ROM_ORG + ROM_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(FMC_ORG, FMC_ORG + FMC_SIZE),
+        ),
+        ImageInfo::new(
+            StackRange::new(STACK_ORG + STACK_SIZE, STACK_ORG),
+            CodeRange::new(RUNTIME_ORG, RUNTIME_ORG + RUNTIME_SIZE),
+        ),
+    ];
+    let rom = caliptra_builder::rom_for_fw_integration_tests().unwrap();
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            security_state,
+            stack_info: Some(StackInfo::new(image_info)),
+            ..Default::default()
+        },
+        BootParams {
+            fw_image: Some(&image.to_bytes().unwrap()),
+            fuses: Fuses {
+                key_manifest_pk_hash: vendor_pk_hash,
+                owner_pk_hash,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+
+    model
+}
+
 pub fn run_rt_test_base(args: RuntimeTestArgs, lms_verify: bool) -> (DefaultHwModel, ImageBundle) {
     let default_rt_fwid = if cfg!(feature = "fpga_realtime") {
         &APP_WITH_UART_FPGA

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended.rs
@@ -17,6 +17,8 @@ use x509_parser::{
 };
 use zerocopy::IntoBytes;
 
+use zerocopy::FromZeros;
+
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs, TEST_LABEL};
 
 #[test]
@@ -226,4 +228,79 @@ fn test_dmtf_other_name_extension_not_present() {
     )
     .unwrap();
     assert!(cert.subject_alternative_name().unwrap().is_none());
+}
+
+#[test]
+fn test_certify_key_extended_different_labels_produce_different_keys() {
+    const OTHER_LABEL: [u8; 48] = [0xab; 48];
+
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let cmd_a = CertifyKeyP384Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    let mut req = MailboxReq::CertifyKeyExtended(CertifyKeyExtendedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        certify_key_req: cmd_a.as_bytes().try_into().unwrap(),
+        flags: CertifyKeyExtendedFlags::empty(),
+    });
+    req.populate_chksum().unwrap();
+    let resp_a = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED),
+            req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("expected a response for call A");
+    let mut outer_a = CertifyKeyExtendedResp::new_zeroed();
+    outer_a.as_mut_bytes()[..resp_a.len()].copy_from_slice(&resp_a);
+    let dpe_a = Response::try_read_from_bytes(
+        &Command::from(&CertifyKeyCommand::P384(&cmd_a)),
+        &outer_a.certify_key_resp,
+    )
+    .unwrap();
+    let Response::CertifyKey(CertifyKeyResp::P384(inner_a)) = dpe_a else {
+        panic!("wrong response type for call A");
+    };
+
+    let cmd_b = CertifyKeyP384Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: OTHER_LABEL,
+    };
+    let mut req = MailboxReq::CertifyKeyExtended(CertifyKeyExtendedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        certify_key_req: cmd_b.as_bytes().try_into().unwrap(),
+        flags: CertifyKeyExtendedFlags::empty(),
+    });
+    req.populate_chksum().unwrap();
+    let resp_b = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED),
+            req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("expected a response for call B");
+    let mut outer_b = CertifyKeyExtendedResp::new_zeroed();
+    outer_b.as_mut_bytes()[..resp_b.len()].copy_from_slice(&resp_b);
+    let dpe_b = Response::try_read_from_bytes(
+        &Command::from(&CertifyKeyCommand::P384(&cmd_b)),
+        &outer_b.certify_key_resp,
+    )
+    .unwrap();
+    let Response::CertifyKey(CertifyKeyResp::P384(inner_b)) = dpe_b else {
+        panic!("wrong response type for call B");
+    };
+
+    assert_ne!(
+        inner_a.header.derived_pubkey_x, inner_b.header.derived_pubkey_x,
+        "different labels must produce different derived P-384 public keys"
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
@@ -1,15 +1,47 @@
 // Licensed under the Apache-2.0 license
 
+use caliptra_api::SocManager;
+use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{
-    CertifyKeyExtendedFlags, CertifyKeyExtendedMldsa87Req, CommandId, MailboxReq, MailboxReqHeader,
+    AddSubjectAltNameReq, CertifyKeyExtendedFlags, CertifyKeyExtendedMldsa87Req,
+    CertifyKeyExtendedMldsa87Resp, CommandId, MailboxReq, MailboxReqHeader, SetPqSeedReq,
+    SET_PQ_SEED_SEED_SIZE,
 };
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::HwModel;
+use caliptra_hw_model::{DefaultHwModel, HwModel};
+use caliptra_runtime::{AddSubjectAltNameCmd, RtBootStatus};
+use cms::{
+    cert::x509::der::{Decode, Encode},
+    content_info::{CmsVersion, ContentInfo},
+    signed_data::SignedData,
+};
+use dpe::{
+    commands::{CertifyKeyCommand, CertifyKeyFlags, CertifyKeyMldsa87Cmd, Command},
+    context::ContextHandle,
+    response::{CertifyKeyResp, Response},
+};
+use x509_parser::{certificate::X509Certificate, extensions::GeneralName, prelude::FromDer};
+use zerocopy::{FromZeros, IntoBytes};
 
-use crate::common::{assert_error, run_pqc_rt_test};
+use crate::common::{
+    assert_error, run_pqc_rt_test, run_pqc_rt_test_wdt, run_rt_test, RuntimeTestArgs, TEST_LABEL,
+};
 
+/// Provision the PQ.DevID seed (as PL0) so PQC mode is enabled.
+fn provision_pq_seed(model: &mut DefaultHwModel) {
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap();
+}
+
+/// Without SET_PQ_SEED there is no PQ.DevID identity, so the command must reject.
 #[test]
-fn test_certify_key_extended_mldsa87_unimplemented() {
+fn test_certify_key_extended_mldsa87_not_initialized() {
     let mut model = run_pqc_rt_test();
 
     let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
@@ -25,9 +57,357 @@ fn test_certify_key_extended_mldsa87_unimplemented() {
             cmd.as_bytes().unwrap(),
         )
         .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_PQC_NOT_INITIALIZED, resp);
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let certify_key_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        flags: CertifyKeyExtendedFlags::empty(),
+        certify_key_req: certify_key_cmd.as_bytes().try_into().unwrap(),
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("expected a response");
+
+    // The full response is large (~25 KB); box it to keep it off the stack.
+    let mut certify_key_extended_resp = Box::new(CertifyKeyExtendedMldsa87Resp::new_zeroed());
+    certify_key_extended_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+
+    let dpe_resp = Response::try_read_from_bytes(
+        &Command::from(&CertifyKeyCommand::Mldsa87(&certify_key_cmd)),
+        &certify_key_extended_resp.certify_key_resp,
+    )
+    .unwrap();
+    let Response::CertifyKey(CertifyKeyResp::Mldsa87(certify_key_resp)) = dpe_resp else {
+        panic!("Wrong response type!");
+    };
+
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
+    // An ML-DSA-87 leaf cert (2,592-byte key + 4,627-byte signature) is large;
+    // a value this size confirms it is the ML-DSA identity, not ECDSA.
+    assert!(
+        cert_bytes.len() > 7000,
+        "unexpectedly small ML-DSA-87 cert: {} bytes",
+        cert_bytes.len()
+    );
+    // Must be a well-formed DER certificate.
+    X509Certificate::from_der(cert_bytes).unwrap();
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_within_wdt() {
+    let mut model = run_pqc_rt_test_wdt();
+    provision_pq_seed(&mut model);
+
+    let certify_key_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        flags: CertifyKeyExtendedFlags::empty(),
+        certify_key_req: certify_key_cmd.as_bytes().try_into().unwrap(),
+    });
+    cmd.populate_chksum().unwrap();
+
+    // Must complete (within the WDT budget) and return a response.
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("CERTIFY_KEY_EXTENDED_MLDSA87 tripped the watchdog (over budget)")
+        .expect("expected a response");
+
+    // No fatal error should have been recorded.
+    assert_eq!(model.soc_ifc().cptra_fw_error_fatal().read(), 0);
+
+    let mut certify_key_extended_resp = Box::new(CertifyKeyExtendedMldsa87Resp::new_zeroed());
+    certify_key_extended_resp.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+
+    let dpe_resp = Response::try_read_from_bytes(
+        &Command::from(&CertifyKeyCommand::Mldsa87(&certify_key_cmd)),
+        &certify_key_extended_resp.certify_key_resp,
+    )
+    .unwrap();
+    let Response::CertifyKey(CertifyKeyResp::Mldsa87(certify_key_resp)) = dpe_resp else {
+        panic!("Wrong response type!");
+    };
+
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
+    X509Certificate::from_der(cert_bytes).unwrap();
+}
+
+// Helper: execute CERTIFY_KEY_EXTENDED_MLDSA87 and return the boxed outer
+// response.  Boxes the response to keep the large ML-DSA cert off the stack.
+fn run_certify_key_mldsa87(
+    model: &mut DefaultHwModel,
+    certify_key_cmd: &CertifyKeyMldsa87Cmd,
+    flags: CertifyKeyExtendedFlags,
+) -> Box<CertifyKeyExtendedMldsa87Resp> {
+    let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        flags,
+        certify_key_req: certify_key_cmd.as_bytes().try_into().unwrap(),
+    });
+    cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("expected a response");
+    let mut out = Box::new(CertifyKeyExtendedMldsa87Resp::new_zeroed());
+    out.as_mut_bytes()[..resp.len()].copy_from_slice(&resp);
+    out
+}
+
+// Helper: parse the DPE certify-key bytes out of the boxed outer response.
+fn parse_mldsa87_dpe_resp<'a>(
+    certify_key_cmd: &'a CertifyKeyMldsa87Cmd,
+    outer: &'a CertifyKeyExtendedMldsa87Resp,
+) -> dpe::response::CertifyKeyMldsa87Resp {
+    let dpe_resp = Response::try_read_from_bytes(
+        &Command::from(&CertifyKeyCommand::Mldsa87(certify_key_cmd)),
+        &outer.certify_key_resp,
+    )
+    .unwrap();
+    let Response::CertifyKey(CertifyKeyResp::Mldsa87(inner)) = dpe_resp else {
+        panic!("wrong response type");
+    };
+    inner
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_dmtf_other_name_present() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let dmtf_device_info_utf8 = "ChipsAlliance:Caliptra:0123456789";
+    let dmtf_device_info_bytes = dmtf_device_info_utf8.as_bytes();
+    let mut dmtf_device_info = [0u8; AddSubjectAltNameReq::MAX_DEVICE_INFO_LEN];
+    dmtf_device_info[..dmtf_device_info_bytes.len()].copy_from_slice(dmtf_device_info_bytes);
+    let mut cmd = MailboxReq::AddSubjectAltName(AddSubjectAltNameReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        dmtf_device_info_size: dmtf_device_info_bytes.len() as u32,
+        dmtf_device_info,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::ADD_SUBJECT_ALT_NAME),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("ADD_SUBJECT_ALT_NAME should succeed");
+
+    let certify_key_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    let outer = run_certify_key_mldsa87(
+        &mut model,
+        &certify_key_cmd,
+        CertifyKeyExtendedFlags::DMTF_OTHER_NAME,
+    );
+    let inner = parse_mldsa87_dpe_resp(&certify_key_cmd, &outer);
+
+    let cert_bytes = &inner.cert[..inner.header.cert_size as usize];
+    let (_, cert) = X509Certificate::from_der(cert_bytes).unwrap();
+
+    let ext = cert.subject_alternative_name().unwrap().unwrap();
+    assert!(!ext.critical);
+    let san = ext.value;
+    assert_eq!(san.general_names.len(), 1);
+    let GeneralName::OtherName(oid, other_name_value) = san.general_names.first().unwrap() else {
+        panic!("wrong SubjectAlternativeName type");
+    };
+    assert_eq!(oid.as_bytes(), AddSubjectAltNameCmd::DMTF_OID);
+    // Skip the 4-byte DER encoding prefix (same convention as ECDSA variant test).
+    assert_eq!(&other_name_value[4..], dmtf_device_info_bytes);
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_dmtf_other_name_not_present() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let certify_key_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+
+    // Case 1: flag set but ADD_SUBJECT_ALT_NAME not yet called → no SAN extension.
+    let outer = run_certify_key_mldsa87(
+        &mut model,
+        &certify_key_cmd,
+        CertifyKeyExtendedFlags::DMTF_OTHER_NAME,
+    );
+    let inner = parse_mldsa87_dpe_resp(&certify_key_cmd, &outer);
+    let cert_bytes = &inner.cert[..inner.header.cert_size as usize];
+    let (_, cert) = X509Certificate::from_der(cert_bytes).unwrap();
+    assert!(cert.subject_alternative_name().unwrap().is_none());
+
+    // Populate DMTF device info.
+    let dmtf_device_info_utf8 = "ChipsAlliance:Caliptra:0123456789";
+    let dmtf_device_info_bytes = dmtf_device_info_utf8.as_bytes();
+    let mut dmtf_device_info = [0u8; AddSubjectAltNameReq::MAX_DEVICE_INFO_LEN];
+    dmtf_device_info[..dmtf_device_info_bytes.len()].copy_from_slice(dmtf_device_info_bytes);
+    let mut cmd = MailboxReq::AddSubjectAltName(AddSubjectAltNameReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        dmtf_device_info_size: dmtf_device_info_bytes.len() as u32,
+        dmtf_device_info,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::ADD_SUBJECT_ALT_NAME),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("ADD_SUBJECT_ALT_NAME should succeed");
+
+    // Case 2: ADD_SUBJECT_ALT_NAME called but flag not set → no SAN extension.
+    let outer = run_certify_key_mldsa87(
+        &mut model,
+        &certify_key_cmd,
+        CertifyKeyExtendedFlags::empty(),
+    );
+    let inner = parse_mldsa87_dpe_resp(&certify_key_cmd, &outer);
+    let cert_bytes = &inner.cert[..inner.header.cert_size as usize];
+    let (_, cert) = X509Certificate::from_der(cert_bytes).unwrap();
+    assert!(cert.subject_alternative_name().unwrap().is_none());
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_cannot_be_called_from_pl1() {
+    use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+
+    // Designate pauser 0x2 as PL0 so we can provision the PQ seed (which is
+    // also PL0-only) before switching to pauser 0x1 (PL1) for the actual test.
+    // The PL1 check is inside certify_key_extended.rs::certify_key(), which is
+    // only reached after the PQC-initialized guard passes.
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = Some(0x2);
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // Provision PQ seed from PL0 (pauser 0x2).
+    model.set_apb_pauser(0x2);
+    provision_pq_seed(&mut model);
+
+    // Switch to PL1 (pauser 0x1); the PQC guard now passes and the PL1 gate fires.
+    model.set_apb_pauser(0x1);
+    let mut cmd = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        flags: CertifyKeyExtendedFlags::empty(),
+        certify_key_req: [0u8; CertifyKeyExtendedMldsa87Req::CERTIFY_KEY_REQ_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
     assert_error(
         &mut model,
-        CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
         resp,
+    );
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_csr_format() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let certify_key_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_CSR,
+        label: TEST_LABEL,
+    };
+    let outer = run_certify_key_mldsa87(
+        &mut model,
+        &certify_key_cmd,
+        CertifyKeyExtendedFlags::empty(),
+    );
+    let inner = parse_mldsa87_dpe_resp(&certify_key_cmd, &outer);
+
+    let csr_bytes = &inner.cert[..inner.header.cert_size as usize];
+    assert!(!csr_bytes.is_empty(), "CSR output must be non-empty");
+
+    // DPE FORMAT_CSR output is a CMS SignedData (ContentInfo wrapper), not a
+    // PKCS#10 CSR.  Verify the envelope parses and has the expected structure.
+    let content_info =
+        ContentInfo::from_der(csr_bytes).expect("CSR output must be a DER ContentInfo");
+    let signed_data = SignedData::from_der(&content_info.content.to_der().unwrap())
+        .expect("ContentInfo must contain SignedData");
+    assert_eq!(signed_data.version, CmsVersion::V3);
+}
+
+#[test]
+fn test_certify_key_extended_mldsa87_different_labels_produce_different_keys() {
+    const OTHER_LABEL: [u8; 48] = [0xab; 48];
+
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let cmd_a = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    let outer_a = run_certify_key_mldsa87(&mut model, &cmd_a, CertifyKeyExtendedFlags::empty());
+    let inner_a = parse_mldsa87_dpe_resp(&cmd_a, &outer_a);
+    let pubkey_a = inner_a.header.pubkey;
+
+    let cmd_b = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: OTHER_LABEL,
+    };
+    let outer_b = run_certify_key_mldsa87(&mut model, &cmd_b, CertifyKeyExtendedFlags::empty());
+    let inner_b = parse_mldsa87_dpe_resp(&cmd_b, &outer_b);
+    let pubkey_b = inner_b.header.pubkey;
+
+    assert_ne!(
+        pubkey_a, pubkey_b,
+        "different labels must produce different derived ML-DSA-87 public keys"
     );
 }


### PR DESCRIPTION
Add support for the certify extended key command, including updates to the DpeCrypto to support the required implementation.  This includes a battery of unit tests validating the certify key functionality.