### PR TITLE
[builder]: Support downloading prebuilt Caliptra artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "caliptra-api"
 version = "0.1.0"
 dependencies = [
@@ -485,12 +505,14 @@ dependencies = [
  "hex",
  "memoffset 0.8.0",
  "once_cell",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2",
  "toml 0.7.8",
  "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -576,7 +598,7 @@ dependencies = [
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "ufmt",
  "zerocopy",
  "zeroize",
@@ -590,7 +612,7 @@ dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "zerocopy",
  "zeroize",
 ]
@@ -1169,7 +1191,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cms",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "coset",
  "ctr",
  "fips204",
@@ -1663,6 +1685,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -3609,6 +3637,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3658,18 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pem"
@@ -4038,7 +4089,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -6247,10 +6300,18 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
+ "aes",
  "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
 ]
 
 [[package]]
@@ -6258,3 +6319,32 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -23,9 +23,11 @@ once_cell.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 sha2.workspace = true
 toml.workspace = true
 zerocopy.workspace = true
+zip = "0.6"
 
 [features]
 default = ["openssl"]

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -3,7 +3,7 @@
 // Centralized list of all firmware targets. This allows us to compile them all
 // ahead of time for executing tests on hosts that can't compile rust code.
 
-use crate::FwId;
+use crate::{FirmwareType, FwId};
 
 pub fn rom_from_env() -> &'static FwId<'static> {
     match std::env::var("CPTRA_ROM_TYPE").as_ref().map(|s| s.as_str()) {
@@ -42,129 +42,187 @@ pub fn fake_rom(fpga: bool) -> &'static FwId<'static> {
 pub const ROM: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["cfi"],
+    fw_type: FirmwareType::Source { features: &["cfi"] },
 };
 
 pub const ROM_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["fpga_realtime", "cfi"],
+    },
 };
 
 pub const ROM_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "cfi"],
+    },
 };
 
 pub const ROM_FAKE_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fake-rom", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-rom", "cfi"],
+    },
 };
 
 pub const ROM_FAKE_WITH_UART_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fake-rom", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-rom", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const ROM_WITH_FIPS_TEST_HOOKS: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fips-test-hooks", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["fips-test-hooks", "cfi"],
+    },
+};
+
+/// Pre-built 2.0.1 ROM release binary target identifier.
+/// Represents the downloaded 2.0.1 release ROM artifact (caliptra-rom-with-log.bin)
+/// from the GitHub caliptra-sw release package.
+pub const ROM_2_0_1_RELEASE: FwId = FwId {
+    crate_name: "caliptra-rom-2_0_1-release",
+    bin_name: "caliptra-rom-with-log.bin",
+    fw_type: FirmwareType::TaggedReleaseFromNetwork {
+        version_tag: "rom-2.0.1",
+        url: "https://github.com/chipsalliance/caliptra-sw/releases/download/rom-2.0.2/caliptra_release_v20260327_0-2.0.zip",
+    },
+};
+
+/// Pre-built 2.0.1 Runtime Firmware bundle release target identifier.
+/// Represents the downloaded 2.0.1 release firmware bundle (image-bundle-mldsa.bin)
+/// containing the FMC and Runtime images from the GitHub caliptra-sw release package.
+pub const FW_2_0_1_RELEASE: FwId = FwId {
+    crate_name: "caliptra-fw-2_0_1-release",
+    bin_name: "image-bundle-mldsa.bin",
+    fw_type: FirmwareType::TaggedReleaseFromNetwork {
+        version_tag: "fw-2.0.1",
+        url: "https://github.com/chipsalliance/caliptra-sw/releases/download/fw-2.0.1/caliptra_release_v20260210_0-2.0.zip",
+    },
 };
 
 pub const ROM_WITH_FIPS_TEST_HOOKS_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fips-test-hooks", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["fips-test-hooks", "fpga_realtime", "cfi"],
+    },
 };
 
 // TODO: delete this when AXI DMA is fixed in the FPGA
 pub const ROM_FPGA_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const FMC_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "cfi"],
+    },
 };
 
 pub const FMC_FAKE_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "fake-fmc", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-fmc", "cfi"],
