### PR TITLE
docs: fix typos across ROM, FMC, emulator, x509

### DIFF
--- a/fmc/README.md
+++ b/fmc/README.md
@@ -515,4 +515,4 @@ Fake FMC should be used with the Fake ROM. Details can be found in the ROM readm
 - Current POR is for FIPS Crypto boundary to encompass all of Caliptra FW, including ROM, FMC, and Runtime. With this boundary, there is no need for any
   dedicated crypto module, and each layer of FW will include the library code it needs to access any required crypto functionality. In the future, if a more
   strict FIPS boundary is created, FMC will need to be changed to handle crypto operations differently. Depending on where it is implemented, it may or may not
-  have to initilize the FIPS Crypto module, and it may need to use a different calling convention.
+  have to initialize the FIPS Crypto module, and it may need to use a different calling convention.

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -961,7 +961,7 @@ ROM supports two commands for firmware download in SUBSYSTEM mode:
 9. Set RI `RECOVERY_STATUS` register `Device Recovery Status` field to 0x2 (`Booting recovery image`).
 10. Validate the image per the [Image Validation Process](#firmware-image-validation-process).
 11. Reset the `RECOVERY_CTRL` register `Activate Recovery Image` field by writing 0x1.
-12. If the validation is succesful, set the `DEVICE_STATUS` register `Device Status` field to 0x5 (`Running Recovery Image ( Recover Reason Code not populated)`)
+12. If the validation is successful, set the `DEVICE_STATUS` register `Device Status` field to 0x5 (`Running Recovery Image ( Recover Reason Code not populated)`)
 13. If the validation fails, set the `RECOVERY_STATUS` register `Device Recovery Status` field to 0xd (`Authentication Error`) and `DEVICE_STATUS` register `Device Status` field to 0xE (`Boot Failure`) with the `Recovery Reason Code` populated for the failure.
 14. Release the mailbox lock.
 

--- a/sw-emulator/lib/cpu/src/instr/op.rs
+++ b/sw-emulator/lib/cpu/src/instr/op.rs
@@ -389,7 +389,7 @@ mod tests {
     test_rr_zerodest!(test_slt_38, slt, 16, 30);
 
     // ---------------------------------------------------------------------------------------------
-    // Tests For Multiply High Singed and Unsigned (`mulhsu`) Instruction
+    // Tests For Multiply High Signed and Unsigned (`mulhsu`) Instruction
     //
     // Test suite based on riscv-tests
     // https://github.com/riscv-software-src/riscv-tests/blob/master/isa/rv64um/mulhsu.S

--- a/sw-emulator/lib/periph/src/dma/encryption_engine.rs
+++ b/sw-emulator/lib/periph/src/dma/encryption_engine.rs
@@ -88,7 +88,7 @@ impl TryFrom<u32> for Control::CMD::Value {
 
 statemachine! {
     transitions: {
-        *Idle + Initialize / initalize_encryption_engine = Initializing,
+        *Idle + Initialize / initialize_encryption_engine = Initializing,
         Idle + InitFail / handle_fatal_error = Fatal,
         Initializing + InitSuccess = Ready,
         Ready + WriteCommandExecution / handle_execute = Processing,
@@ -139,7 +139,7 @@ impl Context {
 }
 
 impl StateMachineContext for Context {
-    fn initalize_encryption_engine(&mut self) -> Result<(), ()> {
+    fn initialize_encryption_engine(&mut self) -> Result<(), ()> {
         if self.raise_fatal_error_flag {
             Err(())
         } else {

--- a/x509/gen/src/cert.rs
+++ b/x509/gen/src/cert.rs
@@ -8,7 +8,7 @@ File Name:
 
 Abstract:
 
-    File contains generation of X509 Certificate To Be Singed (TBS) template that can be
+    File contains generation of X509 Certificate To Be Signed (TBS) template that can be
     substituted at firmware runtime.
 
 --*/

--- a/x509/src/der_helper.rs
+++ b/x509/src/der_helper.rs
@@ -37,7 +37,7 @@ fn encode_length(val: &[u8]) -> usize {
     1
 }
 
-/// Compute len of DER encoding of an unsinged integer
+/// Compute len of DER encoding of an unsigned integer
 #[inline(never)]
 pub fn der_uint_len(val: &[u8]) -> usize {
     let encode_length = encode_length(val);


### PR DESCRIPTION
Fixes six misspellings: successful/initialize in the ROM and FMC READMEs, the initialize_encryption_engine state-machine action name in the DMA emulator peripheral, and Signed/unsigned in emulator and x509 comments. No functional change; the renamed function is private to the emulator crate. cargo check passes on the touched crates.