### PR TITLE
Clear `PqDevIdCdi` when attestation is disabled

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -404,12 +404,26 @@ impl PersistentData {
     /// `RUNTIME_SET_PQ_SEED_ALREADY_SET` and leaves the existing value intact.
     #[cfg(feature = "mldsa_attestation")]
     pub fn set_pq_devid_cdi(&mut self, cdi: PqDevIdCdi) -> CaliptraResult<()> {
+        #[cfg(feature = "runtime")]
+        if self.attestation_disabled.get() {
+            return Err(CaliptraError::RUNTIME_SET_PQ_SEED_ATTESTATION_DISABLED);
+        }
         if self.pqc_mode_enabled() {
             return Err(CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET);
         }
         self.pq_devid_cdi = cdi;
         self.pqc_status_flags |= PQC_MODE_ENABLED_FLAG;
         Ok(())
+    }
+
+    /// When PQC mode is enabled, overwrites the PQ.DevID CDI with dummy bytes
+    /// and zeroizes the exported ML-DSA CDI slots; otherwise, does nothing.
+    #[cfg(feature = "mldsa_attestation")]
+    pub fn erase_pq_devid_cdi(&mut self, dummy_cdi: PqDevIdCdi) {
+        if self.pqc_mode_enabled() {
+            self.pq_devid_cdi = dummy_cdi;
+            self.mldsa_exported_cdi_slots.zeroize();
+        }
     }
 
     pub fn assert_matches_layout() {

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1328,6 +1328,11 @@ impl CaliptraError {
             0x000E006F,
             "Runtime Error: Sign with Exported MLDSA Invalid Parameters"
         ),
+        (
+            RUNTIME_SET_PQ_SEED_ATTESTATION_DISABLED,
+            0x000E0070,
+            "Runtime Error: SET_PQ_SEED rejected because attestation is disabled"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/disable.rs
+++ b/runtime/src/disable.rs
@@ -16,8 +16,8 @@ use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::keyids::KEY_ID_EXPORTED_DPE_CDI;
 use caliptra_drivers::{
-    hmac384_kdf, Array4x12, CaliptraResult, Ecc384Seed, Hmac384Key, KeyId, KeyReadArgs, KeyUsage,
-    KeyWriteArgs,
+    hmac384_kdf, Array4x12, CaliptraResult, Ecc384Seed, Hmac384Key, Hmac384Tag, KeyId, KeyReadArgs,
+    KeyUsage, KeyWriteArgs,
 };
 use dpe::U8Bool;
 
@@ -28,9 +28,11 @@ impl DisableAttestationCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         Self::erase_keys(drivers)?;
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
-        Self::zero_cdi(drivers, key_id_rt_cdi)?;
-        Self::zero_cdi(drivers, KEY_ID_EXPORTED_DPE_CDI)?;
+        Self::zero_ecc384_cdi(drivers, key_id_rt_cdi)?;
+        Self::zero_ecc384_cdi(drivers, KEY_ID_EXPORTED_DPE_CDI)?;
         Self::generate_dice_key(drivers)?;
+        #[cfg(feature = "mldsa_attestation")]
+        Self::zero_pq_devid_cdi(drivers)?;
         drivers.persistent_data.get_mut().attestation_disabled = U8Bool::new(true);
         Ok(())
     }
@@ -53,22 +55,33 @@ impl DisableAttestationCmd {
     /// # Arguments
     ///
     /// * `drivers` - Drivers
+    /// * `key` - KeyId of the ECC384 CDI key vault slot to zero
+    fn zero_ecc384_cdi(drivers: &mut Drivers, key: KeyId) -> CaliptraResult<()> {
+        let key = KeyWriteArgs::new(
+            key,
+            KeyUsage::default()
+                .set_hmac_key_en()
+                .set_ecc_key_gen_seed_en(),
+        );
+        Self::zero_cdi(drivers, key.into())
+    }
+
+    /// Set CDI key vault slot or output buffer to a KDF of a buffer of 0s.
+    ///
+    /// # Arguments
+    ///
+    /// * `drivers` - Drivers
+    /// * `output` - The key vault slot or output buffer to write the zeroed CDI to
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
-    fn zero_cdi(drivers: &mut Drivers, key: KeyId) -> CaliptraResult<()> {
+    fn zero_cdi(drivers: &mut Drivers, output: Hmac384Tag) -> CaliptraResult<()> {
         hmac384_kdf(
             &mut drivers.hmac384,
             Hmac384Key::Array4x12(&Array4x12::default()),
             b"zero_cdi",
             None,
             &mut drivers.trng,
-            KeyWriteArgs::new(
-                key,
-                KeyUsage::default()
-                    .set_hmac_key_en()
-                    .set_ecc_key_gen_seed_en(),
-            )
-            .into(),
+            output,
         )?;
 
         Ok(())
@@ -97,6 +110,24 @@ impl DisableAttestationCmd {
         )?;
         drivers.persistent_data.get_mut().fht.rt_dice_pub_key = pub_key;
 
+        Ok(())
+    }
+
+    /// Set CDI bytes to a KDF of a buffer of 0s.
+    ///
+    /// # Arguments
+    ///
+    /// * `drivers` - Drivers
+    #[cfg(feature = "mldsa_attestation")]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    fn zero_pq_devid_cdi(drivers: &mut Drivers) -> CaliptraResult<()> {
+        let mut out = Array4x12::default();
+        Self::zero_cdi(drivers, (&mut out).into())?;
+
+        drivers
+            .persistent_data
+            .get_mut()
+            .erase_pq_devid_cdi(out.into());
         Ok(())
     }
 }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -101,6 +101,60 @@ pub fn run_pqc_rt_test() -> DefaultHwModel {
     model
 }
 
+#[cfg(feature = "mldsa_attestation")]
+pub const PQ_SEED: [u8; caliptra_common::mailbox_api::SET_PQ_SEED_SEED_SIZE] =
+    [0x5a; caliptra_common::mailbox_api::SET_PQ_SEED_SEED_SIZE];
+
+#[cfg(feature = "mldsa_attestation")]
+pub fn provision_pq_seed(model: &mut DefaultHwModel) {
+    use caliptra_common::mailbox_api::SetPqSeedReq;
+
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: PQ_SEED,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap();
+}
+
+#[cfg(feature = "mldsa_attestation")]
+pub fn get_pq_csr_checksum() -> u32 {
+    caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_CSR), &[])
+}
+
+#[cfg(feature = "mldsa_attestation")]
+pub fn get_pq_csr(model: &mut DefaultHwModel) -> Vec<u8> {
+    use caliptra_common::mailbox_api::GetPqCsrResp;
+    use zerocopy::{FromBytes, IntoBytes};
+
+    let payload = MailboxReqHeader {
+        chksum: get_pq_csr_checksum(),
+    };
+    let response = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_CSR), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let csr_resp = GetPqCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
+    csr_resp.data[..csr_resp.data_size as usize].to_vec()
+}
+
+#[cfg(feature = "mldsa_attestation")]
+pub fn mldsa_csr_public_key(csr_bytes: &[u8]) -> Vec<u8> {
+    use openssl::pkey::Public;
+    use openssl::pkey_ml_dsa::PKeyMlDsaParams;
+    use openssl::x509::X509Req;
+
+    let req = X509Req::from_der(csr_bytes).unwrap();
+    let pkey = req.public_key().unwrap();
+    PKeyMlDsaParams::<Public>::from_pkey(&pkey)
+        .unwrap()
+        .public_key()
+        .unwrap()
+        .to_vec()
+}
+
 // Boot the ML-DSA attestation runtime image **debug-locked** (Production
 // lifecycle) so the firmware actually arms the per-command watchdog. The
 // runtime's `start_wdt` (runtime/src/lib.rs) is a no-op unless the device is

