### PR TITLE
mldsa: refactor size optimizations

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-703531de1bce136fff26c2b63d57c0d7f6f6914efacfbb54e499c2f89f883879af26df97930f5b92f3c280549a8387dc  caliptra-rom-no-log.bin
-acd823efb48ddfdc8d8270466f73b74ded3bd64f1ed870ba8201aa66710554ffca28796b67f0348f971cc671d0d1a482  caliptra-rom-with-log.bin
+9328fbb1378d2fe22c1f19bf39991d5b0fd3412a3ace78412f8b909d731c7e06b2f7bc12e4851a87a9185e37c6b987aa  caliptra-rom-no-log.bin
+bb4104b4d51611fd83e0126781f232fec60d777c0d6e1d665ff69207d31dc946da4240cb09a2da14043cc3f83f1e96d5  caliptra-rom-with-log.bin

--- a/rom/dev/tools/test-fmc/src/main.rs
+++ b/rom/dev/tools/test-fmc/src/main.rs
@@ -45,11 +45,11 @@ pub fn main() {}
 // Dummy RO data to max out FMC image size to 16K.
 // Note: Adjust this value to account for new changes in this FMC image.
 #[cfg(all(feature = "interactive_test_fmc", not(feature = "fake-fmc")))]
-const PAD_LEN: usize = 9624; // TEST_FMC_INTERACTIVE
+const PAD_LEN: usize = 9564; // TEST_FMC_INTERACTIVE
 #[cfg(all(feature = "fake-fmc", not(feature = "interactive_test_fmc")))]
-const PAD_LEN: usize = 9904; // FAKE_TEST_FMC_WITH_UART
+const PAD_LEN: usize = 9832; // FAKE_TEST_FMC_WITH_UART
 #[cfg(all(feature = "interactive_test_fmc", feature = "fake-fmc"))]
-const PAD_LEN: usize = 9976; // FAKE_TEST_FMC_INTERACTIVE
+const PAD_LEN: usize = 9920; // FAKE_TEST_FMC_INTERACTIVE
 #[cfg(not(any(feature = "interactive_test_fmc", feature = "fake-fmc")))]
 const PAD_LEN: usize = 0;
 

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -24,6 +24,7 @@ use caliptra_drivers::{
 };
 use caliptra_error::CaliptraResult;
 use constant_time_eq::constant_time_eq;
+use core::marker::PhantomData;
 use crypto::{
     ecdsa::{
         curve_384::{EcdsaPub384, EcdsaSignature384},
@@ -56,12 +57,23 @@ enum Cdi {
     Mldsa(Zeroizing<Array4x12>),
 }
 
+/// The crypto engines a [`DpeCrypto`] borrows from `Drivers`, bundled so it can be
+/// stored as a single field. Each member is still a distinct borrow, split from
+/// `Drivers` at the call site — this preserves the disjoint borrows that let the
+/// DPE env hold crypto, platform, and state at once. `sha384` is held as its
+/// running `DpeHasher` (the DPE `hasher()` op). (ML-DSA signs in software, so its
+/// constructor ignores `ecc384`.)
+pub struct CryptoEngines<'a> {
+    pub hasher: DpeHasher<'a>,
+    pub trng: &'a mut Trng,
+    pub ecc384: &'a mut Ecc384,
+    pub hmac384: &'a mut Hmac384,
+    pub key_vault: &'a mut KeyVault,
+}
+
 pub struct DpeCrypto<'a> {
-    trng: &'a mut Trng,
-    hmac384: &'a mut Hmac384,
-    key_vault: &'a mut KeyVault,
+    engines: CryptoEngines<'a>,
     signer: Signer<'a>,
-    hasher: DpeHasher<'a>,
     cdi: Option<Cdi>,
     derived_key: Option<DerivedKey>,
     rt_cdi: Cdi,
@@ -69,28 +81,20 @@ pub struct DpeCrypto<'a> {
 }
 
 impl<'a> DpeCrypto<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new_ec(
