### PR TITLE
runtime: store PQ.DevID public key hash in persistent data

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -49,11 +49,16 @@ pub const IDEVID_CSR_SIZE: u32 = 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 1024;
 pub const DPE_PL_CONTEXT_LIMITS_SIZE: u32 = 2;
 pub const PQ_DEVID_CDI_SIZE: u32 = 48;
+pub const PQ_DEVID_PUB_KEY_DIGEST_SIZE: u32 = 32;
 pub const PQC_STATUS_FLAGS_SIZE: u32 = 1;
 #[cfg(feature = "mldsa_attestation")]
 pub const PQC_MODE_ENABLED_FLAG: u8 = 1;
-pub const RESERVED_MEMORY_SIZE: u32 =
-    (3 * 1024) - 2 - PQ_DEVID_CDI_SIZE - PQC_STATUS_FLAGS_SIZE - MLDSA_EXPORTED_CDI_HANDLES_SIZE;
+pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024)
+    - 2
+    - PQ_DEVID_CDI_SIZE
+    - PQ_DEVID_PUB_KEY_DIGEST_SIZE
+    - PQC_STATUS_FLAGS_SIZE
+    - MLDSA_EXPORTED_CDI_HANDLES_SIZE;
 
 pub const PCR_LOG_MAX_COUNT: usize = 17;
 pub const FUSE_LOG_MAX_COUNT: usize = 62;