--- a/runtime/tests/runtime_integration_tests/test_disable.rs
+++ b/runtime/tests/runtime_integration_tests/test_disable.rs
@@ -177,3 +177,168 @@ fn test_attestation_disabled_flag_after_update_reset() {
         .verify(&rt_cert.public_key().unwrap())
         .unwrap());
 }
+
+#[test]
+#[cfg(feature = "mldsa_attestation")]
+fn test_disable_attestation_cmd_mldsa() {
+    use crate::common::{get_pq_csr, mldsa_csr_public_key, provision_pq_seed, run_pqc_rt_test};
+    use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
+    use caliptra_hw_model::HwModel;
+    use zerocopy::FromBytes;
+
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    // Get CSR before disable
+    let csr_bytes = get_pq_csr(&mut model);
+    let pub_key_before = mldsa_csr_public_key(&csr_bytes);
+
+    // Disable attestation
+    let payload_disable = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload_disable.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    // Get CSR after disable
+    let csr_bytes2 = get_pq_csr(&mut model);
+    let pub_key_after = mldsa_csr_public_key(&csr_bytes2);
+
+    // Verify public key changed after disabling attestation
+    assert_ne!(pub_key_before, pub_key_after);
+}
+
+#[test]
+#[cfg(feature = "mldsa_attestation")]
+fn test_disable_attestation_cmd_mldsa_rederive_pubkey() {
+    use crate::common::{get_pq_csr, mldsa_csr_public_key, provision_pq_seed, run_pqc_rt_test};
+    use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, MailboxRespHeader};
+    use caliptra_hw_model::HwModel;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::{PKey, Private, Public};
+    use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVariant};
+    use openssl::sign::Signer;
+    use zerocopy::FromBytes;
+
+    fn hmac_sha384_kdf(key: &[u8], label: &[u8]) -> Vec<u8> {
+        let pkey = PKey::hmac(key).unwrap();
+        let mut signer = Signer::new(MessageDigest::sha384(), &pkey).unwrap();
+        signer.update(&1u32.to_be_bytes()).unwrap();
+        signer.update(label).unwrap();
+        signer.sign_to_vec().unwrap()
+    }
+
+    fn derive_expected_zero_pq_devid_pubkey() -> Vec<u8> {
+        let zero_key = [0u8; 48];
+        let dummy_cdi = hmac_sha384_kdf(&zero_key, b"zero_cdi");
+        let kdf_out = hmac_sha384_kdf(&dummy_cdi, b"pq_devid_keygen");
+        let mldsa_seed: [u8; 32] = kdf_out[..32].try_into().unwrap();
+
+        let private_key =
+            PKeyMlDsaBuilder::<Private>::from_seed(MlDsaVariant::MlDsa87, &mldsa_seed)
+                .unwrap()
+                .build()
+                .unwrap();
+        PKeyMlDsaParams::<Public>::from_pkey(&private_key)
+            .unwrap()
+            .public_key()
+            .unwrap()
+            .to_vec()
+    }
+
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    // Disable attestation
+    let payload_disable = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload_disable.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    // Get CSR after disable
+    let csr_bytes = get_pq_csr(&mut model);
+    let actual_pub_key = mldsa_csr_public_key(&csr_bytes);
+
+    let expected_pub_key = derive_expected_zero_pq_devid_pubkey();
+    assert_eq!(
+        actual_pub_key, expected_pub_key,
+        "Public key after disable_attestation must match public key derived from zeroed CDI"
+    );
+}
+
+#[test]
+#[cfg(feature = "mldsa_attestation")]
+fn test_set_pq_seed_after_disable_attestation_fails() {
+    use crate::common::{assert_error, run_pqc_rt_test, PQ_SEED};
+    use caliptra_common::mailbox_api::{
+        CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, SetPqSeedReq,
+    };
+    use caliptra_error::CaliptraError;
+    use caliptra_hw_model::HwModel;
+    use zerocopy::{FromBytes, IntoBytes};
+
+    let mut model = run_pqc_rt_test();
+
+    // Disable attestation
+    let payload_disable = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload_disable.as_bytes(),
+        )
+        .unwrap()
+        .unwrap();
+    let resp_hdr = MailboxRespHeader::read_from_bytes(resp.as_bytes()).unwrap();
+    assert_eq!(
+        resp_hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    // Attempting SET_PQ_SEED after DISABLE_ATTESTATION must fail with RUNTIME_SET_PQ_SEED_ATTESTATION_DISABLED
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: PQ_SEED,
+    });
+    cmd.populate_chksum().unwrap();
+    let result = model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SET_PQ_SEED_ATTESTATION_DISABLED,
+        result,
+    );
+}

