### PR TITLE
mldsa: Implement libcaliptra mldsa bindings

### DIFF
--- a/libcaliptra/examples/generic/test.c
+++ b/libcaliptra/examples/generic/test.c
@@ -1218,6 +1218,59 @@ int sign_with_exported_ecdsa_cdi_hitless(const test_info* info)
     return 0;
 }
 
+// Provision the PQ.DevID (ML-DSA) seed, then read back the ML-DSA IDevID public
+// key. Exercises SET_PQ_SEED and GET_PQ_INFO.
+int pqc_set_seed_and_get_identity(const test_info* info)
+{
+    int status = boot_to_ready_for_fw(info, false);
+    if (status) {
+        dump_caliptra_error_codes();
+        return 1;
+    }
+
+    status = caliptra_upload_fw(&info->image_bundle, false);
+    if (status) {
+        printf("FW Load Failed: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        return 1;
+    }
+
+    // Provision the PQ.DevID seed (write-once).
+    struct caliptra_set_pq_seed_req seed_req = { 0 };
+    memset(seed_req.seed, 0x5a, sizeof(seed_req.seed));
+    status = caliptra_set_pq_seed(&seed_req, false);
+    if (status) {
+        printf("SET_PQ_SEED failed: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        return 1;
+    }
+
+    // Read the ML-DSA IDevID public key; it must be non-zero once provisioned.
+    struct caliptra_get_pq_info_resp info_resp = { 0 };
+    status = caliptra_get_pq_info(&info_resp, false);
+    if (status) {
+        printf("GET_PQ_INFO failed: 0x%x\n", status);
+        dump_caliptra_error_codes();
+        return 1;
+    }
+
+    bool pubkey_nonzero = false;
+    for (size_t i = 0; i < sizeof(info_resp.pq_pub_key); i++) {
+        if (info_resp.pq_pub_key[i] != 0) {
+            pubkey_nonzero = true;
+            break;
+        }
+    }
+    if (!pubkey_nonzero) {
+        printf("GET_PQ_INFO returned an all-zero public key\n");
+        return 1;
+    }
+
+    printf("PQC set seed + identity: OK (pubkey %zu bytes)\n",
+           sizeof(info_resp.pq_pub_key));
+    return 0;
+}
+
 // Issue FW load commands repeatedly
 // Coverage for piecewise FW load and runtime FW updates
 int upload_fw_piecewise(const test_info* info)
@@ -1561,6 +1614,7 @@ int run_tests(const test_info* info)
     run_test(upload_fw_piecewise, info, "Test Piecewise FW Load");
     run_test(sign_with_exported_ecdsa_cdi, info, "Test Sign with Exported ECDSA");
     run_test(sign_with_exported_ecdsa_cdi_hitless, info, "Test Exported CDI Hitless Update");
+    run_test(pqc_set_seed_and_get_identity, info, "Test PQC Set Seed + Get Identity");
     run_test(test_sha_acc, info,"Test SHA ACC");
 
     if (global_test_result) {

--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -233,6 +233,32 @@ int caliptra_sign_with_exported_ecdsa(struct caliptra_sign_with_exported_ecdsa_r
 // Revoke Exported CDI Handle
 int caliptra_revoke_exported_cdi_handle(struct caliptra_revoke_exported_cdi_handle_req *req, bool async);
 
+// PQC / ML-DSA-87 commands
+
+// Set PQ Seed (provision the PQ.DevID ML-DSA seed)
+int caliptra_set_pq_seed(struct caliptra_set_pq_seed_req *req, bool async);
+
+// Get PQ CSR (ML-DSA IDevID CSR)
+int caliptra_get_pq_csr(struct caliptra_get_pq_csr_resp *resp, bool async);
+
+// Get PQ Info (ML-DSA IDevID public key)
+int caliptra_get_pq_info(struct caliptra_get_pq_info_resp *resp, bool async);
+
+// Get PQ Cert (build ML-DSA IDevID cert from caller TBS + signature)
+int caliptra_get_pq_cert(struct caliptra_get_pq_cert_req *req, struct caliptra_get_pq_cert_resp *resp, bool async);
+
+// Populate PQ Cert (store externally-signed PQ IDevID cert)
+int caliptra_populate_pq_cert(struct caliptra_populate_pq_cert_req *req, bool async);
+
+// Certify Key Extended ML-DSA-87
+int caliptra_certify_key_extended_mldsa87(struct caliptra_certify_key_extended_mldsa87_req *req, struct caliptra_certify_key_extended_mldsa87_resp *resp, bool async);
+
+// Invoke DPE command (ML-DSA-87)
+int caliptra_invoke_dpe_mldsa87(struct caliptra_invoke_dpe_mldsa87_req *req, struct caliptra_invoke_dpe_mldsa87_resp *resp, bool async);
+
+// Sign with Exported ML-DSA
+int caliptra_sign_with_exported_mldsa(struct caliptra_sign_with_exported_mldsa_req *req, struct caliptra_sign_with_exported_mldsa_resp *resp, bool async);
+
 // Self test start
 int caliptra_self_test_start(bool async);
 

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -344,6 +344,108 @@ struct caliptra_revoke_exported_cdi_handle_req
     uint8_t exported_cdi_handle[32];
 };
 
+#define MLDSA87_PUB_KEY_SIZE   2592
+#define MLDSA87_SIGNATURE_SIZE 4627
+#define MLDSA87_SEED_SIZE      32
+#define MLDSA87_MU_SIZE        64
+
+// SET_PQ_SEED: provision the PQ.DevID (ML-DSA) seed. No response body.
+struct caliptra_set_pq_seed_req
+{
+    struct caliptra_req_header hdr;
+    uint8_t seed[MLDSA87_SEED_SIZE];
+};
+
+// GET_PQ_CSR: return the ML-DSA IDevID CSR. No command-specific request args.
+#define GET_PQ_CSR_DATA_MAX_SIZE 12800
+struct caliptra_get_pq_csr_resp
+{
+    struct caliptra_resp_header hdr;
+    uint32_t data_size;
+    uint8_t data[GET_PQ_CSR_DATA_MAX_SIZE]; // variable length
+};
+
+// GET_PQ_INFO: return the ML-DSA IDevID public key. No request args.
+struct caliptra_get_pq_info_resp
+{
+    struct caliptra_resp_header hdr;
+    uint8_t pq_pub_key[MLDSA87_PUB_KEY_SIZE];
+};
+
+// GET_PQ_CERT: build/return the ML-DSA IDevID cert from a caller-supplied
+// TBS + signature. Variable-length request (trailing `tbs` trimmed to
+// `tbs_size`) and response.
+#define GET_PQ_CERT_TBS_MAX_SIZE  3553
+#define GET_PQ_CERT_CERT_MAX_SIZE 8192
+struct caliptra_get_pq_cert_req
+{
+    struct caliptra_req_header hdr;
+    uint32_t tbs_size;
+    uint8_t signature[MLDSA87_SIGNATURE_SIZE];
+    uint8_t tbs[GET_PQ_CERT_TBS_MAX_SIZE]; // variable length
+};
+struct caliptra_get_pq_cert_resp
+{
+    struct caliptra_resp_header hdr;
+    uint32_t cert_size;
+    uint8_t cert[GET_PQ_CERT_CERT_MAX_SIZE]; // variable length
+};
+
+// POPULATE_PQ_CERT: store an externally-signed PQ IDevID cert into the cert
+// chain. No response body. Variable-length request (`cert` trimmed to
+// `cert_size`).
+#define POPULATE_PQ_CERT_MAX_SIZE 8192
+struct caliptra_populate_pq_cert_req
+{
+    struct caliptra_req_header hdr;
+    uint32_t cert_size;
+    uint8_t cert[POPULATE_PQ_CERT_MAX_SIZE]; // variable length
+};
+
+// CERTIFY_KEY_EXTENDED_MLDSA87: ML-DSA variant of certify-key-extended.
+#define CERTIFY_KEY_EXTENDED_MLDSA87_REQ_SIZE  72
+#define CERTIFY_KEY_EXTENDED_MLDSA87_RESP_SIZE 25152
+struct caliptra_certify_key_extended_mldsa87_req
+{
+    struct caliptra_req_header hdr;
+    uint32_t flags;
+    uint8_t certify_key_req[CERTIFY_KEY_EXTENDED_MLDSA87_REQ_SIZE];
+};
+struct caliptra_certify_key_extended_mldsa87_resp
+{
+    struct caliptra_resp_header hdr;
+    uint32_t size;
+    uint8_t certify_key_resp[CERTIFY_KEY_EXTENDED_MLDSA87_RESP_SIZE]; // variable length
+};
+
+// INVOKE_DPE_MLDSA87 request/response structs are defined after the DPE
+// command/response struct definitions below, since the request reuses the DPE
+// command union.
+
+// SIGN_WITH_EXPORTED_MLDSA: sign with an exported-CDI-derived ML-DSA key.
+// Variable-length request (`message` trimmed to `message_size`).
+#define SIGN_WITH_EXPORTED_MLDSA_CDI_MAX_SIZE 32
+#define SIGN_WITH_EXPORTED_MLDSA_MSG_MAX_SIZE 1024
+// sign_mode values (mirror SignWithExportedMldsaReq)
+#define SIGN_WITH_EXPORTED_MLDSA_MODE_DATA        0
+#define SIGN_WITH_EXPORTED_MLDSA_MODE_EXTERNAL_MU 1
+struct caliptra_sign_with_exported_mldsa_req
+{
+    struct caliptra_req_header hdr;
+    uint8_t exported_cdi_handle[SIGN_WITH_EXPORTED_MLDSA_CDI_MAX_SIZE];
+    uint32_t sign_mode;
+    uint32_t message_size;
+    uint8_t message[SIGN_WITH_EXPORTED_MLDSA_MSG_MAX_SIZE]; // variable length
+};
+struct caliptra_sign_with_exported_mldsa_resp
+{
+    struct caliptra_resp_header hdr;
+    uint8_t derived_pubkey[MLDSA87_PUB_KEY_SIZE];
+    uint8_t signature[MLDSA87_SIGNATURE_SIZE];
+    // Pads the struct to a 4-byte multiple (SIG_SIZE is odd). Always zero.
+    uint8_t reserved[1];
+};
+
 struct caliptra_reallocate_dpe_context_limits_req
 {
     struct caliptra_req_header hdr;
@@ -570,4 +672,35 @@ struct caliptra_invoke_dpe_resp
         struct dpe_get_certificate_chain_response get_certificate_chain_resp;
         uint8_t data[0];
     };
+};
+
+// INVOKE_DPE_MLDSA87: invoke a DPE command using ML-DSA signing. The request
+// reuses the ergonomic DPE command union (like `caliptra_invoke_dpe_req`); the
+// response uses a flat buffer sized to the firmware maximum to guarantee enough
+// receive space. Both are variable length (trimmed/read to `data_size`).
+#define INVOKE_DPE_MLDSA87_DATA_MAX_SIZE      512
+#define INVOKE_DPE_MLDSA87_RESP_DATA_MAX_SIZE 25168
+struct caliptra_invoke_dpe_mldsa87_req
+{
+    struct caliptra_req_header hdr;
+    uint32_t data_size;
+    union
+    {
+        struct dpe_cmd_hdr cmd_hdr;
+        struct dpe_get_profile_cmd get_profile_cmd;
+        struct dpe_initialize_context_cmd initialize_context_cmd;
+        struct dpe_derive_context_cmd derive_context_cmd;
+        struct dpe_certify_key_cmd certify_key_cmd;
+        struct dpe_sign_cmd sign_cmd;
+        struct dpe_rotate_context_handle_cmd rotate_context_handle_cmd;
+        struct dpe_destroy_context_cmd destroy_context_cmd;
+        struct dpe_get_certificate_chain_cmd get_certificate_chain_cmd;
+        uint8_t data[INVOKE_DPE_MLDSA87_DATA_MAX_SIZE];
+    };
+};
+struct caliptra_invoke_dpe_mldsa87_resp
+{
+    struct caliptra_resp_header hdr;
+    uint32_t data_size;
+    uint8_t data[INVOKE_DPE_MLDSA87_RESP_DATA_MAX_SIZE]; // variable length
 };

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1322,6 +1322,183 @@ int caliptra_revoke_exported_cdi_handle(struct caliptra_revoke_exported_cdi_hand
     return pack_and_execute_command(&p, async);
 }
 
+// ===================================================================
+// PQC / ML-DSA-87 commands
+// ===================================================================
+
+// Set PQ Seed (provision the PQ.DevID ML-DSA seed). No response body.
+int caliptra_set_pq_seed(struct caliptra_set_pq_seed_req *req, bool async)
+{
+    if (!req)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_resp_header resp_hdr = {};
+
+    CREATE_PARCEL(p, OP_SET_PQ_SEED, req, &resp_hdr);
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Get PQ CSR (ML-DSA IDevID CSR). No command-specific request args.
+int caliptra_get_pq_csr(struct caliptra_get_pq_csr_resp *resp, bool async)
+{
+    if (!resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    caliptra_checksum checksum = 0;
+
+    CREATE_PARCEL(p, OP_GET_PQ_CSR, &checksum, resp);
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Get PQ Info (ML-DSA IDevID public key). No request args.
+int caliptra_get_pq_info(struct caliptra_get_pq_info_resp *resp, bool async)
+{
+    if (!resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    caliptra_checksum checksum = 0;
+
+    CREATE_PARCEL(p, OP_GET_PQ_INFO, &checksum, resp);
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Get PQ Cert. Variable-length request: only the populated prefix of `tbs`
+// (trimmed to `tbs_size`) is sent, mirroring caliptra_invoke_dpe_command.
+int caliptra_get_pq_cert(struct caliptra_get_pq_cert_req *req, struct caliptra_get_pq_cert_resp *resp, bool async)
+{
+    if (!req || !resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    if (req->tbs_size > GET_PQ_CERT_TBS_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
+    uint32_t actual_bytes = sizeof(caliptra_checksum) + sizeof(uint32_t) +
+                            MLDSA87_SIGNATURE_SIZE + req->tbs_size;
+
+    struct parcel p = {
+        .command   = OP_GET_PQ_CERT,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = actual_bytes,
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(*resp),
+    };
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Populate PQ Cert. No response body. Variable-length request: only the
+// populated prefix of `cert` (trimmed to `cert_size`) is sent.
+int caliptra_populate_pq_cert(struct caliptra_populate_pq_cert_req *req, bool async)
+{
+    if (!req)
+    {
+        return INVALID_PARAMS;
+    }
+
+    if (req->cert_size > POPULATE_PQ_CERT_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
+    struct caliptra_resp_header resp_hdr = {};
+
+    uint32_t actual_bytes = sizeof(caliptra_checksum) + sizeof(uint32_t) + req->cert_size;
+
+    struct parcel p = {
+        .command   = OP_POPULATE_PQ_CERT,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = actual_bytes,
+        .rx_buffer = (uint8_t*)&resp_hdr,
+        .rx_bytes  = sizeof(resp_hdr),
+    };
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Certify Key Extended ML-DSA-87 (fixed-size request).
+int caliptra_certify_key_extended_mldsa87(struct caliptra_certify_key_extended_mldsa87_req *req, struct caliptra_certify_key_extended_mldsa87_resp *resp, bool async)
+{
+    if (!req || !resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    CREATE_PARCEL(p, OP_CERTIFY_KEY_EXTENDED_MLDSA87, req, resp);
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Invoke DPE command (ML-DSA-87). Variable-length request: only the populated
+// prefix of `data` (trimmed to `data_size`) is sent.
+int caliptra_invoke_dpe_mldsa87(struct caliptra_invoke_dpe_mldsa87_req *req, struct caliptra_invoke_dpe_mldsa87_resp *resp, bool async)
+{
+    if (!req || !resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    if (req->data_size > INVOKE_DPE_MLDSA87_DATA_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
+    uint32_t actual_bytes = sizeof(caliptra_checksum) + sizeof(uint32_t) + req->data_size;
+
+    struct parcel p = {
+        .command   = OP_INVOKE_DPE_MLDSA87,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = actual_bytes,
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(*resp),
+    };
+
+    return pack_and_execute_command(&p, async);
+}
+
+// Sign with Exported ML-DSA. Variable-length request: only the populated prefix
+// of `message` (trimmed to `message_size`) is sent.
+int caliptra_sign_with_exported_mldsa(struct caliptra_sign_with_exported_mldsa_req *req, struct caliptra_sign_with_exported_mldsa_resp *resp, bool async)
+{
+    if (!req || !resp)
+    {
+        return INVALID_PARAMS;
+    }
+
+    if (req->message_size > SIGN_WITH_EXPORTED_MLDSA_MSG_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
+    uint32_t actual_bytes = sizeof(caliptra_checksum) +
+                            SIGN_WITH_EXPORTED_MLDSA_CDI_MAX_SIZE +
+                            sizeof(uint32_t) /* sign_mode */ +
+                            sizeof(uint32_t) /* message_size */ +
+                            req->message_size;
+
+    struct parcel p = {
+        .command   = OP_SIGN_WITH_EXPORTED_MLDSA,
+        .tx_buffer = (uint8_t*)req,
+        .tx_bytes  = actual_bytes,
+        .rx_buffer = (uint8_t*)resp,
+        .rx_bytes  = sizeof(*resp),
+    };
+
+    return pack_and_execute_command(&p, async);
+}
+
 // Self test start
 int caliptra_self_test_start(bool async)
 {

--- a/libcaliptra/src/caliptra_mbox.h
+++ b/libcaliptra/src/caliptra_mbox.h
@@ -60,6 +60,16 @@ enum mailbox_command {
     OP_REVOKE_EXPORTED_CDI_HANDLE    = 0x52564348, // "RVCH"
     OP_REALLOCATE_DPE_CONTEXT_LIMITS = 0x52435458, // "RCTX"
     OP_GET_PCR_LOG                   = 0x504C4F47, // "PLOG"
+    // PQC / ML-DSA-87 commands (mirror api/src/mailbox.rs `CommandId`,
+    // gated there behind the `mldsa_attestation` feature).
+    OP_GET_PQ_CERT                   = 0x47505143, // "GPQC"
+    OP_POPULATE_PQ_CERT              = 0x50505143, // "PPQC"
+    OP_SET_PQ_SEED                   = 0x50515344, // "PQSD"
+    OP_INVOKE_DPE_MLDSA87            = 0x4D4C4450, // "MLDP"
+    OP_GET_PQ_CSR                    = 0x50514353, // "PQCS"
+    OP_GET_PQ_INFO                   = 0x5051494E, // "PQIN"
+    OP_CERTIFY_KEY_EXTENDED_MLDSA87  = 0x434B454D, // "CKEM"
+    OP_SIGN_WITH_EXPORTED_MLDSA      = 0x53574D4C, // "SWML"
 };
 
 struct parcel {


### PR DESCRIPTION
Implement the bindings for the mldsa variant commands for lib caliptra. Include a battery of tests to validate functionality.