### PR TITLE
[feat] Add owner authorization manifest support (#3824)

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -111,6 +111,9 @@ impl CommandId {
     // Verify the authorization manifest command.
     pub const VERIFY_AUTH_MANIFEST: Self = Self(0x4154_564D); // "ATVM"
 
+    // The owner-only authorization manifest set command.
+    pub const SET_OWNER_AUTH_MANIFEST: Self = Self(0x4F41_4D4E); // "OAMN"
+
     // The authorize and stash command.
     pub const AUTHORIZE_AND_STASH: Self = Self(0x4154_5348); // "ATSH"
 
@@ -535,6 +538,7 @@ pub enum MailboxReq {
     CertifyKeyExtended(CertifyKeyExtendedReq),
     SetAuthManifest(SetAuthManifestReq),
     VerifyAuthManifest(VerifyAuthManifestReq),
+    SetOwnerAuthManifest(SetOwnerAuthManifestReq),
     AuthorizeAndStash(AuthorizeAndStashReq),
     SignWithExportedEcdsa(SignWithExportedEcdsaReq),
     RevokeExportedCdiHandle(RevokeExportedCdiHandleReq),
@@ -616,6 +620,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_bytes()),
             MailboxReq::SetAuthManifest(req) => Ok(req.as_bytes()),
             MailboxReq::VerifyAuthManifest(req) => Ok(req.as_bytes()),
+            MailboxReq::SetOwnerAuthManifest(req) => Ok(req.as_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_bytes()),
@@ -695,6 +700,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SetAuthManifest(req) => Ok(req.as_mut_bytes()),
             MailboxReq::VerifyAuthManifest(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::SetOwnerAuthManifest(req) => Ok(req.as_mut_bytes()),
             MailboxReq::AuthorizeAndStash(req) => Ok(req.as_mut_bytes()),
             MailboxReq::SignWithExportedEcdsa(req) => Ok(req.as_mut_bytes()),
             MailboxReq::RevokeExportedCdiHandle(req) => Ok(req.as_mut_bytes()),
@@ -774,6 +780,7 @@ impl MailboxReq {
             MailboxReq::CertifyKeyExtended(_) => CommandId::CERTIFY_KEY_EXTENDED,
             MailboxReq::SetAuthManifest(_) => CommandId::SET_AUTH_MANIFEST,
             MailboxReq::VerifyAuthManifest(_) => CommandId::VERIFY_AUTH_MANIFEST,
+            MailboxReq::SetOwnerAuthManifest(_) => CommandId::SET_OWNER_AUTH_MANIFEST,
             MailboxReq::AuthorizeAndStash(_) => CommandId::AUTHORIZE_AND_STASH,
             MailboxReq::SignWithExportedEcdsa(_) => CommandId::SIGN_WITH_EXPORTED_ECDSA,
             MailboxReq::RevokeExportedCdiHandle(_) => CommandId::REVOKE_EXPORTED_CDI_HANDLE,
@@ -2010,6 +2017,55 @@ impl Default for VerifyAuthManifestReq {
 }
 impl Request for VerifyAuthManifestReq {
     const ID: CommandId = CommandId::VERIFY_AUTH_MANIFEST;
+    type Resp = MailboxRespHeader;
+}
+
+// SET_OWNER_AUTH_MANIFEST
+//
+// Loads the Owner Authorization Manifest into the dedicated owner-only
+// IME collection. The wire payload is the serialized
+// `OwnerAuthorizationManifest` (preamble + IMC). `manifest_size` is the
+// number of valid bytes in `manifest`.
+#[repr(C)]
+#[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct SetOwnerAuthManifestReq {
+    pub hdr: MailboxReqHeader,
+    pub manifest_size: u32,
+    pub manifest: [u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE],
+}
+impl SetOwnerAuthManifestReq {
+    /// Maximum size of an Owner Authorization Manifest payload. Sized to
+    /// hold the owner Preamble (~12 KiB: pubkeys + 2 signature pairs)
+    /// plus the owner-only IMC (4 + 127 * 80 ≈ 10 KiB), with headroom.
+    pub const MAX_MAN_SIZE: usize = 24 * 1024;
+
+    pub fn as_bytes_partial(&self) -> CaliptraResult<&[u8]> {
+        if self.manifest_size as usize > Self::MAX_MAN_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::MAX_MAN_SIZE - self.manifest_size as usize;
+        Ok(&self.as_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+
+    pub fn as_bytes_partial_mut(&mut self) -> CaliptraResult<&mut [u8]> {
+        if self.manifest_size as usize > Self::MAX_MAN_SIZE {
+            return Err(CaliptraError::RUNTIME_MAILBOX_API_REQUEST_DATA_LEN_TOO_LARGE);
+        }
+        let unused_byte_count = Self::MAX_MAN_SIZE - self.manifest_size as usize;
+        Ok(&mut self.as_mut_bytes()[..size_of::<Self>() - unused_byte_count])
+    }
+}
+impl Default for SetOwnerAuthManifestReq {
+    fn default() -> Self {
+        Self {
+            hdr: MailboxReqHeader::default(),
+            manifest_size: 0,
+            manifest: [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE],
+        }
+    }
+}
+impl Request for SetOwnerAuthManifestReq {
+    const ID: CommandId = CommandId::SET_OWNER_AUTH_MANIFEST;
     type Resp = MailboxRespHeader;
 }
 

--- a/auth-manifest/README.md
+++ b/auth-manifest/README.md
@@ -14,7 +14,7 @@ The Caliptra SOC manifest has two main components: [Preamble](#preamble) and [Im
 | Field                              | Size (bytes) | Description |
 | ---------------------------------- | ------------ | ----------- |
 | **Manifest Marker**                | 4            | Magic number marking the start of the manifest. The value must be `0x324D5441` (`'ATM2'` in ASCII). |
-| **Manifest Size**                  | 4            | Size of the full manifest structure in bytes. |
+| **Preamble Size**                  | 4            | Size of the Preamble in bytes. |
 | **Version**                        | 4            | Manifest version. The current version is `0x00000002`. |
 | **SVN**                            | 4            | Security Version Number used for anti-rollback. The maximum value is vendor-defined and is limited by the maximum size of the Caliptra fuse allocated for anti-rollback. |
 | **Flags**                          | 4            | Manifest feature flags.<br/>**Bit 0** – Vendor Signature Required. If set, the vendor public keys (ECC and PQC) will be used to verify signatures signed with the vendor private keys. If clear, vendor signatures are not used for verification.<br/>**Bits 1–31** – Reserved. |
@@ -38,7 +38,7 @@ Each IME has a hash that matches a SOC image.
 The manifest vendor and owner private keys sign the IMC.
 The Preamble holds the IMC signatures.
 The manifest IMC vendor signatures are optional and are validated only if the **Flags Bit 0 = 1**.
-Up to 127 image hashes are supported.
+Up to 80 image hashes are supported.
 
 | Field                            | Size (bytes) | Description                             |
 | -------------------------------- | ------------ | --------------------------------------- |
@@ -48,11 +48,108 @@ Up to 127 image hashes are supported.
 
 | Field                   | Size (bytes) | Description |
 | ----------------------- | ------------ | ----------- |
-| **Image Hash**          | 48           | SHA2-384 hash of a SOC image. |
-| **Image Identifier**    | 4            | Unique value selected by the vendor to distinguish between images. |
-| **Component Id**        | 4            | Identifies the image component to be loaded. This corresponds to the `ComponentIdentifier` field defined in the DMTF PLDM Firmware Update Specification (DSP0267). |
-| **Flags**               | 4            | Image-specific flags.<br/>**Bits 1:0:** Image source.<br/>**Bit 2:** If set, the image hash will **not** be verified; otherwise, the metadata image hash will be compared against the calculated hash of the image.<br/>**Bits 8–14:** Firmware execution control bit mapped to this image.<br/>Other bits: reserved. |
-| **Image Load Address High** | 4       | High 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
-| **Image Load Address Low**  | 4       | Low 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
-| **Staging Address High**   | 4       | High 4 bytes of the 64-bit AXI address where the image will be temporarily written during firmware update download and verification. |
-| **Staging Address Low**    | 4       | Low 4 bytes of the 64-bit AXI address where the image will be temporarily written during firmware update download and verification. |
+| **Firmware ID (`fw_id`)** | 4           | Platform-wide identifier for a firmware image. It must be unique across the active vendor + owner and owner-only Image Metadata Collections. |
+| **Component ID (`component_id`)** | 4   | Identifies the image component to be loaded. This corresponds to the `ComponentIdentifier` field defined in the DMTF PLDM Firmware Update Specification (DSP0267). |
+| **Classification (`classification`)** | 4 | Component classification value associated with the image. |
+| **Flags (`flags`)**     | 4            | Image-specific flags.<br/>**Bits 1:0:** Image source.<br/>**Bit 2:** If set, the image digest will **not** be verified; otherwise, the metadata image digest will be compared against the calculated digest of the image.<br/>**Bits 8–14:** Firmware execution control bit mapped to this image.<br/>Other bits: reserved. |
+| **Image Load Address Low (`image_load_address.lo`)** | 4 | Low 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
+| **Image Load Address High (`image_load_address.hi`)** | 4 | High 4 bytes of the 64-bit AXI address where the image will be loaded for verification and execution. |
+| **Image Staging Address Low (`image_staging_address.lo`)** | 4 | Low 4 bytes of the 64-bit AXI address where the image will be temporarily written during firmware update download and verification. |
+| **Image Staging Address High (`image_staging_address.hi`)** | 4 | High 4 bytes of the 64-bit AXI address where the image will be temporarily written during firmware update download and verification. |
+| **Image Digest (`digest`)** | 48       | SHA2-384 digest of the SOC image. |
+
+## Owner Authorization Manifest
+
+The Owner Authorization Manifest is a smaller, owner-only manifest loaded with
+[`SET_OWNER_AUTH_MANIFEST`](../runtime/README.md#set_owner-auth-manifest). It
+carries owner public keys, owner signatures, and an owner-only Image Metadata
+Collection. Runtime stores these entries separately from the vendor + owner
+collection loaded by `SET_AUTH_MANIFEST` and searches the owner-only collection
+only if the vendor + owner collection has no matching firmware ID. Runtime
+rejects either manifest if one of its active firmware IDs is already present in
+the other active collection.
+
+The `OwnerAuthorizationManifest` uses the same encoding rules described for the
+SOC Manifest: scalar `u32` fields are little-endian, ECC key and signature
+scalars are stored as big-endian `u32` words, and PQC fields contain their
+algorithm-defined byte encoding.
+
+### **Owner Preamble**
+
+| Offset | Field | Size (bytes) | Description |
+| ------ | ----- | ------------ | ----------- |
+| `0x0000` | **Manifest Marker (`marker`)** | 4 | Magic number identifying an Owner Authorization Manifest. It must be `0x4D4F574F`, which serializes as `OWOM`. |
+| `0x0004` | **Preamble Size (`size`)** | 4 | Size of the Owner Authorization Manifest Preamble. It must be 12,156 bytes (`0x2F7C`). |
+| `0x0008` | **Version (`version`)** | 4 | Owner manifest format version. This field is covered by the owner public-key endorsement signatures. |
+| `0x000C` | **SVN (`svn`)** | 4 | Security Version Number used for anti-rollback. The generator accepts values from 0 through 255. When the check is enabled, Runtime requires this value to be at least the binary value in `SS_STRAP_GENERIC[3][15:8]`; see the [Owner Authorization Manifest minimum SVN contract](../runtime/README.md#owner-authorization-manifest-minimum-svn). |
+| `0x0010` | **Reserved (`flags`)** | 4 | Reserved. Must be zero. |
+| `0x0014` | **Owner ECC Public Key (`owner_pub_keys.ecc_pub_key`)** | 96 | Owner ECDSA P-384 public key carried by this manifest.<br/>**X-Coordinate:** 48 bytes.<br/>**Y-Coordinate:** 48 bytes. |
+| `0x0074` | **Owner PQC Public Key (`owner_pub_keys.pqc_pub_key`)** | 2592 | Owner MLDSA87 or LMS-SHA192-H15 public key. MLDSA87 uses all 2,592 bytes. An LMS key occupies the first 48 bytes and the remaining bytes are zero. |
+| `0x0A94` | **Owner Public-Keys ECC Signature (`owner_pub_keys_signatures.ecc_sig`)** | 96 | ECDSA P-384 signature made by the firmware-image owner key over the owner signed-data range.<br/>**R-Coordinate:** 48 bytes.<br/>**S-Coordinate:** 48 bytes. |
+| `0x0AF4` | **Owner Public-Keys PQC Signature (`owner_pub_keys_signatures.pqc_sig`)** | 4628 | MLDSA87 or LMS signature made by the firmware-image owner key over the owner signed-data range. MLDSA87 uses all 4,628 bytes. An LMS signature occupies the first 1,620 bytes and the remaining bytes are zero. |
+| `0x1D08` | **IMC Owner ECC Signature (`owner_image_metdata_signatures.ecc_sig`)** | 96 | ECDSA P-384 signature made by this manifest's owner key over the Image Metadata Collection.<br/>**R-Coordinate:** 48 bytes.<br/>**S-Coordinate:** 48 bytes. |
+| `0x1D68` | **IMC Owner PQC Signature (`owner_image_metdata_signatures.pqc_sig`)** | 4628 | MLDSA87 or LMS signature made by this manifest's owner key over the Image Metadata Collection. It uses the same fixed-field encoding as the Owner Public-Keys PQC Signature. |
+
+The Owner Authorization Manifest does not contain a PQC algorithm selector.
+Runtime obtains the algorithm from the loaded Caliptra firmware image and, in a
+provisioned lifecycle, requires it to match the fused PQC key type. Runtime
+verifies both ECC and the selected PQC algorithm for each signature pair.
+
+Signature coverage and trust chaining are as follows:
+
+1. `owner_pub_keys_signatures` covers the serialized bytes from `version`
+  through the end of `owner_pub_keys`, inclusive. The marker and Preamble size
+  are excluded from this signed range and are instead checked against their
+  required values. Runtime verifies these signatures with the owner keys from
+  the loaded Caliptra firmware image.
+2. `owner_image_metdata_signatures` covers the serialized owner-only Image
+  Metadata Collection. Runtime verifies these signatures with the
+  `owner_pub_keys` carried in this manifest, after those keys have been chained
+  to the firmware-image owner keys in step 1.
+
+For ECDSA and LMS, the signature input is the SHA2-384 digest of the covered
+bytes. MLDSA87 signs the covered bytes directly.
+
+### **Owner Image Metadata Collection**
+
+| Offset | Field | Size (bytes) | Description |
+| ------ | ----- | ------------ | ----------- |
+| `0x2F7C` | **Image Metadata Entry Count (`entry_count`)** | 4 | Number of active entries. It must be from 1 through 32. |
+| `0x2F80` | **Image Metadata Entries (`image_metadata_list`)** | 2560 | Fixed-capacity array of 32 80-byte entries. Each entry uses the [Image Metadata Entry](#image-metadata-entry) layout described above. |
+
+The canonical encoding generated by the authorization manifest app serializes
+all 32 entry slots, including unused slots, and signs the complete 2,564-byte
+collection. Unused slots retain the default encoding: `fw_id` and
+`component_id` are `0xFFFFFFFF`, and all other fields are zero. The app output
+contains exactly the serialized `OwnerAuthorizationManifest` with no trailing
+padding.
+
+Incoming active entries must have unique `fw_id` values, both within this
+manifest and across the installed vendor + owner manifest. A collision rejects
+the command without modifying either active collection. After verification,
+Runtime replaces the existing owner-only collection with the incoming
+collection.
+
+### **Generating an Owner Authorization Manifest**
+
+Generate one with the authorization manifest app:
+
+```bash
+cargo run -p caliptra-auth-manifest-app -- create-owner-auth-man \
+  --version 1 \
+  --svn 0 \
+  --pqc-key-type 3 \
+  --key-dir path/to/key-files \
+  --config auth-manifest/app/src/auth-man.toml \
+  --out owner-auth-man.bin
+```
+
+The command uses `owner_fw_key_config`, `owner_man_key_config`, and
+`image_metadata_list` from the TOML configuration. `owner_fw_key_config` supplies
+the firmware-image owner private keys that endorse the manifest's owner public
+keys. `owner_man_key_config` supplies the owner public keys carried in the
+manifest and the corresponding private keys used to sign the Image Metadata
+Collection. Vendor key sections are ignored for owner-only manifest generation.
+
+`--pqc-key-type 1` selects MLDSA87 and `--pqc-key-type 3` selects
+LMS-SHA192-H15.

--- a/auth-manifest/app/src/auth-man.toml
+++ b/auth-manifest/app/src/auth-man.toml
@@ -36,16 +36,31 @@ mldsa_priv_key = "own-mldsa-priv-key.bin"
 digest = "C120EED0004B4CF6C344B00F5F501E7B7167C7010B6EA1D36AEE20CC90F1AE373DF1EC91C9AD9E0A5A969326A54E2517"
 source = 1
 fw_id = 1
+exec_bit = 0
 ignore_auth_check = false
+component_id = 0
+image_load_address = 0
+image_staging_address = 0
+classification = 0
 
 [[image_metadata_list]]
 digest = "99514329186b2f6ae4a1329e7ee6c610a729636335174ac6b740f9028396fcc803d0e93863a7c3d90f86beee782f4f3f"
 source = 2
 fw_id = 2
+exec_bit = 0
 ignore_auth_check = true
+component_id = 0
+image_load_address = 0
+image_staging_address = 0
+classification = 0
 
 [[image_metadata_list]]
 digest = "9B514329186b2f6ae4a1329e7ee6c610a729636335174ac6b740f9028396fcc803d0e93863a7c3d90f86beee782f4f3f"
 source = 2
 fw_id = 3
+exec_bit = 0
 ignore_auth_check = false
+component_id = 0
+image_load_address = 0
+image_staging_address = 0
+classification = 0

--- a/auth-manifest/app/src/main.rs
+++ b/auth-manifest/app/src/main.rs
@@ -13,7 +13,9 @@ Abstract:
 --*/
 
 use anyhow::Context;
-use caliptra_auth_man_gen::{AuthManifestGenerator, AuthManifestGeneratorConfig};
+use caliptra_auth_man_gen::{
+    AuthManifestGenerator, AuthManifestGeneratorConfig, OwnerAuthManifestGeneratorConfig,
+};
 use caliptra_auth_man_types::AuthManifestFlags;
 #[cfg(feature = "openssl")]
 use caliptra_image_crypto::OsslCrypto as Crypto;
@@ -28,17 +30,15 @@ use zerocopy::IntoBytes;
 
 mod config;
 
-/// Entry point
-fn main() {
-    let sub_cmds = vec![Command::new("create-auth-man")
-        .about("Create a new authorization manifest")
+fn manifest_command(
+    name: &'static str,
+    about: &'static str,
+    flags_help: Option<&'static str>,
+) -> Command<'static> {
+    let command = Command::new(name)
+        .about(about)
         .arg(
             arg!(--"version" <U32> "Manifest Version Number")
-                .required(true)
-                .value_parser(value_parser!(u32)),
-        )
-        .arg(
-            arg!(--"flags" <U32> "Manifest Flags")
                 .required(true)
                 .value_parser(value_parser!(u32)),
         )
@@ -61,7 +61,34 @@ fn main() {
             arg!(--"out" <FILE> "Output file")
                 .required(true)
                 .value_parser(value_parser!(PathBuf)),
-        )];
+        );
+
+    if let Some(flags_help) = flags_help {
+        command.arg(
+            arg!(--"flags" <U32>)
+                .help(flags_help)
+                .required(true)
+                .value_parser(value_parser!(u32)),
+        )
+    } else {
+        command
+    }
+}
+
+/// Entry point
+fn main() {
+    let sub_cmds = vec![
+        manifest_command(
+            "create-auth-man",
+            "Create a new authorization manifest",
+            Some("Manifest Flags"),
+        ),
+        manifest_command(
+            "create-owner-auth-man",
+            "Create a new owner authorization manifest",
+            None,
+        ),
+    ];
 
     let cmd = Command::new("caliptra-auth-man-app")
         .arg_required_else_help(true)
@@ -71,6 +98,7 @@ fn main() {
 
     let result = match cmd.subcommand().unwrap() {
         ("create-auth-man", args) => run_auth_man_cmd(args),
+        ("create-owner-auth-man", args) => run_owner_auth_man_cmd(args),
         (_, _) => unreachable!(),
     };
 
@@ -170,6 +198,81 @@ pub(crate) fn run_auth_man_cmd(args: &ArgMatches) -> anyhow::Result<()> {
     if padded > len {
         out_file.write_all(&vec![0u8; padded - len])?;
     }
+
+    Ok(())
+}
+
+pub(crate) fn run_owner_auth_man_cmd(args: &ArgMatches) -> anyhow::Result<()> {
+    let version: &u32 = args
+        .get_one::<u32>("version")
+        .with_context(|| "version arg not specified")?;
+
+    let svn: &u32 = args
+        .get_one::<u32>("svn")
+        .with_context(|| "svn arg not specified")?;
+
+    if *svn > 255 {
+        return Err(anyhow::anyhow!("Invalid owner manifest SVN value"));
+    }
+
+    let pqc_key_type: &u32 = args
+        .get_one::<u32>("pqc-key-type")
+        .with_context(|| "Type of PQC key validation: 1: MLDSA; 3: LMS")?;
+    let pqc_key_type = match *pqc_key_type {
+        1 => FwVerificationPqcKeyType::MLDSA,
+        3 => FwVerificationPqcKeyType::LMS,
+        _ => return Err(anyhow::anyhow!("Invalid PQC key type")),
+    };
+
+    let config_path: &PathBuf = args
+        .get_one::<PathBuf>("config")
+        .with_context(|| "config arg not specified")?;
+
+    if !config_path.exists() {
+        return Err(anyhow::anyhow!("Invalid config file path"));
+    }
+
+    let key_dir: &PathBuf = args
+        .get_one::<PathBuf>("key-dir")
+        .with_context(|| "key-dir arg not specified")?;
+
+    if !key_dir.exists() {
+        return Err(anyhow::anyhow!("Invalid key directory path"));
+    }
+
+    let out_path: &PathBuf = args
+        .get_one::<PathBuf>("out")
+        .with_context(|| "out arg not specified")?;
+
+    let config = config::load_auth_man_config_from_file(config_path)?;
+
+    let owner_fw_key_info =
+        config::optional_key_config_from_file(key_dir, &config.owner_fw_key_config)?
+            .ok_or_else(|| anyhow::anyhow!("owner_fw_key_config is required"))?;
+    let owner_man_key_info =
+        config::optional_key_config_from_file(key_dir, &config.owner_man_key_config)?
+            .ok_or_else(|| anyhow::anyhow!("owner_man_key_config is required"))?;
+
+    let gen_config = OwnerAuthManifestGeneratorConfig {
+        version: *version,
+        svn: *svn,
+        pqc_key_type,
+        owner_fw_key_info,
+        owner_man_key_info,
+        image_metadata_list: config::image_metadata_config_from_file(&config.image_metadata_list)?,
+    };
+
+    let gen = AuthManifestGenerator::new(Crypto::default());
+    let manifest = gen.generate_owner(&gen_config)?;
+
+    let mut out_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(out_path)
+        .with_context(|| format!("Failed to create file {}", out_path.display()))?;
+
+    out_file.write_all(manifest.as_bytes())?;
 
     Ok(())
 }

--- a/auth-manifest/gen/src/generator.rs
+++ b/auth-manifest/gen/src/generator.rs
@@ -266,4 +266,142 @@ impl<Crypto: ImageGeneratorCrypto> AuthManifestGenerator<Crypto> {
 
         Ok(auth_manifest)
     }
+
+    pub fn generate_owner(
+        &self,
+        config: &OwnerAuthManifestGeneratorConfig,
+    ) -> anyhow::Result<OwnerAuthorizationManifest> {
+        let mut auth_manifest = OwnerAuthorizationManifest::default();
+
+        if config.image_metadata_list.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Owner authorization manifest requires at least one image metadata entry"
+            ));
+        }
+
+        if config.image_metadata_list.len() > OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT {
+            eprintln!(
+                "Unsupported owner image metadata count, only {} entries supported.",
+                OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT
+            );
+            return Err(anyhow::anyhow!(
+                "Error converting owner image metadata list"
+            ));
+        }
+
+        let owner_fw_priv_keys = config
+            .owner_fw_key_info
+            .priv_keys
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Owner firmware private keys are required"))?;
+        let owner_man_priv_keys = config
+            .owner_man_key_info
+            .priv_keys
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Owner manifest private keys are required"))?;
+
+        let slice = config.image_metadata_list.as_slice();
+        auth_manifest.image_metadata_col.image_metadata_list[..slice.len()].copy_from_slice(slice);
+        auth_manifest.image_metadata_col.entry_count = config.image_metadata_list.len() as u32;
+
+        auth_manifest.preamble.marker = OWNER_AUTH_MANIFEST_MARKER;
+        auth_manifest.preamble.size = size_of::<OwnerAuthManifestPreamble>() as u32;
+        auth_manifest.preamble.version = config.version;
+        auth_manifest.preamble.svn = config.svn;
+
+        auth_manifest.preamble.owner_pub_keys.ecc_pub_key =
+            config.owner_man_key_info.pub_keys.ecc_pub_key;
+        let pqc_pub_key = match config.pqc_key_type {
+            FwVerificationPqcKeyType::LMS => {
+                config.owner_man_key_info.pub_keys.lms_pub_key.as_bytes()
+            }
+            FwVerificationPqcKeyType::MLDSA => config
+                .owner_man_key_info
+                .pub_keys
+                .mldsa_pub_key
+                .0
+                .as_bytes(),
+        };
+        auth_manifest.preamble.owner_pub_keys.pqc_pub_key.0[..pqc_pub_key.len()]
+            .copy_from_slice(pqc_pub_key);
+
+        let range = OwnerAuthManifestPreamble::owner_signed_data_range();
+        let owner_data = auth_manifest
+            .preamble
+            .as_bytes()
+            .get(range.start as usize..)
+            .ok_or_else(|| anyhow::anyhow!("Failed to get owner signed data range start"))?
+            .get(..range.len())
+            .ok_or(anyhow::anyhow!(
+                "Failed to get owner signed data range length"
+            ))?
+            .to_vec();
+        let owner_digest = self.crypto.sha384_digest(&owner_data)?;
+
+        let sig = self.crypto.ecdsa384_sign(
+            &owner_digest,
+            &owner_fw_priv_keys.ecc_priv_key,
+            &config.owner_fw_key_info.pub_keys.ecc_pub_key,
+        )?;
+        auth_manifest.preamble.owner_pub_keys_signatures.ecc_sig = sig;
+
+        if config.pqc_key_type == FwVerificationPqcKeyType::LMS {
+            let lms_sig = self
+                .crypto
+                .lms_sign(&owner_digest, &owner_fw_priv_keys.lms_priv_key)?;
+            let sig = lms_sig.as_bytes();
+            auth_manifest.preamble.owner_pub_keys_signatures.pqc_sig.0[..sig.len()]
+                .copy_from_slice(sig);
+        } else {
+            let mldsa_sig = self.crypto.mldsa_sign(
+                &owner_data,
+                &owner_fw_priv_keys.mldsa_priv_key,
+                &config.owner_fw_key_info.pub_keys.mldsa_pub_key,
+            )?;
+            let sig = mldsa_sig.as_bytes();
+            auth_manifest.preamble.owner_pub_keys_signatures.pqc_sig.0[..sig.len()]
+                .copy_from_slice(sig);
+        }
+
+        let imc_data = auth_manifest.image_metadata_col.as_bytes().to_vec();
+        let imc_digest = self.crypto.sha384_digest(&imc_data)?;
+
+        let sig = self.crypto.ecdsa384_sign(
+            &imc_digest,
+            &owner_man_priv_keys.ecc_priv_key,
+            &config.owner_man_key_info.pub_keys.ecc_pub_key,
+        )?;
+        auth_manifest
+            .preamble
+            .owner_image_metdata_signatures
+            .ecc_sig = sig;
+
+        if config.pqc_key_type == FwVerificationPqcKeyType::LMS {
+            let lms_sig = self
+                .crypto
+                .lms_sign(&imc_digest, &owner_man_priv_keys.lms_priv_key)?;
+            let sig = lms_sig.as_bytes();
+            auth_manifest
+                .preamble
+                .owner_image_metdata_signatures
+                .pqc_sig
+                .0[..sig.len()]
+                .copy_from_slice(sig);
+        } else {
+            let mldsa_sig = self.crypto.mldsa_sign(
+                &imc_data,
+                &owner_man_priv_keys.mldsa_priv_key,
+                &config.owner_man_key_info.pub_keys.mldsa_pub_key,
+            )?;
+            let sig = mldsa_sig.as_bytes();
+            auth_manifest
+                .preamble
+                .owner_image_metdata_signatures
+                .pqc_sig
+                .0[..sig.len()]
+                .copy_from_slice(sig);
+        }
+
+        Ok(auth_manifest)
+    }
 }

--- a/auth-manifest/gen/src/lib.rs
+++ b/auth-manifest/gen/src/lib.rs
@@ -47,3 +47,19 @@ pub struct AuthManifestGeneratorConfig {
 
     pub image_metadata_list: Vec<AuthManifestImageMetadata>,
 }
+
+/// Owner Authorization Manifest Generator Configuration
+#[derive(Default, Clone)]
+pub struct OwnerAuthManifestGeneratorConfig {
+    pub version: u32,
+
+    pub svn: u32,
+
+    pub pqc_key_type: FwVerificationPqcKeyType,
+
+    pub owner_fw_key_info: AuthManifestGeneratorKeyConfig,
+
+    pub owner_man_key_info: AuthManifestGeneratorKeyConfig,
+
+    pub image_metadata_list: Vec<AuthManifestImageMetadata>,
+}

--- a/auth-manifest/types/src/lib.rs
+++ b/auth-manifest/types/src/lib.rs
@@ -23,7 +23,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub const AUTH_MANIFEST_MARKER: u32 = 0x324D_5441;
-pub const AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT: usize = 127;
+pub const AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT: usize = 80;
 pub const AUTH_MANIFEST_PREAMBLE_SIZE: usize = 24292;
 
 bitflags::bitflags! {
@@ -214,9 +214,140 @@ pub struct AuthorizationManifest {
     pub image_metadata_col: AuthManifestImageMetadataCollection,
 }
 
+// =====================================================================
+// Owner Authorization Manifest
+//
+// A separate, owner-only manifest format. Carries owner public keys and
+// owner signatures only; no vendor key or signature fields. Loaded via
+// the dedicated `SET_OWNER_AUTH_MANIFEST` mailbox command into a
+// dedicated owner-only Image Metadata Entry collection (separate from
+// the existing vendor + owner collection populated by
+// `SET_AUTH_MANIFEST`).
+// =====================================================================
+
+/// Magic marker identifying an Owner Authorization Manifest. ASCII "OWOM".
+pub const OWNER_AUTH_MANIFEST_MARKER: u32 = 0x4D4F_574F;
+
+/// Maximum number of Image Metadata Entries in the owner-only IMC.
+/// Sized smaller than the vendor + owner cap because owner-only
+/// manifests are expected to carry on the order of ~16 entries (per
+/// the RFC use case); the cap leaves headroom while keeping the
+/// owner-only DCCM region small.
+pub const OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT: usize = 32;
+
+/// Serialized size of [`OwnerAuthManifestPreamble`] in bytes.
+/// Validated by the unit test below.
+pub const OWNER_AUTH_MANIFEST_PREAMBLE_SIZE: usize = 12156;
+
+/// Serialized size of [`OwnerAuthorizationManifest`] in bytes.
+/// Validated by the unit test below.
+pub const OWNER_AUTH_MANIFEST_SIZE: usize = 14720;
+
+/// Preamble of the Owner Authorization Manifest.
+///
+/// Contains the owner ECC and PQC public keys, the owner endorsement
+/// signatures over the Preamble policy fields, and the owner signatures
+/// over the IMC.
+///
+/// Signature coverage:
+/// - `owner_pub_keys_signatures` covers the Preamble policy fields
+///   (`version`, `svn`, `flags`, `owner_pub_keys`). The marker and
+///   Preamble size are validated separately.
+/// - `owner_image_metdata_signatures` covers the serialized
+///   [`OwnerAuthManifestImageMetadataCollection`] (entry count + IMEs).
+#[repr(C)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct OwnerAuthManifestPreamble {
+    pub marker: u32,
+
+    pub size: u32,
+
+    pub version: u32,
+
+    pub svn: u32,
+
+    pub flags: u32,
+
+    pub owner_pub_keys: AuthManifestPubKeys,
+
+    pub owner_pub_keys_signatures: AuthManifestSignatures,
+
+    pub owner_image_metdata_signatures: AuthManifestSignatures,
+}
+
+impl OwnerAuthManifestPreamble {
+    /// Range covering the Preamble policy fields signed by
+    /// `owner_pub_keys_signatures`.
+    pub fn owner_signed_data_range() -> Range<u32> {
+        let span = span_of!(OwnerAuthManifestPreamble, version..=owner_pub_keys);
+        span.start as u32..span.end as u32
+    }
+
+    /// Range covering `owner_pub_keys_signatures`.
+    pub fn owner_pub_keys_signatures_range() -> Range<u32> {
+        let span = span_of!(OwnerAuthManifestPreamble, owner_pub_keys_signatures);
+        span.start as u32..span.end as u32
+    }
+
+    /// Range covering `owner_image_metdata_signatures`.
+    pub fn owner_image_metdata_signatures_range() -> Range<u32> {
+        let span = span_of!(OwnerAuthManifestPreamble, owner_image_metdata_signatures);
+        span.start as u32..span.end as u32
+    }
+}
+
+/// Owner-only Image Metadata Collection.
+///
+/// Per-entry layout is identical to the existing
+/// [`AuthManifestImageMetadata`] used by the vendor + owner manifest.
+#[repr(C)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct OwnerAuthManifestImageMetadataCollection {
+    pub entry_count: u32,
+
+    pub image_metadata_list:
+        [AuthManifestImageMetadata; OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT],
+}
+
+impl zeroize::Zeroize for OwnerAuthManifestImageMetadataCollection {
+    fn zeroize(&mut self) {
+        self.as_mut_bytes().zeroize();
+    }
+}
+
+impl Default for OwnerAuthManifestImageMetadataCollection {
+    fn default() -> Self {
+        OwnerAuthManifestImageMetadataCollection {
+            entry_count: 0,
+            image_metadata_list: [AuthManifestImageMetadata::default();
+                OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT],
+        }
+    }
+}
+
+/// Caliptra Owner Authorization Manifest.
+///
+/// Loaded via the `SET_OWNER_AUTH_MANIFEST` mailbox command. Carries
+/// owner-only authorization material; never mixed with the vendor +
+/// owner collection populated by `SET_AUTH_MANIFEST`.
+#[repr(C)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Clone, Copy, Debug, Zeroize, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct OwnerAuthorizationManifest {
+    pub preamble: OwnerAuthManifestPreamble,
+
+    pub image_metadata_col: OwnerAuthManifestImageMetadataCollection,
+}
+
 #[cfg(test)]
 mod test {
-    use crate::{AuthManifestPreamble, AUTH_MANIFEST_PREAMBLE_SIZE};
+    use crate::{
+        AuthManifestPreamble, OwnerAuthManifestPreamble, OwnerAuthorizationManifest,
+        AUTH_MANIFEST_PREAMBLE_SIZE, OWNER_AUTH_MANIFEST_MARKER, OWNER_AUTH_MANIFEST_PREAMBLE_SIZE,
+        OWNER_AUTH_MANIFEST_SIZE,
+    };
     use zerocopy::IntoBytes;
 
     #[test]
@@ -225,5 +356,43 @@ mod test {
             AUTH_MANIFEST_PREAMBLE_SIZE,
             AuthManifestPreamble::default().as_bytes().len()
         );
+    }
+
+    #[test]
+    fn test_owner_auth_preamble_size() {
+        assert_eq!(
+            OWNER_AUTH_MANIFEST_PREAMBLE_SIZE,
+            OwnerAuthManifestPreamble::default().as_bytes().len()
+        );
+    }
+
+    #[test]
+    fn test_owner_auth_manifest_size() {
+        assert_eq!(
+            OWNER_AUTH_MANIFEST_SIZE,
+            OwnerAuthorizationManifest::default().as_bytes().len()
+        );
+    }
+
+    #[test]
+    fn test_owner_auth_manifest_marker_value() {
+        // 'O','W','O','M' little-endian.
+        assert_eq!(OWNER_AUTH_MANIFEST_MARKER, 0x4D4F_574F);
+        assert_eq!(&OWNER_AUTH_MANIFEST_MARKER.to_le_bytes(), b"OWOM");
+    }
+
+    #[test]
+    fn test_owner_signed_data_range_covers_policy_fields() {
+        let range = OwnerAuthManifestPreamble::owner_signed_data_range();
+        // The signed range must start at `version` (i.e. skip
+        // `marker` and `size` which are validated by exact equality)
+        // and end at the end of `owner_pub_keys`. It must not include
+        // either signature region.
+        let pub_keys_sigs = OwnerAuthManifestPreamble::owner_pub_keys_signatures_range();
+        let imc_sigs = OwnerAuthManifestPreamble::owner_image_metdata_signatures_range();
+        assert!(range.end <= pub_keys_sigs.start);
+        assert!(pub_keys_sigs.end <= imc_sigs.start);
+        // Non-empty.
+        assert!(range.start < range.end);
     }
 }

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -5,7 +5,7 @@ use core::{marker::PhantomData, mem::size_of, ptr::addr_of};
 #[cfg(feature = "runtime")]
 use caliptra_auth_man_types::{
     AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
-    AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT,
+    OwnerAuthManifestImageMetadataCollection, AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT,
 };
 #[cfg(feature = "runtime")]
 use caliptra_dpe::{ExportedCdiHandle, U8Bool, MAX_HANDLES};
@@ -45,7 +45,11 @@ pub const MEASUREMENT_LOG_SIZE: u32 = 1024;
 pub const FUSE_LOG_SIZE: u32 = 1024;
 pub const DPE_SIZE: u32 = 5 * 1024;
 pub const PCR_RESET_COUNTER_SIZE: u32 = 1024;
-pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 10 * 1024;
+pub const AUTH_MAN_PERSISTENT_DATA_SIZE: u32 = 10 * 1024;
+#[cfg(feature = "runtime")]
+pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 6 * 1024 + 512;
+#[cfg(feature = "runtime")]
+pub const OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 3 * 1024;
 pub const IDEVID_CSR_ENVELOP_SIZE: u32 = 9 * 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 9 * 1024;
 pub const MLDSA87_MAX_CSR_SIZE: usize = 7680;
@@ -417,7 +421,19 @@ pub struct PersistentData {
         - (SHA384_HASH_SIZE + size_of::<AuthManifestImageMetadataCollection>())],
 
     #[cfg(not(feature = "runtime"))]
-    pub auth_manifest_image_metadata_col: [u8; AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize],
+    pub auth_manifest_image_metadata_col: [u8; AUTH_MAN_PERSISTENT_DATA_SIZE as usize],
+
+    #[cfg(feature = "runtime")]
+    pub owner_auth_manifest_image_metadata_col: OwnerAuthManifestImageMetadataCollection,
+    #[cfg(feature = "runtime")]
+    pub owner_auth_manifest_digest: [u32; SHA384_HASH_SIZE / 4],
+    #[cfg(feature = "runtime")]
+    reserved_owner_auth_manifest: [u8; OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize
+        - (SHA384_HASH_SIZE + size_of::<OwnerAuthManifestImageMetadataCollection>())],
+    #[cfg(feature = "runtime")]
+    reserved_auth_manifests: [u8; (AUTH_MAN_PERSISTENT_DATA_SIZE
+        - AUTH_MAN_IMAGE_METADATA_MAX_SIZE
+        - OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE) as usize],
 
     pub idevid_csr_envelop: InitDevIdCsrEnvelope,
     reserved10: [u8; IDEVID_CSR_ENVELOP_SIZE as usize - size_of::<InitDevIdCsrEnvelope>()],
@@ -576,7 +592,22 @@ impl PersistentData {
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
 
-            persistent_data_offset += AUTH_MAN_IMAGE_METADATA_MAX_SIZE;
+            #[cfg(feature = "runtime")]
+            {
+                persistent_data_offset += AUTH_MAN_IMAGE_METADATA_MAX_SIZE;
+                assert_eq!(
+                    addr_of!((*P).owner_auth_manifest_image_metadata_col) as u32,
+                    memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+                );
+                persistent_data_offset += OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE;
+                persistent_data_offset += AUTH_MAN_PERSISTENT_DATA_SIZE
+                    - AUTH_MAN_IMAGE_METADATA_MAX_SIZE
+                    - OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE;
+            }
+            #[cfg(not(feature = "runtime"))]
+            {
+                persistent_data_offset += AUTH_MAN_PERSISTENT_DATA_SIZE;
+            }
             assert_eq!(
                 addr_of!((*P).idevid_csr_envelop) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/drivers/src/soc_ifc.rs
+++ b/drivers/src/soc_ifc.rs
@@ -25,6 +25,9 @@ use crate::{memory_layout, FuseBank};
 
 pub type Lifecycle = DeviceLifecycleE;
 
+const SS_STRAP_GENERIC_3_OWNER_MANIFEST_MIN_SVN_SHIFT: u32 = 8;
+const SS_STRAP_GENERIC_3_OWNER_MANIFEST_MIN_SVN_MASK: u32 = 0xFF;
+
 pub fn report_boot_status(val: u32) {
     let mut soc_ifc = unsafe { soc_ifc::SocIfcReg::new() };
 
@@ -653,6 +656,14 @@ impl SocIfc {
 
     pub fn otp_direct_access_cmd_reg_offset(&self) -> u32 {
         self.soc_ifc.regs().ss_strap_generic().at(1).read() & 0xFFFF
+    }
+
+    /// Returns the Owner Authorization Manifest minimum-SVN floor as
+    /// populated by the MCU into `SS_STRAP_GENERIC[3][15:8]` during boot.
+    pub fn ss_owner_manifest_min_svn(&self) -> u32 {
+        (self.soc_ifc.regs().ss_strap_generic().at(3).read()
+            >> SS_STRAP_GENERIC_3_OWNER_MANIFEST_MIN_SVN_SHIFT)
+            & SS_STRAP_GENERIC_3_OWNER_MANIFEST_MIN_SVN_MASK
     }
 }
 

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1603,6 +1603,102 @@ impl CaliptraError {
             0x000E008D,
             "Runtime Error: DPE response too large"
         ),
+        (
+            RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE_IN_FUSE,
+            0x000E008A,
+            "Runtime Error: Auth manifest invalid PQC key type in fuse"
+        ),
+        (
+            RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE,
+            0x000E008B,
+            "Runtime Error: Auth manifest invalid PQC key type"
+        ),
+        (
+            RUNTIME_AUTH_MANIFEST_PQC_KEY_TYPE_MISMATCH,
+            0x000E008C,
+            "Runtime Error: Auth manifest PQC key type mismatch"
+        ),
+        // Owner Authorization Manifest errors (SET_OWNER_AUTH_MANIFEST).
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_INVALID_MARKER,
+            0x000E009F,
+            "Runtime Error: Owner auth manifest invalid marker"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_LT_MIN,
+            0x000E00A0,
+            "Runtime Error: Owner auth manifest preamble too small"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_MISMATCH,
+            0x000E00A1,
+            "Runtime Error: Owner auth manifest preamble size mismatch"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_SVN_LESS_THAN_MIN,
+            0x000E00A2,
+            "Runtime Error: Owner auth manifest SVN less than enforced minimum from SS_STRAP_GENERIC"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_SVN_GREATER_THAN_MAX,
+            0x000E00A3,
+            "Runtime Error: Owner auth manifest SVN greater than maximum"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_OWNER_ECC_SIGNATURE_INVALID,
+            0x000E00A4,
+            "Runtime Error: Owner auth manifest owner ECC signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID,
+            0x000E00A5,
+            "Runtime Error: Owner auth manifest owner LMS signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_OWNER_MLDSA_SIGNATURE_INVALID,
+            0x000E00A6,
+            "Runtime Error: Owner auth manifest owner MLDSA signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_ECC_SIGNATURE_INVALID,
+            0x000E00A7,
+            "Runtime Error: Owner auth manifest IMC owner ECC signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_LMS_SIGNATURE_INVALID,
+            0x000E00A8,
+            "Runtime Error: Owner auth manifest IMC owner LMS signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_MLDSA_SIGNATURE_INVALID,
+            0x000E00A9,
+            "Runtime Error: Owner auth manifest IMC owner MLDSA signature invalid"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE,
+            0x000E00AA,
+            "Runtime Error: Owner auth manifest IMC invalid size"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_ENTRY_COUNT,
+            0x000E00AB,
+            "Runtime Error: Owner auth manifest IMC invalid entry count"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_IMC_DUPLICATE_FW_ID,
+            0x000E00AC,
+            "Runtime Error: Owner auth manifest IMC duplicate firmware ID"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_INVALID_FLAGS,
+            0x000E00AD,
+            "Runtime Error: Owner auth manifest flags must be zero"
+        ),
+        (
+            RUNTIME_OWNER_AUTH_MANIFEST_OWNER_PUB_KEY_MISMATCH,
+            0x000E00AE,
+            "Runtime Error: Owner auth manifest owner public key does not match firmware-image owner pub key"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -391,6 +391,7 @@ pub struct BootParams<'a> {
     pub initial_repcnt_thresh_reg: Option<CptraItrngEntropyConfig1WriteVal>,
     pub initial_adaptp_thresh_reg: Option<CptraItrngEntropyConfig0WriteVal>,
     pub initial_ss_strap_generic_2: Option<u32>,
+    pub initial_ss_strap_generic_3: Option<u32>,
     pub valid_axi_user: Vec<u32>,
     pub wdt_timeout_cycles: u64,
     // SoC manifest passed via the recovery interface
@@ -407,6 +408,7 @@ impl Default for BootParams<'_> {
             initial_repcnt_thresh_reg: Default::default(),
             initial_adaptp_thresh_reg: Default::default(),
             initial_ss_strap_generic_2: Default::default(),
+            initial_ss_strap_generic_3: Default::default(),
             valid_axi_user: vec![0, 1, 2, 3, 4],
             wdt_timeout_cycles: EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES,
             soc_manifest: Default::default(),
@@ -696,6 +698,9 @@ pub trait HwModel: SocManager {
     {
         if let Some(reg) = boot_params.initial_ss_strap_generic_2 {
             self.soc_ifc().ss_strap_generic().at(2).write(|_| reg);
+        }
+        if let Some(reg) = boot_params.initial_ss_strap_generic_3 {
+            self.soc_ifc().ss_strap_generic().at(3).write(|_| reg);
         }
 
         HwModel::init_fuses(self);

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -2038,6 +2038,10 @@ impl HwModel for ModelFpgaSubsystem {
             self.soc_ifc().ss_strap_generic().at(2).write(|_| reg);
         }
 
+        if let Some(reg) = boot_params.initial_ss_strap_generic_3 {
+            self.soc_ifc().ss_strap_generic().at(3).write(|_| reg);
+        }
+
         let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
         let current = gpio.extract().get();
         // Notify MCU ROM it can start loading the fuse registers

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -71,6 +71,27 @@ Following are the main FUSE & Architectural Registers used by the Caliptra ROM f
 | :------------------------------ | :------------|  :----------------------------------------------------- |
 | CPTRA_OWNER_PK_HASH             | 384          | Owner ECC and LMS or MLDSA Public Key Hash              |
 
+### Subsystem Generic Strap Allocation
+
+The following table is the allocation registry for `SS_STRAP_GENERIC[0..3]` fields consumed by Caliptra firmware. New uses must be assigned to a reserved, non-overlapping range and added to this table. These subsystem straps are sampled at reset, may be overwritten by the SoC before `CPTRA_FUSE_WR_DONE`, and are locked when `CPTRA_FUSE_WR_DONE` is set.
+
+| Register | Field/Bits | Allocation | Consumer |
+| :------- | :--------- | :--------- | :------- |
+| `SS_STRAP_GENERIC[0]` | `[15:0]` | Offset of the OTP controller `STATUS` register from `SS_OTP_FC_BASE_ADDR`. | ROM UDS and Field Entropy programming |
+| `SS_STRAP_GENERIC[0]` | `[31:16]` | Bit index of the DAI idle indicator in the OTP controller `STATUS` register. | ROM UDS and Field Entropy programming |
+| `SS_STRAP_GENERIC[1]` | `[15:0]` | Offset of the OTP controller `DIRECT_ACCESS_CMD` register from `SS_OTP_FC_BASE_ADDR`. | ROM UDS and Field Entropy programming |
+| `SS_STRAP_GENERIC[1]` | `[31:16]` | Reserved. | — |
+| `SS_STRAP_GENERIC[2]` | `[15:0]` | Entropy-source health-test window size. Zero selects the default value of 1024. | ROM entropy-source initialization |
+| `SS_STRAP_GENERIC[2]` | `[16]` | Entropy-source single-bit mode enable. | ROM entropy-source initialization |
+| `SS_STRAP_GENERIC[2]` | `[18:17]` | Entropy-source single-bit lane selector. | ROM entropy-source initialization |
+| `SS_STRAP_GENERIC[2]` | `[30:19]` | Reserved. | — |
+| `SS_STRAP_GENERIC[2]` | `[31]` | Entropy-source conditioning bypass enable. | ROM entropy-source initialization |
+| `SS_STRAP_GENERIC[3]` | `[0]` | Stable Owner Key enable. | ROM stable-key derivation and Runtime cryptographic mailbox |
+| `SS_STRAP_GENERIC[3]` | `[1]` | Wait for device reset before fatal-error reporting. | ROM fatal-error handling |
+| `SS_STRAP_GENERIC[3]` | `[7:2]` | Reserved. | — |
+| `SS_STRAP_GENERIC[3]` | `[15:8]` | Owner Authorization Manifest minimum SVN, encoded as an unsigned integer. | Runtime owner authorization manifest verification |
+| `SS_STRAP_GENERIC[3]` | `[31:16]` | Reserved. | — |
+
 ### Entropy Source Configuration Registers
 
 The ROM configures the entropy source (CSRNG) during initialization using the following registers:

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -180,7 +180,7 @@ The Caliptra Measurement manifest feature expands on Caliptra-provided secure ve
 
 Each of these abilities are tied to Caliptra Vendor and Owner FW signing keys and should be independent of any SoC RoT FW signing keys.
 
-Manifest-based image authorization is implemented via two mailbox commands: [`SET_AUTH_MANIFEST`](#set-auth-manifest), and [`AUTHORIZE_AND_STASH`](#authorize-and-stash).
+Manifest-based image authorization is implemented via three mailbox commands: [`SET_AUTH_MANIFEST`](#set-auth-manifest), [`SET_OWNER_AUTH_MANIFEST`](#set-owner-auth-manifest), and [`AUTHORIZE_AND_STASH`](#authorize-and-stash). A firmware ID identifies one platform firmware image and must be unique across the active vendor + owner and owner-only Image Metadata Collections. Both set commands reject a manifest containing an ID in the other active collection. `AUTHORIZE_AND_STASH` searches the vendor + owner collection first and then the owner-only collection; the provenance of the matching entry is reflected in its `auth_req_result` field.
 
 ### Caliptra-Endorsed Aggregated Measured Boot
 
@@ -1204,7 +1204,7 @@ When `USE_MLDSA` is set, the command operates on the ML-DSA-87 DPE profile; othe
 
 ### SET_AUTH_MANIFEST
 
-The SoC uses this command and `SET_IMAGE_METADTA` to program an image manifest for Manifest-Based Image Authorization to Caliptra. In response to these commands, the Caliptra Runtime will verify the manifest by authenticating the public keys and in turn using them to authenticate the IMC. On successful verification, the Runtime will store the IMEs into DCCM for future use.
+The SoC uses this command and `SET_IMAGE_METADTA` to program an image manifest for Manifest-Based Image Authorization to Caliptra. In response to these commands, the Caliptra Runtime will verify the manifest by authenticating the public keys and in turn using them to authenticate the IMC. On successful verification, the Runtime will store the IMEs into DCCM for future use. Every active `fw_id` must be unique within this manifest and must not appear in the installed owner-only manifest. A collision rejects the command without replacing either active collection.
 
 Command Code: `0x4154_4D4E` ("ATMN")
 
@@ -1231,7 +1231,7 @@ Command Code: `0x4154_4D4E` ("ATMN")
 | metadata\_owner\_ecc384\_sig  | u32[24]      | Metadata Owner ECC384 signature                                             |
 | metadata\_owner\_PQC\_sig     | u32[1157]    | Metadata Owner MLDSA-87 or LMOTS-SHA192-W4 signature                                    |
 | metadata\_entry\_entry\_count | u32          | number of metadata entries                                                  |
-| metadata\_entries             | Metadata[127] | The max number of metadata entries is 127 but less can be used             |
+| metadata\_entries             | Metadata[80] | The max number of metadata entries is 80 but less can be used              |
 
 
 *Table: `AUTH_MANIFEST_FLAGS` input flags*
@@ -1258,11 +1258,54 @@ Command Code: `0x4154_4D4E` ("ATMN")
 
 ### VERIFY_AUTH_MANIFEST
 
-This command verifies the integrity and authenticity of the provided image manifest. Unlike `SET_AUTH_MANIFEST`, it performs validation only and does not persist the manifest in DCCM.
+This command verifies the integrity and authenticity of the provided image manifest. Unlike `SET_AUTH_MANIFEST`, it performs validation only and does not persist the manifest in DCCM. It also rejects a `fw_id` collision with the currently installed owner-only manifest.
 
 Command Code: `0x4154_564D` ("ATVM")
 
 The input arguments are the same as the `SET_AUTH_MANIFEST` command.
+
+
+### SET_OWNER_AUTH_MANIFEST
+
+The SoC uses this command to program an Owner Authorization Manifest, an owner-only authorization document stored independently from the manifest loaded by `SET_AUTH_MANIFEST`. The runtime parses the manifest, verifies its policy fields and Image Metadata Collection (IMC) signatures, and stores the IMC into a dedicated DCCM region. The vendor + owner collection populated by `SET_AUTH_MANIFEST` is never modified by this command.
+
+Command Code: `0x4F41_4D4E` ("OAMN")
+
+Verification chain:
+
+1. The manifest's `owner_pub_keys` are signed by the firmware-image owner key (latched from FMC at boot via `manifest1.preamble.owner_pub_keys`). This signature also covers the policy fields `version`, `svn`, `flags`, and `owner_pub_keys`.
+2. The manifest's IMC is signed by the manifest's own `owner_pub_keys`, which were just verified to chain to the firmware-image owner key.
+3. The manifest's `svn` is checked against the floor encoded in `SS_STRAP_GENERIC[3][15:8]` (subsystem mode only). The check is skipped when the lifecycle is `Unprovisioned` or anti-rollback is disabled.
+
+#### Owner Authorization Manifest Minimum SVN
+
+`SS_STRAP_GENERIC[3][15:8]` carries a binary value in the range `0..255`; it does not carry a fuse bitmap. Before Caliptra starts, MCU firmware is responsible for deriving the owner-manifest minimum SVN from the platform's monotonic storage and programming the resulting integer into this strap. The strap is then locked by `CPTRA_FUSE_WR_DONE`.
+
+This software interface does not define a new Caliptra fuse field. If a platform uses the same thermometer encoding as the existing SVN fuses, a 256-bit-aligned platform field can use bits 0 through 254 to encode SVN values 1 through 255, with all zeros encoding SVN 0 and bit 255 reserved. The authoritative physical fuse allocation belongs to the SoC/platform fuse-controller specification.
+
+The maximum IMC capacity is 32 entries. Every active `fw_id` must be unique within this manifest and must not appear in the installed vendor + owner manifest. A collision rejects the command without replacing either active collection. Each successful call replaces the existing owner-only collection.
+
+*Table: `SET_OWNER_AUTH_MANIFEST` input arguments*
+
+| **Name**                              | **Type**     | **Description** |
+| ------------------------------------- | ------------ | --------------- |
+| chksum                                | u32          | Checksum over other input arguments, computed by the caller. Little endian. |
+| manifest size                         | u32          | The size of the full Owner Authorization Manifest. |
+| preamble\_marker                      | u32          | Marker needs to be `0x4D4F_574F` ("OWOM" little-endian) for the preamble to be valid. |
+| preamble\_size                        | u32          | Size of the Owner Authorization Manifest Preamble. |
+| preamble\_version                     | u32          | Version of the preamble. |
+| preamble\_svn                         | u32          | Security version, range `[0, 255]`. Checked against `SS_STRAP_GENERIC[3][15:8]`. |
+| preamble\_flags                       | u32          | Reserved. Must be zero. |
+| preamble\_owner\_ecc384\_key          | u32[24]      | Owner ECC384 public key carried in the manifest. |
+| preamble\_owner\_pqc\_key             | u32[648]     | Owner MLDSA-87 or LMS-SHA192-H15 public key carried in the manifest. |
+| preamble\_owner\_pub\_keys\_ecc\_sig  | u32[24]      | ECC384 signature by the firmware-image owner key over `version..=owner_pub_keys`. |
+| preamble\_owner\_pub\_keys\_pqc\_sig  | u32[1157]    | PQC signature by the firmware-image owner key over `version..=owner_pub_keys`. |
+| preamble\_owner\_imc\_ecc\_sig        | u32[24]      | ECC384 signature by the manifest's own owner key over the IMC. |
+| preamble\_owner\_imc\_pqc\_sig        | u32[1157]    | PQC signature by the manifest's own owner key over the IMC. |
+| metadata\_entry\_count                | u32          | Number of metadata entries. Must be `1..=32`. |
+| metadata\_entries                     | Metadata[32] | Image Metadata Entries. Per-entry layout is identical to `SET_AUTH_MANIFEST` (see `AUTH_MANIFEST_METADATA_ENTRY` above). |
+
+The response is a `MailboxRespHeader` (no payload).
 
 
 ### AUTHORIZE_AND_STASH
@@ -1297,7 +1340,7 @@ Command Code: `0x4154_5348` ("ATSH")
 | --------------- | -------- | -------------------------------------------------------------------------- |
 | chksum          | u32      | Checksum over other output arguments, computed by Caliptra. Little endian. |
 | fips_status     | u32      | Indicates if the command is FIPS approved or an error.                     |
-| auth_req_result | u32      |AUTHORIZE_IMAGE (0xDEADC0DE), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB)
+| auth_req_result | u32      |IMAGE_AUTHORIZED_VENDOR_OWNER (0xDEADC0DE, alias of legacy `AUTHORIZE_IMAGE`/`IMAGE_AUTHORIZED`), IMAGE_AUTHORIZED_OWNER_ONLY (0xC0DEDEAD), IMAGE_NOT_AUTHORIZED (0x21523F21) or IMAGE_HASH_MISMATCH (0x8BFB95CB). Lookup order: vendor + owner collection first, then owner-only collection populated by `SET_OWNER_AUTH_MANIFEST`. Active firmware IDs are unique across the collections, and the success value indicates which collection produced the match. |
 
 ### GET_IMAGE_INFO
 

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -12,7 +12,7 @@ Abstract:
 
 --*/
 
-use crate::manifest::find_metadata_entry;
+use crate::manifest::{find_metadata_entry, find_owner_metadata_entry};
 use crate::{mutrefbytes, Drivers, PauserPrivileges, StashMeasurementCmd};
 use caliptra_auth_man_types::ImageMetadataFlags;
 #[cfg(feature = "cfi")]
@@ -30,6 +30,8 @@ use zerocopy::FromBytes;
 pub const IMAGE_AUTHORIZED: u32 = 0xDEADC0DE; // Either FW ID and image digest matched or 'ignore_auth_check' is set for the FW ID.
 pub const IMAGE_NOT_AUTHORIZED: u32 = 0x21523F21; // FW ID not found in the image metadata entry collection.
 pub const IMAGE_HASH_MISMATCH: u32 = 0x8BFB95CB; // FW ID matched, but image digest mismatched.
+pub const IMAGE_AUTHORIZED_VENDOR_OWNER: u32 = IMAGE_AUTHORIZED;
+pub const IMAGE_AUTHORIZED_OWNER_ONLY: u32 = 0xC0DE_DEAD;
 
 pub struct AuthorizeAndStashCmd;
 impl AuthorizeAndStashCmd {
@@ -70,7 +72,9 @@ impl AuthorizeAndStashCmd {
         let (auth_result, stash_measurement) = Self::authorize_image(drivers, cmd)?;
 
         // Stash the measurement if the image is authorized.
-        if auth_result == IMAGE_AUTHORIZED {
+        if auth_result == IMAGE_AUTHORIZED_VENDOR_OWNER
+            || auth_result == IMAGE_AUTHORIZED_OWNER_ONLY
+        {
             let flags: AuthAndStashFlags = cmd.flags.into();
             if !flags.contains(AuthAndStashFlags::SKIP_STASH) {
                 let dpe_result = StashMeasurementCmd::stash_measurement(
@@ -113,6 +117,8 @@ impl AuthorizeAndStashCmd {
             &drivers.dma,
         );
         let auth_manifest_image_metadata_col = &persistent_data.auth_manifest_image_metadata_col;
+        let owner_auth_manifest_image_metadata_col =
+            &persistent_data.owner_auth_manifest_image_metadata_col;
 
         let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
         // The measurement used for both authorization and stashing/updating DPE.
@@ -120,56 +126,60 @@ impl AuthorizeAndStashCmd {
         // For LoadAddress/StagingAddress, this is computed from the image in memory.
         let mut stash_measurement = cmd.measurement;
 
-        let auth_result = if let Some(metadata_entry) =
-            find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id)
-        {
-            // If 'ignore_auth_check' is set, then skip the image digest comparison and authorize the image.
-            let flags = ImageMetadataFlags(metadata_entry.flags);
-            if flags.ignore_auth_check() {
-                cfi_assert!(cfi_launder(flags.ignore_auth_check()));
-                IMAGE_AUTHORIZED
-            } else if source == ImageHashSource::InRequest {
-                if cfi_launder(metadata_entry.digest) == cmd.measurement {
-                    caliptra_cfi_lib::cfi_assert_eq_12_words(
-                        &Array4x12::from(metadata_entry.digest).0,
-                        &Array4x12::from(cmd.measurement).0,
-                    );
-                    IMAGE_AUTHORIZED
-                } else {
-                    IMAGE_HASH_MISMATCH
-                }
-            } else if source == ImageHashSource::LoadAddress
-                || source == ImageHashSource::StagingAddress
+        let (metadata_entry, success_code) =
+            if let Some(entry) = find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id) {
+                (entry, IMAGE_AUTHORIZED_VENDOR_OWNER)
+            } else if let Some(entry) =
+                find_owner_metadata_entry(owner_auth_manifest_image_metadata_col, cmd_fw_id)
             {
-                let image_source = if source == ImageHashSource::LoadAddress {
-                    metadata_entry.image_load_address
-                } else {
-                    metadata_entry.image_staging_address
-                };
-
-                let measurement: [u8; 48] = dma_image
-                    .sha384_image(
-                        &mut drivers.sha2_512_384_acc,
-                        AxiAddr {
-                            hi: image_source.hi,
-                            lo: image_source.lo,
-                        },
-                        cmd.image_size,
-                    )
-                    .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?
-                    .into();
-                if cfi_launder(metadata_entry.digest) == measurement {
-                    stash_measurement = measurement;
-                    caliptra_cfi_lib::cfi_assert_eq_12_words(
-                        &Array4x12::from(metadata_entry.digest).0,
-                        &Array4x12::from(measurement).0,
-                    );
-                    IMAGE_AUTHORIZED
-                } else {
-                    IMAGE_HASH_MISMATCH
-                }
+                (entry, IMAGE_AUTHORIZED_OWNER_ONLY)
             } else {
-                IMAGE_NOT_AUTHORIZED
+                return Ok((IMAGE_NOT_AUTHORIZED, stash_measurement));
+            };
+
+        let flags = ImageMetadataFlags(metadata_entry.flags);
+        let auth_result = if flags.ignore_auth_check() {
+            cfi_assert!(cfi_launder(flags.ignore_auth_check()));
+            success_code
+        } else if source == ImageHashSource::InRequest {
+            if cfi_launder(metadata_entry.digest) == cmd.measurement {
+                caliptra_cfi_lib::cfi_assert_eq_12_words(
+                    &Array4x12::from(metadata_entry.digest).0,
+                    &Array4x12::from(cmd.measurement).0,
+                );
+                success_code
+            } else {
+                IMAGE_HASH_MISMATCH
+            }
+        } else if source == ImageHashSource::LoadAddress
+            || source == ImageHashSource::StagingAddress
+        {
+            let image_source = if source == ImageHashSource::LoadAddress {
+                metadata_entry.image_load_address
+            } else {
+                metadata_entry.image_staging_address
+            };
+
+            let measurement: [u8; 48] = dma_image
+                .sha384_image(
+                    &mut drivers.sha2_512_384_acc,
+                    AxiAddr {
+                        hi: image_source.hi,
+                        lo: image_source.lo,
+                    },
+                    cmd.image_size,
+                )
+                .map_err(|_| CaliptraError::RUNTIME_INTERNAL)?
+                .into();
+            if cfi_launder(metadata_entry.digest) == measurement {
+                stash_measurement = measurement;
+                caliptra_cfi_lib::cfi_assert_eq_12_words(
+                    &Array4x12::from(metadata_entry.digest).0,
+                    &Array4x12::from(measurement).0,
+                );
+                success_code
+            } else {
+                IMAGE_HASH_MISMATCH
             }
         } else {
             IMAGE_NOT_AUTHORIZED

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -44,6 +44,7 @@ mod reallocate_dpe_context_limits;
 mod recovery_flow;
 mod revoke_exported_cdi_handle;
 mod set_auth_manifest;
+mod set_owner_auth_manifest;
 mod sign_with_exported_ecdsa;
 mod sign_with_exported_mldsa;
 mod stash_measurement;
@@ -80,7 +81,10 @@ use crate::revoke_exported_cdi_handle::RevokeExportedCdiHandleCmd;
 use crate::sign_with_exported_ecdsa::SignWithExportedEcdsaCmd;
 pub use crate::subject_alt_name::AddSubjectAltNameCmd;
 pub use activate_firmware::ActivateFirmwareCmd;
-pub use authorize_and_stash::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
+pub use authorize_and_stash::{
+    IMAGE_AUTHORIZED, IMAGE_AUTHORIZED_OWNER_ONLY, IMAGE_AUTHORIZED_VENDOR_OWNER,
+    IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED,
+};
 pub use caliptra_common::fips::FipsVersionCmd;
 use caliptra_common::mailbox_api::{populate_checksum, FipsVersionResp, MailboxRespHeader};
 pub use dice::{GetFmcAliasCertCmd, GetLdevCertCmd, IDevIdCertCmd};
@@ -100,6 +104,7 @@ pub use key_ladder::KeyLadder;
 pub use pcr::{GetPcrLogCmd, IncrementPcrResetCounterCmd};
 pub use reallocate_dpe_context_limits::ReallocateDpeContextLimitsCmd;
 pub use set_auth_manifest::SetAuthManifestCmd;
+pub use set_owner_auth_manifest::SetOwnerAuthManifestCmd;
 pub use stash_measurement::StashMeasurementCmd;
 pub use verify::LmsVerifyCmd;
 pub mod packet;
@@ -485,6 +490,7 @@ fn execute_command_with_common_resp(
         CommandId::SHUTDOWN => FipsShutdownCmd::execute(drivers),
         CommandId::SET_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers, cmd_bytes, false),
         CommandId::VERIFY_AUTH_MANIFEST => SetAuthManifestCmd::execute(drivers, cmd_bytes, true),
+        CommandId::SET_OWNER_AUTH_MANIFEST => SetOwnerAuthManifestCmd::execute(drivers, cmd_bytes),
         CommandId::GET_IDEV_ECC384_CSR => GetIdevCsrCmd::execute(drivers, resp),
         CommandId::GET_IDEV_MLDSA87_CSR => GetIdevMldsaCsrCmd::execute(drivers, resp),
         CommandId::GET_FMC_ALIAS_ECC384_CSR => GetFmcAliasCsrCmd::execute(drivers, resp),

--- a/runtime/src/manifest.rs
+++ b/runtime/src/manifest.rs
@@ -12,7 +12,10 @@ Abstract:
 
 --*/
 
-use caliptra_auth_man_types::{AuthManifestImageMetadata, AuthManifestImageMetadataCollection};
+use caliptra_auth_man_types::{
+    AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
+    OwnerAuthManifestImageMetadataCollection,
+};
 
 /// Search for an active metadata entry in the sorted `AuthManifestImageMetadataCollection` that matches the firmware ID.
 ///
@@ -42,4 +45,109 @@ pub fn find_metadata_entry(
         .binary_search_by(|metadata| metadata.fw_id.cmp(&cmd_fw_id))
         .ok()
         .and_then(|index| image_metadata_list.get(index))
+}
+
+/// Search for a metadata entry in the sorted owner-only
+/// `OwnerAuthManifestImageMetadataCollection` that matches the
+/// firmware ID. Mirrors [`find_metadata_entry`] but operates on the
+/// owner-only IMC populated by `SET_OWNER_AUTH_MANIFEST`.
+///
+/// Restricted to the `entry_count` prefix to avoid matching
+/// zero-initialized tail entries (the owner-only collection uses a
+/// distinct lookup path so this stricter behavior cannot regress
+/// callers of the legacy [`find_metadata_entry`]).
+#[inline(never)]
+pub fn find_owner_metadata_entry(
+    owner_auth_manifest_image_metadata_col: &OwnerAuthManifestImageMetadataCollection,
+    cmd_fw_id: u32,
+) -> Option<&AuthManifestImageMetadata> {
+    let count = owner_auth_manifest_image_metadata_col.entry_count as usize;
+    let list = owner_auth_manifest_image_metadata_col
+        .image_metadata_list
+        .get(..count)?;
+    list.binary_search_by(|metadata| metadata.fw_id.cmp(&cmd_fw_id))
+        .ok()
+        .map(|index| &list[index])
+}
+
+/// Return whether two firmware-ID-sorted metadata lists contain the same ID.
+pub fn sorted_metadata_lists_overlap(
+    first: &[AuthManifestImageMetadata],
+    second: &[AuthManifestImageMetadata],
+) -> bool {
+    let (mut first_index, mut second_index) = (0, 0);
+
+    while first_index < first.len() && second_index < second.len() {
+        match first[first_index].fw_id.cmp(&second[second_index].fw_id) {
+            core::cmp::Ordering::Less => first_index += 1,
+            core::cmp::Ordering::Greater => second_index += 1,
+            core::cmp::Ordering::Equal => return true,
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn entry(fw_id: u32) -> AuthManifestImageMetadata {
+        AuthManifestImageMetadata {
+            fw_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn find_owner_metadata_entry_hit_and_miss() {
+        let mut col = OwnerAuthManifestImageMetadataCollection {
+            entry_count: 3,
+            ..Default::default()
+        };
+        col.image_metadata_list[0] = entry(2);
+        col.image_metadata_list[1] = entry(5);
+        col.image_metadata_list[2] = entry(9);
+        // populated entries
+        assert_eq!(find_owner_metadata_entry(&col, 2).unwrap().fw_id, 2);
+        assert_eq!(find_owner_metadata_entry(&col, 5).unwrap().fw_id, 5);
+        assert_eq!(find_owner_metadata_entry(&col, 9).unwrap().fw_id, 9);
+        // miss
+        assert!(find_owner_metadata_entry(&col, 7).is_none());
+    }
+
+    #[test]
+    fn find_owner_metadata_entry_ignores_tail_zero_entries() {
+        // entry_count=1 means the tail (all-zero `fw_id == 0`) must
+        // not be matched even though the search key is 0.
+        let mut col = OwnerAuthManifestImageMetadataCollection {
+            entry_count: 1,
+            ..Default::default()
+        };
+        col.image_metadata_list[0] = entry(42);
+        assert!(find_owner_metadata_entry(&col, 0).is_none());
+        assert_eq!(find_owner_metadata_entry(&col, 42).unwrap().fw_id, 42);
+    }
+
+    #[test]
+    fn find_owner_metadata_entry_empty_collection() {
+        let col = OwnerAuthManifestImageMetadataCollection::default();
+        assert!(find_owner_metadata_entry(&col, 0).is_none());
+        assert!(find_owner_metadata_entry(&col, 100).is_none());
+    }
+
+    #[test]
+    fn sorted_metadata_lists_overlap_detects_collision() {
+        let first = [entry(1), entry(5), entry(9)];
+        let second = [entry(2), entry(5), entry(10)];
+        assert!(sorted_metadata_lists_overlap(&first, &second));
+    }
+
+    #[test]
+    fn sorted_metadata_lists_overlap_accepts_disjoint_lists() {
+        let first = [entry(1), entry(5), entry(9)];
+        let second = [entry(2), entry(6), entry(10)];
+        assert!(!sorted_metadata_lists_overlap(&first, &second));
+        assert!(!sorted_metadata_lists_overlap(&first, &[]));
+    }
 }

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,10 +15,11 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::{drivers::CaliptraManagedDpeContext, Drivers};
+use crate::{drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers};
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
-    AuthManifestPreamble, AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, AUTH_MANIFEST_MARKER,
+    AuthManifestPreamble, OwnerAuthManifestImageMetadataCollection,
+    AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, AUTH_MANIFEST_MARKER,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -52,7 +53,7 @@ pub(crate) enum AuthManifestUpdateMode {
 
 pub struct SetAuthManifestCmd;
 impl SetAuthManifestCmd {
-    fn sha384_digest(
+    pub(crate) fn sha384_digest(
         sha2: &mut Sha2_512_384,
         buf: &[u8],
         offset: u32,
@@ -67,7 +68,7 @@ impl SetAuthManifestCmd {
         Ok(sha2.sha384_digest(data)?.0)
     }
 
-    fn offset_data(buf: &[u8], offset: u32, len: u32) -> CaliptraResult<&[u8]> {
+    pub(crate) fn offset_data(buf: &[u8], offset: u32, len: u32) -> CaliptraResult<&[u8]> {
         let err = CaliptraError::IMAGE_VERIFIER_ERR_DIGEST_OUT_OF_BOUNDS;
         buf.get(offset as usize..)
             .ok_or(err)?
@@ -125,7 +126,7 @@ impl SetAuthManifestCmd {
         )
     }
 
-    fn ecc384_verify(
+    pub(crate) fn ecc384_verify(
         ecc384: &mut Ecc384,
         digest: &ImageDigest384,
         pub_key: &ImageEccPubKey,
@@ -146,7 +147,7 @@ impl SetAuthManifestCmd {
         ecc384.verify_r(&pub_key, &digest, &sig)
     }
 
-    fn lms_verify(
+    pub(crate) fn lms_verify(
         sha256: &mut Sha256,
         digest: &ImageDigest384,
         pub_key: &ImageLmsPublicKey,
@@ -618,6 +619,7 @@ impl SetAuthManifestCmd {
         cmd_buf: &[u8],
         auth_manifest_preamble: &AuthManifestPreamble,
         metadata_persistent: &mut AuthManifestImageMetadataCollection,
+        owner_metadata_persistent: &OwnerAuthManifestImageMetadataCollection,
         sha2: &mut Sha2_512_384,
         ecc384: &mut Ecc384,
         sha256: &mut Sha256,
@@ -688,6 +690,14 @@ impl SetAuthManifestCmd {
 
         Self::sort_and_check_duplicate_fwid(slice)?;
 
+        let owner_slice = owner_metadata_persistent
+            .image_metadata_list
+            .get(..owner_metadata_persistent.entry_count as usize)
+            .ok_or(CaliptraError::RUNTIME_INTERNAL)?;
+        if sorted_metadata_lists_overlap(slice, owner_slice) {
+            Err(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_DUPLICATE_FIRMWARE_ID)?;
+        }
+
         if !verify_only {
             // Clear the previous image metadata collection.
             metadata_persistent.zeroize();
@@ -699,7 +709,7 @@ impl SetAuthManifestCmd {
         Ok(())
     }
 
-    fn sort_and_check_duplicate_fwid(
+    pub(crate) fn sort_and_check_duplicate_fwid(
         slice: &mut [AuthManifestImageMetadata],
     ) -> CaliptraResult<()> {
         for i in 1..slice.len() {
@@ -831,6 +841,7 @@ impl SetAuthManifestCmd {
                 .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
             &auth_manifest_preamble,
             &mut persistent_data.auth_manifest_image_metadata_col,
+            &persistent_data.owner_auth_manifest_image_metadata_col,
             &mut drivers.sha2_512_384,
             &mut drivers.ecc384,
             &mut drivers.sha256,

--- a/runtime/src/set_owner_auth_manifest.rs
+++ b/runtime/src/set_owner_auth_manifest.rs
@@ -1,0 +1,469 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    set_owner_auth_manifest.rs
+
+Abstract:
+
+    File contains the SET_OWNER_AUTH_MANIFEST mailbox command implementation.
+    The Owner Authorization Manifest carries owner-only authorization
+    material stored independently from the collection loaded by
+    `SET_AUTH_MANIFEST`. It is parsed, verified, and stored in a dedicated
+    DCCM region; the vendor + owner collection is never modified by this
+    command.
+
+--*/
+
+use core::mem::size_of;
+
+use crate::manifest::sorted_metadata_lists_overlap;
+use crate::set_auth_manifest::SetAuthManifestCmd;
+use crate::Drivers;
+use caliptra_auth_man_types::{
+    AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
+    OwnerAuthManifestImageMetadataCollection, OwnerAuthManifestPreamble,
+    OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT, OWNER_AUTH_MANIFEST_MARKER,
+    OWNER_AUTH_MANIFEST_SIZE,
+};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq, cfi_launder};
+use caliptra_common::mailbox_api::SetOwnerAuthManifestReq;
+use caliptra_drivers::{
+    Array4xN, CaliptraError, CaliptraResult, Ecc384, HashValue, Lifecycle, Mldsa87, Mldsa87PubKey,
+    Mldsa87Result, Mldsa87Signature, Sha256, Sha2_512_384, SocIfc,
+};
+use caliptra_image_types::{
+    FwVerificationPqcKeyType, ImageDigest384, ImageLmsPublicKey, ImageLmsSignature, ImagePreamble,
+};
+use memoffset::offset_of;
+use zerocopy::{FromBytes, IntoBytes};
+
+pub struct SetOwnerAuthManifestCmd;
+
+impl SetOwnerAuthManifestCmd {
+    /// Verify that the manifest's `owner_pub_keys` are signed by the
+    /// firmware-image owner key (the trust anchor latched from FMC at
+    /// boot via `manifest1.preamble.owner_pub_keys`).
+    fn verify_owner_pub_keys_against_fw_owner(
+        preamble: &OwnerAuthManifestPreamble,
+        fw_preamble: &ImagePreamble,
+        sha2: &mut Sha2_512_384,
+        ecc384: &mut Ecc384,
+        sha256: &mut Sha256,
+        mldsa: &mut Mldsa87,
+        pqc_key_type: FwVerificationPqcKeyType,
+    ) -> CaliptraResult<()> {
+        // The signed range covers `version..=owner_pub_keys` (the policy
+        // fields). Marker and size are validated separately by exact
+        // equality against constants.
+        let range = OwnerAuthManifestPreamble::owner_signed_data_range();
+        let digest = SetAuthManifestCmd::sha384_digest(
+            sha2,
+            preamble.as_bytes(),
+            range.start,
+            range.len() as u32,
+        )?;
+
+        // Verify the owner ECC signature against the firmware-image
+        // owner ECC public key (FMC-bound trust anchor).
+        let fw_owner_ecc_key = &fw_preamble.owner_pub_keys.ecc_pub_key;
+        let verify_r = SetAuthManifestCmd::ecc384_verify(
+            ecc384,
+            &digest,
+            fw_owner_ecc_key,
+            &preamble.owner_pub_keys_signatures.ecc_sig,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_ECC_SIGNATURE_INVALID)?;
+        if cfi_launder(verify_r) != Array4xN(preamble.owner_pub_keys_signatures.ecc_sig.r) {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_ECC_SIGNATURE_INVALID)?;
+        } else {
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
+                &verify_r.0,
+                &preamble.owner_pub_keys_signatures.ecc_sig.r,
+            );
+        }
+
+        // Verify owner PQC signature against the firmware-image owner
+        // PQC public key (FMC-bound trust anchor).
+        if pqc_key_type == FwVerificationPqcKeyType::LMS {
+            let (fw_owner_lms_key, _) = ImageLmsPublicKey::ref_from_prefix(
+                fw_preamble.owner_pub_keys.pqc_pub_key.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID,
+            ))?;
+
+            let (lms_sig, _) = ImageLmsSignature::ref_from_prefix(
+                preamble.owner_pub_keys_signatures.pqc_sig.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID,
+            ))?;
+
+            let candidate_key =
+                SetAuthManifestCmd::lms_verify(sha256, &digest, fw_owner_lms_key, lms_sig)
+                    .map_err(|_| {
+                        CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID
+                    })?;
+            let pub_key_digest = HashValue::from(fw_owner_lms_key.digest);
+            if candidate_key != pub_key_digest {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_LMS_SIGNATURE_INVALID)?;
+            } else {
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+            }
+        } else {
+            let owner_data = SetAuthManifestCmd::offset_data(
+                preamble.as_bytes(),
+                range.start,
+                range.len() as u32,
+            )?;
+
+            let (fw_owner_mldsa_key, _) =
+                Mldsa87PubKey::ref_from_prefix(fw_preamble.owner_pub_keys.pqc_pub_key.0.as_bytes())
+                    .or(Err(
+                        CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_MLDSA_SIGNATURE_INVALID,
+                    ))?;
+
+            let (mldsa_sig, _) = Mldsa87Signature::ref_from_prefix(
+                preamble.owner_pub_keys_signatures.pqc_sig.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_MLDSA_SIGNATURE_INVALID,
+            ))?;
+
+            let result = mldsa.verify_var(fw_owner_mldsa_key, owner_data, mldsa_sig)?;
+            if cfi_launder(result) != Mldsa87Result::Success {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_OWNER_MLDSA_SIGNATURE_INVALID)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Verify the IMC signatures against the manifest's own
+    /// `owner_pub_keys` (which were just verified above to chain to
+    /// the firmware-image owner key).
+    fn verify_imc_signatures(
+        preamble: &OwnerAuthManifestPreamble,
+        imc_digest: &ImageDigest384,
+        ecc384: &mut Ecc384,
+        sha256: &mut Sha256,
+        mldsa: &mut Mldsa87,
+        pqc_key_type: FwVerificationPqcKeyType,
+        imc_bytes: &[u8],
+    ) -> CaliptraResult<()> {
+        // Verify the owner ECC signature over the IMC digest.
+        let verify_r = SetAuthManifestCmd::ecc384_verify(
+            ecc384,
+            imc_digest,
+            &preamble.owner_pub_keys.ecc_pub_key,
+            &preamble.owner_image_metdata_signatures.ecc_sig,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_ECC_SIGNATURE_INVALID)?;
+        if cfi_launder(verify_r) != Array4xN(preamble.owner_image_metdata_signatures.ecc_sig.r) {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_ECC_SIGNATURE_INVALID)?;
+        } else {
+            caliptra_cfi_lib::cfi_assert_eq_12_words(
+                &verify_r.0,
+                &preamble.owner_image_metdata_signatures.ecc_sig.r,
+            );
+        }
+
+        // Verify owner PQC signature over the IMC.
+        if pqc_key_type == FwVerificationPqcKeyType::LMS {
+            let (lms_pub_key, _) = ImageLmsPublicKey::ref_from_prefix(
+                preamble.owner_pub_keys.pqc_pub_key.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_LMS_SIGNATURE_INVALID,
+            ))?;
+
+            let (lms_sig, _) = ImageLmsSignature::ref_from_prefix(
+                preamble.owner_image_metdata_signatures.pqc_sig.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_LMS_SIGNATURE_INVALID,
+            ))?;
+
+            let candidate_key =
+                SetAuthManifestCmd::lms_verify(sha256, imc_digest, lms_pub_key, lms_sig).map_err(
+                    |_| CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_LMS_SIGNATURE_INVALID,
+                )?;
+            let pub_key_digest = HashValue::from(lms_pub_key.digest);
+            if candidate_key != pub_key_digest {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_LMS_SIGNATURE_INVALID)?;
+            } else {
+                caliptra_cfi_lib::cfi_assert_eq_6_words(&candidate_key.0, &pub_key_digest.0);
+            }
+        } else {
+            let imc_data = SetAuthManifestCmd::offset_data(imc_bytes, 0, imc_bytes.len() as u32)?;
+
+            let (mldsa_pub_key, _) =
+                Mldsa87PubKey::ref_from_prefix(preamble.owner_pub_keys.pqc_pub_key.0.as_bytes())
+                    .or(Err(
+                    CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_MLDSA_SIGNATURE_INVALID,
+                ))?;
+
+            let (mldsa_sig, _) = Mldsa87Signature::ref_from_prefix(
+                preamble.owner_image_metdata_signatures.pqc_sig.0.as_bytes(),
+            )
+            .or(Err(
+                CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_MLDSA_SIGNATURE_INVALID,
+            ))?;
+
+            let result = mldsa.verify_var(mldsa_pub_key, imc_data, mldsa_sig)?;
+            if cfi_launder(result) != Mldsa87Result::Success {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_OWNER_MLDSA_SIGNATURE_INVALID)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// SVN check against `SS_STRAP_GENERIC[3][15:8]`. The strap is
+    /// sampled at reset and locked by `CPTRA_FUSE_WR_DONE`. Skipped
+    /// when the lifecycle is `Unprovisioned` or anti-rollback is
+    /// disabled, mirroring the policy in
+    /// [`SetAuthManifestCmd::verify_svn`].
+    pub fn verify_owner_svn(soc_ifc: &SocIfc, svn: u32) -> CaliptraResult<()> {
+        let svn_check_required =
+            if cfi_launder(soc_ifc.lifecycle() as u32) == Lifecycle::Unprovisioned as u32 {
+                cfi_assert_eq(soc_ifc.lifecycle() as u32, Lifecycle::Unprovisioned as u32);
+                false
+            } else if cfi_launder(soc_ifc.fuse_bank().anti_rollback_disable()) {
+                cfi_assert!(soc_ifc.fuse_bank().anti_rollback_disable());
+                false
+            } else {
+                true
+            };
+
+        if svn_check_required {
+            if cfi_launder(svn) > 255 {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_SVN_GREATER_THAN_MAX)?;
+            }
+            let min_svn = soc_ifc.ss_owner_manifest_min_svn();
+            if cfi_launder(svn) < min_svn {
+                Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_SVN_LESS_THAN_MIN)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Parse, verify, and replace the persistent IMC region with the
+    /// collection carried in the manifest.
+    #[allow(clippy::too_many_arguments)]
+    fn process_imc(
+        cmd_buf: &[u8],
+        preamble: &OwnerAuthManifestPreamble,
+        persistent: &mut OwnerAuthManifestImageMetadataCollection,
+        auth_metadata_persistent: &AuthManifestImageMetadataCollection,
+        sha2: &mut Sha2_512_384,
+        ecc384: &mut Ecc384,
+        sha256: &mut Sha256,
+        mldsa: &mut Mldsa87,
+        pqc_key_type: FwVerificationPqcKeyType,
+    ) -> CaliptraResult<()> {
+        if cmd_buf.len() < size_of::<u32>() {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?;
+        }
+
+        let imc_size = size_of::<OwnerAuthManifestImageMetadataCollection>();
+        let buf = cmd_buf
+            .get(..imc_size)
+            .ok_or(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?;
+
+        let (mut imc_candidate, _) =
+            OwnerAuthManifestImageMetadataCollection::read_from_prefix(buf)
+                .map_err(|_| CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?;
+
+        if imc_candidate.entry_count == 0
+            || imc_candidate.entry_count > OWNER_AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT as u32
+        {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_ENTRY_COUNT)?;
+        }
+
+        if buf.len()
+            < (size_of::<u32>()
+                + imc_candidate.entry_count as usize * size_of::<AuthManifestImageMetadata>())
+        {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?;
+        }
+
+        let imc_digest = SetAuthManifestCmd::sha384_digest(sha2, buf, 0, imc_size as u32)?;
+
+        Self::verify_imc_signatures(
+            preamble,
+            &imc_digest,
+            ecc384,
+            sha256,
+            mldsa,
+            pqc_key_type,
+            buf,
+        )?;
+
+        // Sort + duplicate-fwid check on the incoming entries.
+        let new_slice =
+            &mut imc_candidate.image_metadata_list[..imc_candidate.entry_count as usize];
+        SetAuthManifestCmd::sort_and_check_duplicate_fwid(new_slice)
+            .map_err(|_| CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_DUPLICATE_FW_ID)?;
+
+        let auth_slice = auth_metadata_persistent
+            .image_metadata_list
+            .get(..auth_metadata_persistent.entry_count as usize)
+            .ok_or(CaliptraError::RUNTIME_INTERNAL)?;
+        if sorted_metadata_lists_overlap(new_slice, auth_slice) {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_DUPLICATE_FW_ID)?;
+        }
+
+        *persistent = imc_candidate;
+
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<usize> {
+        let manifest_size: usize = {
+            let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
+            let offset = offset_of!(SetOwnerAuthManifestReq, manifest_size);
+            u32::from_le_bytes(
+                cmd_args
+                    .get(offset..offset + 4)
+                    .ok_or(err)?
+                    .try_into()
+                    .map_err(|_| err)?,
+            )
+            .try_into()
+            .unwrap()
+        };
+
+        if manifest_size > SetOwnerAuthManifestReq::MAX_MAN_SIZE {
+            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        }
+
+        let manifest_buf = {
+            let offset = offset_of!(SetOwnerAuthManifestReq, manifest);
+            cmd_args
+                .get(offset..offset + manifest_size)
+                .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?
+        };
+
+        Self::set_owner_auth_manifest(drivers, manifest_buf)?;
+        Ok(0)
+    }
+
+    pub(crate) fn set_owner_auth_manifest(
+        drivers: &mut Drivers,
+        manifest_buf: &[u8],
+    ) -> CaliptraResult<()> {
+        let preamble_size = size_of::<OwnerAuthManifestPreamble>();
+        let preamble = {
+            let err = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_LT_MIN;
+            let bytes = manifest_buf.get(..preamble_size).ok_or(err)?;
+            OwnerAuthManifestPreamble::ref_from_bytes(bytes).map_err(|_| err)?
+        };
+
+        if preamble.marker != OWNER_AUTH_MANIFEST_MARKER {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_INVALID_MARKER)?;
+        }
+
+        if preamble.size as usize != preamble_size {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_MISMATCH)?;
+        }
+        cfi_assert_eq(preamble.size, preamble_size as u32);
+
+        if manifest_buf.len() != OWNER_AUTH_MANIFEST_SIZE {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?;
+        }
+
+        if cfi_launder(preamble.flags) != 0 {
+            Err(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_INVALID_FLAGS)?;
+        }
+        cfi_assert_eq(preamble.flags, 0);
+
+        // SVN floor enforced via SS_STRAP_GENERIC[3][15:8].
+        Self::verify_owner_svn(&drivers.soc_ifc, preamble.svn)?;
+
+        let persistent_data = drivers.persistent_data.get_mut();
+        let manifest_pqc_key_type =
+            FwVerificationPqcKeyType::from_u8(persistent_data.manifest1.pqc_key_type)
+                .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE)?;
+
+        let pqc_key_type = if drivers.soc_ifc.lifecycle() == Lifecycle::Unprovisioned {
+            manifest_pqc_key_type
+        } else {
+            let fuse_pqc_key_type =
+                FwVerificationPqcKeyType::from_u8(drivers.soc_ifc.fuse_bank().pqc_key_type() as u8)
+                    .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE_IN_FUSE)?;
+
+            if fuse_pqc_key_type != manifest_pqc_key_type {
+                return Err(CaliptraError::RUNTIME_AUTH_MANIFEST_PQC_KEY_TYPE_MISMATCH);
+            }
+
+            fuse_pqc_key_type
+        };
+
+        Self::verify_owner_pub_keys_against_fw_owner(
+            preamble,
+            &persistent_data.manifest1.preamble,
+            &mut drivers.sha2_512_384,
+            &mut drivers.ecc384,
+            &mut drivers.sha256,
+            &mut drivers.mldsa87,
+            pqc_key_type,
+        )?;
+
+        Self::process_imc(
+            manifest_buf
+                .get(preamble_size..)
+                .ok_or(CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE)?,
+            preamble,
+            &mut persistent_data.owner_auth_manifest_image_metadata_col,
+            &persistent_data.auth_manifest_image_metadata_col,
+            &mut drivers.sha2_512_384,
+            &mut drivers.ecc384,
+            &mut drivers.sha256,
+            &mut drivers.mldsa87,
+            pqc_key_type,
+        )?;
+
+        // Record the digest of the full manifest buffer for attestation.
+        persistent_data.owner_auth_manifest_digest =
+            drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use caliptra_auth_man_types::AuthManifestImageMetadata;
+
+    fn entry(fw_id: u32) -> AuthManifestImageMetadata {
+        AuthManifestImageMetadata {
+            fw_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_owner_imc_sort_and_dedup_uses_shared_helper() {
+        let mut entries = [entry(7), entry(2), entry(5), entry(2)];
+        // Duplicate fw_id (2) must be detected.
+        let res = SetAuthManifestCmd::sort_and_check_duplicate_fwid(&mut entries);
+        assert!(res.is_err());
+
+        let mut entries = [entry(7), entry(2), entry(5)];
+        let res = SetAuthManifestCmd::sort_and_check_duplicate_fwid(&mut entries);
+        assert!(res.is_ok());
+        assert_eq!(entries[0].fw_id, 2);
+        assert_eq!(entries[1].fw_id, 5);
+        assert_eq!(entries[2].fw_id, 7);
+    }
+}

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -171,6 +171,7 @@ pub struct RuntimeTestArgs<'a> {
     pub soc_manifest_max_svn: Option<u32>,
     pub subsystem_mode: bool,
     pub successful_reach_rt: bool,
+    pub initial_ss_strap_generic_3: Option<u32>,
     pub key_type: Option<FwVerificationPqcKeyType>,
 }
 
@@ -193,6 +194,7 @@ impl Default for RuntimeTestArgs<'_> {
             soc_manifest_max_svn: None,
             subsystem_mode: cfg!(feature = "fpga_subsystem"),
             successful_reach_rt: true,
+            initial_ss_strap_generic_3: None,
             key_type: None,
         }
     }
@@ -336,6 +338,7 @@ pub fn start_rt_test_pqc_model(
         BootParams {
             fw_image: if args.stop_at_rom { None } else { Some(&image) },
             initial_dbg_manuf_service_reg: boot_flags,
+            initial_ss_strap_generic_3: args.initial_ss_strap_generic_3,
             soc_manifest,
             mcu_fw_image,
             ..Default::default()

--- a/runtime/tests/runtime_integration_tests/main.rs
+++ b/runtime/tests/runtime_integration_tests/main.rs
@@ -31,6 +31,7 @@ mod test_reallocate_dpe_context_limits;
 mod test_recovery_flow;
 mod test_revoke_exported_cdi_handle;
 mod test_set_auth_manifest;
+mod test_set_owner_auth_manifest;
 mod test_sign_with_export_ecdsa;
 mod test_stash_measurement;
 mod test_tagging;

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -60,7 +60,7 @@ pub const TEST_SRAM_BASE: Addr64 = Addr64 {
     hi: 0x0000_0000,
 };
 
-fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> DefaultHwModel {
+pub(crate) fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> DefaultHwModel {
     let runtime_args = RuntimeTestArgs {
         test_image_options: Some(ImageOptions {
             pqc_key_type: FwVerificationPqcKeyType::LMS,

--- a/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
@@ -1,0 +1,548 @@
+// Licensed under the Apache-2.0 license
+
+//! Integration tests for `SET_OWNER_AUTH_MANIFEST` and the
+//! `AUTHORIZE_AND_STASH` owner-only fall-through path.
+
+use crate::common::{run_rt_test, RuntimeTestArgs};
+use crate::test_authorize_and_stash::{set_auth_manifest, FW_ID_1, IMAGE_DIGEST1};
+use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+use crate::test_update_reset::update_fw;
+use caliptra_api::{mailbox::VerifyAuthManifestReq, SocManager};
+use caliptra_auth_man_gen::{
+    AuthManifestGenerator, AuthManifestGeneratorKeyConfig, OwnerAuthManifestGeneratorConfig,
+};
+use caliptra_auth_man_types::{
+    AuthManifestImageMetadata, AuthManifestPrivKeysConfig, AuthManifestPubKeysConfig,
+    AuthorizationManifest, ImageMetadataFlags, OwnerAuthorizationManifest,
+};
+use caliptra_builder::{firmware::APP_WITH_UART, ImageOptions};
+use caliptra_common::mailbox_api::{
+    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
+    MailboxReqHeader, SetAuthManifestReq, SetOwnerAuthManifestReq,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, HwModel, ModelError, SecurityState};
+use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_fake_keys::{
+    OWNER_ECC_KEY_PRIVATE, OWNER_ECC_KEY_PUBLIC, OWNER_LMS_KEY_PRIVATE, OWNER_LMS_KEY_PUBLIC,
+    OWNER_MLDSA_KEY_PRIVATE, OWNER_MLDSA_KEY_PUBLIC,
+};
+use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_runtime::{
+    RtBootStatus, IMAGE_AUTHORIZED_OWNER_ONLY, IMAGE_AUTHORIZED_VENDOR_OWNER, IMAGE_HASH_MISMATCH,
+    IMAGE_NOT_AUTHORIZED,
+};
+use zerocopy::{FromBytes, IntoBytes};
+
+/// Owner-only firmware ID (distinct from `FW_ID_1` that lives in the
+/// vendor + owner manifest used by `set_auth_manifest`).
+const OWNER_ONLY_FW_ID: u32 = 11;
+
+/// A 48-byte digest distinct from `IMAGE_DIGEST1`.
+const OWNER_ONLY_DIGEST: [u8; 48] = [
+    0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+    0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+    0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+];
+
+fn owner_key_config() -> AuthManifestGeneratorKeyConfig {
+    AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
+            lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+            mldsa_pub_key: OWNER_MLDSA_KEY_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
+            lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+            mldsa_priv_key: OWNER_MLDSA_KEY_PRIVATE,
+        }),
+    }
+}
+
+/// Build a signed `OwnerAuthorizationManifest` through the shared generator.
+fn build_owner_manifest(
+    entries: Vec<AuthManifestImageMetadata>,
+    svn: u32,
+) -> OwnerAuthorizationManifest {
+    build_owner_manifest_with_pqc(entries, svn, FwVerificationPqcKeyType::LMS)
+}
+
+fn build_owner_manifest_with_pqc(
+    entries: Vec<AuthManifestImageMetadata>,
+    svn: u32,
+    pqc_key_type: FwVerificationPqcKeyType,
+) -> OwnerAuthorizationManifest {
+    let owner_key_config = owner_key_config();
+    let gen = AuthManifestGenerator::new(Crypto::default());
+    gen.generate_owner(&OwnerAuthManifestGeneratorConfig {
+        version: 1,
+        svn,
+        pqc_key_type,
+        owner_fw_key_info: owner_key_config.clone(),
+        owner_man_key_info: owner_key_config,
+        image_metadata_list: entries,
+    })
+    .unwrap()
+}
+
+/// Issue a `SET_OWNER_AUTH_MANIFEST` mailbox command with the
+/// supplied owner manifest and assert success.
+fn send_set_owner_auth_manifest(model: &mut DefaultHwModel, man: &OwnerAuthorizationManifest) {
+    set_owner_auth_manifest(model, man)
+        .unwrap()
+        .expect("SET_OWNER_AUTH_MANIFEST should return a response");
+}
+
+fn set_owner_auth_manifest(
+    model: &mut DefaultHwModel,
+    man: &OwnerAuthorizationManifest,
+) -> Result<Option<Vec<u8>>, ModelError> {
+    let buf = man.as_bytes();
+    let mut slice = [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model.mailbox_execute(
+        u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    )
+}
+
+fn set_vendor_owner_auth_manifest(
+    model: &mut DefaultHwModel,
+    man: &AuthorizationManifest,
+) -> Result<Option<Vec<u8>>, ModelError> {
+    let buf = man.as_bytes();
+    let mut slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetAuthManifest(SetAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model.mailbox_execute(
+        u32::from(CommandId::SET_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    )
+}
+
+fn verify_vendor_owner_auth_manifest(
+    model: &mut DefaultHwModel,
+    man: &AuthorizationManifest,
+) -> Result<Option<Vec<u8>>, ModelError> {
+    let buf = man.as_bytes();
+    let mut slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::VerifyAuthManifest(VerifyAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    model.mailbox_execute(
+        u32::from(CommandId::VERIFY_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    )
+}
+
+fn make_entry(fw_id: u32, digest: [u8; 48]) -> AuthManifestImageMetadata {
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_ignore_auth_check(false);
+    flags.set_image_source(ImageHashSource::InRequest as u32);
+    AuthManifestImageMetadata {
+        fw_id,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }
+}
+
+fn authorize_and_stash_in_request(
+    model: &mut DefaultHwModel,
+    fw_id_le: [u8; 4],
+    measurement: [u8; 48],
+) -> AuthorizeAndStashResp {
+    let mut cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: fw_id_le,
+        measurement,
+        source: ImageHashSource::InRequest as u32,
+        flags: 0,
+        ..Default::default()
+    });
+    cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("AUTHORIZE_AND_STASH should return a response");
+    AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap()
+}
+
+/// End-to-end: vendor + owner manifest is loaded first, then
+/// owner-only manifest is loaded. AUTHORIZE_AND_STASH for a fw_id
+/// present only in the owner-only collection returns
+/// `IMAGE_AUTHORIZED_OWNER_ONLY`. fw_id present in the vendor + owner
+/// collection still returns `IMAGE_AUTHORIZED_VENDOR_OWNER`. Unknown
+/// fw_id returns `IMAGE_NOT_AUTHORIZED`.
+#[test]
+fn test_set_owner_auth_manifest_then_authorize_returns_owner_only() {
+    let mut model = set_auth_manifest(None);
+
+    let owner_man = build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+    send_set_owner_auth_manifest(&mut model, &owner_man);
+
+    // Owner-only collection match.
+    let resp = authorize_and_stash_in_request(
+        &mut model,
+        OWNER_ONLY_FW_ID.to_le_bytes(),
+        OWNER_ONLY_DIGEST,
+    );
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_OWNER_ONLY);
+
+    // Vendor + owner collection still works (FW_ID_1 lives there).
+    let resp = authorize_and_stash_in_request(&mut model, FW_ID_1, IMAGE_DIGEST1);
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_VENDOR_OWNER);
+
+    // Unknown fw_id rejects.
+    let resp = authorize_and_stash_in_request(&mut model, [0xAB, 0xCD, 0, 0], OWNER_ONLY_DIGEST);
+    assert_eq!(resp.auth_req_result, IMAGE_NOT_AUTHORIZED);
+}
+
+#[test]
+fn test_owner_and_vendor_auth_manifests_survive_update_reset() {
+    let mut model = set_auth_manifest(None);
+
+    let owner_man = build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+    send_set_owner_auth_manifest(&mut model, &owner_man);
+
+    update_fw(
+        &mut model,
+        &APP_WITH_UART,
+        ImageOptions {
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        },
+    );
+
+    let resp = authorize_and_stash_in_request(
+        &mut model,
+        OWNER_ONLY_FW_ID.to_le_bytes(),
+        OWNER_ONLY_DIGEST,
+    );
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_OWNER_ONLY);
+
+    let resp = authorize_and_stash_in_request(&mut model, FW_ID_1, IMAGE_DIGEST1);
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_VENDOR_OWNER);
+}
+
+#[test]
+fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
+    const MIN_SVN: u32 = 5;
+    const EXISTING_STRAP_FLAGS: u32 = 0x3;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        security_state: Some(
+            *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Manufacturing),
+        ),
+        subsystem_mode: true,
+        initial_ss_strap_generic_3: Some((MIN_SVN << 8) | EXISTING_STRAP_FLAGS),
+        ..Default::default()
+    });
+    model.step_until_ready_for_runtime();
+
+    let below_floor = build_owner_manifest(
+        vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
+        MIN_SVN - 1,
+    );
+    let err = set_owner_auth_manifest(&mut model, &below_floor)
+        .expect_err("owner manifest SVN below the strap floor must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_SVN_LESS_THAN_MIN.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected owner manifest SVN below minimum, got {err:?}",
+    );
+
+    let at_floor = build_owner_manifest(
+        vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
+        MIN_SVN,
+    );
+    send_set_owner_auth_manifest(&mut model, &at_floor);
+}
+
+#[test]
+fn test_set_owner_auth_manifest_rejects_vendor_owner_fw_id() {
+    let mut model = set_auth_manifest(None);
+
+    let initial_owner_man =
+        build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+    send_set_owner_auth_manifest(&mut model, &initial_owner_man);
+
+    let colliding_owner_man = build_owner_manifest(
+        vec![make_entry(u32::from_le_bytes(FW_ID_1), OWNER_ONLY_DIGEST)],
+        1,
+    );
+    let err = set_owner_auth_manifest(&mut model, &colliding_owner_man)
+        .expect_err("owner-only fw_id collision must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_DUPLICATE_FW_ID.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected owner manifest duplicate firmware ID, got {err:?}",
+    );
+
+    let resp = authorize_and_stash_in_request(
+        &mut model,
+        OWNER_ONLY_FW_ID.to_le_bytes(),
+        OWNER_ONLY_DIGEST,
+    );
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_OWNER_ONLY);
+
+    let resp = authorize_and_stash_in_request(&mut model, FW_ID_1, IMAGE_DIGEST1);
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_VENDOR_OWNER);
+}
+
+#[test]
+fn test_verify_and_set_auth_manifest_reject_owner_only_fw_id() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        key_type: Some(FwVerificationPqcKeyType::LMS),
+        subsystem_mode: !cfg!(feature = "fpga_realtime"),
+        ..Default::default()
+    });
+    model.step_until_ready_for_runtime();
+
+    let owner_man = build_owner_manifest_with_pqc(
+        vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
+        1,
+        FwVerificationPqcKeyType::LMS,
+    );
+    send_set_owner_auth_manifest(&mut model, &owner_man);
+
+    let vendor_owner_man = create_auth_manifest_with_metadata_with_svn(
+        vec![
+            make_entry(OWNER_ONLY_FW_ID, IMAGE_DIGEST1),
+            make_entry(u32::from_le_bytes(FW_ID_1), IMAGE_DIGEST1),
+        ],
+        FwVerificationPqcKeyType::LMS,
+        1,
+    );
+    let expected: u32 =
+        CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_DUPLICATE_FIRMWARE_ID.into();
+
+    let err = verify_vendor_owner_auth_manifest(&mut model, &vendor_owner_man)
+        .expect_err("verifying a colliding vendor + owner fw_id must fail");
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected auth manifest duplicate firmware ID, got {err:?}",
+    );
+
+    let err = set_vendor_owner_auth_manifest(&mut model, &vendor_owner_man)
+        .expect_err("vendor + owner fw_id collision must be rejected");
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected auth manifest duplicate firmware ID, got {err:?}",
+    );
+
+    let resp = authorize_and_stash_in_request(
+        &mut model,
+        OWNER_ONLY_FW_ID.to_le_bytes(),
+        OWNER_ONLY_DIGEST,
+    );
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_OWNER_ONLY);
+
+    let resp = authorize_and_stash_in_request(&mut model, FW_ID_1, IMAGE_DIGEST1);
+    assert_eq!(resp.auth_req_result, IMAGE_NOT_AUTHORIZED);
+}
+
+/// Verify that loading a second manifest replaces the owner-only collection.
+#[test]
+fn test_set_owner_auth_manifest_replaces_collection() {
+    let mut model = set_auth_manifest(None);
+
+    let second_fw_id = OWNER_ONLY_FW_ID + 1;
+    let mut second_digest = OWNER_ONLY_DIGEST;
+    second_digest[0] ^= 0xFF;
+
+    // Initial load with two entries.
+    let owner_man_a = build_owner_manifest(
+        vec![
+            make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST),
+            make_entry(second_fw_id, second_digest),
+        ],
+        1,
+    );
+    send_set_owner_auth_manifest(&mut model, &owner_man_a);
+
+    // Replace the collection with one entry carrying a new digest.
+    let mut updated_digest = OWNER_ONLY_DIGEST;
+    updated_digest[1] ^= 0xFF;
+    let owner_man_b = build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, updated_digest)], 1);
+    send_set_owner_auth_manifest(&mut model, &owner_man_b);
+
+    // The old digest is no longer authorized for the updated entry.
+    let resp = authorize_and_stash_in_request(
+        &mut model,
+        OWNER_ONLY_FW_ID.to_le_bytes(),
+        OWNER_ONLY_DIGEST,
+    );
+    assert_eq!(resp.auth_req_result, IMAGE_HASH_MISMATCH);
+
+    // The replacement digest is authorized.
+    let resp =
+        authorize_and_stash_in_request(&mut model, OWNER_ONLY_FW_ID.to_le_bytes(), updated_digest);
+    assert_eq!(resp.auth_req_result, IMAGE_AUTHORIZED_OWNER_ONLY);
+
+    // The second entry was removed by the replacement.
+    let resp =
+        authorize_and_stash_in_request(&mut model, second_fw_id.to_le_bytes(), second_digest);
+    assert_eq!(resp.auth_req_result, IMAGE_NOT_AUTHORIZED);
+}
+
+/// The former update bit is reserved and must be rejected.
+#[test]
+fn test_set_owner_auth_manifest_rejects_nonzero_flags() {
+    let mut model = set_auth_manifest(None);
+    let mut owner_man =
+        build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+    owner_man.preamble.flags = 1;
+
+    let buf = owner_man.as_bytes();
+    let mut slice = [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let err = result.expect_err("nonzero owner manifest flags must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_INVALID_FLAGS.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected RUNTIME_OWNER_AUTH_MANIFEST_INVALID_FLAGS, got {err:?}",
+    );
+}
+
+/// The embedded size covers the owner manifest Preamble.
+#[test]
+fn test_set_owner_auth_manifest_rejects_invalid_preamble_size() {
+    let mut model = set_auth_manifest(None);
+    let mut owner_man =
+        build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+    owner_man.preamble.size -= 1;
+
+    let buf = owner_man.as_bytes();
+    let mut slice = [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let err = result.expect_err("incorrect owner manifest Preamble size must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_MISMATCH.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected RUNTIME_OWNER_AUTH_MANIFEST_PREAMBLE_SIZE_MISMATCH, got {err:?}",
+    );
+}
+
+/// The mailbox payload length must match the complete serialized manifest.
+#[test]
+fn test_set_owner_auth_manifest_rejects_truncated_manifest() {
+    let mut model = set_auth_manifest(None);
+    let owner_man = build_owner_manifest(vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)], 1);
+
+    let buf = owner_man.as_bytes();
+    let mut slice = [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: (buf.len() - 1) as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let err = result.expect_err("truncated owner manifest must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected RUNTIME_OWNER_AUTH_MANIFEST_IMC_INVALID_SIZE, got {err:?}",
+    );
+}
+
+/// Bad marker is rejected with the dedicated error.
+#[test]
+fn test_set_owner_auth_manifest_invalid_marker() {
+    let mut model = run_rt_test(RuntimeTestArgs {
+        key_type: Some(FwVerificationPqcKeyType::LMS),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut owner_man = build_owner_manifest_with_pqc(
+        vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
+        1,
+        FwVerificationPqcKeyType::LMS,
+    );
+    owner_man.preamble.marker = 0xDEAD_BEEF;
+
+    let buf = owner_man.as_bytes();
+    let mut slice = [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE];
+    slice[..buf.len()].copy_from_slice(buf);
+
+    let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: slice,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+        cmd.as_bytes().unwrap(),
+    );
+
+    let err = result.expect_err("invalid marker must be rejected");
+    let expected: u32 = CaliptraError::RUNTIME_OWNER_AUTH_MANIFEST_INVALID_MARKER.into();
+    assert!(
+        matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
+        "expected RUNTIME_OWNER_AUTH_MANIFEST_INVALID_MARKER, got {err:?}",
+    );
+}


### PR DESCRIPTION
Add the SET_OWNER_AUTH_MANIFEST command and owner-only manifest format, generation, verification, and persistent storage.

Search the owner-only metadata collection as a fallback during image authorization, report the authorization provenance, and enforce firmware ID uniqueness across both active manifest collections.

Original commit: https://github.com/chipsalliance/caliptra-sw/commit/b27bc179c52d584717b8d4703ae5c2e101405748