### PR TITLE
mldsa: pqc info cmd

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -52,6 +52,8 @@ impl CommandId {
     #[cfg(feature = "mldsa_attestation")]
     pub const GET_PQ_CSR: Self = Self(0x50514353); // "PQCS"
     #[cfg(feature = "mldsa_attestation")]
+    pub const GET_PQ_INFO: Self = Self(0x5051_494E); // "PQIN"
+    #[cfg(feature = "mldsa_attestation")]
     pub const CERTIFY_KEY_EXTENDED_MLDSA87: Self = Self(0x434B454D); // "CKEM"
 
     /// FIPS module commands.
@@ -196,6 +198,8 @@ pub enum MailboxResp {
     #[cfg(feature = "mldsa_attestation")]
     GetPqCsr(GetPqCsrResp),
     #[cfg(feature = "mldsa_attestation")]
+    GetPqInfo(GetPqInfoResp),
+    #[cfg(feature = "mldsa_attestation")]
     CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Resp),
     AuthorizeAndStash(AuthorizeAndStashResp),
     GetIdevCsr(GetIdevCsrResp),
@@ -230,6 +234,8 @@ impl MailboxResp {
             #[cfg(feature = "mldsa_attestation")]
             MailboxResp::GetPqCsr(resp) => Ok(resp.as_bytes()),
             #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::GetPqInfo(resp) => Ok(resp.as_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
             MailboxResp::CertifyKeyExtendedMldsa87(resp) => Ok(resp.as_bytes()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetIdevCsr(resp) => Ok(resp.as_bytes()),
@@ -263,6 +269,8 @@ impl MailboxResp {
             MailboxResp::InvokeDpeMldsa87Command(resp) => resp.as_bytes_partial_mut(),
             #[cfg(feature = "mldsa_attestation")]
             MailboxResp::GetPqCsr(resp) => Ok(resp.as_mut_bytes()),
+            #[cfg(feature = "mldsa_attestation")]
+            MailboxResp::GetPqInfo(resp) => Ok(resp.as_mut_bytes()),
             #[cfg(feature = "mldsa_attestation")]
             MailboxResp::CertifyKeyExtendedMldsa87(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::AuthorizeAndStash(resp) => Ok(resp.as_mut_bytes()),
@@ -1376,6 +1384,41 @@ impl Default for GetPqCsrResp {
             hdr: MailboxRespHeader::default(),
             data_size: 0,
             data: [0u8; Self::DATA_MAX_SIZE],
+        }
+    }
+}
+
+// GET_PQ_INFO
+// No command-specific input args
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Default, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetPqInfoReq {
+    pub hdr: MailboxReqHeader,
+}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Request for GetPqInfoReq {
+    const ID: CommandId = CommandId::GET_PQ_INFO;
+    type Resp = GetPqInfoResp;
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct GetPqInfoResp {
+    pub hdr: MailboxRespHeader,
+    pub pq_pub_key: [u8; MLDSA87_PUBLIC_KEY_BYTES],
+}
+#[cfg(feature = "mldsa_attestation")]
+impl Response for GetPqInfoResp {}
+
+#[cfg(feature = "mldsa_attestation")]
+impl Default for GetPqInfoResp {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxRespHeader::default(),
+            pq_pub_key: [0u8; MLDSA87_PUBLIC_KEY_BYTES],
         }
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -908,7 +908,7 @@ impl Drivers {
 
     #[cfg(feature = "mldsa_attestation")]
     #[inline(never)]
-    fn derive_devid_seed(&mut self, seed: &mut Mldsa87Seed) -> CaliptraResult<()> {
+    pub(crate) fn derive_devid_seed(&mut self, seed: &mut Mldsa87Seed) -> CaliptraResult<()> {
         let pq_devid_cdi = self.persistent_data.get().pq_devid_cdi()?;
         dice::derive_devid_seed(&pq_devid_cdi, seed, &mut self.hmac384, &mut self.trng)
     }

--- a/runtime/src/get_pq_info.rs
+++ b/runtime/src/get_pq_info.rs
@@ -1,0 +1,45 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    get_pq_info.rs
+
+Abstract:
+
+    File contains the GET_PQ_INFO mailbox command, which returns the PQ.DevID
+    ML-DSA-87 public key -- the post-quantum sibling of GET_IDEV_INFO.
+
+    Unlike the ECDSA IDevID public key (cached in the FHT), the ML-DSA-87 public
+    key is re-derived on demand from the persisted PQ.DevID CDI: the seed is
+    reconstructed, the public key is computed from it, and the transient seed is
+    zeroized.
+
+--*/
+
+use crate::packet::{copy_from_mbox, copy_to_mbox};
+use crate::Drivers;
+use caliptra_common::mailbox_api::{GetPqInfoReq, GetPqInfoResp};
+use caliptra_drivers::{CaliptraResult, Mldsa87, Mldsa87PubKey, Mldsa87Seed};
+use zerocopy::{FromZeros, IntoBytes};
+
+pub struct GetPqInfoCmd;
+
+impl GetPqInfoCmd {
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
+        copy_from_mbox(drivers, GetPqInfoReq::new_zeroed().as_mut_bytes())?;
+
+        let mut seed = Mldsa87Seed::default();
+        drivers.derive_devid_seed(&mut seed)?;
+
+        let mut pub_key = Mldsa87PubKey::default();
+        Mldsa87::pub_from_seed(&seed, &mut pub_key, None)?;
+        drop(seed);
+
+        let mut resp = GetPqInfoResp::new_zeroed();
+        resp.pq_pub_key.copy_from_slice(pub_key.as_slice());
+        copy_to_mbox(drivers, resp.as_mut_bytes())
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,6 +28,8 @@ mod get_fmc_alias_csr;
 mod get_idev_csr;
 #[cfg(feature = "mldsa_attestation")]
 mod get_pq_csr;
+#[cfg(feature = "mldsa_attestation")]
+mod get_pq_info;
 pub mod handoff;
 mod hmac;
 pub mod info;
@@ -66,6 +68,8 @@ pub use crate::certify_key_extended::CertifyKeyExtendedCmd;
 pub use crate::certify_key_extended_mldsa::CertifyKeyExtendedMldsa87Cmd;
 #[cfg(feature = "mldsa_attestation")]
 pub use crate::get_pq_csr::GetPqCsrCmd;
+#[cfg(feature = "mldsa_attestation")]
+pub use crate::get_pq_info::GetPqInfoCmd;
 pub use crate::hmac::Hmac;
 pub use crate::invoke_dpe::CaliptraDpeProfile;
 #[cfg(feature = "mldsa_attestation")]
@@ -299,6 +303,8 @@ fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
         CommandId::INVOKE_DPE_MLDSA87 => InvokeDpeMldsa87Cmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
         CommandId::GET_PQ_CSR => GetPqCsrCmd::execute(drivers),
+        #[cfg(feature = "mldsa_attestation")]
+        CommandId::GET_PQ_INFO => GetPqInfoCmd::execute(drivers),
         #[cfg(feature = "mldsa_attestation")]
         CommandId::CERTIFY_KEY_EXTENDED_MLDSA87 => CertifyKeyExtendedMldsa87Cmd::execute(drivers),
         CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers),

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -17,6 +17,8 @@ mod test_get_idev_csr;
 mod test_get_pq_cert;
 #[cfg(feature = "mldsa_attestation")]
 mod test_get_pq_csr;
+#[cfg(feature = "mldsa_attestation")]
+mod test_get_pq_info;
 mod test_info;
 mod test_invoke_dpe;
 #[cfg(feature = "mldsa_attestation")]

--- a/runtime/tests/runtime_integration_tests/test_get_pq_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_pq_info.rs
@@ -1,0 +1,177 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_common::mailbox_api::{
+    CommandId, GetPqInfoResp, MailboxReq, MailboxReqHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::HwModel;
+use caliptra_mldsa::MLDSA87_PUBLIC_KEY_BYTES;
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private, Public};
+use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVariant};
+use openssl::sign::Signer;
+use zerocopy::{FromBytes, IntoBytes};
+
+use crate::common::{assert_error, run_pqc_rt_test};
+
+/// Seed provisioned via SET_PQ_SEED in these tests.
+const PQ_SEED: [u8; SET_PQ_SEED_SEED_SIZE] = [0x5a; SET_PQ_SEED_SEED_SIZE];
+
+fn get_pq_info_checksum() -> u32 {
+    caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_INFO), &[])
+}
+
+/// Provision the PQ.DevID seed (as PL0) so that PQC mode is enabled and
+/// GET_PQ_INFO can derive the public key.
+fn provision_pq_seed(model: &mut caliptra_hw_model::DefaultHwModel) {
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: PQ_SEED,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap();
+}
+
+/// SP 800-108 counter-mode KDF (single iteration) with HMAC-SHA384, reproducing
+/// the firmware's `hmac384_kdf` fixed-input format: `be32(1) || label` (these
+/// derivations use no context). Returns the full 48-byte HMAC-SHA384 output.
+fn hmac_sha384_kdf(key: &[u8], label: &[u8]) -> Vec<u8> {
+    let pkey = PKey::hmac(key).unwrap();
+    let mut signer = Signer::new(MessageDigest::sha384(), &pkey).unwrap();
+    signer.update(&1u32.to_be_bytes()).unwrap();
+    signer.update(label).unwrap();
+    signer.sign_to_vec().unwrap()
+}
+
+/// Independently reproduce the firmware's PQ.DevID public-key derivation, using
+/// OpenSSL as the oracle:
+///   seed  --KDF "pq_devid_cdi"-->    PQ.DevID CDI (48 B)
+///         --KDF "pq_devid_keygen"--> ML-DSA seed (first 32 B of the output)
+///         --ML-DSA-87 KeyGen-->      encoded public key (2,592 B)
+///
+/// This mirrors `SetPqSeedCmd::derive_pq_devid_cdi` and the runtime's
+/// `derive_devid_seed` used by `GetPqInfoCmd`.
+fn derive_expected_pq_devid_pubkey(seed: &[u8; SET_PQ_SEED_SEED_SIZE]) -> Vec<u8> {
+    let cdi = hmac_sha384_kdf(seed, b"pq_devid_cdi");
+    let kdf_out = hmac_sha384_kdf(&cdi, b"pq_devid_keygen");
+    let mldsa_seed: [u8; 32] = kdf_out[..32].try_into().unwrap();
+
+    let private_key = PKeyMlDsaBuilder::<Private>::from_seed(MlDsaVariant::MlDsa87, &mldsa_seed)
+        .unwrap()
+        .build()
+        .unwrap();
+    PKeyMlDsaParams::<Public>::from_pkey(&private_key)
+        .unwrap()
+        .public_key()
+        .unwrap()
+        .to_vec()
+}
+
+/// Error path: PQC mode has not been initialized (no SET_PQ_SEED). The request
+/// itself is well-formed, so the command-specific guard is what rejects it.
+#[test]
+fn test_get_pq_info_not_initialized() {
+    let mut model = run_pqc_rt_test();
+
+    let payload = MailboxReqHeader {
+        chksum: get_pq_info_checksum(),
+    };
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), payload.as_bytes())
+        .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_PQC_NOT_INITIALIZED, resp);
+}
+
+/// Error path: the request header carries an invalid checksum.
+#[test]
+fn test_get_pq_info_invalid_checksum() {
+    let mut model = run_pqc_rt_test();
+
+    // Corrupt an otherwise-valid checksum.
+    let payload = MailboxReqHeader {
+        chksum: get_pq_info_checksum().wrapping_add(1),
+    };
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), payload.as_bytes())
+        .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_INVALID_CHECKSUM, resp);
+}
+
+/// Error path: the request is larger than the (header-only) GET_PQ_INFO request,
+/// so the mailbox rejects it before dispatch.
+#[test]
+fn test_get_pq_info_request_too_large() {
+    let mut model = run_pqc_rt_test();
+
+    // GET_PQ_INFO takes only a MailboxReqHeader; send extra words to overflow it.
+    let payload = [0u8; core::mem::size_of::<MailboxReqHeader>() + 4];
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), &payload)
+        .unwrap_err();
+    assert_error(&mut model, CaliptraError::RUNTIME_INSUFFICIENT_MEMORY, resp);
+}
+
+/// Happy path: with PQC mode enabled, GET_PQ_INFO returns the 2,592-byte
+/// ML-DSA-87 public key, and it is reproducible across calls.
+#[test]
+fn test_get_pq_info_success() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let payload = MailboxReqHeader {
+        chksum: get_pq_info_checksum(),
+    };
+
+    let response = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+
+    let info_resp = GetPqInfoResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+    // Deterministic: re-deriving from the same CDI yields the identical key.
+    let response2 = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let info_resp2 = GetPqInfoResp::ref_from_bytes(response2.as_bytes()).unwrap();
+    assert_eq!(
+        info_resp.pq_pub_key, info_resp2.pq_pub_key,
+        "GET_PQ_INFO should be deterministic across calls"
+    );
+}
+
+/// The returned public key must match one independently derived from the
+/// provisioned seed (via OpenSSL), confirming the firmware derives the PQ.DevID
+/// key correctly through the seed -> CDI -> ML-DSA-87 keypair chain.
+#[test]
+fn test_get_pq_info_public_key_matches_derivation() {
+    let mut model = run_pqc_rt_test();
+    provision_pq_seed(&mut model);
+
+    let payload = MailboxReqHeader {
+        chksum: get_pq_info_checksum(),
+    };
+    let response = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_INFO), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let info_resp = GetPqInfoResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+    let expected = derive_expected_pq_devid_pubkey(&PQ_SEED);
+    assert_eq!(
+        expected.len(),
+        MLDSA87_PUBLIC_KEY_BYTES,
+        "ML-DSA-87 public key is 2,592 bytes"
+    );
+    assert_eq!(
+        info_resp.pq_pub_key.as_slice(),
+        expected.as_slice(),
+        "GET_PQ_INFO public key must match the key derived from the provisioned seed"
+    );
+}


### PR DESCRIPTION
Implement the get_pqc_info command.  This is a simple command to return the public key associated with the pqc cdi.