@@ -358,6 +363,7 @@ pub struct PersistentData {
     // `pq_devid_cdi()`, which hands out a reference exclusively once the seed
     // has been provisioned (see `pqc_mode_enabled`).
     pq_devid_cdi: PqDevIdCdi,
+    pq_devid_pub_key_digest: [u8; PQ_DEVID_PUB_KEY_DIGEST_SIZE as usize],
     pqc_status_flags: u8,
 
     #[cfg(all(feature = "mldsa_attestation", feature = "runtime"))]
@@ -398,6 +404,17 @@ impl PersistentData {
             .ok_or(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED)
     }
 
+    /// Returns a copy of the SHA-256 hash of the PQ.DevID public key, if PQC mode
+    /// has been enabled.
+    #[cfg(feature = "mldsa_attestation")]
+    pub fn pq_devid_pub_key_digest(
+        &self,
+    ) -> CaliptraResult<[u8; PQ_DEVID_PUB_KEY_DIGEST_SIZE as usize]> {
+        self.pqc_mode_enabled()
+            .then_some(self.pq_devid_pub_key_digest)
+            .ok_or(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED)
+    }
+
     /// Stores the PQ.DevID CDI and atomically marks PQC mode enabled, upholding
     /// the invariant that a readable CDI always has its status flag set. The CDI
     /// is write-once: attempting to overwrite an already-provisioned CDI returns
@@ -424,6 +441,18 @@ impl PersistentData {
             self.pq_devid_cdi = dummy_cdi;
             self.mldsa_exported_cdi_slots.zeroize();
         }
+    }
+
+    #[cfg(feature = "mldsa_attestation")]
+    pub fn set_pq_devid_pub_key_digest(
+        &mut self,
+        digest: [u8; PQ_DEVID_PUB_KEY_DIGEST_SIZE as usize],
+    ) -> CaliptraResult<()> {
+        if !self.pqc_mode_enabled() {
+            return Err(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED);
+        }
+        self.pq_devid_pub_key_digest = digest;
+        Ok(())
     }
 
     pub fn assert_matches_layout() {
@@ -526,6 +555,12 @@ impl PersistentData {
             );
 
             persistent_data_offset += PQ_DEVID_CDI_SIZE;
+            assert_eq!(
+                addr_of!((*P).pq_devid_pub_key_digest) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+
+            persistent_data_offset += PQ_DEVID_PUB_KEY_DIGEST_SIZE;
             assert_eq!(
                 addr_of!((*P).pqc_status_flags) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1333,6 +1333,7 @@ impl CaliptraError {
             0x000E0070,
             "Runtime Error: SET_PQ_SEED rejected because attestation is disabled"
         ),
+        (
             RUNTIME_PQ_INVALID_PUBKEY_DIGEST,
             0x000E0071,
             "Runtime Error: Invalid PQ.DevID Public Key Hash"

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1333,6 +1333,10 @@ impl CaliptraError {
             0x000E0070,
             "Runtime Error: SET_PQ_SEED rejected because attestation is disabled"
         ),
+            RUNTIME_PQ_INVALID_PUBKEY_DIGEST,
+            0x000E0071,
+            "Runtime Error: Invalid PQ.DevID Public Key Hash"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -516,7 +516,7 @@ fn mldsa_dpe_env(
     dmtf_device_info: Option<ArrayVec<u8, { MAX_OTHER_NAME_SIZE }>>,
     ueid: Option<[u8; 17]>,
 ) -> CaliptraResult<CaliptraDpeEnv<'_>> {
-    let (_, _, digest) = drivers.compute_mldsa_key_material()?;
+    let digest = drivers.persistent_data.get().pq_devid_pub_key_digest()?;
     let pdata = drivers.persistent_data.get_mut();
     let pq_devid_cdi = pdata.pq_devid_cdi()?;
     let crypto = DpeCrypto::new_mldsa87(
@@ -538,7 +538,7 @@ fn mldsa_dpe_env(
         platform: DpePlatform::new(
             CaliptraDpeProfile::Mldsa,
             pl0_pauser,
-            digest,
+            digest.into(),
             &drivers.mldsa_cert_chain,
             nb,
             nf,

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -39,6 +39,20 @@ impl SetPqSeedCmd {
             .get_mut()
             .set_pq_devid_cdi(out.into())?;
 
+        // Calculate the digest of the PQ.DevID public key and cache it
+        // in the persistent data to avoid repeated key generation passes
+        // involved in DPE invocation.
+        let (_, _, digest) = drivers.compute_mldsa_key_material()?;
+        drivers
+            .persistent_data
+            .get_mut()
+            .set_pq_devid_pub_key_digest(
+                digest
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| CaliptraError::RUNTIME_PQ_INVALID_PUBKEY_DIGEST)?,
+            )?;
+
         crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }
 

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -16,6 +16,7 @@ use crate::{Drivers, PauserPrivileges};
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{MailboxRespHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE};
 use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult};
+use crypto::{Digest, Sha256};
 use zerocopy::{FromZeros, IntoBytes};
 
 pub struct SetPqSeedCmd;
@@ -42,16 +43,13 @@ impl SetPqSeedCmd {
         // Calculate the digest of the PQ.DevID public key and cache it
         // in the persistent data to avoid repeated key generation passes
         // involved in DPE invocation.
-        let (_, _, digest) = drivers.compute_mldsa_key_material()?;
+        let (_, _, Digest::Sha256(Sha256(digest))) = drivers.compute_mldsa_key_material()? else {
+            return Err(CaliptraError::RUNTIME_PQ_INVALID_PUBKEY_DIGEST);
+        };
         drivers
             .persistent_data
             .get_mut()
-            .set_pq_devid_pub_key_digest(
-                digest
-                    .as_slice()
-                    .try_into()
-                    .map_err(|_| CaliptraError::RUNTIME_PQ_INVALID_PUBKEY_DIGEST)?,
-            )?;
+            .set_pq_devid_pub_key_digest(digest)?;
 
         crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }


### PR DESCRIPTION
Calculate the SHA-256 hash of the PQ.DevID public key after setting PQ seed and store it in persistent data. This saves a full key generation pass at the entry of `mldsa_dpe_env`, which is called at the beginning of each DPE command invocation.

Performance before and after this change:
```
command                                cycles   command                                cycles
----------------------------------------------  ----------------------------------------------
CERTIFY_KEY_EXTENDED_MLDSA87        114696878   SELF_TEST_GET_RESULTS(+KATs)         48587836
SELF_TEST_GET_RESULTS(+KATs)         48577427   CERTIFY_KEY_EXTENDED_MLDSA87         35417842
```

The change takes 300+ bytes of additional instruction memory:
Before:
```
┌────────────────────────┬─────────┬──────┬─────────┬───────┬────────┐
│         Binary         │  Text   │ Data │ Budget  │ Used% │  Free  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 101,308 │ 128  │ 103,684 │ 97.8% │ 2,248  │
└────────────────────────┴─────────┴──────┴─────────┴───────┴────────┘
```
after:
```
┌────────────────────────┬─────────┬──────┬─────────┬────────┬────────┐
│         Binary         │  Text   │ Data │ Budget  │ Used%  │  Free  │
├────────────────────────┼─────────┼──────┼─────────┼────────┼────────┤
│ Runtime with ML-DSA    │ 101,684 │ 128  │ 103,684 │ 98.19% │ 1,872  │
└────────────────────────┴─────────┴──────┴─────────┴────────┴────────┘
```