### PR TITLE
Fix to nightly release for stack usage test

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -78,3 +78,4 @@ cfi = ["caliptra-image-verify/cfi", "caliptra-image-types/cfi", "caliptra-driver
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
 "hw-1.0" = ["caliptra-builder/hw-1.0", "caliptra-drivers/hw-1.0", "caliptra-kat/hw-1.0","caliptra-cpu/hw-1.0", "caliptra-hw-model/hw-1.0"]
 fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]
+sw_emu_stack_check_disable = []

--- a/runtime/tests/runtime_integration_tests/test_stack_usage.rs
+++ b/runtime/tests/runtime_integration_tests/test_stack_usage.rs
@@ -25,7 +25,11 @@
 //!
 //! The mechanism relies on the emulator's stack-pointer tracking, so this test
 //! only runs against the software emulator (not verilator/FPGA).
-#![cfg(not(any(feature = "verilator", feature = "fpga_realtime")))]
+#![cfg(not(any(
+    feature = "verilator",
+    feature = "fpga_realtime",
+    feature = "sw_emu_stack_check_disable"
+)))]
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_measurements_common::{run_command_suite, CommandSampler};


### PR DESCRIPTION
- Exclude measure_runtime_command_stack_usage when sw_emu_stack_check_disable is set for nightly testing with 1.0 ROM (with known, benign stack overflow)