--- a/runtime/tests/runtime_integration_tests/test_get_pq_csr.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_pq_csr.rs
@@ -1,8 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_common::mailbox_api::{
-    CommandId, GetPqCsrResp, MailboxReq, MailboxReqHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
-};
+use caliptra_common::mailbox_api::{CommandId, MailboxReqHeader, SET_PQ_SEED_SEED_SIZE};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::HwModel;
 use openssl::hash::MessageDigest;
@@ -10,29 +8,12 @@ use openssl::pkey::{PKey, Private, Public};
 use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVariant};
 use openssl::sign::Signer;
 use openssl::x509::X509Req;
-use zerocopy::{FromBytes, IntoBytes};
+use zerocopy::IntoBytes;
 
-use crate::common::{assert_error, run_pqc_rt_test};
-
-/// Seed provisioned via SET_PQ_SEED in these tests.
-const PQ_SEED: [u8; SET_PQ_SEED_SEED_SIZE] = [0x5a; SET_PQ_SEED_SEED_SIZE];
-
-fn get_pq_csr_checksum() -> u32 {
-    caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_CSR), &[])
-}
-
-/// Provision the PQ.DevID seed (as PL0) so that PQC mode is enabled and
-/// GET_PQ_CSR can produce a CSR.
-fn provision_pq_seed(model: &mut caliptra_hw_model::DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: PQ_SEED,
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .unwrap();
-}
+use crate::common::{
+    assert_error, get_pq_csr, get_pq_csr_checksum, mldsa_csr_public_key, provision_pq_seed,
+    run_pqc_rt_test, PQ_SEED,
+};
 
 /// SP 800-108 counter-mode KDF (single iteration) with HMAC-SHA384, reproducing
 /// the firmware's `hmac384_kdf` fixed-input format: `be32(1) || label` (these
