### PR TITLE
docs: fix spelling typos in runtime README

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -41,7 +41,7 @@ The Runtime Firmware main function SHALL perform the following on cold boot rese
 
 * Initialize the [DICE Protection Environment (DPE)](#dice-protection-environment-dpe)
 * Initialize any SRAM structures used by Runtime Firmware
-* Upload the firwmare to the Manufacturer Control Unit (2.0, susbystem mode only)
+* Upload the firmware to the Manufacturer Control Unit (2.0, subsystem mode only)
 
 #### Encrypted Firmware Support (2.1, subsystem mode only)
 


### PR DESCRIPTION
Fixes two spelling typos in `runtime/README.md` (`firwmare`->`firmware`, `susbystem`->`subsystem`). Docs-only, no functional change.