### PR TITLE
runtime: Harden DPE index cache

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -112,7 +112,10 @@ pub use pcr_reset::PcrResetCounter;
 pub use persistent::fmc_alias_csr::FmcAliasCsrs;
 pub use persistent::IDEVID_CSR_ENVELOP_MARKER;
 #[cfg(feature = "runtime")]
-pub use persistent::{AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles};
+pub use persistent::{
+    AuthManifestImageMetadataList, CaliptraManagedDpeContextIndices, ExportedCdiEntry,
+    ExportedCdiHandles,
+};
 pub use persistent::{
     Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, PcrLogArray,
     PersistentData, PersistentDataAccessor, StashMeasurementArray, ECC384_MAX_FMC_ALIAS_CSR_SIZE,

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -98,12 +98,48 @@ pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
 #[cfg(feature = "runtime")]
-#[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize, Default)]
+#[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct CaliptraManagedDpeContextIndices {
+    pub initialized: U8Bool,
     pub cciv: u8,
     pub mcu_rt: u8,
-    pub reserved: [u8; 2],
+    pub reserved: [u8; 1],
+}
+
+#[cfg(feature = "runtime")]
+impl CaliptraManagedDpeContextIndices {
+    pub const INVALID_INDEX: u8 = 0xff;
+
+    pub fn invalidate(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.initialized.get()
+    }
+
+    pub fn set_cciv(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.cciv = idx;
+    }
+
+    pub fn set_mcu_rt(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.mcu_rt = idx;
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl Default for CaliptraManagedDpeContextIndices {
+    fn default() -> Self {
+        Self {
+            initialized: U8Bool::new(false),
+            cciv: Self::INVALID_INDEX,
+            mcu_rt: Self::INVALID_INDEX,
+            reserved: [Self::INVALID_INDEX; 1],
+        }
+    }
 }
 
 #[derive(Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes, Zeroize)]

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -15,7 +15,7 @@ Abstract:
 use core::mem::offset_of;
 
 use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
-use crate::drivers::{McuFwStatus, McuResetReason};
+use crate::drivers::{CaliptraManagedDpeContext, McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
 use caliptra_api::mailbox::{AuthorizeAndStashReq, ImageHashSource};
@@ -223,7 +223,7 @@ impl ActivateFirmwareCmd {
             }
             drivers
                 .update_caliptra_managed_measurement(
-                    Drivers::MCU_RT_TCI_TYPE,
+                    CaliptraManagedDpeContext::McuRt,
                     &measurement,
                     Some(pl0_pauser_locality),
                 )

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -57,9 +57,9 @@ use caliptra_drivers::{
     hand_off::DataStore,
     pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
-    Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms, Mldsa87,
-    Mldsa87PubKey, PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha1, Sha256, Sha256Alg,
-    Sha2_512_384, Sha2_512_384Acc, SocIfc, Trng,
+    Aes, Array4x12, CaliptraError, CaliptraManagedDpeContextIndices, CaliptraResult, Ecc384, Hmac,
+    KeyId, KeyVault, Lms, Mldsa87, Mldsa87PubKey, PcrBank, PersistentDataAccessor, Pic,
+    ResetReason, Sha1, Sha256, Sha256Alg, Sha2_512_384, Sha2_512_384Acc, SocIfc, Trng,
 };
 use caliptra_drivers::{Dma, DmaMmio};
 use caliptra_image_types::ImageManifest;
@@ -95,6 +95,21 @@ pub enum McuResetReason {
 impl From<McuResetReason> for u32 {
     fn from(reason: McuResetReason) -> Self {
         reason as u32
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum CaliptraManagedDpeContext {
+    Cciv,
+    McuRt,
+}
+
+impl CaliptraManagedDpeContext {
+    fn tci_type(self) -> u32 {
+        match self {
+            Self::Cciv => Drivers::CCIV_TCI_TYPE,
+            Self::McuRt => Drivers::MCU_RT_TCI_TYPE,
+        }
     }
 }
 
@@ -229,21 +244,22 @@ impl Drivers {
         match reset_reason {
             ResetReason::ColdReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::ColdReset);
+                self.persistent_data
+                    .get_mut()
+                    .caliptra_managed_dpe_context_indices
+                    .invalidate();
                 Self::initialize_dpe(self)?;
                 if self.soc_ifc.subsystem_mode() {
                     RecoveryFlow::recovery_flow(self)?;
                 }
-                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::UpdateReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::UpdateReset);
                 Self::validate_dpe_structure(self)?;
                 Self::validate_context_tags(self)?;
+                self.init_dpe_index_cache()?;
                 Self::update_dpe_rt_tci(self)?;
                 Self::update_dpe_cciv(self)?;
-                // Repopulate appended context-index cache for hitless updates
-                // from older runtimes that did not have these persistent fields.
-                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::WarmReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::WarmReset);
@@ -321,22 +337,39 @@ impl Drivers {
     }
 
     #[inline(always)]
-    fn get_caliptra_managed_dpe_context_index(&self, tci_type: u32) -> CaliptraResult<usize> {
+    fn get_caliptra_managed_dpe_context_index(
+        &self,
+        context: CaliptraManagedDpeContext,
+    ) -> Option<usize> {
         let indices = self
             .persistent_data
             .get()
             .caliptra_managed_dpe_context_indices;
-        let idx = match tci_type {
-            Self::CCIV_TCI_TYPE => indices.cciv,
-            Self::MCU_RT_TCI_TYPE => indices.mcu_rt,
-            _ => return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND),
+
+        if !indices.is_initialized() {
+            return None;
+        }
+
+        let idx = match context {
+            CaliptraManagedDpeContext::Cciv => indices.cciv,
+            CaliptraManagedDpeContext::McuRt => indices.mcu_rt,
         };
 
-        Ok(idx as usize)
+        if idx == CaliptraManagedDpeContextIndices::INVALID_INDEX {
+            None
+        } else {
+            Some(idx as usize)
+        }
     }
 
-    fn cache_caliptra_managed_dpe_context_indices(&mut self) -> CaliptraResult<()> {
-        if self.persistent_data.get().attestation_disabled.get() {
+    fn init_dpe_index_cache(&mut self) -> CaliptraResult<()> {
+        if self.persistent_data.get().attestation_disabled.get()
+            || self
+                .persistent_data
+                .get()
+                .caliptra_managed_dpe_context_indices
+                .is_initialized()
+        {
             return Ok(());
         }
 
@@ -364,11 +397,14 @@ impl Drivers {
             .persistent_data
             .get_mut()
             .caliptra_managed_dpe_context_indices;
-        indices.cciv =
-            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        indices.set_cciv(
+            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        );
         if let Some(mcu_rt_idx) = mcu_rt_idx {
-            indices.mcu_rt = u8::try_from(mcu_rt_idx)
-                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            indices.set_mcu_rt(
+                u8::try_from(mcu_rt_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
         }
 
         Ok(())
@@ -378,32 +414,34 @@ impl Drivers {
     #[inline(never)]
     pub(crate) fn update_caliptra_managed_measurement(
         &mut self,
-        tci_type: u32,
+        caliptra_managed_context: CaliptraManagedDpeContext,
         measurement: &[u8; 48],
         locality: Option<u32>,
     ) -> CaliptraResult<()> {
-        let persistent_data = self.persistent_data.get();
-        let idx = self.get_caliptra_managed_dpe_context_index(tci_type)?;
-        let ctx = persistent_data
-            .state
-            .contexts
-            .get(idx)
-            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
-        if ctx.state == ContextState::Inactive
-            || ctx.context_type != ContextType::Normal
-            || ctx.tci.tci_type != tci_type
-            || locality.is_some_and(|locality| ctx.locality != locality)
-        {
-            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
-        }
-        let prev_journey = persistent_data
-            .state
-            .contexts
-            .get(idx)
-            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?
-            .tci
-            .tci_cumulative
-            .0;
+        let tci_type = caliptra_managed_context.tci_type();
+        let (idx, prev_journey) = {
+            let persistent_data = self.persistent_data.get();
+            let Some(idx) = self.get_caliptra_managed_dpe_context_index(caliptra_managed_context)
+            else {
+                return Ok(());
+            };
+            let ctx = persistent_data
+                .state
+                .contexts
+                .get(idx)
+                .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            if ctx.state == ContextState::Inactive
+                || ctx.context_type != ContextType::Normal
+                || ctx.tci.tci_type != tci_type
+                || locality.is_some_and(|locality| ctx.locality != locality)
+            {
+                return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
+            }
+            if ctx.tci.tci_current.0 == *measurement {
+                return Ok(());
+            }
+            (idx, ctx.tci.tci_cumulative.0)
+        };
 
         let mut digest_op = self.sha2_512_384.sha384_digest_init()?;
         digest_op.update(&prev_journey)?;
@@ -509,31 +547,8 @@ impl Drivers {
         }
         let initialization_values_hash: [u8; 48] =
             <[u8; 48]>::from(Self::compute_initialization_values_hash(drivers)?);
-        // Only update if changed
-        let dpe = &drivers.persistent_data.get().state;
-        let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
-        let cciv_idx =
-            Self::get_dpe_context_idx_by_tci_type(dpe, Self::CCIV_TCI_TYPE, None, Some(root_idx))?;
-        let cciv_ctx = drivers
-            .persistent_data
-            .get()
-            .state
-            .contexts
-            .get(cciv_idx)
-            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
-        if cciv_ctx.state == ContextState::Inactive
-            || cciv_ctx.context_type != ContextType::Normal
-            || cciv_ctx.tci.tci_type != Self::CCIV_TCI_TYPE
-        {
-            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
-        }
-        let prev_current: [u8; 48] = cciv_ctx.tci.tci_current.0;
-        if prev_current == initialization_values_hash {
-            return Ok(());
-        }
-
         drivers.update_caliptra_managed_measurement(
-            Self::CCIV_TCI_TYPE,
+            CaliptraManagedDpeContext::Cciv,
             &initialization_values_hash,
             None,
         )
@@ -759,12 +774,15 @@ impl Drivers {
             }
             Err(CaliptraError::RUNTIME_ADD_CCIV_MEASUREMENT_TO_DPE_FAILED)?
         }
-        pdata.caliptra_managed_dpe_context_indices.cciv = u8::try_from(
+        let cciv_idx = u8::try_from(
             env.state
                 .get_active_context_pos(&ContextHandle::default(), pl0_pauser_locality)
                 .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
         )
         .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        pdata
+            .caliptra_managed_dpe_context_indices
+            .set_cciv(cciv_idx);
 
         // Call DeriveContext to create TCIs for each measurement added in ROM
         let num_measurements = pdata.fht.meas_log_index as usize;

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -105,12 +105,13 @@ impl StashMeasurementCmd {
                     .state
                     .get_active_context_pos(&ContextHandle::default(), locality)
                     .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                let mcu_rt_dpe_context_idx = u8::try_from(mcu_rt_dpe_context_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
                 drivers
                     .persistent_data
                     .get_mut()
                     .caliptra_managed_dpe_context_indices
-                    .mcu_rt = u8::try_from(mcu_rt_dpe_context_idx)
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                    .set_mcu_rt(mcu_rt_dpe_context_idx);
             }
 
             // Extend the measurement into PCR31

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -334,16 +334,14 @@ fn test_activate_mcu_fw_success() {
     {
         let updated_mcu_tci = get_mcu_tci(&mut model);
         assert_eq!(updated_mcu_tci.tci_current, mcu_digest);
-
-        let mut hasher = Sha384::new();
-        hasher.update(initial_mcu_tci.tci_cumulative);
-        hasher.update(mcu_digest);
-        let expected_updated_cumulative: [u8; 48] = hasher.finalize().into();
-        assert_eq!(updated_mcu_tci.tci_cumulative, expected_updated_cumulative);
+        assert_eq!(
+            updated_mcu_tci.tci_cumulative,
+            initial_mcu_tci.tci_cumulative
+        );
     }
 }
 
-#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {


### PR DESCRIPTION
Follow-up to #3729.

- Update reset initializes the cache only if the marker is missing, supporting 2.1.1 -> 2.1.2 once, without rescanning on later 2.1.2+ updates.

- Switched cached-index users from raw u32 tci_type to CaliptraManagedDpeContext enum.

- Moved measurement unchanged check into update_caliptra_managed_measurement() so CCIV/MCFW no-op updates do not extend cumulative state.