### PR TITLE
fmc + rt: Enable icf (identical code folding)

### DIFF
--- a/fmc/build.rs
+++ b/fmc/build.rs
@@ -33,6 +33,13 @@ fn main() {
             println!("cargo:rustc-link-arg=-Tmemory.x");
 
             println!("cargo:rustc-link-arg=-Tlink.x");
+
+            // Identical-code folding: fold byte-identical functions (e.g. dual
+            // monomorphizations) in the linked FMC binary. Scoped here rather than
+            // in .cargo/config so it applies only to the deployed FMC/Runtime, not
+            // to ROM or the test firmwares (whose sizes are separately calibrated).
+            println!("cargo:rustc-link-arg=--icf=all");
+
             println!("cargo:rerun-if-changed=build.rs");
         }
     }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -33,6 +33,13 @@ fn main() {
             println!("cargo:rustc-link-arg=-Tmemory.x");
 
             println!("cargo:rustc-link-arg=-Tlink.x");
+
+            // Identical-code folding: fold byte-identical functions (e.g. dual
+            // monomorphizations) in the linked Runtime binary. Scoped here rather
+            // than in .cargo/config so it applies only to the deployed FMC/Runtime,
+            // not to ROM or the test firmwares (whose sizes are separately calibrated).
+            println!("cargo:rustc-link-arg=--icf=all");
+
             println!("cargo:rerun-if-changed=build.rs");
         }
     }


### PR DESCRIPTION
Enable the icf optimization, which reduces code utilization around ~400 bytes.  This optimization can change function pointers from expectations, but since we are not relying on function pointer comparison this is a safe change.