### PR TITLE
runtime: merge functions to reduce code size

### DIFF
--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -633,41 +633,22 @@ fn expand_s2_short(s2: &mut Vector8, sigma: &[u8; K_SIGMA_BYTES]) {
     }
 }
 
-fn expand_s1_ntt_mul_scalar(
+fn expand_s1_or_s2_ntt_mul_scalar(
     out: &mut Scalar,
     i: usize,
     sigma: &[u8; K_SIGMA_BYTES],
     sk_opt: Option<&[u8; MLDSA87_PRIVATE_KEY_BYTES]>,
+    sk_off: usize,
+    seed_idx: usize,
     rhs: &Scalar,
 ) {
     if let Some(sk) = sk_opt {
-        let off = SK_S1_OFF + i * SK_S_PACK_BYTES;
+        let off = sk_off + i * SK_S_PACK_BYTES;
         unpack_scalar_bits(out, &sk[off..off + SK_S_PACK_BYTES], 3, 2);
     } else {
         let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
         derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
-        derived_seed[K_SIGMA_BYTES] = i as u8;
-        derived_seed[K_SIGMA_BYTES + 1] = 0;
-        scalar_uniform_2(out, &derived_seed);
-    }
-    scalar_ntt(out);
-    scalar_mul_assign(out, rhs);
-}
-
-fn expand_s2_ntt_mul_scalar(
-    out: &mut Scalar,
-    i: usize,
-    sigma: &[u8; K_SIGMA_BYTES],
-    sk_opt: Option<&[u8; MLDSA87_PRIVATE_KEY_BYTES]>,
-    rhs: &Scalar,
-) {
-    if let Some(sk) = sk_opt {
-        let off = SK_S2_OFF + i * SK_S_PACK_BYTES;
-        unpack_scalar_bits(out, &sk[off..off + SK_S_PACK_BYTES], 3, 2);
-    } else {
-        let mut derived_seed = [0u8; K_SIGMA_BYTES + 2];
-        derived_seed[..K_SIGMA_BYTES].copy_from_slice(sigma);
-        derived_seed[K_SIGMA_BYTES] = (i + 7) as u8;
+        derived_seed[K_SIGMA_BYTES] = seed_idx as u8;
         derived_seed[K_SIGMA_BYTES + 1] = 0;
         scalar_uniform_2(out, &derived_seed);
     }
@@ -1014,7 +995,15 @@ fn sign_internal_with_mu(
 
         for i in 0..7 {
             let mut cs_i = Scalar::default();
-            expand_s1_ntt_mul_scalar(&mut cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
+            expand_s1_or_s2_ntt_mul_scalar(
+                &mut cs_i,
+                i,
+                &priv_key.sigma,
+                sk_opt,
+                SK_S1_OFF,
+                i,
+                &c_ntt,
+            );
             scalar_inverse_ntt(&mut cs_i);
 
             let mut z_i = Scalar::default();
@@ -1037,7 +1026,15 @@ fn sign_internal_with_mu(
 
         for i in 0..8 {
             let mut cs_i = Scalar::default();
-            expand_s2_ntt_mul_scalar(&mut cs_i, i, &priv_key.sigma, sk_opt, &c_ntt);
+            expand_s1_or_s2_ntt_mul_scalar(
+                &mut cs_i,
+                i,
+                &priv_key.sigma,
+                sk_opt,
+                SK_S2_OFF,
+                i + 7,
+                &c_ntt,
+            );
             scalar_inverse_ntt(&mut cs_i);
 
             let mut r0_i = Scalar::default();

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -153,20 +153,13 @@ impl GetRtAliasCertCmd {
 ///
 /// # Returns
 ///
-/// * `Ecc384Scalar` - The s portion of the LDevId cert signature
-fn get_dice_sign_portion(
-    handle: HandOffDataHandle,
-    dv: &DataVault,
-) -> CaliptraResult<Ecc384Scalar> {
-    let ds: DataStore = handle
-        .try_into()
-        .map_err(|_| CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?;
-
+/// * `Ecc384Scalar` - The r or s portion of the cert signature
+fn get_dice_sign_portion(handle: HandOffDataHandle, dv: &DataVault) -> Option<Ecc384Scalar> {
     // The data store is either a warm reset entry or a cold reset entry.
-    match ds {
-        DataStore::DataVaultNonSticky48(dv_entry) => Ok(dv.read_warm_reset_entry48(dv_entry)),
-        DataStore::DataVaultSticky48(dv_entry) => Ok(dv.read_cold_reset_entry48(dv_entry)),
-        _ => Err(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED),
+    match handle.try_into() {
+        Ok(DataStore::DataVaultNonSticky48(dv_entry)) => Some(dv.read_warm_reset_entry48(dv_entry)),
+        Ok(DataStore::DataVaultSticky48(dv_entry)) => Some(dv.read_cold_reset_entry48(dv_entry)),
+        _ => None,
     }
 }
 
@@ -185,8 +178,10 @@ pub fn ldevid_dice_sign(
     dv: &DataVault,
 ) -> CaliptraResult<Ecc384Signature> {
     Ok(Ecc384Signature {
-        r: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_r_dv_hdl, dv)?,
-        s: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_s_dv_hdl, dv)?,
+        r: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_r_dv_hdl, dv)
+            .ok_or(CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED)?,
+        s: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_s_dv_hdl, dv)
+            .ok_or(CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED)?,
     })
 }
 
@@ -230,8 +225,10 @@ pub fn fmc_dice_sign(
     dv: &DataVault,
 ) -> CaliptraResult<Ecc384Signature> {
     Ok(Ecc384Signature {
-        r: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_r_dv_hdl, dv)?,
-        s: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_s_dv_hdl, dv)?,
+        r: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_r_dv_hdl, dv)
+            .ok_or(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?,
+        s: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_s_dv_hdl, dv)
+            .ok_or(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?,
     })
 }
 

--- a/runtime/src/dice.rs
+++ b/runtime/src/dice.rs
@@ -23,8 +23,8 @@ use crate::Drivers;
 #[cfg(feature = "mldsa_attestation")]
 use caliptra_drivers::Mldsa87Signature;
 use caliptra_drivers::{
-    hand_off::DataStore, CaliptraError, CaliptraResult, DataVault, Ecc384Scalar, Ecc384Signature,
-    PersistentData,
+    hand_off::{DataStore, HandOffDataHandle},
+    CaliptraError, CaliptraResult, DataVault, Ecc384Scalar, Ecc384Signature, PersistentData,
 };
 #[cfg(feature = "mldsa_attestation")]
 use caliptra_x509::MlDsa87CertBuilder;
@@ -144,59 +144,29 @@ impl GetRtAliasCertCmd {
     }
 }
 
-/// Retrieve the r portion of the LDevId cert signature
+/// Retrieve the r or s portion of the a cert signature
 ///
 /// # Arguments
 ///
-/// * `persistent_data` - PersistentData
-/// * `dv` - DataVault
-///
-/// # Returns
-///
-/// * `Ecc384Scalar` - The r portion of the LDevId cert signature
-fn ldevid_dice_sign_r(
-    persistent_data: &PersistentData,
-    dv: &DataVault,
-) -> CaliptraResult<Ecc384Scalar> {
-    let ds: DataStore = persistent_data
-        .fht
-        .ldevid_cert_sig_r_dv_hdl
-        .try_into()
-        .map_err(|_| CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED)?;
-
-    // The data store is either a warm reset entry or a cold reset entry.
-    match ds {
-        DataStore::DataVaultNonSticky48(dv_entry) => Ok(dv.read_warm_reset_entry48(dv_entry)),
-        DataStore::DataVaultSticky48(dv_entry) => Ok(dv.read_cold_reset_entry48(dv_entry)),
-        _ => Err(CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED),
-    }
-}
-
-/// Retrieve the s portion of the LDevId cert signature
-///
-/// # Arguments
-///
-/// * `persistent_data` - PersistentData
+/// * `handle` - handle to the corresponding signature
 /// * `dv` - DataVault
 ///
 /// # Returns
 ///
 /// * `Ecc384Scalar` - The s portion of the LDevId cert signature
-fn ldevid_dice_sign_s(
-    persistent_data: &PersistentData,
+fn get_dice_sign_portion(
+    handle: HandOffDataHandle,
     dv: &DataVault,
 ) -> CaliptraResult<Ecc384Scalar> {
-    let ds: DataStore = persistent_data
-        .fht
-        .ldevid_cert_sig_s_dv_hdl
+    let ds: DataStore = handle
         .try_into()
-        .map_err(|_| CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED)?;
+        .map_err(|_| CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?;
 
     // The data store is either a warm reset entry or a cold reset entry.
     match ds {
         DataStore::DataVaultNonSticky48(dv_entry) => Ok(dv.read_warm_reset_entry48(dv_entry)),
         DataStore::DataVaultSticky48(dv_entry) => Ok(dv.read_cold_reset_entry48(dv_entry)),
-        _ => Err(CaliptraError::RUNTIME_LDEVID_CERT_HANDOFF_FAILED),
+        _ => Err(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED),
     }
 }
 
@@ -215,8 +185,8 @@ pub fn ldevid_dice_sign(
     dv: &DataVault,
 ) -> CaliptraResult<Ecc384Signature> {
     Ok(Ecc384Signature {
-        r: ldevid_dice_sign_r(persistent_data, dv)?,
-        s: ldevid_dice_sign_s(persistent_data, dv)?,
+        r: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_r_dv_hdl, dv)?,
+        s: get_dice_sign_portion(persistent_data.fht.ldevid_cert_sig_s_dv_hdl, dv)?,
     })
 }
 
@@ -245,62 +215,6 @@ pub fn copy_ldevid_cert(
         .map_err(|_| CaliptraError::RUNTIME_GET_LDEVID_CERT_FAILED)
 }
 
-/// Retrieve the r portion of the FMC alias cert signature
-///
-/// # Arguments
-///
-/// * `persistent_data` - PersistentData
-/// * `dv` - DataVault
-///
-/// # Returns
-///
-/// * `Ecc384Scalar` - The r portion of the FMC alias cert signature
-fn fmc_dice_sign_r(
-    persistent_data: &PersistentData,
-    dv: &DataVault,
-) -> CaliptraResult<Ecc384Scalar> {
-    let ds: DataStore = persistent_data
-        .fht
-        .fmc_cert_sig_r_dv_hdl
-        .try_into()
-        .map_err(|_| CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?;
-
-    // The data store is either a warm reset entry or a cold reset entry.
-    match ds {
-        DataStore::DataVaultNonSticky48(dv_entry) => Ok(dv.read_warm_reset_entry48(dv_entry)),
-        DataStore::DataVaultSticky48(dv_entry) => Ok(dv.read_cold_reset_entry48(dv_entry)),
-        _ => Err(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED),
-    }
-}
-
-/// Retrieve the s portion of the FMC alias cert signature
-///
-/// # Arguments
-///
-/// * `persistent_data` - PersistentData
-/// * `dv` - DataVault
-///
-/// # Returns
-///
-/// * `Ecc384Scalar` - The s portion of the FMC alias cert signature
-fn fmc_dice_sign_s(
-    persistent_data: &PersistentData,
-    dv: &DataVault,
-) -> CaliptraResult<Ecc384Scalar> {
-    let ds: DataStore = persistent_data
-        .fht
-        .fmc_cert_sig_s_dv_hdl
-        .try_into()
-        .map_err(|_| CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED)?;
-
-    // The data store is either a warm reset entry or a cold reset entry.
-    match ds {
-        DataStore::DataVaultNonSticky48(dv_entry) => Ok(dv.read_warm_reset_entry48(dv_entry)),
-        DataStore::DataVaultSticky48(dv_entry) => Ok(dv.read_cold_reset_entry48(dv_entry)),
-        _ => Err(CaliptraError::RUNTIME_FMC_CERT_HANDOFF_FAILED),
-    }
-}
-
 /// Piece together the r and s portions of the FMC alias cert signature
 ///
 /// # Arguments
@@ -316,8 +230,8 @@ pub fn fmc_dice_sign(
     dv: &DataVault,
 ) -> CaliptraResult<Ecc384Signature> {
     Ok(Ecc384Signature {
-        r: fmc_dice_sign_r(persistent_data, dv)?,
-        s: fmc_dice_sign_s(persistent_data, dv)?,
+        r: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_r_dv_hdl, dv)?,
+        s: get_dice_sign_portion(persistent_data.fht.fmc_cert_sig_s_dv_hdl, dv)?,
     })
 }
 


### PR DESCRIPTION
- merge `*_dice_sign_*`
- merge `expand_*_ntt_mul_scalar`

Reduce code size by 230 bytes:

```
┌────────────────────────┬─────────┬──────┬─────────┬───────┬────────┐
│         Binary         │  Text   │ Data │ Budget  │ Used% │  Free  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 100,212 │ 128  │ 103,684 │ 96.7% │ 3,344  │
├────────────────────────┼─────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 99,980  │ 128  │ 103,684 │ 96.5% │ 3,576  │
└────────────────────────┴─────────┴──────┴─────────┴───────┴────────┘
```