### PR TITLE
hw-model: make caliptra-builder a dev-dependency again

### DIFF
--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -29,7 +29,6 @@ caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
-caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }


### PR DESCRIPTION
caliptra-builder is only used by hw-model's own tests: every reference is inside `#[cfg(test)] mod tests` in src/lib.rs, it is not re-exported, and no non-test code path (lib or bin) uses it. It was added to [dependencies] in #3999 while also remaining in [dev-dependencies], so it is now compiled for every downstream library consumer even though none of them use it.

That drags caliptra-builder -> caliptra-image-crypto (default `openssl` feature, for ML-DSA) -> openssl-sys into consumers' builds. On platforms without a system OpenSSL (e.g. Windows CI) openssl-sys falls back to building OpenSSL from source, which needs perl -- so hw-model consumers that previously had no OpenSSL dependency at all now fail to build. This is a regression for external consumers of hw-model as a library.

Remove the [dependencies] entry; the existing [dev-dependencies] entry still covers hw-model's tests, so there is no functional change. This restores hw-model/Cargo.toml to its pre-#3999 dependency set. (caliptra-1.x is unaffected -- it never took #3999.)