+    },
 };
 
 // TODO: delete this when AXI DMA is fixed in the FPGA
 pub const FMC_FPGA_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const APP: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["fips_self_test", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["fips_self_test", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_OCP_LOCK: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "ocp-lock", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "ocp-lock", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_FIPS_TEST_HOOKS: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "fips-test-hooks", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "fips-test-hooks", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_FIPS_TEST_HOOKS_FPGA: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &[
-        "emu",
-        "fips_self_test",
-        "fips-test-hooks",
-        "fpga_subsystem",
-        "cfi",
-    ],
+    fw_type: FirmwareType::Source {
+        features: &[
+            "emu",
+            "fips_self_test",
+            "fips-test-hooks",
+            "fpga_subsystem",
+            "cfi",
+        ],
+    },
 };
 
 pub const APP_WITH_UART_FPGA: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_OCP_LOCK_FPGA: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "fpga_realtime", "ocp-lock", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "fpga_realtime", "ocp-lock", "cfi"],
+    },
 };
 
 pub const APP_ZEROS: FwId = FwId {
     crate_name: "caliptra-zeros",
     bin_name: "caliptra-zeros",
-    features: &[],
+    fw_type: FirmwareType::Source { features: &[] },
 };
 
 pub const FMC_ZEROS: FwId = FwId {
     crate_name: "caliptra-zeros",
     bin_name: "caliptra-zeros",
-    features: &["fmc"],
+    fw_type: FirmwareType::Source { features: &["fmc"] },
 };
 
 pub mod caliptra_builder_tests {
@@ -173,7 +231,7 @@ pub mod caliptra_builder_tests {
     pub const FWID: FwId = FwId {
         crate_name: "caliptra-drivers-test-bin",
         bin_name: "test_success",
-        features: &[],
+        fw_type: FirmwareType::Source { features: &[] },
     };
 }
 
@@ -183,7 +241,7 @@ pub mod hw_model_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-hw-model-test-fw",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const MAILBOX_RESPONDER: FwId = FwId {
@@ -253,7 +311,7 @@ pub mod driver_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-drivers-test-bin",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const DOE: FwId = FwId {
@@ -293,7 +351,9 @@ pub mod driver_tests {
 
     pub const KEYVAULT_FPGA: FwId = FwId {
         bin_name: "keyvault",
-        features: &["emu", "fpga_realtime"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_realtime"],
+        },
         ..BASE_FWID
     };
 
@@ -475,37 +535,49 @@ pub mod driver_tests {
     // TODO: delete this when AXI DMA is fixed in the FPGA
     pub const DMA_SHA384_FPGA: FwId = FwId {
         bin_name: "dma_sha384",
-        features: &["emu", "fpga_subsystem"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_subsystem"],
+        },
         ..BASE_FWID
     };
 
     pub const OCP_LOCK: FwId = FwId {
         bin_name: "ocp_lock",
-        features: &["fpga_realtime"],
+        fw_type: FirmwareType::Source {
+            features: &["fpga_realtime"],
+        },
         ..BASE_FWID
     };
 
     pub const OCP_LOCK_WARM_RESET: FwId = FwId {
         bin_name: "ocp_lock_warm_reset",
-        features: &["fpga_realtime"],
+        fw_type: FirmwareType::Source {
+            features: &["fpga_realtime"],
+        },
         ..BASE_FWID
     };
 
     pub const DMA_AES: FwId = FwId {
         bin_name: "dma_aes",
-        features: &["emu", "fpga_subsystem"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_subsystem"],
+        },
         ..BASE_FWID
     };
 
     pub const AXI_BYPASS: FwId = FwId {
         bin_name: "axi_bypass",
-        features: &["emu", "fpga_subsystem"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_subsystem"],
+        },
         ..BASE_FWID
     };
 
     pub const HPKE: FwId = FwId {
         bin_name: "hpke",
-        features: &["emu", "fpga_subsystem"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_subsystem"],
+        },
         ..BASE_FWID
     };
 }
@@ -516,7 +588,7 @@ pub mod rom_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-rom",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const ASM_TESTS: FwId = FwId {
@@ -527,31 +599,41 @@ pub mod rom_tests {
     pub const TEST_FMC_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "cfi"],
+        },
     };
 
     pub const TEST_RT_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-rt",
         bin_name: "caliptra-rom-test-rt",
