### PR TITLE
tests: mldsa additional tests

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -606,11 +606,42 @@ pub struct GetPqCertReq {
     pub tbs_size: u32,
     pub signature: [u8; MLDSA87_SIGNATURE_BYTES],
     pub tbs: [u8; GetPqCertReq::DATA_MAX_SIZE], // variable length
+    pub _pad: [u8; GetPqCertReq::PAD_LEN],
 }
 #[cfg(feature = "mldsa_attestation")]
 impl GetPqCertReq {
-    // GetPqCertResp::DATA_MAX_SIZE - MAX_MLDSA87_SIG_DER_LEN + 2-byte padding for alignment
-    pub const DATA_MAX_SIZE: usize = 3553;
+    // A GET_PQ_CERT response certificate is the DER SEQUENCE
+    //   `{ tbs, signatureAlgorithm, signatureValue }`
+    // assembled into the `GetPqCertResp::DATA_MAX_SIZE` cert buffer. The largest
+    // TBS we can accept is that buffer minus everything else the certificate
+    // carries, so any TBS within DATA_MAX_SIZE is guaranteed to fit in the
+    // response (larger TBS is rejected up front as RUNTIME_MAILBOX_INVALID_PARAMS).
+
+    /// DER length of the ML-DSA-87 `signatureValue` BIT STRING: tag (1) +
+    /// long-form length (3, for a >255-byte value) + unused-bits byte (1) +
+    /// the fixed-size signature.
+    const SIG_DER_LEN: usize = 1 + 3 + 1 + MLDSA87_SIGNATURE_BYTES;
+    /// DER length of the `id-ml-dsa-87` AlgorithmIdentifier (see the ML-DSA-87
+    /// `oid_der()` in `caliptra-x509`).
+    const SIG_ALG_OID_DER_LEN: usize = 13;
+    /// Outer certificate SEQUENCE header: tag (1) + long-form length (3).
+    const CERT_SEQ_HEADER_LEN: usize = 1 + 3;
+
+    /// Largest TBS whose assembled certificate fits `GetPqCertResp`'s cert
+    /// buffer, so any TBS this size is guaranteed to fit in the response.
+    pub const DATA_MAX_SIZE: usize = GetPqCertResp::DATA_MAX_SIZE
+        - Self::SIG_DER_LEN
+        - Self::SIG_ALG_OID_DER_LEN
+        - Self::CERT_SEQ_HEADER_LEN;
+
+    // Calculate the length of the pad, so that the overall messge is 4 byte aligned
+    const PAD_LEN: usize = (4
+        - (size_of::<MailboxReqHeader>()
+            + size_of::<u32>()
+            + MLDSA87_SIGNATURE_BYTES
+            + Self::DATA_MAX_SIZE)
+            % 4)
+        % 4;
 
     pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
         if self.tbs_size as usize > Self::DATA_MAX_SIZE {
@@ -636,6 +667,7 @@ impl Default for GetPqCertReq {
             tbs_size: 0,
             signature: [0u8; MLDSA87_SIGNATURE_BYTES],
             tbs: [0u8; GetPqCertReq::DATA_MAX_SIZE],
+            _pad: [0u8; Self::PAD_LEN],
         }
     }
 }

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -119,6 +119,98 @@ pub fn provision_pq_seed(model: &mut DefaultHwModel) {
         .unwrap();
 }
 
+/// Populate the ML-DSA PQ certificate (a prerequisite for exporting an ML-DSA
+/// CDI with a certificate). Returns the DER certificate that was populated.
+#[cfg(feature = "mldsa_attestation")]
+pub fn populate_pq_cert(model: &mut DefaultHwModel) -> Vec<u8> {
+    use caliptra_common::mailbox_api::PopulatePqCertReq;
+    use caliptra_drivers::Mldsa87Signature;
+    use caliptra_x509::MlDsa87CertBuilder;
+    use openssl::pkey::Private;
+    use openssl::pkey_ctx::PkeyCtx;
+    use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, Variant};
+    use openssl::signature::Signature;
+
+    // Generate an ML-DSA-87 key pair and self-sign a placeholder TBS.
+    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
+    let priv_key = pk_builder.build().unwrap();
+    let tbs: &[u8] = b"this is going to be the TBS";
+    let mut sig_bytes = vec![];
+    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
+    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
+    ctx.sign_message_init(&mut algo).unwrap();
+    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
+    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
+    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
+    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
+    let cert_size = builder.build(&mut cert).unwrap();
+
+    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cert_size: cert_size as u32,
+        cert,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::POPULATE_PQ_CERT),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap();
+
+    cert[..cert_size].to_vec()
+}
+
+/// Export a CDI for `profile` via `DeriveContext{EXPORT_CDI | CREATE_CERTIFICATE
+/// | RETAIN_PARENT_CONTEXT}` and return the exported-CDI handle. Retaining the
+/// parent keeps the root context valid so multiple exports can run in one boot.
+/// An ML-DSA export requires SET_PQ_SEED (+ POPULATE_PQ_CERT) first.
+#[cfg(feature = "mldsa_attestation")]
+pub fn export_cdi_with_profile(
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+) -> [u8; 32] {
+    use dpe::{
+        commands::{DeriveContextCmd, DeriveContextFlags},
+        context::ContextHandle,
+        tci::TciMeasurement,
+        TCI_SIZE,
+    };
+
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: TciMeasurement([0; TCI_SIZE]),
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+        tci_type: 0,
+        target_locality: 0,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        profile,
+        model,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
+        panic!("expected derive context exported cdi resp!");
+    };
+    resp.header.exported_cdi
+}
+
+/// Export the ML-DSA (PQ.DevID) CDI and return its handle.
+#[cfg(feature = "mldsa_attestation")]
+pub fn export_mldsa_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
+    export_cdi_with_profile(model, CaliptraDpeProfile::Mldsa)
+}
+
+/// Export the ECDSA (RT-alias) CDI and return its handle.
+#[cfg(feature = "mldsa_attestation")]
+pub fn export_ecdsa_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
+    export_cdi_with_profile(model, CaliptraDpeProfile::Ecc384)
+}
+
 #[cfg(feature = "mldsa_attestation")]
 pub fn get_pq_csr_checksum() -> u32 {
     caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_CSR), &[])