-        sha384: &'a mut Sha384,
-        trng: &'a mut Trng,
-        ecc384: &'a mut Ecc384,
-        hmac384: &'a mut Hmac384,
-        key_vault: &'a mut KeyVault,
+        engines: CryptoEngines<'a>,
         rt_pub_key: PubKey,
         key_id_rt_cdi: KeyId,
         key_id_rt_priv_key: KeyId,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
     ) -> CaliptraResult<Self> {
         Ok(Self {
-            trng,
-            hmac384,
-            key_vault,
+            engines,
             signer: Signer::Ec {
-                ecc384,
                 rt_pub_key,
                 rt_priv_key: key_id_rt_priv_key,
+                _marker: PhantomData,
             },
-            hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
             rt_cdi: Cdi::Ec(key_id_rt_cdi),
@@ -98,23 +102,16 @@ impl<'a> DpeCrypto<'a> {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "mldsa_attestation")]
     pub fn new_mldsa87(
-        sha384: &'a mut Sha384,
-        trng: &'a mut Trng,
-        hmac384: &'a mut Hmac384,
-        key_vault: &'a mut KeyVault,
+        engines: CryptoEngines<'a>,
         root_cdi: Zeroizing<PqDevIdCdi>,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
         exported_cdi_slot: &'a mut MldsaExportedCdiEntry,
     ) -> CaliptraResult<Self> {
         Ok(Self {
-            trng,
-            hmac384,
-            key_vault,
+            engines,
             signer: Signer::Mldsa { exported_cdi_slot },
-            hasher: DpeHasher::new(sha384)?,
             cdi: None,
             derived_key: None,
             rt_cdi: Cdi::Mldsa(Zeroizing::new(Array4x12::from(&*root_cdi))),
@@ -135,11 +132,11 @@ impl<'a> DpeCrypto<'a> {
     ) -> Result<(), CryptoError> {
         let context = self.hash_all(&[&measurement.as_slice(), &info])?;
         hmac384_kdf(
-            self.hmac384,
+            self.engines.hmac384,
             key,
             b"derive_cdi",
             Some(context.as_slice()),
-            self.trng,
+            self.engines.trng,
             output,
         )
         .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
@@ -206,11 +203,11 @@ impl<'a> DpeCrypto<'a> {
     ) -> Result<(), CryptoError> {
         let mut output = Zeroizing::new(Array4x12::default());
         hmac384_kdf(
-            self.hmac384,
+            self.engines.hmac384,
             cdi_key,
             label,
             Some(info),
-            self.trng,
+            self.engines.trng,
             (&mut *output).into(),
         )
         .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
@@ -231,23 +228,25 @@ impl<'a> DpeCrypto<'a> {
         let mut usage: KeyUsage = KeyUsage::default();
         let usage = usage.set_ecc_key_gen_seed_en();
 
-        match &mut self.signer {
-            Signer::Ec { ecc384, .. } => {
+        match &self.signer {
+            Signer::Ec { .. } => {
                 hmac384_kdf(
-                    self.hmac384,
+                    self.engines.hmac384,
                     KeyReadArgs::new(*cdi).into(),
                     label,
                     Some(info),
-                    self.trng,
+                    self.engines.trng,
                     KeyWriteArgs::new(KEY_ID_TMP, usage).into(),
                 )
                 .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
 
-                let pub_key = ecc384
+                let pub_key = self
+                    .engines
+                    .ecc384
                     .key_pair(
                         &Ecc384Seed::Key(KeyReadArgs::new(KEY_ID_TMP)),
                         &Array4x12::default(),
-                        self.trng,
+                        self.engines.trng,
                         KeyWriteArgs::new(key_id, KeyUsage::default().set_ecc_private_key_en())
                             .into(),
                     )
@@ -314,28 +313,19 @@ impl<'a> DpeCrypto<'a> {
     }
 
     fn sign_helper_ec(
-        signer: &mut Signer,
-        hasher: &mut DpeHasher,
-        trng: &mut Trng,
+        engines: &mut CryptoEngines,
         data: &SignData,
-        key_pair: Option<(&PubKey, &KeyId)>,
+        pub_key: &PubKey,
+        priv_key: &KeyId,
     ) -> Result<Signature, CryptoError> {
-        match (signer, key_pair) {
-            (Signer::Ec { ecc384, .. }, Some((pub_key, priv_key))) => {
-                Self::sign_ec(ecc384, hasher.driver(), trng, data, priv_key, pub_key)
-            }
-            (
-                Signer::Ec {
-                    ecc384,
-                    rt_pub_key,
-                    rt_priv_key,
-                    ..
-                },
-                None,
-            ) => Self::sign_ec(ecc384, hasher.driver(), trng, data, rt_priv_key, rt_pub_key),
-            #[cfg(feature = "mldsa_attestation")]
-            _ => Err(CryptoError::MismatchedAlgorithm),
-        }
+        Self::sign_ec(
+            engines.ecc384,
+            engines.hasher.driver(),
+            engines.trng,
+            data,
+            priv_key,
+            pub_key,
+        )
     }
 
     #[cfg(feature = "mldsa_attestation")]
@@ -383,9 +373,9 @@ impl DigestType for DpeCrypto<'_> {
 
 impl Drop for DpeCrypto<'_> {
     fn drop(&mut self) {
-        let _ = self.key_vault.erase_key(KEY_ID_DPE_CDI);
-        let _ = self.key_vault.erase_key(KEY_ID_DPE_PRIV_KEY);
-        let _ = self.key_vault.erase_key(KEY_ID_TMP);
+        let _ = self.engines.key_vault.erase_key(KEY_ID_DPE_CDI);
+        let _ = self.engines.key_vault.erase_key(KEY_ID_DPE_PRIV_KEY);
+        let _ = self.engines.key_vault.erase_key(KEY_ID_TMP);
     }
 }
 
@@ -393,7 +383,8 @@ impl Crypto for DpeCrypto<'_> {
     fn rand_bytes(&mut self, dst: &mut [u8]) -> Result<(), CryptoError> {
         for chunk in dst.chunks_mut(48) {
             let trng_bytes = <[u8; 48]>::from(
-                self.trng
+                self.engines
+                    .trng
                     .generate()
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?,
             );
@@ -403,7 +394,7 @@ impl Crypto for DpeCrypto<'_> {
     }
 
     fn hasher(&mut self) -> Result<&mut dyn Hasher, CryptoError> {
-        Ok(&mut self.hasher)
+        Ok(&mut self.engines.hasher)
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
@@ -557,10 +548,12 @@ impl Crypto for DpeCrypto<'_> {
     }
 
     fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
-        match self.signer {
-            Signer::Ec { .. } => {
-                Self::sign_helper_ec(&mut self.signer, &mut self.hasher, self.trng, data, None)
-            }
+        match &self.signer {
+            Signer::Ec {
+                rt_pub_key,
+                rt_priv_key,
+                ..
+            } => Self::sign_helper_ec(&mut self.engines, data, rt_pub_key, rt_priv_key),
 
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa { .. } => {
@@ -569,8 +562,13 @@ impl Crypto for DpeCrypto<'_> {
                     _ => return Err(CryptoError::MismatchedAlgorithm),
                 };
                 let mut seed = Mldsa87Seed::default();
-                dice::derive_devid_seed(&((*cdi).into()), &mut seed, self.hmac384, self.trng)
-                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                dice::derive_devid_seed(
+                    &((*cdi).into()),
+                    &mut seed,
+                    self.engines.hmac384,
+                    self.engines.trng,
+                )
+                .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
                 Self::sign_helper_mldsa(data, &seed)
             }
         }
@@ -627,13 +625,7 @@ impl crypto::Signer for DpeCrypto<'_> {
                 let Some(DerivedKey::Ec((priv_key, pub_key))) = &self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
-                Self::sign_helper_ec(
-                    &mut self.signer,
-                    &mut self.hasher,
-                    self.trng,
-                    data,
-                    Some((pub_key, priv_key)),
-                )
+                Self::sign_helper_ec(&mut self.engines, data, pub_key, priv_key)
             }
 
             #[cfg(feature = "mldsa_attestation")]
@@ -665,9 +657,11 @@ impl crypto::Signer for DpeCrypto<'_> {
 #[allow(clippy::large_enum_variant)]
 enum Signer<'a> {
     Ec {
-        ecc384: &'a mut Ecc384,
         rt_pub_key: PubKey,
         rt_priv_key: KeyId,
+        // The ECC engine lives in `DpeCrypto::engines`; this keeps `'a` used when
+        // the ML-DSA variant (the only other `'a` borrow) is compiled out.
+        _marker: PhantomData<&'a ()>,
     },
     #[cfg(feature = "mldsa_attestation")]
     Mldsa {

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -18,8 +18,8 @@ Abstract:
 pub use crate::fips::fips_self_test_cmd::SelfTestStatus;
 
 use crate::{
-    dice, CaliptraDpeEnv, CaliptraDpeProfile, DisableAttestationCmd, DpeCrypto, DpePlatform,
-    Mailbox, CALIPTRA_LOCALITY, DPE_SUPPORT, MAX_CERT_CHAIN_SIZE,
+    dice, CaliptraDpeEnv, CaliptraDpeProfile, CryptoEngines, DisableAttestationCmd, DpeCrypto,
+    DpePlatform, Mailbox, CALIPTRA_LOCALITY, DPE_SUPPORT, MAX_CERT_CHAIN_SIZE,
     PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD, PL0_PAUSER_FLAG,
     PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
@@ -36,6 +36,7 @@ use caliptra_cfi_lib::{
 };
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
 use caliptra_dpe_response_buffer::SliceResponseBuffer;
+use caliptra_drivers::sha384::DpeHasher;
 use caliptra_drivers::KeyId;
 use caliptra_drivers::{
     cprintln,
@@ -509,11 +510,13 @@ impl Drivers {
             &rt_pub_key.y.into(),
         )));
         let crypto = DpeCrypto::new_ec(
-            &mut drivers.sha384,
-            &mut drivers.trng,
-            &mut drivers.ecc384,
-            &mut drivers.hmac384,
-            &mut drivers.key_vault,
+            CryptoEngines {
+                hasher: DpeHasher::new(&mut drivers.sha384)?,
+                trng: &mut drivers.trng,
+                ecc384: &mut drivers.ecc384,
+                hmac384: &mut drivers.hmac384,
+                key_vault: &mut drivers.key_vault,
+            },
             rt_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -54,18 +54,14 @@ impl InvokeDpeCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
-        let profile = CaliptraDpeProfile::Ecc384;
         let mut cmd = InvokeDpeReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-
-        // Validate data length
-        if cmd.data_size as usize > cmd.data.len() {
-            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-        }
-        let command = Command::deserialize(profile.into(), &cmd.data[..cmd.data_size as usize])
-            .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-
-        execute(drivers, profile, command)
+        execute(
+            drivers,
+            CaliptraDpeProfile::Ecc384,
+            &cmd.data,
+            cmd.data_size as usize,
+        )
     }
 }
 
@@ -110,27 +106,32 @@ impl InvokeDpeMldsa87Cmd {
             return Err(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED);
         }
 
-        let profile = CaliptraDpeProfile::Mldsa;
         let mut cmd = InvokeDpeMldsa87Req::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
-
-        // Validate data length
-        if cmd.data_size as usize > cmd.data.len() {
-            return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
-        }
-
-        let command = Command::deserialize(profile.into(), &cmd.data[..cmd.data_size as usize])
-            .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
-
-        execute(drivers, profile, command)
+        execute(
+            drivers,
+            CaliptraDpeProfile::Mldsa,
+            &cmd.data,
+            cmd.data_size as usize,
+        )
     }
 }
 
+/// Bounds-check the request payload, deserialize the DPE command for `profile`,
+/// and execute it. Non-generic over the request type so both entry points share
+/// one copy, and takes the raw payload (rather than a deserialized `Command`) so
+/// the large `Command` enum never crosses a call boundary by value.
 fn execute(
     drivers: &mut Drivers,
     profile: CaliptraDpeProfile,
-    command: Command<'_>,
+    data: &[u8],
+    data_size: usize,
 ) -> CaliptraResult<()> {
+    if data_size > data.len() {
+        return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
+    }
+    let command = Command::deserialize(profile.into(), &data[..data_size])
+        .map_err(|_| CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED)?;
     let caller_privilege_level = drivers.caller_privilege_level();
     // Determine the target privilege level of a new context then check if we exceed thresholds
     let new_context_privilege_level = match command {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -57,6 +57,7 @@ use authorize_and_stash::AuthorizeAndStashCmd;
 use caliptra_cfi_lib::{
     cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_assert_ne, cfi_launder, CfiCounter,
 };
+use caliptra_drivers::sha384::DpeHasher;
 pub use drivers::{Drivers, PauserPrivileges};
 use mailbox::Mailbox;
 
@@ -86,7 +87,7 @@ use dice::PqCertCmd;
 pub use dice::{GetFmcAliasCertCmd, GetLdevCertCmd, IDevIdCertCmd};
 pub use disable::DisableAttestationCmd;
 pub use dpe::State;
-use dpe_crypto::DpeCrypto;
+use dpe_crypto::{CryptoEngines, DpeCrypto};
 pub use dpe_platform::{DpePlatform, VENDOR_ID, VENDOR_SKU};
 pub use fips::FipsShutdownCmd;
 #[cfg(feature = "fips_self_test")]
@@ -472,11 +473,13 @@ fn ec_dpe_env(
         &rt_pub_key.y.into(),
     )));
     let crypto = DpeCrypto::new_ec(
-        &mut drivers.sha384,
-        &mut drivers.trng,
-        &mut drivers.ecc384,
-        &mut drivers.hmac384,
-        &mut drivers.key_vault,
+        CryptoEngines {
+            hasher: DpeHasher::new(&mut drivers.sha384)?,
+            trng: &mut drivers.trng,
+            ecc384: &mut drivers.ecc384,
+            hmac384: &mut drivers.hmac384,
+            key_vault: &mut drivers.key_vault,
+        },
         rt_pub_key,
         key_id_rt_cdi,
         key_id_rt_priv_key,
@@ -511,10 +514,13 @@ fn mldsa_dpe_env(
     let pdata = drivers.persistent_data.get_mut();
     let pq_devid_cdi = pdata.pq_devid_cdi()?;
     let crypto = DpeCrypto::new_mldsa87(
-        &mut drivers.sha384,
-        &mut drivers.trng,
-        &mut drivers.hmac384,
-        &mut drivers.key_vault,
+        CryptoEngines {
+            hasher: DpeHasher::new(&mut drivers.sha384)?,
+            trng: &mut drivers.trng,
+            ecc384: &mut drivers.ecc384,
+            hmac384: &mut drivers.hmac384,
+            key_vault: &mut drivers.key_vault,
+        },
         pq_devid_cdi,
         &mut pdata.exported_cdi_slots,
         &mut pdata.mldsa_exported_cdi_slots,

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -1,6 +1,10 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
+use crate::{
+    dpe_crypto::{CryptoEngines, DpeCrypto},
+    Drivers, PauserPrivileges,
+};
+use caliptra_drivers::sha384::DpeHasher;
 
 use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(feature = "cfi")]
@@ -46,11 +50,13 @@ impl SignWithExportedEcdsaCmd {
         )));
 
         let mut crypto = DpeCrypto::new_ec(
-            &mut drivers.sha384,
-            &mut drivers.trng,
-            &mut drivers.ecc384,
-            &mut drivers.hmac384,
-            &mut drivers.key_vault,
+            CryptoEngines {
+                hasher: DpeHasher::new(&mut drivers.sha384)?,
+                trng: &mut drivers.trng,
+                ecc384: &mut drivers.ecc384,
+                hmac384: &mut drivers.hmac384,
+                key_vault: &mut drivers.key_vault,
+            },
             rt_pub_key,
             key_id_rt_cdi,
             key_id_rt_priv_key,

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -1,12 +1,16 @@
 // Licensed under the Apache-2.0 license
 
 use crate::sign_with_exported_ecdsa::{sign_exported, ExportedSignError};
-use crate::{dpe_crypto::DpeCrypto, Drivers, PauserPrivileges};
+use crate::{
+    dpe_crypto::{CryptoEngines, DpeCrypto},
+    Drivers, PauserPrivileges,
+};
 
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 
 use caliptra_common::mailbox_api::{SignWithExportedMldsaReq, SignWithExportedMldsaResp};
+use caliptra_drivers::sha384::DpeHasher;
 use caliptra_drivers::MLDSA87_MU_BYTES;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
@@ -57,10 +61,13 @@ impl SignWithExportedMldsaCmd {
         let pdata = drivers.persistent_data.get_mut();
         let root_cdi = pdata.pq_devid_cdi()?;
         let mut crypto = DpeCrypto::new_mldsa87(
-            &mut drivers.sha384,
-            &mut drivers.trng,
-            &mut drivers.hmac384,
-            &mut drivers.key_vault,
+            CryptoEngines {
+                hasher: DpeHasher::new(&mut drivers.sha384)?,
+                trng: &mut drivers.trng,
+                ecc384: &mut drivers.ecc384,
+                hmac384: &mut drivers.hmac384,
+                key_vault: &mut drivers.key_vault,
+            },
             root_cdi,
             &mut pdata.exported_cdi_slots,
             &mut pdata.mldsa_exported_cdi_slots,

--- a/x509/src/cert_bldr.rs
+++ b/x509/src/cert_bldr.rs
@@ -145,45 +145,18 @@ impl<'a, S: Signature<MAX_DER_SIZE>, const MAX_DER_SIZE: usize> CertBuilder<'a, 
     ///
     /// * `buf` - Buffer to construct the certificate in
     pub fn build(&self, buf: &mut [u8]) -> Option<usize> {
-        if buf.len() < self.len {
-            return None;
-        }
-
-        let mut pos = 0;
-
-        // Copy Tag
-        *buf.get_mut(pos)? = DER_SEQ_TAG;
-        pos += 1;
-
-        // Copy Length
+        // Re-encode the signature (the only signature-type-specific work); the DER
+        // framing is delegated to the non-generic `build_der` so it is compiled
+        // once rather than monomorphized per signature type.
         let mut sig_buf = [0u8; MAX_DER_SIZE];
         let sig_len = self.sig.to_der(&mut sig_buf)?;
-        let len = self.tbs.len() + S::oid_der().len() + sig_len;
-
-        if buf.len() < len + 4 {
-            return None;
-        }
-
-        pos += der_encode_len(len, buf.get_mut(pos..)?)?;
-
-        // Copy Value
-
-        // Copy TBS DER
-        buf.get_mut(pos..pos + self.tbs.len())?
-            .copy_from_slice(self.tbs);
-        pos += self.tbs.len();
-
-        // Copy OID DER
-        buf.get_mut(pos..pos + S::oid_der().len())?
-            .copy_from_slice(S::oid_der());
-        pos += S::oid_der().len();
-
-        // Copy Signature DER
-        buf.get_mut(pos..pos + sig_len)?
-            .copy_from_slice(sig_buf.get(..sig_len)?);
-        pos += sig_len;
-
-        Some(pos)
+        build_der(
+            buf,
+            self.tbs,
+            S::oid_der(),
+            sig_buf.get(..sig_len)?,
+            self.len,
+        )
     }
 
     /// Return the length of Certificate or Certificate Signing Request
@@ -211,6 +184,54 @@ impl<'a, S: Signature<MAX_DER_SIZE>, const MAX_DER_SIZE: usize> CertBuilder<'a, 
         // TAG (1 byte) + LEN (len_bytes bytes) + len (Length of the sequence contents)
         Some(1 + len_bytes + len)
     }
+}
+
+/// DER-frame a signed Cert/CSR: `SEQUENCE { tbs, sig_alg_oid, signature }`.
+/// Non-generic (all inputs are slices) so it is compiled once and shared across
+/// every `CertBuilder` signature-type instantiation. `expected_len` is the
+/// precomputed total length (`CertBuilder::len`) used for the up-front bounds check.
+fn build_der(
+    buf: &mut [u8],
+    tbs: &[u8],
+    oid: &[u8],
+    sig_der: &[u8],
+    expected_len: usize,
+) -> Option<usize> {
+    if buf.len() < expected_len {
+        return None;
+    }
+
+    let mut pos = 0;
+
+    // Copy Tag
+    *buf.get_mut(pos)? = DER_SEQ_TAG;
+    pos += 1;
+
+    // Copy Length
+    let len = tbs.len() + oid.len() + sig_der.len();
+
+    if buf.len() < len + 4 {
+        return None;
+    }
+
+    pos += der_encode_len(len, buf.get_mut(pos..)?)?;
+
+    // Copy Value
+
+    // Copy TBS DER
+    buf.get_mut(pos..pos + tbs.len())?.copy_from_slice(tbs);
+    pos += tbs.len();
+
+    // Copy OID DER
+    buf.get_mut(pos..pos + oid.len())?.copy_from_slice(oid);
+    pos += oid.len();
+
+    // Copy Signature DER
+    buf.get_mut(pos..pos + sig_der.len())?
+        .copy_from_slice(sig_der);
+    pos += sig_der.len();
+
+    Some(pos)
 }
 
 // Type alias for ECDSA-384 Certificate Builder


### PR DESCRIPTION
A collection of minor code optimizations and refactoring changes which together reduce the instruction memory usage of the mldsa_attestation feature by ~600 Bytes.