### PR TITLE
Dpe soc manifest contexts

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -104,7 +104,9 @@ pub struct CaliptraManagedDpeContextIndices {
     pub initialized: U8Bool,
     pub cciv: u8,
     pub mcu_rt: u8,
-    pub reserved: [u8; 1],
+    pub somv: u8,
+    pub somo: u8,
+    pub reserved: [u8; 3],
 }
 
 #[cfg(feature = "runtime")]
@@ -128,6 +130,16 @@ impl CaliptraManagedDpeContextIndices {
         self.initialized = U8Bool::new(true);
         self.mcu_rt = idx;
     }
+
+    pub fn set_somv(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.somv = idx;
+    }
+
+    pub fn set_somo(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.somo = idx;
+    }
 }
 
 #[cfg(feature = "runtime")]
@@ -137,7 +149,9 @@ impl Default for CaliptraManagedDpeContextIndices {
             initialized: U8Bool::new(false),
             cciv: Self::INVALID_INDEX,
             mcu_rt: Self::INVALID_INDEX,
-            reserved: [Self::INVALID_INDEX; 1],
+            somv: Self::INVALID_INDEX,
+            somo: Self::INVALID_INDEX,
+            reserved: [Self::INVALID_INDEX; 3],
         }
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -19,7 +19,7 @@ use crate::debug_unlock::ProductionDebugUnlock;
 use crate::dpe_crypto::DpeCrypto;
 #[cfg(feature = "fips_self_test")]
 pub use crate::fips::fips_self_test_cmd::SelfTestStatus;