--- a/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_certify_key_extended_mldsa.rs
@@ -4,8 +4,7 @@ use caliptra_api::SocManager;
 use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{
     AddSubjectAltNameReq, CertifyKeyExtendedFlags, CertifyKeyExtendedMldsa87Req,
-    CertifyKeyExtendedMldsa87Resp, CommandId, MailboxReq, MailboxReqHeader, SetPqSeedReq,
-    SET_PQ_SEED_SEED_SIZE,
+    CertifyKeyExtendedMldsa87Resp, CommandId, MailboxReq, MailboxReqHeader,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel};
@@ -24,20 +23,9 @@ use x509_parser::{certificate::X509Certificate, extensions::GeneralName, prelude
 use zerocopy::{FromZeros, IntoBytes};
 
 use crate::common::{
-    assert_error, run_pqc_rt_test, run_pqc_rt_test_wdt, run_rt_test, RuntimeTestArgs, TEST_LABEL,
+    assert_error, provision_pq_seed, run_pqc_rt_test, run_pqc_rt_test_wdt, run_rt_test,
+    RuntimeTestArgs, TEST_LABEL,
 };
-
-/// Provision the PQ.DevID seed (as PL0) so PQC mode is enabled.
-fn provision_pq_seed(model: &mut DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .unwrap();
-}
 
 /// Without SET_PQ_SEED there is no PQ.DevID identity, so the command must reject.
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_get_pq_cert.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_pq_cert.rs
@@ -40,6 +40,7 @@ fn make_req() -> GetPqCertReq {
         tbs: tbs_buf,
         tbs_size: tbs.len() as u32,
         signature: *sig,
+        ..Default::default()
     }
 }
 
@@ -87,4 +88,35 @@ fn test_get_pq_cert_tbs_size_too_large() {
         CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS,
         resp,
     );
+}
+
+#[test]
+fn test_get_pq_cert_max_tbs_size() {
+    // The command must handle the maximum TBS it advertises: GetPqCertReq::
+    // DATA_MAX_SIZE is sized so the assembled certificate (TBS + signature-
+    // algorithm OID + signature + SEQUENCE framing) exactly fits the response
+    // cert buffer. Regression guard against the sizing being set too large.
+    let mut model = run_pqc_rt_test();
+
+    let mut req = make_req();
+    req.tbs = [0xABu8; GetPqCertReq::DATA_MAX_SIZE];
+    req.tbs_size = GetPqCertReq::DATA_MAX_SIZE as u32;
+
+    // Build the expected cert client-side; this also confirms a max-size TBS
+    // fits within the cert buffer.
+    let sig = Mldsa87Signature::new(req.signature);
+    let builder = MlDsa87CertBuilder::new(&req.tbs[..req.tbs_size as usize], &sig).unwrap();
+    let mut cert = [0u8; GetPqCertResp::DATA_MAX_SIZE];
+    let cert_size = builder.build(&mut cert).unwrap();
+
+    let mut cmd = MailboxReq::GetPqCert(req);
+    cmd.populate_chksum().unwrap();
+    let resp_bytes = model
+        .mailbox_execute(u32::from(CommandId::GET_PQ_CERT), cmd.as_bytes().unwrap())
+        .unwrap()
+        .unwrap();
+    let (resp, _) = GetPqCertResp::ref_from_prefix(&resp_bytes).unwrap();
+
+    assert_eq!(resp.cert_size as usize, cert_size);
+    assert_eq!(&resp.cert[..cert_size], &cert[..cert_size]);
 }

--- a/runtime/tests/runtime_integration_tests/test_get_pq_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_get_pq_info.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_common::mailbox_api::{
-    CommandId, GetPqInfoResp, MailboxReq, MailboxReqHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
+    CommandId, GetPqInfoResp, MailboxReqHeader, SET_PQ_SEED_SEED_SIZE,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::HwModel;
@@ -12,26 +12,14 @@ use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant as MlDsaVa
 use openssl::sign::Signer;
 use zerocopy::{FromBytes, IntoBytes};
 
-use crate::common::{assert_error, run_pqc_rt_test};
+use crate::common::{assert_error, provision_pq_seed, run_pqc_rt_test};
 
-/// Seed provisioned via SET_PQ_SEED in these tests.
+/// Seed provisioned via SET_PQ_SEED in these tests. Matches `common::PQ_SEED`
+/// used by `provision_pq_seed`; kept here to derive the expected public key.
 const PQ_SEED: [u8; SET_PQ_SEED_SEED_SIZE] = [0x5a; SET_PQ_SEED_SEED_SIZE];
 
 fn get_pq_info_checksum() -> u32 {
     caliptra_common::checksum::calc_checksum(u32::from(CommandId::GET_PQ_INFO), &[])
-}
-
-/// Provision the PQ.DevID seed (as PL0) so that PQC mode is enabled and
-/// GET_PQ_INFO can derive the public key.
-fn provision_pq_seed(model: &mut caliptra_hw_model::DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: PQ_SEED,
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .unwrap();
 }
 
 /// SP 800-108 counter-mode KDF (single iteration) with HMAC-SHA384, reproducing

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::common::run_pqc_rt_test;
-use crate::common::{execute_dpe_cmd, DpeResult, TEST_DIGEST_MLDSA, TEST_LABEL};
+use crate::common::{assert_error, execute_dpe_cmd, DpeResult, TEST_DIGEST_MLDSA, TEST_LABEL};
 use caliptra_api::{
     mailbox::{FwInfoResp, ReallocateDpeContextLimitsReq},
     SocManager,
@@ -674,4 +674,54 @@ fn test_certify_key_with_max_contexts() {
             DpeResult::Success,
         );
     }
+}
+
+#[test]
+fn test_invoke_dpe_mldsa_before_set_pq_seed() {
+    let mut model = run_pqc_rt_test();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // Without SET_PQ_SEED the ML-DSA INVOKE_DPE entry point rejects the command
+    // before dispatching it to DPE.
+    execute_dpe_cmd(
+        PROFILE,
+        &mut model,
+        &mut Command::GetProfile(&GetProfileCmd),
+        DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED),
+    );
+}
+
+#[test]
+fn test_invoke_dpe_mldsa_deserialization_failed() {
+    let mut model = run_pqc_rt_test();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+    set_pq_seed(&mut model);
+
+    // A well-sized payload whose DPE command bytes are not a valid command (the
+    // DPEC magic is wrong) must fail deserialization inside the runtime, after
+    // the PQC-init and bounds checks pass.
+    let mut data = [0u8; InvokeDpeMldsa87Req::DATA_MAX_SIZE];
+    data[..8].copy_from_slice(&[0xAAu8; 8]);
+    let mut cmd = MailboxReq::InvokeDpeMldsa87Command(InvokeDpeMldsa87Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        data,
+        data_size: 8,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::INVOKE_DPE_MLDSA87),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_DPE_COMMAND_DESERIALIZATION_FAILED,
+        resp,
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe_mldsa.rs
@@ -1,7 +1,10 @@
 // Licensed under the Apache-2.0 license
 
 use crate::common::run_pqc_rt_test;
-use crate::common::{assert_error, execute_dpe_cmd, DpeResult, TEST_DIGEST_MLDSA, TEST_LABEL};
+use crate::common::{
+    assert_error, execute_dpe_cmd, populate_pq_cert, provision_pq_seed, DpeResult,
+    TEST_DIGEST_MLDSA, TEST_LABEL,
+};
 use caliptra_api::{
     mailbox::{FwInfoResp, ReallocateDpeContextLimitsReq},
     SocManager,
@@ -12,14 +15,11 @@ use caliptra_builder::{
 };
 use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
-    CommandId, GetPqCsrResp, InvokeDpeMldsa87Req, MailboxReq, MailboxReqHeader, PopulatePqCertReq,
-    SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
+    CommandId, GetPqCsrResp, InvokeDpeMldsa87Req, MailboxReq, MailboxReqHeader,
 };
-use caliptra_drivers::Mldsa87Signature;
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use caliptra_hw_model::{HwModel, ModelError};
 use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus, DPE_SUPPORT, VENDOR_ID, VENDOR_SKU};