@@ -63,17 +44,6 @@ fn derive_expected_pq_devid_pubkey(seed: &[u8; SET_PQ_SEED_SEED_SIZE]) -> Vec<u8
         .build()
         .unwrap();
     PKeyMlDsaParams::<Public>::from_pkey(&private_key)
-        .unwrap()
-        .public_key()
-        .unwrap()
-        .to_vec()
-}
-
-/// Extract the raw ML-DSA-87 public key embedded in a DER-encoded CSR.
-fn csr_public_key(csr_bytes: &[u8]) -> Vec<u8> {
-    let req = X509Req::from_der(csr_bytes).unwrap();
-    let pkey = req.public_key().unwrap();
-    PKeyMlDsaParams::<Public>::from_pkey(&pkey)
         .unwrap()
         .public_key()
         .unwrap()
@@ -134,33 +104,17 @@ fn test_get_pq_csr_success() {
     let mut model = run_pqc_rt_test();
     provision_pq_seed(&mut model);
 
-    let payload = MailboxReqHeader {
-        chksum: get_pq_csr_checksum(),
-    };
-
-    let response = model
-        .mailbox_execute(u32::from(CommandId::GET_PQ_CSR), payload.as_bytes())
-        .unwrap()
-        .unwrap();
-
-    let csr_resp = GetPqCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
-    assert_ne!(0, csr_resp.data_size);
-    let csr_bytes = &csr_resp.data[..csr_resp.data_size as usize];
+    let csr_bytes = get_pq_csr(&mut model);
 
     // Parses as a CSR and its signature verifies against the embedded key.
-    let req = X509Req::from_der(csr_bytes).unwrap();
+    let req = X509Req::from_der(&csr_bytes).unwrap();
     let pub_key = req.public_key().unwrap();
     assert!(req.verify(&pub_key).unwrap());
 
     // Deterministic: regenerating from the same CDI yields the identical CSR.
-    let response2 = model
-        .mailbox_execute(u32::from(CommandId::GET_PQ_CSR), payload.as_bytes())
-        .unwrap()
-        .unwrap();
-    let csr_resp2 = GetPqCsrResp::ref_from_bytes(response2.as_bytes()).unwrap();
+    let csr_bytes2 = get_pq_csr(&mut model);
     assert_eq!(
-        csr_bytes,
-        &csr_resp2.data[..csr_resp2.data_size as usize],
+        csr_bytes, csr_bytes2,
         "GET_PQ_CSR should be deterministic across calls"
     );
 }
@@ -173,21 +127,12 @@ fn test_get_pq_csr_public_key_matches_derivation() {
     let mut model = run_pqc_rt_test();
     provision_pq_seed(&mut model);
 
-    let payload = MailboxReqHeader {
-        chksum: get_pq_csr_checksum(),
-    };
-    let response = model
-        .mailbox_execute(u32::from(CommandId::GET_PQ_CSR), payload.as_bytes())
-        .unwrap()
-        .unwrap();
-    let csr_resp = GetPqCsrResp::ref_from_bytes(response.as_bytes()).unwrap();
-    assert_ne!(0, csr_resp.data_size);
-    let csr_bytes = &csr_resp.data[..csr_resp.data_size as usize];
+    let csr_bytes = get_pq_csr(&mut model);
 
     let expected = derive_expected_pq_devid_pubkey(&PQ_SEED);
     assert_eq!(expected.len(), 2592, "ML-DSA-87 public key is 2,592 bytes");
     assert_eq!(
-        csr_public_key(csr_bytes),
+        mldsa_csr_public_key(&csr_bytes),
         expected,
         "CSR public key must match the key derived from the provisioned seed"
     );


### PR DESCRIPTION
This overwrites the `PqDevIdCdi` with a default "zeroized" value. This models the other attestation forms when disabled. This allows the system to stay alive and respond to commands, but in a degraded state. It can respond, but attestations will fail. This can help with debugging.

This now returns an error when trying to set the `PqDevIdCdi` when attestation is disabled to avoid re-enabling attestation.

The ECDSA variants also re-derive public keys that are stored in persistent data so the verify checks during signing will still work. This doesn't apply to ML-DSA because we lazily generate the keys in all use cases.