-use crate::invoke_dpe::dpe_error_detail;
+use crate::invoke_dpe::{dpe_error_detail, invoke_dpe_cmd};
 use crate::recovery_flow::RecoveryFlow;
 use crate::{
     dice, CaliptraDpeEnv, CaliptraDpeProfile, DisableAttestationCmd, DpePlatform, Mailbox,
@@ -38,7 +38,7 @@ use caliptra_common::cfi_check;
 use caliptra_common::crypto::Crypto;
 use caliptra_common::dice::{copy_ldevid_ecc384_cert, copy_ldevid_mldsa87_cert};
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
-use caliptra_dpe::commands::DeriveContextCmd;
+use caliptra_dpe::commands::{Command, DeriveContextCmd};
 use caliptra_dpe::context::{Context, ContextState, ContextType};
 use caliptra_dpe::response::DeriveContextResp;
 use caliptra_dpe::tci::TciMeasurement;
@@ -73,7 +73,10 @@ use caliptra_registers::{
 use caliptra_ureg::MmioMut;
 use caliptra_x509::{NotAfter, NotBefore};
 
-use core::cmp::Ordering::{Equal, Greater};
+use core::{
+    cmp::Ordering::{Equal, Greater},
+    mem::size_of,
+};
 use zerocopy::IntoBytes;
 
 pub const MCI_TOP_REG_RESET_REASON_OFFSET: u32 = 0x38;
@@ -101,6 +104,8 @@ impl From<McuResetReason> for u32 {
 #[derive(Clone, Copy)]
 pub(crate) enum CaliptraManagedDpeContext {
     Cciv,
+    Somv,
+    Somo,
     McuRt,
 }
 
@@ -108,7 +113,27 @@ impl CaliptraManagedDpeContext {
     fn tci_type(self) -> u32 {
         match self {
             Self::Cciv => Drivers::CCIV_TCI_TYPE,
+            Self::Somv => Drivers::SOMV_TCI_TYPE,
+            Self::Somo => Drivers::SOMO_TCI_TYPE,
             Self::McuRt => Drivers::MCU_RT_TCI_TYPE,
+        }
+    }
+
+    fn cached_index(self, indices: &CaliptraManagedDpeContextIndices) -> u8 {
+        match self {
+            Self::Cciv => indices.cciv,
+            Self::Somv => indices.somv,
+            Self::Somo => indices.somo,
+            Self::McuRt => indices.mcu_rt,
+        }
+    }
+
+    fn set_cached_index(self, indices: &mut CaliptraManagedDpeContextIndices, idx: u8) {
+        match self {
+            Self::Cciv => indices.set_cciv(idx),
+            Self::Somv => indices.set_somv(idx),
+            Self::Somo => indices.set_somo(idx),
+            Self::McuRt => indices.set_mcu_rt(idx),
         }
     }
 }
@@ -183,6 +208,8 @@ pub struct Drivers {
 
 impl Drivers {
     pub const CCIV_TCI_TYPE: u32 = u32::from_be_bytes(*b"CCIV");
+    pub const SOMV_TCI_TYPE: u32 = u32::from_be_bytes(*b"SOMV");
+    pub const SOMO_TCI_TYPE: u32 = u32::from_be_bytes(*b"SOMO");
     pub const MCU_RT_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
 
     /// # Safety
@@ -350,10 +377,7 @@ impl Drivers {
             return None;
         }
 
-        let idx = match context {
-            CaliptraManagedDpeContext::Cciv => indices.cciv,
-            CaliptraManagedDpeContext::McuRt => indices.mcu_rt,
-        };
+        let idx = context.cached_index(&indices);
 
         if idx == CaliptraManagedDpeContextIndices::INVALID_INDEX {
             None
@@ -373,7 +397,7 @@ impl Drivers {
             return Ok(());
         }
 
-        let (cciv_idx, mcu_rt_idx) = {
+        let (cciv_idx, somv_idx, somo_idx, mcu_rt_idx) = {
             let persistent_data = self.persistent_data.get();
             let dpe = &persistent_data.state;
             let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
@@ -383,6 +407,10 @@ impl Drivers {
                 None,
                 Some(root_idx),
             )?;
+            let somv_idx =
+                Self::get_dpe_context_idx_by_tci_type(dpe, Self::SOMV_TCI_TYPE, None, None).ok();
+            let somo_idx =
+                Self::get_dpe_context_idx_by_tci_type(dpe, Self::SOMO_TCI_TYPE, None, None).ok();
             let mcu_rt_idx = Self::get_dpe_context_idx_by_tci_type(
                 dpe,
                 Self::MCU_RT_TCI_TYPE,
@@ -390,7 +418,7 @@ impl Drivers {
                 None,
             )
             .ok();
-            (cciv_idx, mcu_rt_idx)
+            (cciv_idx, somv_idx, somo_idx, mcu_rt_idx)
         };
 
         let indices = &mut self
@@ -400,6 +428,16 @@ impl Drivers {
         indices.set_cciv(
             u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
         );
+        if let Some(somv_idx) = somv_idx {
+            indices.set_somv(
+                u8::try_from(somv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
+        }
+        if let Some(somo_idx) = somo_idx {
+            indices.set_somo(
+                u8::try_from(somo_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
+        }
         if let Some(mcu_rt_idx) = mcu_rt_idx {
             indices.set_mcu_rt(
                 u8::try_from(mcu_rt_idx)
@@ -407,6 +445,89 @@ impl Drivers {
             );
         }
 
+        Ok(())
+    }
+
+    pub(crate) fn create_or_update_caliptra_managed_measurement(
+        &mut self,
+        caliptra_managed_context: CaliptraManagedDpeContext,
+        measurement: &[u8; 48],
+        svn: u32,
+        locality: u32,
+        create_if_missing: bool,
+    ) -> CaliptraResult<()> {
+        if self
+            .get_caliptra_managed_dpe_context_index(caliptra_managed_context)
+            .is_some()
+        {
+            return self.update_caliptra_managed_measurement(
+                caliptra_managed_context,
+                measurement,
+                Some(locality),
+            );
+        }
+
+        if !create_if_missing {
+            return Ok(());
+        }
+
+        // Creating missing Caliptra-managed contexts is only used during recovery
+        // boot before MCFW is created. Hitless update paths update existing cached
+        // contexts only. Behavior is unspecified for existing chains that do not
+        // already contain SOMV/SOMO, so runtime does not insert them mid-chain.
+        self.is_dpe_context_threshold_exceeded(PauserPrivileges::PL0)?;
+
+        let flags = DeriveContextFlags::MAKE_DEFAULT
+            | DeriveContextFlags::CHANGE_LOCALITY
+            | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
+            | DeriveContextFlags::INPUT_ALLOW_X509
+            | DeriveContextFlags::ALLOW_RECURSIVE;
+        let cmd = DeriveContextCmd {
+            handle: ContextHandle::default(),
+            data: TciMeasurement(*measurement),
+            flags,
+            tci_type: caliptra_managed_context.tci_type(),
+            target_locality: locality,
+            svn,
+        };
+        let cmd = &Command::from(&cmd);
+        let mut resp_buf = [0u8; size_of::<DeriveContextResp>()];
+        let ueid = Some(self.soc_ifc.fuse_bank().ueid());
+        invoke_dpe_cmd(
+            CaliptraDpeProfile::Ecc384,
+            self,
+            cmd,
+            None,
+            ueid,
+            Some(locality),
+            &mut resp_buf,
+        )
+        .map_err(|e| {
+            if let Some(ext_err) = dpe_error_detail(&e) {
+                self.soc_ifc.set_fw_extended_error(ext_err);
+            }
+            CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR
+        })?;
+
+        let idx = u8::try_from(
+            self.persistent_data
+                .get()
+                .state
+                .get_active_context_pos(&ContextHandle::default(), locality)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        let indices = &mut self
+            .persistent_data
+            .get_mut()
+            .caliptra_managed_dpe_context_indices;
+        caliptra_managed_context.set_cached_index(indices, idx);
+
+        self.pcr_bank.extend_pcr(
+            PCR_ID_STASH_MEASUREMENT,
+            &mut self.sha2_512_384,
+            measurement,
+        )?;
         Ok(())
     }
 

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -15,7 +15,7 @@ Abstract:
 use crate::{
     authorize_and_stash::AuthorizeAndStashCmd,
     drivers::{McuFwStatus, McuResetReason},
-    set_auth_manifest::AuthManifestSource,
+    set_auth_manifest::{AuthManifestSource, AuthManifestUpdateMode},
     Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
 };
 #[cfg(feature = "cfi")]
@@ -81,9 +81,12 @@ impl RecoveryFlow {
         };
         result?;
 
-        if let Err(err) =
-            SetAuthManifestCmd::set_auth_manifest(drivers, AuthManifestSource::Mailbox, false)
-        {
+        if let Err(err) = SetAuthManifestCmd::set_auth_manifest(
+            drivers,
+            AuthManifestSource::Mailbox,
+            false,
+            AuthManifestUpdateMode::CreateMissingDpeContexts,
+        ) {
             let recovery_reason = DmaRecovery::recovery_reason_from_auth_manifest_error(err);
             Self::set_recovery_boot_failure(drivers, SOC_MANIFEST_INDEX, recovery_reason)?;
             return Err(err);

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,7 +15,7 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::Drivers;
+use crate::{drivers::CaliptraManagedDpeContext, Drivers};
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, AUTH_MANIFEST_MARKER,
@@ -44,6 +44,12 @@ pub(crate) enum AuthManifestSource<'a> {
     Slice(&'a [u8]),
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum AuthManifestUpdateMode {
+    UpdateExisting,
+    CreateMissingDpeContexts,
+}
+
 pub struct SetAuthManifestCmd;
 impl SetAuthManifestCmd {
     fn sha384_digest(
@@ -67,6 +73,56 @@ impl SetAuthManifestCmd {
             .ok_or(err)?
             .get(..len as usize)
             .ok_or(err)
+    }
+
+    fn digest_to_measurement(digest: &ImageDigest384) -> [u8; SHA384_DIGEST_BYTE_SIZE] {
+        Array4x12::from(digest).into()
+    }
+
+    fn update_soc_manifest_dpe_contexts(
+        drivers: &mut Drivers,
+        auth_manifest_preamble: &AuthManifestPreamble,
+        update_mode: AuthManifestUpdateMode,
+    ) -> CaliptraResult<()> {
+        if drivers.persistent_data.get().attestation_disabled.get() {
+            return Ok(());
+        }
+
+        let create_if_missing = matches!(
+            update_mode,
+            AuthManifestUpdateMode::CreateMissingDpeContexts
+        );
+        let manifest_bytes = auth_manifest_preamble.as_bytes();
+        let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+        let vendor_measurement = Self::digest_to_measurement(&Self::sha384_digest(
+            &mut drivers.sha2_512_384,
+            manifest_bytes,
+            vendor_range.start,
+            vendor_range.len() as u32,
+        )?);
+        let owner_range = AuthManifestPreamble::owner_pub_keys_range();
+        let owner_measurement = Self::digest_to_measurement(&Self::sha384_digest(
+            &mut drivers.sha2_512_384,
+            manifest_bytes,
+            owner_range.start,
+            owner_range.len() as u32,
+        )?);
+        let pl0_pauser_locality = drivers.persistent_data.get().manifest1.header.pl0_pauser;
+
+        drivers.create_or_update_caliptra_managed_measurement(
+            CaliptraManagedDpeContext::Somv,
+            &vendor_measurement,
+            auth_manifest_preamble.svn,
+            pl0_pauser_locality,
+            create_if_missing,
+        )?;
+        drivers.create_or_update_caliptra_managed_measurement(
+            CaliptraManagedDpeContext::Somo,
+            &owner_measurement,
+            0,
+            pl0_pauser_locality,
+            create_if_missing,
+        )
     }
 
     fn ecc384_verify(
@@ -707,6 +763,7 @@ impl SetAuthManifestCmd {
             drivers,
             AuthManifestSource::Slice(manifest_buf),
             verify_only,
+            AuthManifestUpdateMode::UpdateExisting,
         )?;
         Ok(0)
     }
@@ -715,6 +772,7 @@ impl SetAuthManifestCmd {
         drivers: &mut Drivers,
         manifest_src: AuthManifestSource,
         verify_only: bool,
+        update_mode: AuthManifestUpdateMode,
     ) -> CaliptraResult<()> {
         let manifest_buf = match manifest_src {
             AuthManifestSource::Mailbox => drivers.mbox.raw_mailbox_contents(),
@@ -724,7 +782,7 @@ impl SetAuthManifestCmd {
         let auth_manifest_preamble = {
             let err = CaliptraError::RUNTIME_AUTH_MANIFEST_PREAMBLE_SIZE_LT_MIN;
             let bytes = manifest_buf.get(..preamble_size).ok_or(err)?;
-            AuthManifestPreamble::ref_from_bytes(bytes).map_err(|_| err)?
+            *AuthManifestPreamble::ref_from_bytes(bytes).map_err(|_| err)?
         };
 
         // Check if the preamble has the required marker.
@@ -747,7 +805,7 @@ impl SetAuthManifestCmd {
         let persistent_data = drivers.persistent_data.get_mut();
         // Verify the vendor signed data (vendor public keys + flags).
         Self::verify_vendor_signed_data(
-            auth_manifest_preamble,
+            &auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
@@ -758,7 +816,7 @@ impl SetAuthManifestCmd {
 
         // Verify the owner public keys.
         Self::verify_owner_pub_keys(
-            auth_manifest_preamble,
+            &auth_manifest_preamble,
             &persistent_data.manifest1.preamble,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
@@ -771,7 +829,7 @@ impl SetAuthManifestCmd {
             manifest_buf
                 .get(preamble_size..)
                 .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
-            auth_manifest_preamble,
+            &auth_manifest_preamble,
             &mut persistent_data.auth_manifest_image_metadata_col,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
@@ -782,12 +840,13 @@ impl SetAuthManifestCmd {
         )?;
 
         if !verify_only {
-            persistent_data.auth_manifest_digest =
-                drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            let auth_manifest_digest = drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            drivers.persistent_data.get_mut().auth_manifest_digest = auth_manifest_digest;
             // Store the SoC manifest SVN for use as the MCU RT current_svn
             // when creating the MCU RT DPE context during recovery boot or
             // hitless update.
-            persistent_data.soc_manifest_svn = auth_manifest_preamble.svn;
+            drivers.persistent_data.get_mut().soc_manifest_svn = auth_manifest_preamble.svn;
+            Self::update_soc_manifest_dpe_contexts(drivers, &auth_manifest_preamble, update_mode)?;
         }
         Ok(())
     }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -7,7 +7,7 @@ use caliptra_api::{
     SocManager,
 };
 use caliptra_auth_man_types::{
-    AuthManifestImageMetadata, AuthorizationManifest, ImageMetadataFlags,
+    AuthManifestImageMetadata, AuthManifestPreamble, AuthorizationManifest, ImageMetadataFlags,
 };
 use caliptra_builder::{
     firmware::{APP_WITH_UART, APP_WITH_UART_FPGA, FMC_WITH_UART},
@@ -56,6 +56,7 @@ use openssl::{
     x509::{X509Builder, X509},
     x509::{X509Name, X509NameBuilder},
 };
+use sha2::{Digest as Sha2DigestTrait, Sha384 as Sha384Hasher};
 use std::borrow::Cow;
 use std::io;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -108,6 +109,30 @@ fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> Aut
 pub fn default_soc_manifest_bytes(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> Vec<u8> {
     let manifest = default_soc_manifest(pqc_key_type, svn);
     manifest.as_bytes().to_vec()
+}
+
+pub fn soc_manifest_measurements(manifest: &AuthorizationManifest) -> ([u8; 48], [u8; 48]) {
+    let preamble = manifest.preamble.as_bytes();
+    let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+    let owner_range = AuthManifestPreamble::owner_pub_keys_range();
+    (
+        Sha384Hasher::digest(&preamble[vendor_range.start as usize..vendor_range.end as usize])
+            .into(),
+        Sha384Hasher::digest(&preamble[owner_range.start as usize..owner_range.end as usize])
+            .into(),
+    )
+}
+
+pub fn default_soc_manifest_measurements(
+    pqc_key_type: FwVerificationPqcKeyType,
+    svn: u32,
+) -> ([u8; 48], [u8; 48]) {
+    let manifest = default_soc_manifest(pqc_key_type, svn);
+    soc_manifest_measurements(&manifest)
+}
+
+pub fn default_lms_soc_manifest_measurements(svn: u32) -> ([u8; 48], [u8; 48]) {
+    default_soc_manifest_measurements(FwVerificationPqcKeyType::LMS, svn)
 }
 
 pub fn test_upload_firmware<T: HwModel>(

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,6 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    soc_manifest_measurements, RuntimeTestArgs,
+};
 use crate::test_set_auth_manifest::{
     create_auth_manifest, create_auth_manifest_with_metadata, AuthManifestBuilderCfg,
 };
@@ -219,6 +222,9 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
@@ -285,6 +291,14 @@ fn test_authorize_and_stash_cmd_success() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
+            manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            svn: 1,
+        });
+        let (somv_measurement, somo_measurement) = soc_manifest_measurements(&auth_manifest);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -14,7 +14,8 @@ use sha2::{Digest, Sha384};
 use zerocopy::IntoBytes;
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, run_rt_test, run_rt_test_return_fw, RuntimeTestArgs,
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements,
+    default_soc_manifest_measurements, run_rt_test, run_rt_test_return_fw, RuntimeTestArgs,
     DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQC_KEY_TYPE,
 };
 
@@ -188,6 +189,9 @@ fn test_boot_tci_data() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
@@ -270,8 +274,12 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
         hasher.update(cptra_config_init_vals_hash);
         hasher.update(measurement);
         if model.subsystem_mode() {
+            let (somv_measurement, somo_measurement) =
+                default_soc_manifest_measurements(*pqc_key_type, 1);
             let mut mcu_hasher = Sha384::new();
             mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+            hasher.update(somv_measurement);
+            hasher.update(somo_measurement);
             hasher.update(mcu_hasher.finalize());
         }
         let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -489,7 +489,7 @@ fn test_export_cdi_destroyed_root_context() {
 
 #[test]
 #[cfg_attr(feature = "fpga_realtime", ignore)]
-fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
+fn test_subsystem_leaf_cert_contains_caliptra_managed_tci_types() {
     let mut model = run_rt_test(RuntimeTestArgs {
         subsystem_mode: true,
         ..Default::default()
@@ -519,10 +519,15 @@ fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
 
     let parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
 
-    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
-    let found_mcfw = parsed_tcb_infos
-        .filter(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
-        .count()
-        == 1;
-    assert!(found_mcfw);
+    let tcb_infos: Vec<TcbInfo> = parsed_tcb_infos.collect();
+    for expected_tci_type in [b"SOMV", b"SOMO", b"MCFW"] {
+        let expected_tci_type = u32::from_be_bytes(*expected_tci_type);
+        assert_eq!(
+            tcb_infos
+                .iter()
+                .filter(|tcb_info| tcb_info.tci_type == Some(expected_tci_type.as_bytes()))
+                .count(),
+            1
+        );
+    }
 }

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -68,12 +68,10 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     let mut handle = rotate_ctx_resp.handle;
 
     // Call DeriveContext with PL0 enough times to breach the threshold on the last iteration.
-    // 2 PL0 contexts are used by default by Caliptra. When we initialize DPE, we measure mailbox valid pausers in pl0_pauser's locality.
-    // The RT Journey measurement also is counted against PL0's limit. Thus, we can call derive child
-    // from PL0 exactly 14 times, and the last iteration of this loop, is expected to throw a threshold reached error.
+    // Caliptra-owned PL0 contexts consume part of the PL0 threshold before mailbox commands run.
     let num_iterations = if model.subsystem_mode() {
-        // Subsystem uses a context for the MCU FW
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        // Subsystem uses contexts for SOMV, SOMO, and MCU FW.
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 4
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -189,9 +187,9 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // 2 PL0 contexts are used by Caliptra
+    // Caliptra-owned PL0 contexts consume part of the PL0 threshold before mailbox commands run.
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 4
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -671,10 +669,10 @@ fn test_stash_measurement_pl_context_thresholds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // Root node and RT journey (which is technically the Caliptra locality) count as PL0
-    // In subsystem mode, the MCU FW is also measured into a PL0 context.
+    // Root node and RT journey (which is technically the Caliptra locality) count as PL0.
+    // In subsystem mode, SOMV, SOMO, and MCU FW are also measured into PL0 contexts.
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 5
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
     };
@@ -719,12 +717,11 @@ fn test_measurement_log_pl_context_threshold() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // Upload (PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1) measurements to measurement log
-    // Since 2 measurements taken by Caliptra upon startup, this will cause
-    // the PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD to be breached.
+    // Upload enough measurements to the measurement log to breach the PL0 DPE context threshold
+    // after accounting for Caliptra-owned startup contexts.
     let invocations = if model.subsystem_mode() {
-        // MCU uses an extra DPE context
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
+        // SOMV, SOMO, and MCU FW use extra DPE contexts.
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 4
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };

--- a/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
+++ b/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
@@ -21,9 +21,10 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
         ..Default::default()
     };
 
-    // In subsystem mode, Caliptra uses 3 base PL0 contexts (root + RT journey + MCU FW);
+    // In subsystem mode, Caliptra uses 5 base PL0 contexts
+    // (root + RT journey + SOMV + SOMO + MCU FW);
     // otherwise, 2 (root + RT journey).
-    let caliptra_base_pl0: u32 = if model.subsystem_mode() { 3 } else { 2 };
+    let caliptra_base_pl0: u32 = if model.subsystem_mode() { 5 } else { 2 };
 
     // Fill PL0 contexts
     println!("Filling PL0 contexts up to limit {}", pl0_limit);
@@ -96,10 +97,11 @@ fn reallocate_pl0_pl1_dpe_contexts(
 
 #[test]
 fn test_pl0_pl1_reallocation_range() {
-    // In subsystem mode, Caliptra uses 3 base PL0 contexts (root + RT journey + MCU FW);
+    // In subsystem mode, Caliptra uses 5 base PL0 contexts
+    // (root + RT journey + SOMV + SOMO + MCU FW);
     // we cannot reallocate below the used count.
     let first_model = run_rt_test(RuntimeTestArgs::default());
-    let min_pl0_limit: u32 = if first_model.subsystem_mode() { 3 } else { 2 };
+    let min_pl0_limit: u32 = if first_model.subsystem_mode() { 5 } else { 2 };
     drop(first_model);
 
     for pl0_limit in min_pl0_limit..caliptra_dpe::MAX_HANDLES as u32 {
@@ -172,8 +174,9 @@ fn test_pl0_pl1_reallocation_pl0_less_than_used() {
         ..Default::default()
     };
 
-    // Use some PL0 contexts
-    for _ in 0..12 {
+    // Use some PL0 contexts without breaching the default PL0 limit first.
+    let initial_pl0_contexts = if model.subsystem_mode() { 10 } else { 12 };
+    for _ in 0..initial_pl0_contexts {
         let _ = execute_dpe_cmd(
             &mut model,
             &mut Command::from(&derive_context_cmd),
@@ -256,8 +259,9 @@ fn test_pl0_pl1_reallocation_warm_reset() {
         ..Default::default()
     };
 
-    // Use some PL0 contexts
-    for _ in 0..12 {
+    // Use some PL0 contexts without breaching the default PL0 limit first.
+    let initial_pl0_contexts = if model.subsystem_mode() { 10 } else { 12 };
+    for _ in 0..initial_pl0_contexts {
         let _ = execute_dpe_cmd(
             &mut model,
             &mut Command::from(&derive_context_cmd),
@@ -281,10 +285,11 @@ fn test_pl0_pl1_reallocation_warm_reset() {
         .unwrap();
 
     // Use the rest of the PL0 contexts
-    // In subsystem mode, 3 contexts are used by Caliptra (root + RT journey + MCU FW);
+    // In subsystem mode, 5 contexts are used by Caliptra
+    // (root + RT journey + SOMV + SOMO + MCU FW);
     // otherwise, 2 contexts are used (root + RT journey).
-    let caliptra_contexts: u32 = if model.subsystem_mode() { 3 } else { 2 };
-    let remaining = 24 - caliptra_contexts - 12;
+    let caliptra_contexts: u32 = if model.subsystem_mode() { 5 } else { 2 };
+    let remaining = 24 - caliptra_contexts - initial_pl0_contexts;
     for _ in 0..remaining {
         let _ = execute_dpe_cmd(
             &mut model,

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -2,22 +2,36 @@
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+use caliptra_auth_man_gen::{
+    AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
+};
+use caliptra_auth_man_types::{
+    AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPreamble, AuthManifestPrivKeysConfig,
+    AuthManifestPubKeysConfig, AuthorizationManifest, ImageMetadataFlags,
+};
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp,
+    SetAuthManifestReq,
+};
 #[cfg(not(feature = "fpga_subsystem"))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{HwModel, InitParams};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams};
 use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_fake_keys::*;
 use caliptra_image_gen::from_hw_format;
 use caliptra_image_gen::ImageGeneratorCrypto;
-use zerocopy::IntoBytes;
+use caliptra_image_types::FwVerificationPqcKeyType;
+use sha2::{Digest, Sha384};
+use zerocopy::{FromBytes, IntoBytes};
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
+const PCR_ID_STASH_MEASUREMENT: usize = 31;
 
 #[derive(asn1::Asn1Read)]
 struct Fwid<'a> {
     _hash_alg: asn1::ObjectIdentifier,
-    _digest: &'a [u8],
+    digest: &'a [u8],
 }
 
 #[derive(asn1::Asn1Read)]
@@ -45,7 +59,7 @@ struct TcbInfo<'a> {
     #[implicit(5)]
     _index: Option<u64>,
     #[implicit(6)]
-    _fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+    fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
     #[implicit(7)]
     _flags: Option<asn1::BitString<'a>>,
     #[implicit(8)]
@@ -56,6 +70,199 @@ struct TcbInfo<'a> {
     _operational_flags_mask: Option<asn1::BitString<'a>>,
     #[implicit(11)]
     _integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
+}
+
+struct TcbSnapshot {
+    tci_type: [u8; 4],
+    svn: Option<u64>,
+    digest: Option<[u8; 48]>,
+}
+
+fn sha384_digest(data: &[u8]) -> [u8; 48] {
+    Sha384::digest(data).into()
+}
+
+fn preamble_range_digest(
+    preamble: &AuthManifestPreamble,
+    range: core::ops::Range<u32>,
+) -> [u8; 48] {
+    let preamble_bytes = preamble.as_bytes();
+    sha384_digest(&preamble_bytes[range.start as usize..range.end as usize])
+}
+
+fn somv_measurement(manifest: &AuthorizationManifest) -> [u8; 48] {
+    preamble_range_digest(
+        &manifest.preamble,
+        AuthManifestPreamble::vendor_signed_data_range(),
+    )
+}
+
+fn somo_measurement(manifest: &AuthorizationManifest) -> [u8; 48] {
+    preamble_range_digest(
+        &manifest.preamble,
+        AuthManifestPreamble::owner_pub_keys_range(),
+    )
+}
+
+fn create_auth_manifest_with_alt_owner_keys(
+    image_metadata_list: Vec<AuthManifestImageMetadata>,
+    pqc_key_type: FwVerificationPqcKeyType,
+    svn: u32,
+) -> AuthorizationManifest {
+    let vendor_fw_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_0_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_0_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_0_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_0_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_0_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_0_PRIVATE,
+        }),
+    });
+    let vendor_man_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_1_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_1_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_1_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_1_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_1_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_1_PRIVATE,
+        }),
+    });
+    let owner_fw_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
+            lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+            mldsa_pub_key: OWNER_MLDSA_KEY_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
+            lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+            mldsa_priv_key: OWNER_MLDSA_KEY_PRIVATE,
+        }),
+    });
+    let owner_man_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_2_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_2_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_2_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_2_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_2_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_2_PRIVATE,
+        }),
+    });
+
+    let gen = AuthManifestGenerator::new(Crypto::default());
+    gen.generate(&AuthManifestGeneratorConfig {
+        vendor_fw_key_info,
+        vendor_man_key_info,
+        owner_fw_key_info,
+        owner_man_key_info,
+        image_metadata_list,
+        version: 1,
+        flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+        pqc_key_type,
+        svn,
+    })
+    .unwrap()
+}
+
+fn set_auth_manifest(model: &mut DefaultHwModel, manifest: &AuthorizationManifest) {
+    let buf = manifest.as_bytes();
+    let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
+    auth_manifest_slice[..buf.len()].copy_from_slice(buf);
+
+    let mut set_auth_manifest_cmd = MailboxReq::SetAuthManifest(SetAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: auth_manifest_slice,
+    });
+    set_auth_manifest_cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            u32::from(CommandId::SET_AUTH_MANIFEST),
+            set_auth_manifest_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+}
+
+fn quote_pcr31(model: &mut DefaultHwModel) -> [u8; 48] {
+    let mut cmd = MailboxReq::QuotePcrsEcc384(QuotePcrsEcc384Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        nonce: [0xf5; 32],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::QUOTE_PCRS_ECC384),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let resp = QuotePcrsEcc384Resp::read_from_bytes(resp.as_slice()).unwrap();
+    resp.pcrs[PCR_ID_STASH_MEASUREMENT]
+}
+
+fn dpe_tcb_snapshots(model: &mut DefaultHwModel) -> Vec<TcbSnapshot> {
+    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
+    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
+    use x509_parser::{nom::Parser, prelude::*};
+
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+    let CertifyKeyResp::P384(certify_key_resp) = certify_key(model, certify_key_cmd).unwrap()
+    else {
+        panic!("Wrong response type!");
+    };
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
+    let (_, cert) = X509CertificateParser::new()
+        .with_deep_parse_extensions(true)
+        .parse(cert_bytes)
+        .unwrap();
+    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
+    let ext = cert
+        .get_extension_unique(&multi_tcb_info_oid)
+        .unwrap()
+        .expect("MultiTcbInfo extension missing");
+    let parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
+    parsed_tcb_infos
+        .filter_map(|mut tcb_info| {
+            let tci_type: [u8; 4] = tcb_info.tci_type?.try_into().ok()?;
+            let digest = tcb_info
+                .fwids
+                .as_mut()
+                .and_then(|fwids| fwids.next().and_then(|fwid| fwid.digest.try_into().ok()));
+            Some(TcbSnapshot {
+                tci_type,
+                svn: tcb_info.svn,
+                digest,
+            })
+        })
+        .collect()
+}
+
+fn find_tcb_snapshot<'a>(snapshots: &'a [TcbSnapshot], tci_type: &[u8; 4]) -> &'a TcbSnapshot {
+    let tci_type = u32::from_be_bytes(*tci_type);
+    snapshots
+        .iter()
+        .find(|snapshot| snapshot.tci_type == tci_type.as_bytes())
+        .unwrap_or_else(|| {
+            panic!(
+                "{} TCB info missing",
+                core::str::from_utf8(tci_type.as_bytes()).unwrap()
+            )
+        })
 }
 
 #[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
@@ -155,7 +362,6 @@ fn test_recovery_flow_with_svn() {
     // Test that recovery boot passes the SoC manifest SVN to the MCU RT DPE context.
     // The manifest is created with SVN=5, and fuses are configured to allow it.
     use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
-    use caliptra_image_types::FwVerificationPqcKeyType;
 
     let mcu_fw = vec![0x37u8; 256];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
@@ -171,10 +377,10 @@ fn test_recovery_flow_with_svn() {
     }];
     let soc_manifest = create_auth_manifest_with_metadata_with_svn(
         metadata,
-        FwVerificationPqcKeyType::LMS,
+        FwVerificationPqcKeyType::MLDSA,
         5, // SVN = 5
     );
-    let soc_manifest = soc_manifest.as_bytes();
+    let soc_manifest_bytes = soc_manifest.as_bytes();
     let mut args = RuntimeTestArgs::default();
     let rom = crate::common::rom_for_fw_integration_tests().unwrap();
     args.init_params = Some(InitParams {
@@ -182,39 +388,133 @@ fn test_recovery_flow_with_svn() {
         subsystem_mode: true,
         ..Default::default()
     });
-    args.soc_manifest = Some(soc_manifest);
+    args.soc_manifest = Some(soc_manifest_bytes);
     args.mcu_fw_image = Some(&mcu_fw);
     args.soc_manifest_svn = Some(5);
     args.soc_manifest_max_svn = Some(127);
+    args.key_type = Some(FwVerificationPqcKeyType::MLDSA);
     let mut model = run_rt_test(args);
     model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
 
-    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
-    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
-    use x509_parser::{nom::Parser, prelude::*};
+    let snapshots = dpe_tcb_snapshots(&mut model);
+    let somv_tcb_info = find_tcb_snapshot(&snapshots, b"SOMV");
+    assert_eq!(somv_tcb_info.svn, Some(5));
+    assert_eq!(somv_tcb_info.digest, Some(somv_measurement(&soc_manifest)));
+    let somo_tcb_info = find_tcb_snapshot(&snapshots, b"SOMO");
+    assert_eq!(somo_tcb_info.svn, Some(0));
+    assert_eq!(somo_tcb_info.digest, Some(somo_measurement(&soc_manifest)));
+    let mcfw_tcb_info = find_tcb_snapshot(&snapshots, b"MCFW");
+    assert_eq!(mcfw_tcb_info.svn, Some(5));
+}
 
-    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
-        format: CertifyKeyCommand::FORMAT_X509,
+#[cfg_attr(
+    any(
+        feature = "verilator",
+        feature = "fpga_realtime",
+        feature = "fpga_subsystem"
+    ),
+    ignore
+)]
+#[test]
+fn test_set_auth_manifest_updates_soc_manifest_dpe_contexts() {
+    use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+
+    let mcu_fw = vec![0x37u8; 256];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest_v5 = create_auth_manifest_with_metadata_with_svn(
+        metadata.clone(),
+        FwVerificationPqcKeyType::MLDSA,
+        5,
+    );
+    let soc_manifest_v5_bytes = soc_manifest_v5.as_bytes();
+    let mut args = RuntimeTestArgs::default();
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    args.init_params = Some(InitParams {
+        rom: &rom,
+        subsystem_mode: true,
         ..Default::default()
     });
-    let CertifyKeyResp::P384(certify_key_resp) = certify_key(&mut model, certify_key_cmd).unwrap()
-    else {
-        panic!("Wrong response type!");
-    };
-    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
-    let (_, cert) = X509CertificateParser::new()
-        .with_deep_parse_extensions(true)
-        .parse(cert_bytes)
-        .unwrap();
-    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
-    let ext = cert
-        .get_extension_unique(&multi_tcb_info_oid)
-        .unwrap()
-        .expect("MultiTcbInfo extension missing");
-    let mut parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
-    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
-    let mcfw_tcb_info = parsed_tcb_infos
-        .find(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
-        .expect("MCFW TCB info missing");
-    assert_eq!(mcfw_tcb_info.svn, Some(5));
+    args.soc_manifest = Some(soc_manifest_v5_bytes);
+    args.mcu_fw_image = Some(&mcu_fw);
+    args.soc_manifest_svn = Some(5);
+    args.soc_manifest_max_svn = Some(127);
+    args.key_type = Some(FwVerificationPqcKeyType::MLDSA);
+    let mut model = run_rt_test(args);
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    let initial_snapshots = dpe_tcb_snapshots(&mut model);
+    let initial_somv = find_tcb_snapshot(&initial_snapshots, b"SOMV");
+    assert_eq!(initial_somv.svn, Some(5));
+    assert_eq!(
+        initial_somv.digest,
+        Some(somv_measurement(&soc_manifest_v5))
+    );
+    let initial_somo = find_tcb_snapshot(&initial_snapshots, b"SOMO");
+    assert_eq!(initial_somo.svn, Some(0));
+    assert_eq!(
+        initial_somo.digest,
+        Some(somo_measurement(&soc_manifest_v5))
+    );
+    let initial_pcr31 = quote_pcr31(&mut model);
+
+    set_auth_manifest(&mut model, &soc_manifest_v5);
+    let same_manifest_snapshots = dpe_tcb_snapshots(&mut model);
+    let same_somv = find_tcb_snapshot(&same_manifest_snapshots, b"SOMV");
+    assert_eq!(same_somv.svn, Some(5));
+    assert_eq!(same_somv.digest, initial_somv.digest);
+    let same_somo = find_tcb_snapshot(&same_manifest_snapshots, b"SOMO");
+    assert_eq!(same_somo.svn, Some(0));
+    assert_eq!(same_somo.digest, initial_somo.digest);
+    assert_eq!(quote_pcr31(&mut model), initial_pcr31);
+
+    let soc_manifest_v6 =
+        create_auth_manifest_with_metadata_with_svn(metadata, FwVerificationPqcKeyType::MLDSA, 6);
+    set_auth_manifest(&mut model, &soc_manifest_v6);
+    let updated_snapshots = dpe_tcb_snapshots(&mut model);
+    let updated_somv = find_tcb_snapshot(&updated_snapshots, b"SOMV");
+    assert_eq!(updated_somv.svn, Some(5));
+    assert_eq!(
+        updated_somv.digest,
+        Some(somv_measurement(&soc_manifest_v6))
+    );
+    assert_ne!(updated_somv.digest, initial_somv.digest);
+    let updated_somo = find_tcb_snapshot(&updated_snapshots, b"SOMO");
+    assert_eq!(updated_somo.svn, Some(0));
+    assert_eq!(updated_somo.digest, initial_somo.digest);
+    assert_ne!(quote_pcr31(&mut model), initial_pcr31);
+
+    let pcr31_after_somv_update = quote_pcr31(&mut model);
+    let soc_manifest_alt_owner = create_auth_manifest_with_alt_owner_keys(
+        vec![AuthManifestImageMetadata {
+            fw_id: 2,
+            flags: flags.0,
+            digest,
+            ..Default::default()
+        }],
+        FwVerificationPqcKeyType::MLDSA,
+        6,
+    );
+    set_auth_manifest(&mut model, &soc_manifest_alt_owner);
+    let owner_updated_snapshots = dpe_tcb_snapshots(&mut model);
+    let owner_updated_somv = find_tcb_snapshot(&owner_updated_snapshots, b"SOMV");
+    assert_eq!(owner_updated_somv.svn, Some(5));
+    assert_eq!(owner_updated_somv.digest, updated_somv.digest);
+    let owner_updated_somo = find_tcb_snapshot(&owner_updated_snapshots, b"SOMO");
+    assert_eq!(owner_updated_somo.svn, Some(0));
+    assert_eq!(
+        owner_updated_somo.digest,
+        Some(somo_measurement(&soc_manifest_alt_owner))
+    );
+    assert_ne!(owner_updated_somo.digest, initial_somo.digest);
+    assert_ne!(quote_pcr31(&mut model), pcr31_after_somv_update);
 }

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -1,7 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs, DEFAULT_MCU_FW,
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    RuntimeTestArgs, DEFAULT_MCU_FW,
 };
 use caliptra_api::SocManager;
 use caliptra_builder::{
@@ -84,6 +85,9 @@ fn test_stash_measurement() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -76,14 +76,13 @@ fn read_48_byte_test_response(model: &mut DefaultHwModel, cmd: u32) -> [u8; 48] 
         .unwrap()
 }
 
-fn read_dpe_index_cache(model: &mut DefaultHwModel) -> [u8; 4] {
+fn read_dpe_index_cache(model: &mut DefaultHwModel) -> Vec<u8> {
     model
         .mailbox_execute(OPCODE_READ_DPE_INDEX_CACHE, &[])
         .unwrap()
         .expect("We should have received a response")
         .as_bytes()
-        .try_into()
-        .unwrap()
+        .to_vec()
 }
 
 fn extend_journey_measurement(prev_journey: [u8; 48], current: [u8; 48]) -> [u8; 48] {


### PR DESCRIPTION
**Changes:**

- Add SOMV/SOMO cached DPE context indices and TCI types.
- Create SOMV/SOMO during recovery SET_AUTH_MANIFEST and update existing contexts on mailbox SET_AUTH_MANIFEST.
- Measure SOMV from vendor preamble policy/key fields and SOMO from owner key fields.
- Report manifest SVN on SOMV TCB info and keep SOMO SVN at 0.

**Hitless / update policy:**
- Recovery/cold boot creates `SOMV` and `SOMO` before `MCFW`.
- Mailbox `SET_AUTH_MANIFEST` only updates existing cached `SOMV`/`SOMO` contexts; it does not create missing contexts mid-chain.
- On `SET_AUTH_MANIFEST`, runtime recomputes SOMV/SOMO measurements and compares them against the current DPE TCI.
- If the recomputed digest is unchanged, the update is a no-op:
  - no DPE current TCI update
  - no DPE cumulative/journey update
  - no PCR31 extension
- If the recomputed digest changes:
  - DPE current TCI is updated
  - DPE cumulative/journey TCI is extended
  - PCR31 is extended
- Vendor preamble field changes (`version || svn || flags || vendor_pub_keys`) update only `SOMV`.
- Owner key changes update only `SOMO`.

**Tests:**

- Verify SOMV/SOMO/MCFW TCBInfo presence, SVN, and digest contents in DPE certs.
- Verify same-manifest update is a no-op for SOMV/SOMO and PCR31.
- Verify SVN-only update changes SOMV/PCR31 but not SOMO.
- Verify owner-key update changes SOMO/PCR31 but not SOMV.

Fixes #3758 