### PR TITLE
[cherry-pick][hw-model]: Remove CFI from dependency tree (#4039)

### DIFF
--- a/coverage/Cargo.toml
+++ b/coverage/Cargo.toml
@@ -18,4 +18,4 @@ caliptra-builder.workspace = true
 elf.workspace = true
 regex.workspace = true
 caliptra-image-types.workspace = true
-caliptra-drivers.workspace=true
+caliptra-drivers = { workspace = true, default-features = false }

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["coverage"]
+default = []
 verilator = ["dep:caliptra-verilated"]
 fpga_realtime = ["dep:uio"]
 itrng = ["caliptra-verilated?/itrng"]

--- a/image/types/Cargo.toml
+++ b/image/types/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-caliptra-cfi-derive.workspace = true
-caliptra-cfi-lib.workspace = true
+caliptra-cfi-derive = { workspace = true, optional = true }
+caliptra-cfi-lib = { workspace = true, optional = true }
 caliptra-error = { workspace = true, default-features = false }
 caliptra-lms-types.workspace = true
 memoffset.workspace = true
@@ -23,4 +23,4 @@ zeroize.workspace = true
 [features]
 default = ["std", "cfi"]
 std = ["dep:serde", "dep:serde_derive", "caliptra-lms-types/std"]
-cfi = ["caliptra-lms-types/cfi"]
+cfi = ["dep:caliptra-cfi-derive", "dep:caliptra-cfi-lib", "caliptra-lms-types/cfi"]

--- a/lms-types/Cargo.toml
+++ b/lms-types/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 
 [dependencies]
 arbitrary = { workspace = true, optional = true }
-caliptra-cfi-derive.workspace = true
-caliptra-cfi-lib.workspace = true
+caliptra-cfi-derive = { workspace = true, optional = true }
+caliptra-cfi-lib = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 zerocopy.workspace = true
 zeroize.workspace = true
 
 [features]
-default = ["cfi"]
+default = []
 std = ["dep:serde", "dep:serde_derive"]
-cfi = []
+cfi = ["dep:caliptra-cfi-derive", "dep:caliptra-cfi-lib"]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -17,6 +17,7 @@ caliptra_common = { workspace = true, default-features = false }
 caliptra-coverage.workspace = true
 caliptra-drivers = { workspace = true, features = ["fips-test-hooks"] }
 caliptra-hw-model-types.workspace = true
+caliptra-hw-model = { workspace = true, features = ["coverage"] }
 caliptra-image-crypto.workspace = true
 caliptra-image-elf.workspace = true
 caliptra-auth-man-gen.workspace = true
@@ -24,7 +25,7 @@ caliptra-auth-man-types.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-lms-types.workspace = true
 caliptra-image-gen.workspace = true
-caliptra-image-types.workspace = true
+caliptra-image-types = { workspace = true, features = ["cfi"] }
 caliptra-image-verify = { workspace = true, default-features = false }
 caliptra-runtime = { workspace = true, default-features = false }
 elf.workspace = true
@@ -32,7 +33,6 @@ openssl.workspace = true
 rand.workspace = true
 regex.workspace = true
 zerocopy.workspace = true
-caliptra-hw-model.workspace = true
 dpe.workspace = true
 ureg.workspace = true
 


### PR DESCRIPTION
The CFI crates are annoying to compile on non-firmware targets. The CFI should not get pulled into non-firwmare and this cleans up the crate defaults that are pulling it in. 

Now CFI no longer gets pulled into the caliptra-hw-model

(cherry picked from commit 13e460a5deac9ca6094f60b4c1fdc2a2871d5058)