### PR TITLE
[hw-model]: Remove CFI from dependency tree

### DIFF
--- a/coverage/Cargo.toml
+++ b/coverage/Cargo.toml
@@ -18,4 +18,4 @@ caliptra-builder.workspace = true
 elf.workspace = true
 regex.workspace = true
 caliptra-image-types.workspace = true
-caliptra-drivers.workspace=true
+caliptra-drivers = { workspace = true, default-features = false }

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["coverage"]
+default = []
 verilator = ["dep:caliptra-verilated"]
 fpga_realtime = ["dep:uio"]
 fpga_subsystem  = ["dep:uio"]

--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-caliptra-cfi-derive.workspace = true
-caliptra-cfi-lib.workspace = true
+caliptra-cfi-derive = { workspace = true, optional = true }
+caliptra-cfi-lib = { workspace = true, optional = true }
 caliptra-error = { workspace = true, default-features = false }
 caliptra-lms-types.workspace = true
 memoffset.workspace = true
@@ -23,4 +23,4 @@ zeroize.workspace = true
 [features]
 default = ["std", "cfi"]
 std = ["dep:serde", "dep:serde_derive", "caliptra-lms-types/std"]
-cfi = ["caliptra-lms-types/cfi"]
+cfi = ["dep:caliptra-cfi-derive", "dep:caliptra-cfi-lib", "caliptra-lms-types/cfi"]

--- a/lms-types/Cargo.toml
+++ b/lms-types/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-caliptra-cfi-derive.workspace = true
-caliptra-cfi-lib.workspace = true
+caliptra-cfi-derive = { workspace = true, optional = true }
+caliptra-cfi-lib = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 zerocopy.workspace = true
 zeroize.workspace = true
 
 [features]
-default = ["cfi"]
+default = []
 std = ["dep:serde", "dep:serde_derive"]
-cfi = []
+cfi = ["dep:caliptra-cfi-derive", "dep:caliptra-cfi-lib"]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -20,12 +20,12 @@ caliptra-coverage.workspace = true
 caliptra-drivers = { workspace = true, features = ["fips-test-hooks"] }
 caliptra-dpe.workspace = true
 caliptra-hw-model-types.workspace = true
-caliptra-hw-model.workspace = true
+caliptra-hw-model = { workspace = true, features = ["coverage"] }
 caliptra-image-crypto.workspace = true
 caliptra-image-elf.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
+caliptra-image-types = { workspace = true, features = ["cfi"] }
 caliptra-image-verify = { workspace = true, default-features = false }
 caliptra-runtime = { workspace = true, default-features = false }
 caliptra-common = { workspace = true, default-features = false }


### PR DESCRIPTION
The CFI crates are annoying to compile on non-firmware targets. The CFI should not get pulled into non-firwmare and this cleans up the crate defaults that are pulling it in. 

Now CFI no longer gets pulled into the caliptra-hw-model

