### PR TITLE
runtime: Test DPE index cache across hitless update

### DIFF
--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -29,6 +29,12 @@ const OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT: u32 = 0x6000_0000;
 const OPCODE_READ_DPE_ROOT_CONTEXT_CUMULATIVE: u32 = 0x6000_0001;
 const OPCODE_READ_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0002;
 const OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0003;
+const OPCODE_INVALIDATE_DPE_INDEX_CACHE: u32 = 0x6000_0004;
+const OPCODE_READ_DPE_INDEX_CACHE: u32 = 0x6000_0005;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0006;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0007;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT: u32 = 0x6000_0008;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE: u32 = 0x6000_0009;
 const OPCODE_READ_DPE_TAGS: u32 = 0x7000_0000;
 const OPCODE_CORRUPT_CONTEXT_TAGS: u32 = 0x8000_0000;
 const OPCODE_CORRUPT_CONTEXT_HAS_TAG: u32 = 0x9000_0000;
@@ -222,6 +228,69 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     .tci_cumulative
                     .as_bytes();
                 write_response(&mut drivers.mbox, cciv_measurement);
+            }
+            CommandId(OPCODE_INVALIDATE_DPE_INDEX_CACHE) => {
+                drivers
+                    .persistent_data
+                    .get_mut()
+                    .caliptra_managed_dpe_context_indices
+                    .invalidate();
+                write_response(&mut drivers.mbox, &[]);
+            }
+            CommandId(OPCODE_READ_DPE_INDEX_CACHE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                write_response(&mut drivers.mbox, indices.as_bytes());
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.cciv as usize]
+                    .tci
+                    .tci_current
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.cciv as usize]
+                    .tci
+                    .tci_cumulative
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.mcu_rt as usize]
+                    .tci
+                    .tci_current
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.mcu_rt as usize]
+                    .tci
+                    .tci_cumulative
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
             }
             CommandId(OPCODE_READ_DPE_TAGS) => {
                 let context_tags = drivers.persistent_data.get().context_tags;

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -59,6 +59,42 @@ pub fn mbox_test_image_without_uart() -> &'static FwId<'static> {
     }
 }
 
