### PR TITLE
sw-emulator: fix latching SoC IFC interrupt lines; expose CPU halt state

### DIFF
--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -162,6 +162,19 @@ impl ModelEmulated {
     }
 }
 
+impl ModelEmulated {
+    /// Returns true when the emulated CPU is halted via the VeeR MPMC
+    /// low-power CSR (not the RISC-V `wfi` instruction, which this emulator
+    /// treats as a no-op).
+    ///
+    /// This reflects the VeeR EL2 core-halt power-management state tracked by the
+    /// CPU (`Cpu::read_halted`), used by external schedulers to drop the core off
+    /// their event queue while it is idle.
+    pub fn cpu_halted(&self) -> bool {
+        self.cpu.read_halted()
+    }
+}
+
 fn hash_slice(slice: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     std::hash::Hash::hash_slice(slice, &mut hasher);

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -548,6 +548,13 @@ impl<TBus: Bus> Cpu<TBus> {
         self.csrs.write(self.priv_mode, csr, val)
     }
 
+    /// Returns true when the core is halted via the VeeR MPMC low-power CSR
+    /// (not the RISC-V `wfi` instruction, which this emulator treats as a
+    /// no-op).
+    pub fn read_halted(&self) -> bool {
+        self.halted
+    }
+
     /// Write the specified Configuration status register as if we were in M mode
     ///
     /// # Arguments

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -492,16 +492,18 @@ impl Bus for SocRegistersInternal {
                 .modify(NotifGlobalIntr::AGG_STS.val(1));
         }
 
-        if regs.global_intr_en_r.reg.is_set(GlobalIntrEn::ERROR_EN)
-            && regs.error_intr_en_r.reg.get() & regs.error_internal_intr_r.reg.get() != 0
-        {
-            regs.err_irq.set_level(true);
-        }
-        if regs.global_intr_en_r.reg.is_set(GlobalIntrEn::NOTIF_EN)
-            && regs.notif_intr_en_r.reg.get() & regs.notif_internal_intr_r.reg.get() != 0
-        {
-            regs.notif_irq.set_level(true);
-        }
+        // Level interrupts: raise when an enabled status bit is pending, and
+        // (fix) LOWER when none remain. Without the else-branch the irq line
+        // latches high forever after the first event, so a core that halts
+        // (WFI/MPMC) waiting on this interrupt is immediately and perpetually
+        // re-woken -- breaking interrupt-driven idle / external descheduling.
+        let err_pending = regs.global_intr_en_r.reg.is_set(GlobalIntrEn::ERROR_EN)
+            && regs.error_intr_en_r.reg.get() & regs.error_internal_intr_r.reg.get() != 0;
+        regs.err_irq.set_level(err_pending);
+
+        let notif_pending = regs.global_intr_en_r.reg.is_set(GlobalIntrEn::NOTIF_EN)
+            && regs.notif_intr_en_r.reg.get() & regs.notif_internal_intr_r.reg.get() != 0;
+        regs.notif_irq.set_level(notif_pending);
     }
 
     fn warm_reset(&mut self) {


### PR DESCRIPTION
**AI usage disclosure statement:**  claude found the interrupt bug while I was using it to set up some experiments driving a custom scheduler in our hw-model harness (which is why exposing the halted flag is necessary).  It drafted up the fix and while I have inspected it thoroughly, it is still in a portion of the sw-emulator I am not the most familiar with.  I also let claude do this PR bug writeup, and then reviewing it myself.  Suggest keeping this in mind while reviewing. 

  ## Summary

  `SocRegistersInternal::poll()` asserts the SoC IFC error/notification interrupt lines but never deasserts them, so once raised
  they stay latched high forever. This breaks any firmware that halts the core waiting on one of these interrupts. This PR
  makes `poll()` drive the lines to track their live pending state (both edges), and also adds two small read-only accessors      (`Cpu::read_halted()` / `ModelEmulated::cpu_halted()`) that let external tooling observe the core's halt state.                                                                                                                                                 
 
 ## The bug

  Caliptra's SoC IFC error and notification interrupts are **level-triggered** (the PIC gateway `meigwctrl` resets to
  `LevelTriggered`/`ActiveHigh`, and firmware never reconfigures it). Their asserted state is, in hardware, a combinational
  function of `global_enable && (per_event_enable & status)`.

  `SocRegistersInternal::poll()` modeled only half of that:

  ```rust
  if <global && per_en & status != 0> {
      regs.notif_irq.set_level(true);   // raise-only; no else
  }
  ```

  It called Irq::set_level(true) when the condition held, but there was no set_level(false) when the condition cleared. Because
  these are level gateways, the PIC pending bit (meip) is driven directly from the last level written — so once set_level(true)
  ran, the line remained asserted permanently, even after firmware W1C-cleared the underlying status register. The emulator       modeled the interrupt's rising edge but never its falling edge.                                                                                                                                                                                                 The fix

  Recompute the live pending condition each poll() and drive set_level with it unconditionally, for both the error and
  notification lines:

```rust
  let notif_pending = <global && per_en & status != 0>;
  regs.notif_irq.set_level(notif_pending);   // tracks the real state, both directions
 ```

  The pending-condition expression is byte-for-byte identical to the old if condition — the only change is that the line is now
  also driven low when the condition no longer holds. Irq::set_level is idempotent for a level gateway, so evaluating and
  driving every poll is safe.

##  Why this has never caused problems until now

  The bug is only observable if something actually depends on the line going low again. The overwhelmingly common way the
  sw-emulator is used — by the caliptra-sw test suites and CI — is to step() / step_until(...) the core continuously toward a
  milestone and then issue the next mailbox command. In that mode the core is never parked waiting on the interrupt line to       deassert: a stuck-high line just produces a redundant external interrupt that firmware services and moves on from. Nothing in   the existing test surface waits on the line falling, so the latch was invisible (and no existing test depends on the old        behavior).                                                                                                                    
  It only becomes fatal for interrupt-driven idle — where firmware enables the notification interrupt, halts the core (VeeR MPMC  low-power halt) with interrupts enabled, and expects to sleep until the next command. There the stuck-high line immediately
  re-wakes the core every poll: halt → wake → service → clear → halt → wake, in a tight loop, so the core never actually stays    idle. That path simply hadn't been exercised against the emulator before.