-        features: &["emu", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "cfi"],
+        },
     };
 
     pub const FAKE_TEST_FMC_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "fake-fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fake-fmc", "cfi"],
+        },
     };
 
     pub const TEST_FMC_INTERACTIVE: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "interactive_test_fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "interactive_test_fmc", "cfi"],
+        },
     };
 
     pub const FAKE_TEST_FMC_INTERACTIVE: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "interactive_test_fmc", "fake-fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "interactive_test_fmc", "fake-fmc", "cfi"],
+        },
     };
 
     pub const TEST_PMP_TESTS: FwId = FwId {
@@ -566,7 +648,9 @@ pub mod runtime_tests {
     const RUNTIME_TEST_FWID_BASE: FwId = FwId {
         crate_name: "caliptra-runtime-test-bin",
         bin_name: "",
-        features: &["emu", "riscv", "runtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "riscv", "runtime", "cfi"],
+        },
     };
 
     pub const BOOT: FwId = FwId {
@@ -581,20 +665,26 @@ pub mod runtime_tests {
 
     pub const MBOX_FPGA: FwId = FwId {
         bin_name: "mbox",
-        features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
     // Used to test updates between RT FW images.
     pub const MBOX_WITHOUT_UART: FwId = FwId {
         bin_name: "mbox",
-        features: &["riscv", "runtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["riscv", "runtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
     pub const MBOX_WITHOUT_UART_FPGA: FwId = FwId {
         bin_name: "mbox",
-        features: &["riscv", "runtime", "fpga_realtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["riscv", "runtime", "fpga_realtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
@@ -610,7 +700,9 @@ pub mod runtime_tests {
 
     pub const MOCK_RT_INTERACTIVE_FPGA: FwId = FwId {
         bin_name: "mock_rt_interact",
-        features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 }
@@ -621,7 +713,7 @@ pub mod api_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-api-test-bin",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const MAILBOX: FwId = FwId {
@@ -629,6 +721,8 @@ pub mod api_tests {
         ..BASE_FWID
     };
 }
+
+pub const PREBUILT_FW: &[&FwId] = &[&ROM_2_0_1_RELEASE, &FW_2_0_1_RELEASE];
 
 pub const REGISTERED_FW: &[&FwId] = &[
     &ROM,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -27,6 +27,7 @@ use zerocopy::IntoBytes;
 
 mod elf_symbols;
 pub mod firmware;
+pub mod release_artifacts;
 mod sha256;
 pub mod version;
 
@@ -85,6 +86,18 @@ pub fn run_cmd_stdout(cmd: &mut Command, input: Option<&[u8]>) -> io::Result<Str
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub enum FirmwareType<'a> {
+    Source { features: &'a [&'a str] },
+    TaggedReleaseFromNetwork { version_tag: &'a str, url: &'a str },
+}
+
+impl Default for FirmwareType<'_> {
+    fn default() -> Self {
+        FirmwareType::Source { features: &[] }
+    }
+}
+
 // Represent the Cargo identity of a firmware binary.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct FwId<'a> {
@@ -95,11 +108,26 @@ pub struct FwId<'a> {
     // for a binary crate.
     pub bin_name: &'a str,
 
-    // The features to use the build the binary
-    pub features: &'a [&'a str],
+    // The type of firmware target
+    pub fw_type: FirmwareType<'a>,
 }
 
-impl FwId<'_> {
+type PrebuiltCacheMap = Lazy<Mutex<HashMap<FwId<'static>, &'static [u8]>>>;
+
+impl From<&'static FwId<'static>> for &'static [u8] {
+    fn from(id: &'static FwId<'static>) -> &'static [u8] {
+        get_prebuilt_firmware_static(id).expect("Failed to fetch prebuilt firmware artifact")
+    }
+}
+
+impl<'a> FwId<'a> {
+    pub fn features(&self) -> &'a [&'a str] {
+        match self.fw_type {
+            FirmwareType::Source { features } => features,
+            _ => &[],
+        }
+    }
+
     /// A reasonably unique filename to be used for saving elf files containing
     /// this firmware.
     pub fn elf_filename(&self) -> String {
@@ -110,8 +138,8 @@ impl FwId<'_> {
         if self.bin_name != self.crate_name {
             write!(&mut result, "--{}", self.bin_name).unwrap();
         }
-        if !self.features.is_empty() {
-            write!(&mut result, "--{}", self.features.join("-")).unwrap();
+        if !self.features().is_empty() {
+            write!(&mut result, "--{}", self.features().join("-")).unwrap();
         }
         write!(&mut result, ".elf").unwrap();
         result
@@ -260,8 +288,8 @@ fn cargo_invocations_from_fwids<'a>(
 
         remaining_fwids.retain(|&fwid| {
             let invocation = invocation_map
-                .entry((fwid.crate_name, fwid.features))
-                .or_insert_with(|| CargoInvocation::new(fwid.crate_name, fwid.features));
+                .entry((fwid.crate_name, fwid.features()))
+                .or_insert_with(|| CargoInvocation::new(fwid.crate_name, fwid.features()));
             if invocation
                 .fwids
                 .iter()
@@ -484,9 +512,49 @@ pub fn rom_for_fw_integration_tests_fpga(fpga: bool) -> io::Result<Cow<'static, 
     }
 }
 
+pub fn get_prebuilt_firmware(id: &FwId<'static>) -> io::Result<Vec<u8>> {
+    if !crate::firmware::PREBUILT_FW.contains(&id) {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("FwId {id:?} is not a registered prebuilt firmware target"),
+        ));
+    }
+
+    match id.fw_type {
+        FirmwareType::TaggedReleaseFromNetwork { version_tag, url } => {
+            let artifacts = release_artifacts::download_and_extract_release(version_tag, url)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            artifacts.get_file(id.bin_name)
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("FwId {id:?} is not a supported prebuilt firmware ID"),
+        )),
+    }
+}
+
+pub fn get_prebuilt_firmware_static(id: &FwId<'static>) -> io::Result<&'static [u8]> {
+    static CACHE: PrebuiltCacheMap = Lazy::new(|| Mutex::new(HashMap::new()));
+
+    let mut cache = CACHE.lock().unwrap();
+    if let Some(&bytes) = cache.get(id) {
+        return Ok(bytes);
+    }
+
+    let bytes = build_firmware_rom(id)?;
+    let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+    cache.insert(*id, leaked);
+    Ok(leaked)
+}
+
 pub fn build_firmware_rom(id: &FwId<'static>) -> io::Result<Vec<u8>> {
-    let elf_bytes = build_firmware_elf(id)?;
-    elf2rom(&elf_bytes)
+    match id.fw_type {
+        FirmwareType::TaggedReleaseFromNetwork { .. } => get_prebuilt_firmware(id),
+        FirmwareType::Source { .. } => {
+            let elf_bytes = build_firmware_elf(id)?;
+            elf2rom(&elf_bytes)
+        }
+    }
 }
 
 pub fn elf2rom(elf_bytes: &[u8]) -> io::Result<Vec<u8>> {
@@ -651,7 +719,7 @@ mod test {
         static FWID: FwId = FwId {
             crate_name: "caliptra-drivers-test-bin",
             bin_name: "test_success2",
-            features: &[],
+            fw_type: FirmwareType::Source { features: &[] },
         };
         // Ensure that we can build the ELF and elf2rom can parse it
         let err = build_firmware_rom(&FWID).unwrap_err();
@@ -712,42 +780,58 @@ mod test {
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter", "uart"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter", "uart"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test1",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test2",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test2",
-                    features: &["pc-load-letter", "uart"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter", "uart"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test3",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw2",
                     bin_name: "test1",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw2",
                     bin_name: "test4",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
             ];
 
@@ -760,17 +844,23 @@ mod test {
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test1",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test2",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test3",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                         ]
                     },
@@ -781,12 +871,16 @@ mod test {
                             &FwId {
                                 crate_name: "test-fw2",
                                 bin_name: "test1",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw2",
                                 bin_name: "test4",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                         ],
                     },
@@ -796,7 +890,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "initech-firmware",
                             bin_name: "initech-firmware",
-                            features: &["pc-load-letter"],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter"]
+                            },
                         },],
                     },
                     CargoInvocation {
@@ -805,7 +901,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "initech-firmware",
                             bin_name: "initech-firmware",
-                            features: &["pc-load-letter", "uart",],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter", "uart",]
+                            },
                         },]
                     },
                     CargoInvocation {
@@ -814,7 +912,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "test-fw",
                             bin_name: "test2",
-                            features: &["pc-load-letter", "uart",],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter", "uart",]
+                            },
                         },],
                     },
                 ],
