### PR TITLE
mldsa87: merge mu generation into signing

### DIFF
--- a/common/crypto/mldsa/src/lib.rs
+++ b/common/crypto/mldsa/src/lib.rs
@@ -3,9 +3,9 @@
 #![cfg_attr(not(test), no_std)]
 
 use crate::mldsa87::{
-    mldsa87_generate_mu, mldsa87_key_pair_from_seed, mldsa87_pub_from_seed, mldsa87_sign,
-    mldsa87_sign_deterministic, mldsa87_sign_mu, mldsa87_sign_mu_deterministic, mldsa87_verify,
-    mldsa87_verify_mu, mldsa87_verify_with_context,
+    mldsa87_generate_sign_mu_deterministic, mldsa87_key_pair_from_seed, mldsa87_pub_from_seed,
+    mldsa87_sign, mldsa87_sign_deterministic, mldsa87_sign_mu, mldsa87_sign_mu_deterministic,
+    mldsa87_verify, mldsa87_verify_mu, mldsa87_verify_with_context,
 };
 #[cfg(test)]
 use crate::mldsa87::{
@@ -142,14 +142,15 @@ impl Mldsa87 {
         mldsa87_sign_mu_deterministic_from_sk(sig, sk, mu);
     }
 
-    /// Generate the mu for an MLDSA operation based on the given response buffer and public key.
-    pub fn generate_mu(
+    /// Generate the mu for an MLDSA operation based on the given response buffer and public key
+    /// and then sign it.
+    pub fn generate_sign_mu_deterministic(
         seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
         msg: &dyn ResponseBuffer,
         msg_range: core::ops::Range<usize>,
-        out_mu: &mut [u8; MLDSA87_MU_BYTES],
+        sig: &mut [u8; MLDSA87_SIGNATURE_BYTES],
     ) -> Result<(), ResponseBufError> {
-        mldsa87_generate_mu(seed, msg, msg_range, out_mu)
+        mldsa87_generate_sign_mu_deterministic(sig, seed, msg, msg_range)
     }
 
     /// Verify a signature using an explicit signing `context`.

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -1415,25 +1415,28 @@ pub fn mldsa87_sign_mu_from_sk(
 }
 
 /// Compute `mu` (the 64-byte message representative) from a private key seed
-/// and a message supplied via a [`ResponseBuffer`].
+/// and a message supplied via a [`ResponseBuffer`] and then sign it, reusing
+/// the private key from the generation.
 ///
 /// Implements FIPS 204 HashML-DSA with an empty (zero-length) context:
 /// `mu = SHAKE256(tr || 0x00 || 0x00 || M)` where `tr = SHAKE256(pk)` and
 /// `pk` is derived from `seed`.
-pub fn mldsa87_generate_mu(
+pub fn mldsa87_generate_sign_mu_deterministic(
+    out_encoded_signature: &mut [u8; MLDSA87_SIGNATURE_BYTES],
     private_key_seed: &[u8; MLDSA87_PRIVATE_SEED_BYTES],
     msg: &dyn ResponseBuffer,
     msg_range: core::ops::Range<usize>,
-    out_mu: &mut [u8; MLDSA87_MU_BYTES],
 ) -> Result<(), ResponseBufError> {
-    let mut pub_key = [0u8; MLDSA87_PUBLIC_KEY_BYTES];
-    mldsa87_pub_from_seed(&mut pub_key, private_key_seed);
-
+    let mut priv_key = PrivateKey {
+        rho: [0u8; K_RHO_BYTES],
+        k: [0u8; K_K_BYTES],
+        sigma: [0u8; K_SIGMA_BYTES],
+        t0_ntt: Vector8::default(),
+    };
     let mut tr = [0u8; K_TR_BYTES];
-    let mut shake256 = Shake256::new();
-    shake256.absorb(&pub_key);
-    shake256.squeeze(&mut tr);
+    generate_priv_internal(&mut priv_key, private_key_seed, Some(&mut tr));
 
+    let mut mu = [0u8; K_MU_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(&tr);
     shake256.absorb(&[0u8, 0u8]);
@@ -1441,7 +1444,10 @@ pub fn mldsa87_generate_mu(
         shake256.absorb(d);
         Ok(())
     })?;
-    shake256.squeeze(out_mu);
+    shake256.squeeze(&mut mu);
+
+    let randomizer = [0u8; MLDSA87_RANDOMIZER_BYTES];
+    sign_internal_with_mu(out_encoded_signature, &priv_key, &mu, &randomizer, None);
     Ok(())
 }
 

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -129,15 +129,15 @@ impl Mldsa87 {
         Ok(())
     }
 
-    /// Compute `mu` from a seed and a message in a [`ResponseBuffer`].
+    /// Compute `mu` from a seed and a message in a [`ResponseBuffer`] and then sign it.
     #[inline(never)]
-    pub fn generate_mu(
+    pub fn generate_sign_mu_deterministic(
         seed: &Mldsa87Seed,
         msg: &dyn ResponseBuffer,
         msg_range: core::ops::Range<usize>,
-        out_mu: &mut Mldsa87Mu,
+        sig: &mut Mldsa87Signature,
     ) -> Result<(), ResponseBufError> {
-        Mldsa87Sw::generate_mu(seed, msg, msg_range, out_mu)
+        Mldsa87Sw::generate_sign_mu_deterministic(seed, msg, msg_range, sig)
     }
 
     /// Deterministically sign `mu` with the key derived from `seed`.
@@ -151,6 +151,7 @@ impl Mldsa87 {
     /// * `seed` - 32-byte private seed
     /// * `mu` - Message digest to be signed
     /// * `sig` - Buffer that receives the encoded signature
+    #[inline(never)]
     pub fn sign_mu_deterministic(
         seed: &Mldsa87Seed,
         mu: &Mldsa87Mu,

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -343,11 +343,8 @@ impl<'a> DpeCrypto<'a> {
         let mut sig = Mldsa87Signature::default();
         match data {
             SignData::ResponseBuffer(buf, range) => {
-                let mut mu = Mldsa87Mu::default();
-                Mldsa87::generate_mu(seed, *buf, range.clone(), &mut mu)
-                    .map_err(|_| CryptoError::HashError(0))?;
-                Mldsa87::sign_mu_deterministic(seed, &mu, &mut sig)
-                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
+                Mldsa87::generate_sign_mu_deterministic(seed, *buf, range.clone(), &mut sig)
+                    .map_err(|_| CryptoError::HashError(0))
             }
             SignData::Raw(msg) => Mldsa87::sign_deterministic(seed, msg, &mut sig)
                 .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),


### PR DESCRIPTION
Based on the current usage, the only purpose of `mldsa87_generate_mu` is to generate a mu that is then immediately signed with `mldsa87_sign_mu`. However both APIs call `generate_key_internal` under the hood such that two key generation passes on the same seed are involved.

This commit introduces `mldsa87_generate_sign_mu_deterministic` as one combined step in order to reuse the private key generated in the first pass, reducing the number of cycles burnt on the call path.

Here's the comparison of cycles spent on command `CERTIFY_KEY_EXTENDED_MLDSA87` before and after this change (23882879 cycles fewer):

```
command                                cycles   command                                cycles
----------------------------------------------  ----------------------------------------------
CERTIFY_KEY_EXTENDED_MLDSA87         83821879   CERTIFY_KEY_EXTENDED_MLDSA87         59939000
```

Impact on code size:

Before:
```
┌────────────────────────┬─────────┬──────┬─────────┬───────┬────────┐
│         Binary         │  Text   │ Data │ Budget  │ Used% │  Free  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 101,248 │ 128  │ 103,684 │ 97.8% │ 2,308  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime without ML-DSA │ 79,984  │ 128  │ 103,684 │ 77.3% │ 23,572 │
└────────────────────────┴─────────┴──────┴─────────┴───────┴────────┘
```
After:
```
┌────────────────────────┬─────────┬──────┬─────────┬───────┬────────┐
│         Binary         │  Text   │ Data │ Budget  │ Used% │  Free  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 101,224 │ 128  │ 103,684 │ 97.8% │ 2,332  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime without ML-DSA │ 79,984  │ 128  │ 103,684 │ 77.3% │ 23,572 │
└────────────────────────┴─────────┴──────┴─────────┴───────┴────────┘
```