### PR TITLE
Add stack optimizations to `SIGN_WITH_EXPORTED_MLDSA`

### DIFF
--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -34,7 +34,8 @@ impl SignWithExportedMldsaCmd {
         env: &mut DpeCrypto,
         data: &SignData,
         exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
-    ) -> CaliptraResult<(Signature, PubKey)> {
+        resp: &mut SignWithExportedMldsaResp,
+    ) -> CaliptraResult<()> {
         let key_pair =
             env.derive_key_pair_exported(exported_cdi_handle, PROFILE_DESC, PROFILE_DESC);
 
@@ -50,7 +51,19 @@ impl SignWithExportedMldsaCmd {
         let sig = okref(&sig)
             .map_err(|_| CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED)?;
 
-        Ok((sig.clone(), pub_key.clone()))
+        let (
+            Signature::Mldsa(MldsaSignature(sig_bytes)),
+            PubKey::Mldsa(MldsaPublicKey(pubkey_bytes)),
+        ) = (sig, pub_key)
+        else {
+            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_SIGNATURE);
+        };
+
+        resp.derived_pubkey.copy_from_slice(pubkey_bytes);
+        resp.signature.copy_from_slice(sig_bytes);
+        resp.hdr = MailboxRespHeader::default();
+
+        Ok(())
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
@@ -107,21 +120,9 @@ impl SignWithExportedMldsaCmd {
                 SignData::Raw(&cmd.tbs[..cmd.tbs_size as usize])
             }
         };
-        let result = Self::mldsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle);
-        let (sig, pubkey) = okref(&result)?;
-        let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pubkey))) =
-            (sig, pubkey)
-        else {
-            return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_SIGNATURE);
-        };
 
-        let resp = mutrefbytes::<SignWithExportedMldsaResp>(resp)?;
-        *resp = SignWithExportedMldsaResp {
-            hdr: MailboxRespHeader::default(),
-            derived_pubkey: *pubkey,
-            signature: *sig,
-            _padding: Default::default(),
-        };
+        let resp_struct = mutrefbytes::<SignWithExportedMldsaResp>(resp)?;
+        Self::mldsa_sign(&mut crypto, &data, &cmd.exported_cdi_handle, resp_struct)?;
         Ok(core::mem::size_of::<SignWithExportedMldsaResp>())
     }
 }


### PR DESCRIPTION
#4010 saw a potential stack overflow while executing this command. This should relieve the pressure on the stack by ~7KB bytes.