@@ -828,12 +928,16 @@ mod test {
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
             ];
             assert!(cargo_invocations_from_fwids(&fwids)
@@ -849,7 +953,7 @@ mod test {
             FwId {
                 crate_name: "caliptra-rom",
                 bin_name: "caliptra-rom",
-                features: &[]
+                fw_type: FirmwareType::Source { features: &[] },
             }
             .elf_filename(),
             "caliptra-rom.elf"
@@ -858,7 +962,9 @@ mod test {
             FwId {
                 crate_name: "caliptra-rom",
                 bin_name: "caliptra-rom",
-                features: &["uart", "debug"]
+                fw_type: FirmwareType::Source {
+                    features: &["uart", "debug"]
+                },
             }
             .elf_filename(),
             "caliptra-rom--uart-debug.elf"
@@ -867,7 +973,7 @@ mod test {
             &FwId {
                 crate_name: "caliptra-test",
                 bin_name: "smoke_test",
-                features: &[]
+                fw_type: FirmwareType::Source { features: &[] },
             }
             .elf_filename(),
             "caliptra-test--smoke_test.elf"
@@ -876,7 +982,9 @@ mod test {
             &FwId {
                 crate_name: "caliptra-test",
                 bin_name: "smoke_test",
-                features: &["uart", "debug"]
+                fw_type: FirmwareType::Source {
+                    features: &["uart", "debug"]
+                },
             }
             .elf_filename(),
             "caliptra-test--smoke_test--uart-debug.elf"

--- a/builder/src/release_artifacts.rs
+++ b/builder/src/release_artifacts.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache-2.0 license
+
+use std::io::{self, Cursor};
+use std::path::PathBuf;
+
+pub struct ReleaseArtifacts {
+    pub cache_dir: PathBuf,
+}
+
+impl ReleaseArtifacts {
+    pub fn get_file(&self, bin_name: &str) -> io::Result<Vec<u8>> {
+        let file_path = self.cache_dir.join(bin_name);
+        std::fs::read(&file_path).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("Failed to read release binary {bin_name} from {file_path:?}: {e}"),
+            )
+        })
+    }
+}
+
+/// Downloads and extracts release artifacts from a GitHub release ZIP URL using `reqwest` and `zip::ZipArchive::extract`.
+/// Results are cached locally in the system temp directory under `caliptra_release_cache/{version_tag}`.
+pub fn download_and_extract_release(
+    version_tag: &str,
+    url: &str,
+) -> anyhow::Result<ReleaseArtifacts> {
+    let cache_dir = std::env::temp_dir()
+        .join("caliptra_release_cache")
+        .join(version_tag);
+
+    std::fs::create_dir_all(&cache_dir)?;
+
+    let rom_path = cache_dir.join("caliptra-rom-with-log.bin");
+    let fw_path = cache_dir.join("image-bundle-mldsa.bin");
+
+    if !rom_path.exists() && !fw_path.exists() {
+        let response = reqwest::blocking::get(url)?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to download release zip from {}: HTTP status {}",
+                url,
+                response.status()
+            );
+        }
+
+        let bytes = response.bytes()?;
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes))?;
+        archive.extract(&cache_dir)?;
+    }
+
+    Ok(ReleaseArtifacts { cache_dir })
+}

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -29,6 +29,7 @@ caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
+caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }


### PR DESCRIPTION
Establish a pattern to reference prebuilt firmware as a FWID. This makes it easier to write integration tests against older released firmware.
