### PR TITLE
hw-model: force cfi-test feature on caliptra-cfi-lib for host builds

### DIFF
--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -18,6 +18,11 @@ coverage = ["dep:caliptra-coverage"]
 ocp-lock = []
 
 [dependencies]
+# Enable cfi-test for host builds. This dep exists solely to add the feature
+# to the transitive copy pulled in by caliptra-image-types/caliptra-lms-types.
+# Without this, debug builds fail with unresolved CFI_STATE_ORG/cfi_panic_handler.
+caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
+
 anyhow.workspace = true
 bitfield.workspace = true
 bitflags.workspace = true


### PR DESCRIPTION
caliptra-image-types / caliptra-lms-types pull in caliptra-cfi-lib with only the `cfi`/`cfi-counter` features. That transitive copy emits the firmware-only externs CFI_STATE_ORG and cfi_panic_handler without `cfi-test`, which the host link cannot resolve: debug builds fail with unresolved-symbol errors (LNK2019/LNK1120 on Windows), while release only links because dead-code elimination happens to drop the references.

Add caliptra-cfi-lib as a direct hw-model dependency with `cfi-test` enabled. Cargo unifies features additively across a single resolved instance of a crate, so this turns CFI_STATE into a real static and cfi_panic into a `panic!` for every consumer of hw-model, fixing a Windows debug link failure without touching the firmware-only call sites.