### PR TITLE
mldsa: Add mldsa attestation capability bit

### DIFF
--- a/api/src/capabilities.rs
+++ b/api/src/capabilities.rs
@@ -13,13 +13,16 @@ Abstract:
 --*/
 
 bitflags::bitflags! {
-    /// First 64 bits are reserved for RT, next 32 bits are reserved for FMC, and final 32 bits are reserved for ROM
+    /// First 32 bits are reserved for ROM, next 32 bits are rserved for FMC, and final 64 bits for
+    /// RT.
     #[derive(Default, Copy, Clone, Debug)]
     pub struct Capabilities : u128 {
         // Represents base capabilities present in Caliptra ROM v1.0
         const ROM_BASE = 0b1;
         // Represents base capabilities present in Caliptra Runtime v1.0
         const RT_BASE = 0b1 << 64;
+        // Represents ML-DSA attestation support in Caliptra Runtime
+        const RT_MLDSA_ATTESTATION = 0b1 << 65;
     }
 }
 

--- a/runtime/src/capabilities.rs
+++ b/runtime/src/capabilities.rs
@@ -28,6 +28,11 @@ impl CapabilitiesCmd {
         let mut capabilities = Capabilities::default();
         capabilities |= Capabilities::RT_BASE;
 
+        #[cfg(feature = "mldsa_attestation")]
+        {
+            capabilities |= Capabilities::RT_MLDSA_ATTESTATION;
+        }
+
         let mut resp = CapabilitiesResp {
             hdr: MailboxRespHeader::default(),
             capabilities: capabilities.to_bytes(),

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -200,4 +200,25 @@ fn test_capabilities() {
     let capabilities_resp = CapabilitiesResp::read_from_bytes(resp.as_slice()).unwrap();
     let capabilities = Capabilities::try_from(capabilities_resp.capabilities.as_bytes()).unwrap();
     assert!(capabilities.contains(Capabilities::RT_BASE));
+    // The base (non-PQC) runtime image must not advertise ML-DSA attestation.
+    assert!(!capabilities.contains(Capabilities::RT_MLDSA_ATTESTATION));
+}
+
+#[cfg(feature = "mldsa_attestation")]
+#[test]
+fn test_capabilities_mldsa_attestation() {
+    use crate::common::run_pqc_rt_test;
+
+    let mut model = run_pqc_rt_test();
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::CAPABILITIES), &[]),
+    };
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::CAPABILITIES), payload.as_bytes())
+        .unwrap()
+        .unwrap();
+    let capabilities_resp = CapabilitiesResp::read_from_bytes(resp.as_slice()).unwrap();
+    let capabilities = Capabilities::try_from(capabilities_resp.capabilities.as_bytes()).unwrap();
+    assert!(capabilities.contains(Capabilities::RT_BASE));
+    assert!(capabilities.contains(Capabilities::RT_MLDSA_ATTESTATION));
 }


### PR DESCRIPTION
Add a bit indicating the firmware supports MLDSA attestation to the capability command.

Note: Also updated the comment to match the apparent structure of the Capabilities struct.