### PR TITLE
mldsa87: remove temporary on-stack copy of Vector8

### DIFF
--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -168,6 +168,12 @@ fn scalar_add(out: &mut Scalar, lhs: &Scalar, rhs: &Scalar) {
     }
 }
 
+fn scalar_add_assign(out: &mut Scalar, rhs: &Scalar) {
+    for i in 0..K_DEGREE {
+        out.c[i] = reduce_once(out.c[i].wrapping_add(rhs.c[i]));
+    }
+}
+
 fn scalar_sub(out: &mut Scalar, lhs: &Scalar, rhs: &Scalar) {
     for i in 0..K_DEGREE {
         out.c[i] = mod_sub(lhs.c[i], rhs.c[i]);
@@ -254,9 +260,9 @@ fn vector8_zero(out: &mut Vector8) {
     *out = Vector8::default();
 }
 
-fn vector8_add(out: &mut Vector8, lhs: &Vector8, rhs: &Vector8) {
+fn vector8_add_assign(out: &mut Vector8, rhs: &Vector8) {
     for i in 0..8 {
-        scalar_add(&mut out.v[i], &lhs.v[i], &rhs.v[i]);
+        scalar_add_assign(&mut out.v[i], &rhs.v[i]);
     }
 }
 
@@ -880,8 +886,7 @@ fn generate_key_internal(
         }
     }
 
-    let t0_copy = priv_key.t0_ntt;
-    vector8_add(&mut priv_key.t0_ntt, &t0_copy, s2_ntt);
+    vector8_add_assign(&mut priv_key.t0_ntt, s2_ntt);
 
     state = KeygenState::V8(Vector8::default());
     let t1 = match &mut state {


### PR DESCRIPTION
Currently `vector8_add(a, b, c)` performs the operation of `a = b + c` but requires 3 different references. However at its only callsite `a` and `b` point to the same vector so we have to store a copy on the stack, using about 8 KiB stack space. This commit replaces `vector8_add` with `vector8_add_assign` to perform `a += c` instead, removing the 8 KiB copy from stack.

The stack frame of function `generate_key_internal` reserved before this change was 0x41e0 (16864) bytes :
```
4000ee7a <_ZN14caliptra_mldsa7mldsa8721generate_key_internal17ha306696a845f07d0E>:
4000ee7a:       7111                    addi    sp,sp,-256
...
4000ee96:       6791                    lui     a5,0x4
4000ee98:       1e078793                addi    a5,a5,480 # 41e0 <DATA_SIZE+0x39e0>
4000ee9c:       40f10133                sub     sp,sp,a5
...
```

After this change the stack frame is now reduced to 0x21d0 (8656) bytes:
```
4000ee7a <_ZN14caliptra_mldsa7mldsa8721generate_key_internal17ha306696a845f07d0E>:
4000ee7a:       7111                    addi    sp,sp,-256
...
4000ee94:       6789                    lui     a5,0x2
4000ee96:       1d078793                addi    a5,a5,464 # 21d0 <DATA_SIZE+0x19d0>
4000ee9a:       40f10133                sub     sp,sp,a5
...
```