### PR TITLE
Fix smoke test assertion failure in subsystem mode

### DIFF
--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -457,9 +457,11 @@ fn smoke_test() {
                 String::from_utf8_lossy(&fmc_alias_cert.to_text().unwrap())
             );
 
+            let owner_pk_in_fuses = (fuses.owner_pk_hash != [0u32; 12]) && !hw.subsystem_mode();
+
             let mut hasher = Sha384::new();
             hasher.update(&owner_pk_hash);
-            hasher.update(&[(fuses.owner_pk_hash != [0u32; 12]) as u8]);
+            hasher.update(&[owner_pk_in_fuses as u8]);
             hasher.update(&[fuses.anti_rollback_disable as u8]);
             hasher.update(&[fuses.fuse_ecc_revocation as u8]);
             hasher.update(&fuses.fuse_lms_revocation.to_le_bytes());
@@ -529,7 +531,7 @@ fn smoke_test() {
                 &Pcr0::derive(&Pcr0Input {
                     fmc_digest: image.manifest.fmc.digest,
                     owner_pub_key_hash: owner_pk_hash_words,
-                    owner_pub_key_hash_in_fuses: fuses.owner_pk_hash != [0u32; 12],
+                    owner_pub_key_hash_in_fuses: owner_pk_in_fuses,
                     anti_rollback_disable: fuses.anti_rollback_disable,
                     vendor_ecc_pub_key_revocation: fuses.fuse_ecc_revocation as u8,
                     vendor_lms_pub_key_revocation: fuses.fuse_lms_revocation,


### PR DESCRIPTION
Update smoke_test.rs to account for subsystem mode when determining if owner_pk_hash is present in fuses. In subsystem mode, the MCU ROM delivers the owner PK hash via the DOT mailbox command rather than direct fuse register writes, so owner_pub_keys_digest_in_fuses is false.

This resolves the regression in nightly release tests introduced when upgrading the MCU ROM dependency in commit 9bf3a565d (#3900).

TAG=agy
CONV=13283bff-f8f1-4309-838c-10c12a63a693