+const OPCODE_INVALIDATE_DPE_INDEX_CACHE: u32 = 0x6000_0004;
+const OPCODE_READ_DPE_INDEX_CACHE: u32 = 0x6000_0005;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0006;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0007;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT: u32 = 0x6000_0008;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE: u32 = 0x6000_0009;
+
+fn read_48_byte_test_response(model: &mut DefaultHwModel, cmd: u32) -> [u8; 48] {
+    model
+        .mailbox_execute(cmd, &[])
+        .unwrap()
+        .expect("We should have received a response")
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
+
+fn read_dpe_index_cache(model: &mut DefaultHwModel) -> [u8; 4] {
+    model
+        .mailbox_execute(OPCODE_READ_DPE_INDEX_CACHE, &[])
+        .unwrap()
+        .expect("We should have received a response")
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
+
+fn extend_journey_measurement(prev_journey: [u8; 48], current: [u8; 48]) -> [u8; 48] {
+    use sha2::{Digest, Sha384};
+
+    let mut hasher = Sha384::new();
+    hasher.update(prev_journey);
+    hasher.update(current);
+    hasher.finalize().into()
+}
+
 #[test]
 fn test_rt_pcr_updated_in_dpe() {
     let image_options = ImageOptions {
@@ -892,4 +928,98 @@ fn test_cciv_updated_in_dpe() {
     // Compare actual vs expected
     assert_eq!(cciv_hash_mbox_bundle_exp, cciv_current);
     assert_eq!(cciv_journey_exp, cciv_journey);
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_dpe_index_cache_initialized_after_hitless_update() {
+    let image_opts = ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    let image_bundle_standard =
+        caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_opts.clone())
+            .unwrap();
+
+    // Boot with the mailbox responder so the test can inspect persistent DPE state.
+    // Clearing the new cache fields simulates a fw-2.0.2 cold boot whose DCCM
+    // did not initialize the cache appended by fw-2.0.3.
+    let args = RuntimeTestArgs {
+        subsystem_mode: true,
+        test_fwid: Some(mbox_test_image()),
+        test_image_options: Some(image_opts.clone()),
+        ..Default::default()
+    };
+    let (mut model, image_bundle_mbox) = run_rt_test_return_fw(args);
+
+    let cciv_hash_mbox_bundle_exp: [u8; 48] =
+        calculate_cptra_config_init_vals_hash(&mut model, &image_bundle_mbox);
+    let cciv_hash_standard_bundle_exp: [u8; 48] =
+        calculate_cptra_config_init_vals_hash(&mut model, &image_bundle_standard);
+    assert_ne!(cciv_hash_mbox_bundle_exp, cciv_hash_standard_bundle_exp);
+
+    let initial_cciv_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE);
+    let initial_mcu_rt_current = read_48_byte_test_response(
+        &mut model,
+        OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT,
+    );
+    let initial_mcu_rt_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE);
+
+    model
+        .mailbox_execute(OPCODE_INVALIDATE_DPE_INDEX_CACHE, &[])
+        .unwrap()
+        .expect("We should have received a response");
+    let invalid_cache = read_dpe_index_cache(&mut model);
+    assert_eq!(invalid_cache[0], 0);
+    assert_eq!(invalid_cache[1], 0xff);
+    assert_eq!(invalid_cache[2], 0xff);
+
+    // Hitlessly update from the simulated fw-2.0.2 DPE state to the new runtime.
+    // Update reset should initialize the cache once, then use it to update CCIV.
+    model
+        .mailbox_execute(
+            u32::from(CommandId::FIRMWARE_LOAD),
+            &image_bundle_standard.to_bytes().unwrap(),
+        )
+        .unwrap();
+    model.step_until_ready_for_runtime();
+
+    // Perform a second hitless update back to the mailbox responder. This proves
+    // the cache initialized during the first update persisted and remains usable.
+    model
+        .mailbox_execute(
+            u32::from(CommandId::FIRMWARE_LOAD),
+            &image_bundle_mbox.to_bytes().unwrap(),
+        )
+        .unwrap();
+    model.step_until_ready_for_runtime();
+
+    let initialized_cache = read_dpe_index_cache(&mut model);
+    assert_ne!(initialized_cache[0], 0);
+    assert_ne!(initialized_cache[1], 0xff);
+    assert_ne!(initialized_cache[2], 0xff);
+
+    let expected_cciv_journey_after_standard =
+        extend_journey_measurement(initial_cciv_journey, cciv_hash_standard_bundle_exp);
+    let expected_cciv_journey_after_mbox = extend_journey_measurement(
+        expected_cciv_journey_after_standard,
+        cciv_hash_mbox_bundle_exp,
+    );
+    let cciv_current =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT);
+    let cciv_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE);
+    assert_eq!(cciv_current, cciv_hash_mbox_bundle_exp);
+    assert_eq!(cciv_journey, expected_cciv_journey_after_mbox);
+
+    let mcu_rt_current = read_48_byte_test_response(
+        &mut model,
+        OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT,
+    );
+    let mcu_rt_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE);
+    assert_eq!(mcu_rt_current, initial_mcu_rt_current);
+    assert_eq!(mcu_rt_journey, initial_mcu_rt_journey);
 }


### PR DESCRIPTION
Follow-up to #3988.

This adds integration coverage for the fw-2.0.2 -> fw-2.0.3 hitless update case:
- fw-2.0.2 cold boot establishes DPE state and MCFW.
- The test simulates the old DCCM state by invalidating the new DPE index cache fields.
- A hitless update to fw-2.0.3 initializes the DPE index cache during update reset.
- A second hitless update verifies the persisted cache remains valid.
- The test verifies CCIV and MCFW cache-backed DPE state through the update sequence.