-use caliptra_x509::MlDsa87CertBuilder;
 use cms::{
     cert::x509::der::{Decode, Encode},
     content_info::{CmsVersion, ContentInfo},
@@ -39,9 +39,9 @@ use dpe::{
     TCI_SIZE,
 };
 use openssl::hash::{hash, MessageDigest};
-use openssl::pkey::{Private, Public};
+use openssl::pkey::Public;
 use openssl::pkey_ctx::PkeyCtx;
-use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, PKeyMlDsaParams, Variant};
+use openssl::pkey_ml_dsa::{PKeyMlDsaParams, Variant};
 use openssl::signature::Signature;
 use openssl::x509::X509Req;
 use platform::MAX_CHUNK_SIZE;
@@ -49,54 +49,6 @@ use x509_parser::{nom::Parser, prelude::*};
 use zerocopy::{FromBytes, IntoBytes};
 
 const PROFILE: CaliptraDpeProfile = CaliptraDpeProfile::Mldsa;
-
-// Invoke SET_PQ_SEED to set the PQ seed and thus enable PQC mode.
-fn set_pq_seed(model: &mut DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .unwrap();
-}
-
-// Build a cert out of a test TBS and invoke POPULATE_PQ_CERT to initialize the PQ cert.
-// Return the built cert for other test purposes.
-fn populate_pq_cert(model: &mut DefaultHwModel) -> Vec<u8> {
-    // Generate an ML-DSA87 key pair
-    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
-    let priv_key = pk_builder.build().unwrap();
-
-    // Sign the TBS with ML-DSA87
-    let tbs: &[u8] = b"this is going to be the TBS";
-    let mut sig_bytes = vec![];
-    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
-    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
-    ctx.sign_message_init(&mut algo).unwrap();
-    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
-    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
-    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
-    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
-    let cert_size = builder.build(&mut cert).unwrap();
-
-    // Build the request
-    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        cert_size: cert_size as u32,
-        cert,
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(
-            u32::from(CommandId::POPULATE_PQ_CERT),
-            cmd.as_bytes().unwrap(),
-        )
-        .unwrap();
-
-    cert[..cert_size].to_vec()
-}
 
 #[test]
 fn test_invoke_dpe_get_profile_cmd() {
@@ -106,7 +58,7 @@ fn test_invoke_dpe_get_profile_cmd() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     let mut cmd: Command<'_> = Command::GetProfile(&GetProfileCmd);
     let resp = execute_dpe_cmd(PROFILE, &mut model, &mut cmd, DpeResult::Success);
@@ -142,7 +94,7 @@ fn test_invoke_dpe_get_certificate_chain_cmd() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     let populated_cert = populate_pq_cert(&mut model);
 
     // Collect the full chain by concatenating multiple chunks.
@@ -185,7 +137,7 @@ fn test_invoke_dpe_sign_and_certify_key_cmds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let sign_cmd = SignMldsa87Cmd {
@@ -242,7 +194,7 @@ fn test_invoke_dpe_asymmetric_sign() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let sign_cmd = SignMldsa87Cmd {
@@ -276,7 +228,7 @@ fn test_dpe_header_error_code() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // cannot initialize non-simulation contexts so expect DPE cmd to fail
     let init_ctx_cmd = InitCtxCmd::new_use_default();
@@ -303,7 +255,7 @@ fn test_invoke_dpe_certify_key_csr() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let certify_key_cmd = CertifyKeyMldsa87Cmd {
@@ -381,7 +333,7 @@ fn test_invoke_dpe_rotate_context() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     let rotate_ctx_cmd = RotateCtxCmd {
         handle: ContextHandle::default(),
@@ -440,7 +392,7 @@ fn test_invoke_dpe_certify_key_with_non_critical_dice_extensions() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let certify_key_cmd = CertifyKeyMldsa87Cmd {
@@ -469,7 +421,7 @@ fn test_invoke_dpe_export_cdi_with_non_critical_dice_extensions() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let derive_ctx_cmd = DeriveContextCmd {
@@ -504,7 +456,7 @@ fn test_export_cdi_attestation_not_disabled_after_update_reset() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let derive_ctx_cmd = DeriveContextCmd {
@@ -558,7 +510,7 @@ fn test_export_cdi_destroyed_root_context() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     // You probably want to retain the parent context, otherwise the whole DPE chain _may be
@@ -615,7 +567,7 @@ fn test_certify_key_with_max_contexts() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     // Set the limit to 32 so we don't have to deal with the PL1 locality
@@ -699,7 +651,7 @@ fn test_invoke_dpe_mldsa_deserialization_failed() {
     model.step_until(|m| {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // A well-sized payload whose DPE command bytes are not a valid command (the
     // DPEC magic is wrong) must fail deserialization inside the runtime, after

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
@@ -3,109 +3,16 @@
 use caliptra_api::SocManager;
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, RevokeExportedCdiHandleReq,
-    SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
+    CommandId, MailboxReq, MailboxReqHeader, RevokeExportedCdiHandleReq,
 };
-use caliptra_drivers::Mldsa87Signature;
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{DefaultHwModel, HwModel};
-use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
-use caliptra_x509::MlDsa87CertBuilder;
-use dpe::{
-    commands::{Command, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
-    response::Response,
-    tci::TciMeasurement,
-    TCI_SIZE,
-};
-use openssl::pkey::Private;
-use openssl::pkey_ctx::PkeyCtx;
-use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, Variant};
-use openssl::signature::Signature;
+use caliptra_hw_model::HwModel;
+use caliptra_runtime::RtBootStatus;
 
 use crate::common::{
-    assert_error, execute_dpe_cmd, run_pqc_rt_test, run_rt_test, DpeResult, RuntimeTestArgs,
+    assert_error, export_ecdsa_cdi, export_mldsa_cdi, populate_pq_cert, provision_pq_seed,
+    run_pqc_rt_test, run_rt_test, RuntimeTestArgs,
 };
-
-/// Provision the PQ.DevID CDI (as PL0), enabling PQC mode.
-fn set_pq_seed(model: &mut DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .expect("SET_PQ_SEED failed");
-}
-
-/// Populate the ML-DSA PQ certificate (a prerequisite for exporting a CDI).
-fn populate_pq_cert(model: &mut DefaultHwModel) {
-    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
-    let priv_key = pk_builder.build().unwrap();
-    let tbs: &[u8] = b"this is going to be the TBS";
-    let mut sig_bytes = vec![];
-    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
-    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
-    ctx.sign_message_init(&mut algo).unwrap();
-    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
-    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
-    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
-    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
-    let cert_size = builder.build(&mut cert).unwrap();
-
-    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        cert_size: cert_size as u32,
-        cert,
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(
-            u32::from(CommandId::POPULATE_PQ_CERT),
-            cmd.as_bytes().unwrap(),
-        )
-        .expect("POPULATE_PQ_CERT failed");
-}
-
-/// Export an ML-DSA CDI via INVOKE_DPE_MLDSA87 + `DeriveContext{EXPORT_CDI}` and
-/// return the exported-CDI handle. RETAIN_PARENT_CONTEXT keeps the root context
-/// valid so a second export can run in the same boot (used by the re-export
-/// test). Requires SET_PQ_SEED and POPULATE_PQ_CERT first.
-fn export_cdi_with_profile(model: &mut DefaultHwModel, profile: CaliptraDpeProfile) -> [u8; 32] {
-    let derive_ctx_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: TciMeasurement([0; TCI_SIZE]),
-        flags: DeriveContextFlags::EXPORT_CDI
-            | DeriveContextFlags::CREATE_CERTIFICATE
-            | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-        tci_type: 0,
-        target_locality: 0,
-        ..Default::default()
-    };
-    let resp = execute_dpe_cmd(
-        profile,
-        model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
-        panic!("expected derive context exported cdi resp!");
-    };
-    resp.header.exported_cdi
-}
-
-/// Export an ML-DSA CDI (the PQ.DevID identity) and return its handle.
-fn export_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
-    export_cdi_with_profile(model, CaliptraDpeProfile::Mldsa)
-}
-
-/// Export an ECDSA CDI (the RT-alias identity) and return its handle. Shares the
-/// DPE context tree with the ML-DSA export but lands in the separate key-vault
-/// exported-CDI slot.
-fn export_ecdsa_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
-    export_cdi_with_profile(model, CaliptraDpeProfile::Ecc384)
-}
 
 /// Build a REVOKE_EXPORTED_CDI_HANDLE request for `handle`.
 fn revoke_req(handle: [u8; 32]) -> MailboxReq {
@@ -194,9 +101,9 @@ fn test_revoke_exported_cdi_handle_mldsa_pl1_rejected() {
 #[test]
 fn test_revoke_exported_cdi_handle_mldsa_success() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // Revoking the handle of an active exported-CDI slot succeeds.
     let cmd = revoke_req(handle);
@@ -211,9 +118,9 @@ fn test_revoke_exported_cdi_handle_mldsa_success() {
 #[test]
 fn test_revoke_exported_cdi_handle_mldsa_double_revoke() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     let cmd = revoke_req(handle);
     model
@@ -239,9 +146,9 @@ fn test_revoke_exported_cdi_handle_mldsa_double_revoke() {
 #[test]
 fn test_revoke_exported_cdi_handle_mldsa_reexport_after_revoke() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // Revoking frees the single ML-DSA exported-CDI slot.
     let cmd = revoke_req(handle);
@@ -254,7 +161,7 @@ fn test_revoke_exported_cdi_handle_mldsa_reexport_after_revoke() {
 
     // With the slot freed, a fresh export succeeds instead of hitting the
     // single-slot limit.
-    let _new_handle = export_cdi(&mut model);
+    let _new_handle = export_mldsa_cdi(&mut model);
 }
 
 // Export both an ECDSA (RT-alias) and an ML-DSA (PQ.DevID) CDI, then revoke each
@@ -264,11 +171,11 @@ fn test_revoke_exported_cdi_handle_mldsa_reexport_after_revoke() {
 #[test]
 fn test_revoke_exported_cdi_handle_both_populated_revoke_ecdsa_first() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let ecdsa_handle = export_ecdsa_cdi(&mut model);
-    let mldsa_handle = export_cdi(&mut model);
+    let mldsa_handle = export_mldsa_cdi(&mut model);
     assert_ne!(
         ecdsa_handle, mldsa_handle,
         "the ECDSA and ML-DSA handles must differ for this test to be meaningful"
@@ -305,11 +212,11 @@ fn test_revoke_exported_cdi_handle_both_populated_revoke_ecdsa_first() {
 #[test]
 fn test_revoke_exported_cdi_handle_both_populated_revoke_mldsa_first() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
 
     let ecdsa_handle = export_ecdsa_cdi(&mut model);
-    let mldsa_handle = export_cdi(&mut model);
+    let mldsa_handle = export_mldsa_cdi(&mut model);
     assert_ne!(
         ecdsa_handle, mldsa_handle,
         "the ECDSA and ML-DSA handles must differ for this test to be meaningful"

--- a/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_revoke_exported_cdi_handle_mldsa.rs
@@ -3,13 +3,119 @@
 use caliptra_api::SocManager;
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, RevokeExportedCdiHandleReq,
+    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, RevokeExportedCdiHandleReq,
+    SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
 };
+use caliptra_drivers::Mldsa87Signature;
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::HwModel;
-use caliptra_runtime::RtBootStatus;
+use caliptra_hw_model::{DefaultHwModel, HwModel};
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
+use caliptra_x509::MlDsa87CertBuilder;
+use dpe::{
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
+    context::ContextHandle,
+    response::Response,
+    tci::TciMeasurement,
+    TCI_SIZE,
+};
+use openssl::pkey::Private;
+use openssl::pkey_ctx::PkeyCtx;
+use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, Variant};
+use openssl::signature::Signature;
 
-use crate::common::{assert_error, run_pqc_rt_test, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    assert_error, execute_dpe_cmd, run_pqc_rt_test, run_rt_test, DpeResult, RuntimeTestArgs,
+};
+
+/// Provision the PQ.DevID CDI (as PL0), enabling PQC mode.
+fn set_pq_seed(model: &mut DefaultHwModel) {
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .expect("SET_PQ_SEED failed");
+}
+
+/// Populate the ML-DSA PQ certificate (a prerequisite for exporting a CDI).
+fn populate_pq_cert(model: &mut DefaultHwModel) {
+    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
+    let priv_key = pk_builder.build().unwrap();
+    let tbs: &[u8] = b"this is going to be the TBS";
+    let mut sig_bytes = vec![];
+    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
+    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
+    ctx.sign_message_init(&mut algo).unwrap();
+    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
+    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
+    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
+    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
+    let cert_size = builder.build(&mut cert).unwrap();
+
+    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cert_size: cert_size as u32,
+        cert,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::POPULATE_PQ_CERT),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("POPULATE_PQ_CERT failed");
+}
+
+/// Export an ML-DSA CDI via INVOKE_DPE_MLDSA87 + `DeriveContext{EXPORT_CDI}` and
+/// return the exported-CDI handle. RETAIN_PARENT_CONTEXT keeps the root context
+/// valid so a second export can run in the same boot (used by the re-export
+/// test). Requires SET_PQ_SEED and POPULATE_PQ_CERT first.
+fn export_cdi_with_profile(model: &mut DefaultHwModel, profile: CaliptraDpeProfile) -> [u8; 32] {
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: TciMeasurement([0; TCI_SIZE]),
+        flags: DeriveContextFlags::EXPORT_CDI
+            | DeriveContextFlags::CREATE_CERTIFICATE
+            | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+        tci_type: 0,
+        target_locality: 0,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        profile,
+        model,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
+        panic!("expected derive context exported cdi resp!");
+    };
+    resp.header.exported_cdi
+}
+
+/// Export an ML-DSA CDI (the PQ.DevID identity) and return its handle.
+fn export_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
+    export_cdi_with_profile(model, CaliptraDpeProfile::Mldsa)
+}
+
+/// Export an ECDSA CDI (the RT-alias identity) and return its handle. Shares the
+/// DPE context tree with the ML-DSA export but lands in the separate key-vault
+/// exported-CDI slot.
+fn export_ecdsa_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
+    export_cdi_with_profile(model, CaliptraDpeProfile::Ecc384)
+}
+
+/// Build a REVOKE_EXPORTED_CDI_HANDLE request for `handle`.
+fn revoke_req(handle: [u8; 32]) -> MailboxReq {
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: handle,
+    });
+    cmd.populate_chksum().unwrap();
+    cmd
+}
 
 #[test]
 fn test_revoke_exported_cdi_handle_mldsa_not_found() {
@@ -83,4 +189,156 @@ fn test_revoke_exported_cdi_handle_mldsa_pl1_rejected() {
         CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
         result.unwrap_err(),
     );
+}
+
+#[test]
+fn test_revoke_exported_cdi_handle_mldsa_success() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // Revoking the handle of an active exported-CDI slot succeeds.
+    let cmd = revoke_req(handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("REVOKE_EXPORTED_CDI_HANDLE should succeed for an active handle");
+}
+
+#[test]
+fn test_revoke_exported_cdi_handle_mldsa_double_revoke() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    let cmd = revoke_req(handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("first revoke should succeed");
+
+    // The slot is now inactive, so revoking the same handle again returns
+    // NOT_FOUND.
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_revoke_exported_cdi_handle_mldsa_reexport_after_revoke() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // Revoking frees the single ML-DSA exported-CDI slot.
+    let cmd = revoke_req(handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("revoke should succeed");
+
+    // With the slot freed, a fresh export succeeds instead of hitting the
+    // single-slot limit.
+    let _new_handle = export_cdi(&mut model);
+}
+
+// Export both an ECDSA (RT-alias) and an ML-DSA (PQ.DevID) CDI, then revoke each
+// in turn and confirm the command matches the right slot: revoking one handle
+// must not disturb the other, and each handle must still be found afterwards.
+
+#[test]
+fn test_revoke_exported_cdi_handle_both_populated_revoke_ecdsa_first() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+
+    let ecdsa_handle = export_ecdsa_cdi(&mut model);
+    let mldsa_handle = export_cdi(&mut model);
+    assert_ne!(
+        ecdsa_handle, mldsa_handle,
+        "the ECDSA and ML-DSA handles must differ for this test to be meaningful"
+    );
+
+    // Revoke the ECDSA handle: it is found (in the key-vault slots) and removed.
+    let cmd = revoke_req(ecdsa_handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("revoking the ECDSA handle should succeed");
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.unwrap_err(),
+    );
+
+    // The ML-DSA slot was left intact, so its handle is still revocable.
+    let cmd = revoke_req(mldsa_handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("the ML-DSA handle must still be revocable after revoking ECDSA");
+}
+
+#[test]
+fn test_revoke_exported_cdi_handle_both_populated_revoke_mldsa_first() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+
+    let ecdsa_handle = export_ecdsa_cdi(&mut model);
+    let mldsa_handle = export_cdi(&mut model);
+    assert_ne!(
+        ecdsa_handle, mldsa_handle,
+        "the ECDSA and ML-DSA handles must differ for this test to be meaningful"
+    );
+
+    // Revoke the ML-DSA handle: it is found (in the ML-DSA slot) and removed.
+    let cmd = revoke_req(mldsa_handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("revoking the ML-DSA handle should succeed");
+    let result = model.mailbox_execute(
+        CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+        cmd.as_bytes().unwrap(),
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_REVOKE_EXPORTED_CDI_HANDLE_NOT_FOUND,
+        result.unwrap_err(),
+    );
+
+    // The ECDSA slot was left intact, so its handle is still revocable.
+    let cmd = revoke_req(ecdsa_handle);
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("the ECDSA handle must still be revocable after revoking ML-DSA");
 }

--- a/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_pq_seed.rs
@@ -1,13 +1,15 @@
 // Licensed under the Apache-2.0 license
 
 use caliptra_api::SocManager;
-use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
+use caliptra_builder::{firmware::APP_MLDSA_ATTESTATION, ImageOptions};
+use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
     CommandId, MailboxReq, MailboxReqHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
+use zerocopy::IntoBytes;
 
 use crate::common::{assert_error, run_rt_test, RuntimeTestArgs};
 
@@ -57,6 +59,75 @@ fn test_repeated_set_pq_seed_rejected() {
     assert_error(
         &mut model,
         CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET,
+        resp,
+    );
+}
+
+#[test]
+fn test_set_pq_seed_pl1_rejected() {
+    // SET_PQ_SEED is PL0-only. Boot with no PL0 pauser so the caller is PL1.
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        resp,
+    );
+}
+
+#[test]
+fn test_set_pq_seed_attestation_disabled() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // Disable attestation before provisioning the PQ seed.
+    let payload = MailboxReqHeader {
+        chksum: calc_checksum(u32::from(CommandId::DISABLE_ATTESTATION), &[]),
+    };
+    model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload.as_bytes(),
+        )
+        .expect("DISABLE_ATTESTATION failed");
+
+    // With attestation disabled, provisioning the PQ.DevID CDI must be rejected.
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SET_PQ_SEED_ATTESTATION_DISABLED,
         resp,
     );
 }

--- a/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
@@ -3,8 +3,8 @@
 //! Integration tests for the SIGN_WITH_EXPORTED_MLDSA mailbox command.
 //!
 //! An exported ML-DSA CDI slot is produced by INVOKE_DPE_MLDSA87 carrying a DPE
-//! `DeriveContext{EXPORT_CDI | CREATE_CERTIFICATE}` (see `export_cdi` below), so
-//! the successful-sign lineage is exercised here alongside the
+//! `DeriveContext{EXPORT_CDI | CREATE_CERTIFICATE}` (see `common::export_mldsa_cdi`),
+//! so the successful-sign lineage is exercised here alongside the
 //! request-validation paths (privilege, malformed request, handle-not-found)
 //! that run before the CDI lookup.
 
@@ -12,29 +12,18 @@ use caliptra_api::SocManager;
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, RevokeExportedCdiHandleReq,
-    SetPqSeedReq, SignWithExportedMldsaReq, SignWithExportedMldsaResp, SET_PQ_SEED_SEED_SIZE,
+    CommandId, MailboxReq, MailboxReqHeader, RevokeExportedCdiHandleReq, SignWithExportedMldsaReq,
+    SignWithExportedMldsaResp,
 };
-use caliptra_drivers::{Mldsa87Signature, MLDSA87_MU_BYTES};
+use caliptra_drivers::MLDSA87_MU_BYTES;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
-use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
-use caliptra_x509::MlDsa87CertBuilder;
-use dpe::{
-    commands::{Command, DeriveContextCmd, DeriveContextFlags},
-    context::ContextHandle,
-    response::Response,
-    tci::TciMeasurement,
-    TCI_SIZE,
-};
-use openssl::pkey::Private;
-use openssl::pkey_ctx::PkeyCtx;
-use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, Variant};
-use openssl::signature::Signature;
+use caliptra_runtime::RtBootStatus;
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
-    assert_error, execute_dpe_cmd, run_pqc_rt_test, run_rt_test, DpeResult, RuntimeTestArgs,
+    assert_error, export_mldsa_cdi, populate_pq_cert, provision_pq_seed, run_pqc_rt_test,
+    run_rt_test, RuntimeTestArgs,
 };
 
 /// Issue SIGN_WITH_EXPORTED_MLDSA and return the raw response bytes.
@@ -89,74 +78,6 @@ fn sign_full(
         .map(|resp| resp.expect("expected a SIGN_WITH_EXPORTED_MLDSA response"))
 }
 
-/// Provision the PQ.DevID CDI via SET_PQ_SEED, enabling PQC mode. Signing with an
-/// exported CDI requires this to have run first.
-fn set_pq_seed(model: &mut DefaultHwModel) {
-    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
-        .expect("SET_PQ_SEED failed");
-}
-
-/// Populate the ML-DSA PQ certificate. Exporting a CDI with a certificate
-/// requires the PQ cert to have been populated first.
-fn populate_pq_cert(model: &mut DefaultHwModel) {
-    // Generate an ML-DSA-87 key pair and self-sign a placeholder TBS.
-    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
-    let priv_key = pk_builder.build().unwrap();
-    let tbs: &[u8] = b"this is going to be the TBS";
-    let mut sig_bytes = vec![];
-    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
-    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
-    ctx.sign_message_init(&mut algo).unwrap();
-    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
-    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
-    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
-    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
-    let cert_size = builder.build(&mut cert).unwrap();
-
-    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        cert_size: cert_size as u32,
-        cert,
-    });
-    cmd.populate_chksum().unwrap();
-    model
-        .mailbox_execute(
-            u32::from(CommandId::POPULATE_PQ_CERT),
-            cmd.as_bytes().unwrap(),
-        )
-        .expect("POPULATE_PQ_CERT failed");
-}
-
-/// Export an ML-DSA CDI via INVOKE_DPE_MLDSA87 + `DeriveContext{EXPORT_CDI}` and
-/// return the exported-CDI handle that SIGN/REVOKE consume. Requires SET_PQ_SEED
-/// and POPULATE_PQ_CERT to have run first.
-fn export_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
-    let derive_ctx_cmd = DeriveContextCmd {
-        handle: ContextHandle::default(),
-        data: TciMeasurement([0; TCI_SIZE]),
-        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-        tci_type: 0,
-        target_locality: 0,
-        ..Default::default()
-    };
-    let resp = execute_dpe_cmd(
-        CaliptraDpeProfile::Mldsa,
-        model,
-        &mut Command::DeriveContext(&derive_ctx_cmd),
-        DpeResult::Success,
-    );
-    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
-        panic!("expected derive context exported cdi resp!");
-    };
-    resp.header.exported_cdi
-}
-
 /// Issue REVOKE_EXPORTED_CDI_HANDLE for `handle`, expecting success.
 fn revoke_cdi(model: &mut DefaultHwModel, handle: [u8; 32]) {
     let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
@@ -175,9 +96,9 @@ fn revoke_cdi(model: &mut DefaultHwModel, handle: [u8; 32]) {
 #[test]
 fn test_sign_with_exported_mldsa_success_sign_data() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // Data mode: the firmware signs the raw message directly.
     let message = b"caliptra exported ml-dsa sign-data test message";
@@ -200,9 +121,9 @@ fn test_sign_with_exported_mldsa_success_sign_data() {
 #[test]
 fn test_sign_with_exported_mldsa_success_sign_external_mu() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // External-mu mode: the caller supplies the 64-byte mu and the firmware signs
     // it directly.
@@ -226,11 +147,11 @@ fn test_sign_with_exported_mldsa_success_sign_external_mu() {
 #[test]
 fn test_sign_with_exported_mldsa_wrong_handle_after_export() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
     // A CDI is exported, but a handle that does not match the active slot must
     // still be rejected as not found.
-    let _handle = export_cdi(&mut model);
+    let _handle = export_mldsa_cdi(&mut model);
 
     let result = sign(
         &mut model,
@@ -248,9 +169,9 @@ fn test_sign_with_exported_mldsa_wrong_handle_after_export() {
 #[test]
 fn test_sign_with_exported_mldsa_sign_after_revoke() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // Signing succeeds while the exported-CDI slot is active.
     sign(
@@ -281,9 +202,9 @@ fn test_sign_with_exported_mldsa_sign_after_revoke() {
 #[test]
 fn test_sign_with_exported_mldsa_sign_after_disable_attestation() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
     populate_pq_cert(&mut model);
-    let handle = export_cdi(&mut model);
+    let handle = export_mldsa_cdi(&mut model);
 
     // Signing succeeds before attestation is disabled.
     sign(
@@ -323,7 +244,7 @@ fn test_sign_with_exported_mldsa_sign_after_disable_attestation() {
 #[test]
 fn test_sign_with_exported_mldsa_invalid_sign_mode() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // sign_mode is neither SIGN_MODE_DATA nor SIGN_MODE_EXTERNAL_MU.
     let result = sign(&mut model, [0u8; 32], 0xDEAD_BEEF, b"message");
@@ -337,7 +258,7 @@ fn test_sign_with_exported_mldsa_invalid_sign_mode() {
 #[test]
 fn test_sign_with_exported_mldsa_external_mu_wrong_size() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // External-mu mode requires exactly MLDSA87_MU_BYTES (64) of message; any
     // other length is rejected before the CDI lookup.
@@ -360,7 +281,7 @@ fn test_sign_with_exported_mldsa_external_mu_wrong_size() {
 #[test]
 fn test_sign_with_exported_mldsa_message_too_large() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // A message_size larger than the buffer must be rejected as invalid params
     // (and must not be used to index the message buffer).
@@ -379,7 +300,7 @@ fn test_sign_with_exported_mldsa_message_too_large() {
 #[test]
 fn test_sign_with_exported_mldsa_handle_not_found() {
     let mut model = run_pqc_rt_test();
-    set_pq_seed(&mut model);
+    provision_pq_seed(&mut model);
 
     // No CDI has been exported, so any handle must be rejected as not found.
     let result = sign(

--- a/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
+++ b/runtime/tests/runtime_integration_tests/test_sign_with_exported_mldsa.rs
@@ -2,25 +2,40 @@
 
 //! Integration tests for the SIGN_WITH_EXPORTED_MLDSA mailbox command.
 //!
-//! The exported ML-DSA CDI slot is normally populated by a DPE export command
-//! that does not exist yet, and there is no test backdoor to seed it. Until one
-//! exists the successful-sign path is deferred, but every request-validation
-//! path (privilege, malformed request, handle-not-found) runs before the CDI
-//! lookup and so is covered here.
+//! An exported ML-DSA CDI slot is produced by INVOKE_DPE_MLDSA87 carrying a DPE
+//! `DeriveContext{EXPORT_CDI | CREATE_CERTIFICATE}` (see `export_cdi` below), so
+//! the successful-sign lineage is exercised here alongside the
+//! request-validation paths (privilege, malformed request, handle-not-found)
+//! that run before the CDI lookup.
 
 use caliptra_api::SocManager;
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, SetPqSeedReq, SignWithExportedMldsaReq,
-    SET_PQ_SEED_SEED_SIZE,
+    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, RevokeExportedCdiHandleReq,
+    SetPqSeedReq, SignWithExportedMldsaReq, SignWithExportedMldsaResp, SET_PQ_SEED_SEED_SIZE,
 };
+use caliptra_drivers::{Mldsa87Signature, MLDSA87_MU_BYTES};
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{HwModel, ModelError};
-use caliptra_runtime::RtBootStatus;
-use zerocopy::IntoBytes;
+use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
+use caliptra_x509::MlDsa87CertBuilder;
+use dpe::{
+    commands::{Command, DeriveContextCmd, DeriveContextFlags},
+    context::ContextHandle,
+    response::Response,
+    tci::TciMeasurement,
+    TCI_SIZE,
+};
+use openssl::pkey::Private;
+use openssl::pkey_ctx::PkeyCtx;
+use openssl::pkey_ml_dsa::{PKeyMlDsaBuilder, Variant};
+use openssl::signature::Signature;
+use zerocopy::{FromBytes, IntoBytes};
 
-use crate::common::{assert_error, run_pqc_rt_test, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    assert_error, execute_dpe_cmd, run_pqc_rt_test, run_rt_test, DpeResult, RuntimeTestArgs,
+};
 
 /// Issue SIGN_WITH_EXPORTED_MLDSA and return the raw response bytes.
 fn sign(
@@ -76,7 +91,7 @@ fn sign_full(
 
 /// Provision the PQ.DevID CDI via SET_PQ_SEED, enabling PQC mode. Signing with an
 /// exported CDI requires this to have run first.
-fn set_pq_seed(model: &mut caliptra_hw_model::DefaultHwModel) {
+fn set_pq_seed(model: &mut DefaultHwModel) {
     let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
         hdr: MailboxReqHeader { chksum: 0 },
         seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
@@ -85,6 +100,224 @@ fn set_pq_seed(model: &mut caliptra_hw_model::DefaultHwModel) {
     model
         .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
         .expect("SET_PQ_SEED failed");
+}
+
+/// Populate the ML-DSA PQ certificate. Exporting a CDI with a certificate
+/// requires the PQ cert to have been populated first.
+fn populate_pq_cert(model: &mut DefaultHwModel) {
+    // Generate an ML-DSA-87 key pair and self-sign a placeholder TBS.
+    let pk_builder = PKeyMlDsaBuilder::<Private>::from_seed(Variant::MlDsa87, &[0u8; 32]).unwrap();
+    let priv_key = pk_builder.build().unwrap();
+    let tbs: &[u8] = b"this is going to be the TBS";
+    let mut sig_bytes = vec![];
+    let mut ctx = PkeyCtx::new(&priv_key).unwrap();
+    let mut algo = Signature::for_ml_dsa(Variant::MlDsa87).unwrap();
+    ctx.sign_message_init(&mut algo).unwrap();
+    ctx.sign_to_vec(tbs, &mut sig_bytes).unwrap();
+    let sig = Mldsa87Signature::new(sig_bytes.try_into().unwrap());
+    let builder = MlDsa87CertBuilder::new(tbs, &sig).unwrap();
+    let mut cert = [0u8; PopulatePqCertReq::MAX_CERT_SIZE];
+    let cert_size = builder.build(&mut cert).unwrap();
+
+    let mut cmd = MailboxReq::PopulatePqCert(PopulatePqCertReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cert_size: cert_size as u32,
+        cert,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::POPULATE_PQ_CERT),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("POPULATE_PQ_CERT failed");
+}
+
+/// Export an ML-DSA CDI via INVOKE_DPE_MLDSA87 + `DeriveContext{EXPORT_CDI}` and
+/// return the exported-CDI handle that SIGN/REVOKE consume. Requires SET_PQ_SEED
+/// and POPULATE_PQ_CERT to have run first.
+fn export_cdi(model: &mut DefaultHwModel) -> [u8; 32] {
+    let derive_ctx_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: TciMeasurement([0; TCI_SIZE]),
+        flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
+        tci_type: 0,
+        target_locality: 0,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        CaliptraDpeProfile::Mldsa,
+        model,
+        &mut Command::DeriveContext(&derive_ctx_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::DeriveContextExportedCdi(resp)) = resp else {
+        panic!("expected derive context exported cdi resp!");
+    };
+    resp.header.exported_cdi
+}
+
+/// Issue REVOKE_EXPORTED_CDI_HANDLE for `handle`, expecting success.
+fn revoke_cdi(model: &mut DefaultHwModel, handle: [u8; 32]) {
+    let mut cmd = MailboxReq::RevokeExportedCdiHandle(RevokeExportedCdiHandleReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        exported_cdi_handle: handle,
+    });
+    cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            CommandId::REVOKE_EXPORTED_CDI_HANDLE.into(),
+            cmd.as_bytes().unwrap(),
+        )
+        .expect("REVOKE_EXPORTED_CDI_HANDLE failed");
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_success_sign_data() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // Data mode: the firmware signs the raw message directly.
+    let message = b"caliptra exported ml-dsa sign-data test message";
+    let resp = sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        message,
+    )
+    .expect("SIGN_WITH_EXPORTED_MLDSA (data mode) should succeed");
+
+    let (sign_resp, _) = SignWithExportedMldsaResp::ref_from_prefix(resp.as_bytes()).unwrap();
+    assert_eq!(
+        caliptra_mldsa::Mldsa87::verify(&sign_resp.derived_pubkey, &sign_resp.signature, message,),
+        caliptra_mldsa::Mldsa87Result::Success,
+        "returned signature must verify under the returned public key"
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_success_sign_external_mu() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // External-mu mode: the caller supplies the 64-byte mu and the firmware signs
+    // it directly.
+    let mu = [0x42u8; MLDSA87_MU_BYTES];
+    let resp = sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_EXTERNAL_MU,
+        &mu,
+    )
+    .expect("SIGN_WITH_EXPORTED_MLDSA (external-mu mode) should succeed");
+
+    let (sign_resp, _) = SignWithExportedMldsaResp::ref_from_prefix(resp.as_bytes()).unwrap();
+    assert_eq!(
+        caliptra_mldsa::Mldsa87::verify_mu(&sign_resp.derived_pubkey, &sign_resp.signature, &mu),
+        caliptra_mldsa::Mldsa87Result::Success,
+        "returned signature must verify under the returned public key"
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_wrong_handle_after_export() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    // A CDI is exported, but a handle that does not match the active slot must
+    // still be rejected as not found.
+    let _handle = export_cdi(&mut model);
+
+    let result = sign(
+        &mut model,
+        [0xFFu8; 32],
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_sign_after_revoke() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // Signing succeeds while the exported-CDI slot is active.
+    sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    )
+    .expect("sign before revoke should succeed");
+
+    revoke_cdi(&mut model, handle);
+
+    // Revoking zeroizes the slot (active = false), so the same handle no longer
+    // matches and signing is rejected as not found.
+    let result = sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND,
+        result.unwrap_err(),
+    );
+}
+
+#[test]
+fn test_sign_with_exported_mldsa_sign_after_disable_attestation() {
+    let mut model = run_pqc_rt_test();
+    set_pq_seed(&mut model);
+    populate_pq_cert(&mut model);
+    let handle = export_cdi(&mut model);
+
+    // Signing succeeds before attestation is disabled.
+    sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    )
+    .expect("sign before disable-attestation should succeed");
+
+    // DISABLE_ATTESTATION zeroizes the exported ML-DSA CDI slot. Unlike ECDSA
+    // (which still returns a now-invalid signature), the ML-DSA slot goes
+    // inactive, so signing fails outright as not found.
+    let payload = MailboxReqHeader {
+        chksum: calc_checksum(u32::from(CommandId::DISABLE_ATTESTATION), &[]),
+    };
+    model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload.as_bytes(),
+        )
+        .expect("DISABLE_ATTESTATION failed");
+
+    let result = sign(
+        &mut model,
+        handle,
+        SignWithExportedMldsaReq::SIGN_MODE_DATA,
+        b"message",
+    );
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND,
+        result.unwrap_err(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add additional unit tests which validate more involved mldsa functionality.

This found a small bug in the size of the max TBS size which could be provided to the GET_PQ_CERT command, which is fixed.