```
caliptra-hw-model v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/hw-model) 
├── anyhow v1.0.98
├── bit-vec v0.6.3
├── bitfield v0.14.0
├── bitflags v2.11.0
├── caliptra-api v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/api)
│   ├── bitflags v2.11.0
│   ├── caliptra-api-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/api/types)
│   │   └── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types)
│   │       ├── caliptra-error v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/error)
│   │       ├── caliptra-lms-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/lms-types)
│   │       │   ├── serde v1.0.228
│   │       │   │   ├── serde_core v1.0.228
│   │       │   │   └── serde_derive v1.0.228 (proc-macro)
│   │       │   │       ├── proc-macro2 v1.0.95
│   │       │   │       │   └── unicode-ident v1.0.18
│   │       │   │       ├── quote v1.0.40
│   │       │   │       │   └── proc-macro2 v1.0.95 (*)
│   │       │   │       └── syn v2.0.117
│   │       │   │           ├── proc-macro2 v1.0.95 (*)
│   │       │   │           ├── quote v1.0.40 (*)
│   │       │   │           └── unicode-ident v1.0.18
│   │       │   ├── serde_derive v1.0.228 (proc-macro) (*)
│   │       │   ├── zerocopy v0.8.26
│   │       │   │   └── zerocopy-derive v0.8.26 (proc-macro)
│   │       │   │       ├── proc-macro2 v1.0.95 (*)
│   │       │   │       ├── quote v1.0.40 (*)
│   │       │   │       └── syn v2.0.117 (*)
│   │       │   └── zeroize v1.8.2
│   │       │       └── zeroize_derive v1.4.2 (proc-macro)
│   │       │           ├── proc-macro2 v1.0.95 (*)
│   │       │           ├── quote v1.0.40 (*)
│   │       │           └── syn v2.0.117 (*)
│   │       ├── memoffset v0.8.0
│   │       │   [build-dependencies]
│   │       │   └── autocfg v1.5.0
│   │       ├── serde v1.0.228 (*)
│   │       ├── serde_derive v1.0.228 (proc-macro) (*)
│   │       ├── zerocopy v0.8.26 (*)
│   │       └── zeroize v1.8.2 (*)
│   ├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
│   ├── caliptra-error v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/error)
│   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   ├── caliptra-registers v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/registers)
│   │   ├── caliptra-registers-latest v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/hw/latest/registers)
│   │   │   └── caliptra-ureg v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/ureg)
│   │   └── caliptra-registers-rev-2-1 v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/hw/rev-2_1/registers)
│   │       └── caliptra-ureg v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/ureg)
│   ├── caliptra-ureg v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/ureg)
│   └── zerocopy v0.8.26 (*)
├── caliptra-api-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/api/types) (*)
├── caliptra-builder v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/builder)
│   ├── anyhow v1.0.98
│   ├── caliptra-image-crypto v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/crypto)
│   │   ├── anyhow v1.0.98
│   │   ├── caliptra-image-gen v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/gen)
│   │   │   ├── anyhow v1.0.98
│   │   │   ├── bitflags v2.11.0
│   │   │   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   │   │   ├── caliptra-lms-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/lms-types) (*)
│   │   │   ├── fips204 v0.4.6
│   │   │   │   ├── rand_core v0.6.4
│   │   │   │   │   └── getrandom v0.2.16
│   │   │   │   │       ├── cfg-if v1.0.1
│   │   │   │   │       └── libc v0.2.174
│   │   │   │   ├── sha2 v0.10.9
│   │   │   │   │   ├── cfg-if v1.0.1
│   │   │   │   │   ├── cpufeatures v0.2.17
│   │   │   │   │   └── digest v0.10.7
│   │   │   │   │       ├── block-buffer v0.10.4
│   │   │   │   │       │   └── generic-array v0.14.7
│   │   │   │   │       │       ├── typenum v1.18.0
│   │   │   │   │       │       └── zeroize v1.8.2 (*)
│   │   │   │   │       │       [build-dependencies]
│   │   │   │   │       │       └── version_check v0.9.5
│   │   │   │   │       ├── const-oid v0.9.6
│   │   │   │   │       ├── crypto-common v0.1.6
│   │   │   │   │       │   ├── generic-array v0.14.7 (*)
│   │   │   │   │       │   ├── rand_core v0.6.4 (*)
│   │   │   │   │       │   └── typenum v1.18.0
│   │   │   │   │       └── subtle v2.6.1
│   │   │   │   ├── sha3 v0.10.8
│   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   └── keccak v0.1.5
│   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   ├── memoffset v0.8.0 (*)
│   │   │   ├── p384 v0.13.1
│   │   │   │   ├── ecdsa v0.16.9
│   │   │   │   │   ├── der v0.7.10
│   │   │   │   │   │   ├── const-oid v0.9.6
│   │   │   │   │   │   ├── pem-rfc7468 v0.7.0
│   │   │   │   │   │   │   └── base64ct v1.8.0
│   │   │   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   ├── elliptic-curve v0.13.8
│   │   │   │   │   │   ├── base16ct v0.2.0
│   │   │   │   │   │   ├── crypto-bigint v0.5.5
│   │   │   │   │   │   │   ├── generic-array v0.14.7 (*)
│   │   │   │   │   │   │   ├── rand_core v0.6.4 (*)
│   │   │   │   │   │   │   ├── subtle v2.6.1
│   │   │   │   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   │   ├── ff v0.13.1
│   │   │   │   │   │   │   ├── rand_core v0.6.4 (*)
│   │   │   │   │   │   │   └── subtle v2.6.1
│   │   │   │   │   │   ├── generic-array v0.14.7 (*)
│   │   │   │   │   │   ├── group v0.13.0
│   │   │   │   │   │   │   ├── ff v0.13.1 (*)
│   │   │   │   │   │   │   ├── rand_core v0.6.4 (*)
│   │   │   │   │   │   │   └── subtle v2.6.1
│   │   │   │   │   │   ├── hkdf v0.12.4
│   │   │   │   │   │   │   └── hmac v0.12.1
│   │   │   │   │   │   │       └── digest v0.10.7 (*)
│   │   │   │   │   │   ├── pem-rfc7468 v0.7.0 (*)
│   │   │   │   │   │   ├── pkcs8 v0.10.2
│   │   │   │   │   │   │   ├── der v0.7.10 (*)
│   │   │   │   │   │   │   └── spki v0.7.3
│   │   │   │   │   │   │       └── der v0.7.10 (*)
│   │   │   │   │   │   ├── rand_core v0.6.4 (*)
│   │   │   │   │   │   ├── sec1 v0.7.3
│   │   │   │   │   │   │   ├── base16ct v0.2.0
│   │   │   │   │   │   │   ├── der v0.7.10 (*)
│   │   │   │   │   │   │   ├── generic-array v0.14.7 (*)
│   │   │   │   │   │   │   ├── pkcs8 v0.10.2 (*)
│   │   │   │   │   │   │   ├── subtle v2.6.1
│   │   │   │   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   │   │   ├── subtle v2.6.1
│   │   │   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   │   ├── rfc6979 v0.4.0
│   │   │   │   │   │   ├── hmac v0.12.1 (*)
│   │   │   │   │   │   └── subtle v2.6.1
│   │   │   │   │   ├── signature v2.2.0
│   │   │   │   │   │   ├── digest v0.10.7 (*)
│   │   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   │   └── spki v0.7.3 (*)
│   │   │   │   ├── elliptic-curve v0.13.8 (*)
│   │   │   │   ├── primeorder v0.13.6
│   │   │   │   │   └── elliptic-curve v0.13.8 (*)
│   │   │   │   └── sha2 v0.10.9 (*)
│   │   │   ├── rand v0.8.5
│   │   │   │   ├── libc v0.2.174
│   │   │   │   ├── rand_chacha v0.3.1
│   │   │   │   │   ├── ppv-lite86 v0.2.21
│   │   │   │   │   │   └── zerocopy v0.8.26 (*)
│   │   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   │   └── rand_core v0.6.4 (*)
│   │   │   ├── serde v1.0.228 (*)
│   │   │   ├── serde_derive v1.0.228 (proc-macro) (*)
│   │   │   └── zerocopy v0.8.26 (*)
│   │   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   │   ├── caliptra-lms-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/lms-types) (*)
│   │   ├── cfg-if v1.0.1
│   │   ├── fips204 v0.4.6 (*)
│   │   ├── openssl v0.10.72 (https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d)
│   │   │   ├── bitflags v2.11.0
│   │   │   ├── cfg-if v1.0.1
│   │   │   ├── foreign-types v0.3.2
│   │   │   │   └── foreign-types-shared v0.1.1
│   │   │   ├── libc v0.2.174
│   │   │   ├── once_cell v1.21.3
│   │   │   ├── openssl-macros v0.1.1 (proc-macro) (https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d)
│   │   │   │   ├── proc-macro2 v1.0.95 (*)
│   │   │   │   ├── quote v1.0.40 (*)
│   │   │   │   └── syn v2.0.117 (*)
│   │   │   └── openssl-sys v0.9.108 (https://github.com/clundin25/rust-openssl.git?rev=4ada1c1d7c264e052e7bb71ecddbd196a5c2a0c7#4ada1c1d)
│   │   │       └── libc v0.2.174
│   │   │       [build-dependencies]
│   │   │       ├── cc v1.2.61
│   │   │       │   ├── find-msvc-tools v0.1.9
│   │   │       │   ├── jobserver v0.1.34
│   │   │       │   │   └── libc v0.2.174
│   │   │       │   ├── libc v0.2.174
│   │   │       │   └── shlex v1.3.0
│   │   │       ├── openssl-src v300.5.0+3.5.0
│   │   │       │   └── cc v1.2.61 (*)
│   │   │       ├── pkg-config v0.3.32
│   │   │       └── vcpkg v0.2.15
│   │   └── zerocopy v0.8.26 (*)
│   ├── caliptra-image-elf v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/elf)
│   │   ├── anyhow v1.0.98
│   │   ├── caliptra-image-gen v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/gen) (*)
│   │   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   │   └── elf v0.7.4
│   ├── caliptra-image-fake-keys v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/fake-keys)
│   │   ├── caliptra-image-gen v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/gen) (*)
│   │   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   │   ├── caliptra-lms-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/lms-types) (*)
│   │   └── zerocopy v0.8.26 (*)
│   ├── caliptra-image-gen v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/gen) (*)
│   ├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
│   ├── clap v4.5.60
│   │   ├── clap_builder v4.5.60
│   │   │   ├── anstream v0.6.21
│   │   │   │   ├── anstyle v1.0.13
│   │   │   │   ├── anstyle-parse v0.2.7
│   │   │   │   │   └── utf8parse v0.2.2
│   │   │   │   ├── anstyle-query v1.1.5
│   │   │   │   ├── colorchoice v1.0.4
│   │   │   │   ├── is_terminal_polyfill v1.70.2
│   │   │   │   └── utf8parse v0.2.2
│   │   │   ├── anstyle v1.0.13
│   │   │   ├── clap_lex v1.0.0
│   │   │   ├── strsim v0.11.1
│   │   │   ├── terminal_size v0.4.3
│   │   │   │   └── rustix v1.0.7
│   │   │   │       ├── bitflags v2.11.0
│   │   │   │       └── linux-raw-sys v0.9.4
│   │   │   ├── unicase v2.8.1
│   │   │   └── unicode-width v0.2.2
│   │   └── clap_derive v4.5.55 (proc-macro)
│   │       ├── heck v0.5.0
│   │       ├── proc-macro2 v1.0.95 (*)
│   │       ├── quote v1.0.40 (*)
│   │       └── syn v2.0.117 (*)
│   ├── elf v0.7.4
│   ├── fslock v0.2.1
│   │   └── libc v0.2.174
│   ├── hex v0.4.3
│   │   └── serde v1.0.228 (*)
│   ├── memoffset v0.8.0 (*)
│   ├── once_cell v1.21.3
│   ├── reqwest v0.12.28
│   │   ├── base64 v0.22.1
│   │   ├── bytes v1.10.1
│   │   ├── futures-channel v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   └── futures-sink v0.3.31
│   │   ├── futures-core v0.3.31
│   │   ├── futures-util v0.3.31
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-io v0.3.31
│   │   │   ├── futures-sink v0.3.31
│   │   │   ├── futures-task v0.3.31
│   │   │   ├── memchr v2.7.5
│   │   │   ├── pin-project-lite v0.2.16
│   │   │   ├── pin-utils v0.1.0
│   │   │   └── slab v0.4.12
│   │   ├── http v1.4.0
│   │   │   ├── bytes v1.10.1
│   │   │   └── itoa v1.0.15
│   │   ├── http-body v1.0.1
│   │   │   ├── bytes v1.10.1
│   │   │   └── http v1.4.0 (*)
│   │   ├── http-body-util v0.1.3
│   │   │   ├── bytes v1.10.1
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── http v1.4.0 (*)
│   │   │   ├── http-body v1.0.1 (*)
│   │   │   └── pin-project-lite v0.2.16
│   │   ├── hyper v1.8.1
│   │   │   ├── atomic-waker v1.1.2
│   │   │   ├── bytes v1.10.1
│   │   │   ├── futures-channel v0.3.31 (*)
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── http v1.4.0 (*)
│   │   │   ├── http-body v1.0.1 (*)
│   │   │   ├── httparse v1.10.1
│   │   │   ├── itoa v1.0.15
│   │   │   ├── pin-project-lite v0.2.16
│   │   │   ├── pin-utils v0.1.0
│   │   │   ├── smallvec v1.15.1
│   │   │   ├── tokio v1.49.0
│   │   │   │   ├── bytes v1.10.1
│   │   │   │   ├── libc v0.2.174
│   │   │   │   ├── mio v1.1.0
│   │   │   │   │   └── libc v0.2.174
│   │   │   │   ├── pin-project-lite v0.2.16
│   │   │   │   └── socket2 v0.6.2
│   │   │   │       └── libc v0.2.174
│   │   │   └── want v0.3.1
│   │   │       └── try-lock v0.2.5
│   │   ├── hyper-rustls v0.27.7
│   │   │   ├── http v1.4.0 (*)
│   │   │   ├── hyper v1.8.1 (*)
│   │   │   ├── hyper-util v0.1.20
│   │   │   │   ├── base64 v0.22.1
│   │   │   │   ├── bytes v1.10.1
│   │   │   │   ├── futures-channel v0.3.31 (*)
│   │   │   │   ├── futures-util v0.3.31 (*)
│   │   │   │   ├── http v1.4.0 (*)
│   │   │   │   ├── http-body v1.0.1 (*)
│   │   │   │   ├── hyper v1.8.1 (*)
│   │   │   │   ├── ipnet v2.12.0
│   │   │   │   ├── libc v0.2.174
│   │   │   │   ├── percent-encoding v2.3.2
│   │   │   │   ├── pin-project-lite v0.2.16
│   │   │   │   ├── socket2 v0.6.2 (*)
│   │   │   │   ├── tokio v1.49.0 (*)
│   │   │   │   ├── tower-service v0.3.3
│   │   │   │   └── tracing v0.1.44
│   │   │   │       ├── pin-project-lite v0.2.16
│   │   │   │       └── tracing-core v0.1.36
│   │   │   │           └── once_cell v1.21.3
│   │   │   ├── rustls v0.23.37
│   │   │   │   ├── once_cell v1.21.3
│   │   │   │   ├── ring v0.17.14
│   │   │   │   │   ├── cfg-if v1.0.1
│   │   │   │   │   ├── getrandom v0.2.16 (*)
│   │   │   │   │   └── untrusted v0.9.0
│   │   │   │   │   [build-dependencies]
│   │   │   │   │   └── cc v1.2.61 (*)
│   │   │   │   ├── rustls-pki-types v1.14.0
│   │   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   │   ├── rustls-webpki v0.103.10
│   │   │   │   │   ├── ring v0.17.14 (*)
│   │   │   │   │   ├── rustls-pki-types v1.14.0 (*)
│   │   │   │   │   └── untrusted v0.9.0
│   │   │   │   ├── subtle v2.6.1
│   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   ├── rustls-pki-types v1.14.0 (*)
│   │   │   ├── tokio v1.49.0 (*)
│   │   │   ├── tokio-rustls v0.26.4
│   │   │   │   ├── rustls v0.23.37 (*)
│   │   │   │   └── tokio v1.49.0 (*)
│   │   │   ├── tower-service v0.3.3
│   │   │   └── webpki-roots v1.0.6
│   │   │       └── rustls-pki-types v1.14.0 (*)
│   │   ├── hyper-util v0.1.20 (*)
│   │   ├── log v0.4.29
│   │   ├── percent-encoding v2.3.2
│   │   ├── pin-project-lite v0.2.16
│   │   ├── rustls v0.23.37 (*)
│   │   ├── rustls-pki-types v1.14.0 (*)
│   │   ├── serde v1.0.228 (*)
│   │   ├── serde_urlencoded v0.7.1
│   │   │   ├── form_urlencoded v1.2.2
│   │   │   │   └── percent-encoding v2.3.2
│   │   │   ├── itoa v1.0.15
│   │   │   ├── ryu v1.0.23
│   │   │   └── serde v1.0.228 (*)
│   │   ├── sync_wrapper v1.0.2
│   │   │   └── futures-core v0.3.31
│   │   ├── tokio v1.49.0 (*)
│   │   ├── tokio-rustls v0.26.4 (*)
│   │   ├── tower v0.5.3
│   │   │   ├── futures-core v0.3.31
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── pin-project-lite v0.2.16
│   │   │   ├── sync_wrapper v1.0.2 (*)
│   │   │   ├── tokio v1.49.0 (*)
│   │   │   ├── tower-layer v0.3.3
│   │   │   └── tower-service v0.3.3
│   │   ├── tower-http v0.6.8
│   │   │   ├── bitflags v2.11.0
│   │   │   ├── bytes v1.10.1
│   │   │   ├── futures-util v0.3.31 (*)
│   │   │   ├── http v1.4.0 (*)
│   │   │   ├── http-body v1.0.1 (*)
│   │   │   ├── iri-string v0.7.10
│   │   │   ├── pin-project-lite v0.2.16
│   │   │   ├── tower v0.5.3 (*)
│   │   │   ├── tower-layer v0.3.3
│   │   │   └── tower-service v0.3.3
│   │   ├── tower-service v0.3.3
│   │   ├── url v2.5.8
│   │   │   ├── form_urlencoded v1.2.2 (*)
│   │   │   ├── idna v1.1.0
│   │   │   │   ├── idna_adapter v1.1.0
│   │   │   │   │   ├── idna_mapping v1.1.0
│   │   │   │   │   │   └── unicode-joining-type v1.0.0
│   │   │   │   │   ├── unicode-bidi v0.3.18
│   │   │   │   │   └── unicode-normalization v0.1.25
│   │   │   │   │       └── tinyvec v1.11.0
│   │   │   │   │           └── tinyvec_macros v0.1.1
│   │   │   │   ├── smallvec v1.15.1
│   │   │   │   └── utf8_iter v1.0.4
│   │   │   └── percent-encoding v2.3.2
│   │   └── webpki-roots v1.0.6 (*)
│   ├── serde v1.0.228 (*)
│   ├── serde_derive v1.0.228 (proc-macro) (*)
│   ├── serde_json v1.0.149
│   │   ├── itoa v1.0.15
│   │   ├── memchr v2.7.5
│   │   ├── serde_core v1.0.228
│   │   └── zmij v1.0.21
│   ├── sha2 v0.10.9 (*)
│   ├── toml v0.7.8
│   │   ├── serde v1.0.228 (*)
│   │   ├── serde_spanned v0.6.9
│   │   │   └── serde v1.0.228 (*)
│   │   ├── toml_datetime v0.6.11
│   │   │   └── serde v1.0.228 (*)
│   │   └── toml_edit v0.19.15
│   │       ├── indexmap v2.13.1
│   │       │   ├── equivalent v1.0.2
│   │       │   └── hashbrown v0.16.1
│   │       ├── serde v1.0.228 (*)
│   │       ├── serde_spanned v0.6.9 (*)
│   │       ├── toml_datetime v0.6.11 (*)
│   │       └── winnow v0.5.40
│   ├── zerocopy v0.8.26 (*)
│   └── zip v0.6.6
│       ├── aes v0.8.4
│       │   ├── cfg-if v1.0.1
│       │   ├── cipher v0.4.4
│       │   │   ├── crypto-common v0.1.6 (*)
│       │   │   └── inout v0.1.4
│       │   │       ├── block-padding v0.3.3
│       │   │       │   └── generic-array v0.14.7 (*)
│       │   │       └── generic-array v0.14.7 (*)
│       │   └── cpufeatures v0.2.17
│       ├── byteorder v1.5.0
│       ├── bzip2 v0.4.4
│       │   ├── bzip2-sys v0.1.13+1.0.8
│       │   │   [build-dependencies]
│       │   │   ├── cc v1.2.61 (*)
│       │   │   └── pkg-config v0.3.32
│       │   └── libc v0.2.174
│       ├── constant_time_eq v0.1.5
│       ├── crc32fast v1.5.0
│       │   └── cfg-if v1.0.1
│       ├── flate2 v1.1.9
│       │   ├── crc32fast v1.5.0 (*)
│       │   └── miniz_oxide v0.8.9
│       │       ├── adler2 v2.0.1
│       │       └── simd-adler32 v0.3.9
│       ├── hmac v0.12.1 (*)
│       ├── pbkdf2 v0.11.0
│       │   ├── digest v0.10.7 (*)
│       │   ├── hmac v0.12.1 (*)
│       │   ├── password-hash v0.4.2
│       │   │   ├── base64ct v1.8.0
│       │   │   ├── rand_core v0.6.4 (*)
│       │   │   └── subtle v2.6.1
│       │   └── sha2 v0.10.9 (*)
│       ├── sha1 v0.10.6
│       │   ├── cfg-if v1.0.1
│       │   ├── cpufeatures v0.2.17
│       │   └── digest v0.10.7 (*)
│       ├── time v0.3.45
│       │   ├── deranged v0.5.8
│       │   │   └── powerfmt v0.2.0
│       │   ├── num-conv v0.1.0
│       │   ├── powerfmt v0.2.0
│       │   └── time-core v0.1.7
│       └── zstd v0.11.2+zstd.1.5.2
│           └── zstd-safe v5.0.2+zstd.1.5.2
│               ├── libc v0.2.174
│               └── zstd-sys v2.0.16+zstd.1.5.7
│                   [build-dependencies]
│                   ├── cc v1.2.61 (*)
│                   └── pkg-config v0.3.32
├── caliptra-emu-bus v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/bus)
│   ├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
│   ├── caliptra-ureg v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/ureg)
│   └── tock-registers v0.9.0 (https://github.com/tock/tock.git?rev=release-2.2#9554639b)
├── caliptra-emu-cpu v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/cpu)
│   ├── bit-vec v0.6.3
│   ├── bitfield v0.14.0
│   ├── caliptra-emu-bus v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/bus) (*)
│   ├── caliptra-emu-derive v0.1.0 (proc-macro) (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/derive)
│   │   ├── caliptra-emu-bus v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/bus) (*)
│   │   ├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
│   │   ├── proc-macro2 v1.0.95 (*)
│   │   └── quote v1.0.40 (*)
│   ├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
│   ├── lazy_static v1.5.0
│   └── tock-registers v0.9.0 (https://github.com/tock/tock.git?rev=release-2.2#9554639b)
├── caliptra-emu-periph v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/periph)
│   ├── aes v0.8.4 (*)
│   ├── arrayref v0.3.9
│   ├── bitfield v0.14.0
│   ├── caliptra-api-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/api/types) (*)
│   ├── caliptra-emu-bus v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/bus) (*)
│   ├── caliptra-emu-cpu v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/cpu) (*)
│   ├── caliptra-emu-crypto v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/crypto)
│   │   ├── aes v0.8.4 (*)
│   │   ├── aes-gcm v0.10.3
│   │   │   ├── aead v0.5.2
│   │   │   │   ├── crypto-common v0.1.6 (*)
│   │   │   │   └── generic-array v0.14.7 (*)
│   │   │   ├── aes v0.8.4 (*)
│   │   │   ├── cipher v0.4.4 (*)
│   │   │   ├── ctr v0.9.2
│   │   │   │   └── cipher v0.4.4 (*)
│   │   │   ├── ghash v0.5.1
│   │   │   │   ├── opaque-debug v0.3.1
│   │   │   │   └── polyval v0.6.2
│   │   │   │       ├── cfg-if v1.0.1
│   │   │   │       ├── cpufeatures v0.2.17
│   │   │   │       ├── opaque-debug v0.3.1
│   │   │   │       └── universal-hash v0.5.1
│   │   │   │           ├── crypto-common v0.1.6 (*)
│   │   │   │           └── subtle v2.6.1
│   │   │   └── subtle v2.6.1
│   │   ├── cbc v0.1.2
│   │   │   └── cipher v0.4.4 (*)
│   │   ├── cipher v0.4.4 (*)
│   │   ├── ctr v0.9.2 (*)
│   │   ├── p384 v0.13.1 (*)
│   │   ├── rfc6979 v0.4.0 (*)
│   │   ├── sha2 v0.10.9 (*)
│   │   └── sha3 v0.10.8 (*)
│   ├── caliptra-emu-derive v0.1.0 (proc-macro) (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/derive) (*)
│   ├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
│   ├── caliptra-hw-model-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/hw-model/types)
│   │   ├── caliptra-api-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/api/types) (*)
│   │   └── rand v0.8.5 (*)
│   ├── caliptra-registers v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/registers) (*)
│   ├── const-random v0.1.18
│   │   └── const-random-macro v0.1.16 (proc-macro)
│   │       ├── getrandom v0.2.16
│   │       │   ├── cfg-if v1.0.1
│   │       │   └── libc v0.2.174
│   │       ├── once_cell v1.21.3
│   │       └── tiny-keccak v2.0.2
│   │           └── crunchy v0.2.4
│   ├── fips204 v0.4.6 (*)
│   ├── lazy_static v1.5.0
│   ├── ml-dsa v0.1.0-rc.9
│   │   ├── const-oid v0.10.1
│   │   ├── ctutils v0.4.2
│   │   │   └── cmov v0.5.3
│   │   ├── hybrid-array v0.4.8
│   │   │   ├── ctutils v0.4.2 (*)
│   │   │   └── typenum v1.18.0
│   │   ├── module-lattice v0.2.2
│   │   │   ├── ctutils v0.4.2 (*)
│   │   │   ├── hybrid-array v0.4.8 (*)
│   │   │   └── num-traits v0.2.19
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.5.0
│   │   ├── pkcs8 v0.11.0
│   │   │   ├── der v0.8.0
│   │   │   │   ├── const-oid v0.10.1
│   │   │   │   └── zeroize v1.8.2 (*)
│   │   │   └── spki v0.8.0
│   │   │       └── der v0.8.0 (*)
│   │   ├── rand_core v0.10.0
│   │   ├── sha3 v0.11.0
│   │   │   ├── digest v0.11.1
│   │   │   │   ├── block-buffer v0.12.0
│   │   │   │   │   └── hybrid-array v0.4.8 (*)
│   │   │   │   └── crypto-common v0.2.1
│   │   │   │       └── hybrid-array v0.4.8 (*)
│   │   │   └── keccak v0.2.0
│   │   │       └── cfg-if v1.0.1
│   │   └── signature v3.0.0-rc.10
│   │       ├── digest v0.11.1 (*)
│   │       └── rand_core v0.10.0
│   ├── ml-kem v0.2.1
│   │   ├── hybrid-array v0.2.3
│   │   │   └── typenum v1.18.0
│   │   ├── kem v0.3.0-pre.0
│   │   │   ├── rand_core v0.6.4 (*)
│   │   │   └── zeroize v1.8.2 (*)
│   │   ├── rand_core v0.6.4 (*)
│   │   └── sha3 v0.10.8 (*)
│   ├── rand v0.8.5 (*)
│   ├── sha2 v0.10.9 (*)
│   ├── sha3 v0.10.8 (*)
│   ├── smlang v0.8.0
│   │   └── smlang-macros v0.8.0 (proc-macro)
│   │       ├── proc-macro2 v1.0.95 (*)
│   │       ├── quote v1.0.40 (*)
│   │       ├── string_morph v0.1.0
│   │       └── syn v1.0.109
│   │           ├── proc-macro2 v1.0.95 (*)
│   │           ├── quote v1.0.40 (*)
│   │           └── unicode-ident v1.0.18
│   ├── tock-registers v0.9.0 (https://github.com/tock/tock.git?rev=release-2.2#9554639b)
│   └── zerocopy v0.8.26 (*)
├── caliptra-emu-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/sw-emulator/lib/types)
├── caliptra-hw-model-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/hw-model/types) (*)
├── caliptra-image-fake-keys v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/fake-keys) (*)
├── caliptra-image-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/image/types) (*)
├── caliptra-registers v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/registers) (*)
├── caliptra-ureg v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/ureg)
├── libc v0.2.174
├── nix v0.26.4
│   ├── bitflags v1.3.2
│   ├── cfg-if v1.0.1
│   ├── libc v0.2.174
│   ├── memoffset v0.7.1
│   │   [build-dependencies]
│   │   └── autocfg v1.5.0
│   └── pin-utils v0.1.0
├── once_cell v1.21.3
├── rand v0.8.5 (*)
├── regex v1.11.1
│   ├── aho-corasick v1.1.3
│   │   └── memchr v2.7.5
│   ├── memchr v2.7.5
│   ├── regex-automata v0.4.9
│   │   ├── aho-corasick v1.1.3 (*)
│   │   ├── memchr v2.7.5
│   │   └── regex-syntax v0.8.5
│   └── regex-syntax v0.8.5
├── rustix v1.0.7 (*)
├── scopeguard v1.2.0
├── serde v1.0.228 (*)
├── sha2 v0.10.9 (*)
├── sha3 v0.10.8 (*)
├── smlang v0.8.0 (*)
├── thiserror v2.0.16
│   └── thiserror-impl v2.0.16 (proc-macro)
│       ├── proc-macro2 v1.0.95 (*)
│       ├── quote v1.0.40 (*)
│       └── syn v2.0.117 (*)
├── tock-registers v0.9.0 (https://github.com/tock/tock.git?rev=release-2.2#9554639b)
└── zerocopy v0.8.26 (*)
[build-dependencies]
├── deser-hjson v2.2.6
│   └── serde v1.0.228 (*)
└── serde v1.0.228 (*)
[dev-dependencies]
├── caliptra-builder v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/builder) (*)
├── caliptra-registers v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/registers) (*)
├── caliptra-test-harness-types v0.1.0 (/usr/local/google/home/clundin/code/caliptra-sw/test-harness/types)
└── nix v0.26.4 (*)
```