### PR TITLE
mldsa: Implement hitless update tests

### DIFF
--- a/runtime/tests/runtime_integration_tests/test_mldsa_attestation_workflow.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_attestation_workflow.rs
@@ -1,25 +1,32 @@
 // Licensed under the Apache-2.0 license
 
-//! End-to-end ML-DSA attestation workflow, modelled on an SPDM certificate +
-//! challenge exchange.
+//! End-to-end ML-DSA attestation workflows, modelled on an SPDM certificate +
+//! challenge exchange. Every test shares the same setup — provision the PQ.DevID
+//! identity, obtain its CSR, and issue a CA-rooted DevID certificate certifying
+//! the PQ.DevID key (`provision_and_build_devid_chain`) — then loads it as the
+//! ML-DSA cert chain and validates it (`populate_and_validate_chain`).
 //!
-//! The flow ties every step together cryptographically:
-//!   1. SET_PQ_SEED provisions the PQ.DevID identity.
-//!   2. GET_PQ_CSR yields the PQ.DevID CSR (self-signed by the PQ.DevID key).
-//!   3. A test Root CA issues a DevID certificate certifying the PQ.DevID key.
-//!   4. POPULATE_PQ_CERT loads that DevID cert as the ML-DSA cert chain.
-//!   5. GET_CERTIFICATE_CHAIN (SPDM GET_CERTIFICATE) returns the DevID cert;
-//!      it verifies under the Root CA and certifies the PQ.DevID key.
-//!   6. A measured child DPE context is derived (an attested component).
-//!   7. CERTIFY_KEY issues the leaf cert; it is signed directly by the PQ.DevID
-//!      key (the ML-DSA DPE profile has no intermediate alias).
-//!   8. SIGN over a nonce (SPDM CHALLENGE) verifies under the certified leaf key.
+//! From there the file covers three flows:
+//!   * `test_mldsa_full_attestation_workflow` — the leaf path: a measured DPE
+//!     context is certified (leaf signed directly by the PQ.DevID key) and
+//!     challenged (`run_leaf_attestation_round`).
+//!   * `test_mldsa_exported_cdi_attestation_workflow` — the exported-CDI path:
+//!     DeriveContext { EXPORT_CDI } yields a cert + handle, challenged via
+//!     SIGN_WITH_EXPORTED_MLDSA.
+//!   * `test_mldsa_attestation_survives_hitless_update` — the leaf workflow run
+//!     on both sides of a hitless firmware update, reusing the persisted
+//!     PQ.DevID identity (SET_PQ_SEED / GET_PQ_CSR happen only once).
 
 use caliptra_api::SocManager;
-use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, SignWithExportedMldsaReq,
-    SignWithExportedMldsaResp,
+use caliptra_builder::{
+    firmware::{APP_MLDSA_ATTESTATION, FMC_WITH_UART},
+    ImageOptions,
 };
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, PopulatePqCertReq, SetPqSeedReq,
+    SignWithExportedMldsaReq, SignWithExportedMldsaResp,
+};
+use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel};
 use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
 use dpe::{
@@ -44,8 +51,9 @@ use platform::MAX_CHUNK_SIZE;
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
-    execute_dpe_cmd, get_pq_csr, mldsa_csr_public_key, provision_pq_seed, run_pqc_rt_test,
-    DpeResult, TEST_DIGEST_MLDSA, TEST_LABEL,
+    assert_error, execute_dpe_cmd, get_pq_csr, mldsa_csr_public_key, provision_pq_seed,
+    run_pqc_rt_test, DpeResult, DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQ_SEED,
+    TEST_DIGEST_MLDSA, TEST_LABEL,
 };
 
 const PROFILE: CaliptraDpeProfile = CaliptraDpeProfile::Mldsa;
@@ -189,18 +197,23 @@ fn get_certificate_chain(model: &mut DefaultHwModel) -> Vec<u8> {
     chain
 }
 
-#[test]
-fn test_mldsa_full_attestation_workflow() {
-    let mut model = run_pqc_rt_test();
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+/// The CA-rooted PQ.DevID chain built once per boot: the test Root CA key, the
+/// PQ.DevID public key (from the CSR) and its raw form, and the DER of the
+/// CA-issued DevID certificate.
+struct DevidChain {
+    ca: TestPqCa,
+    devid_pubkey: PKey<Public>,
+    devid_pubkey_raw: Vec<u8>,
+    devid_der: Vec<u8>,
+}
 
-    // 1. Provision the PQ.DevID identity.
-    provision_pq_seed(&mut model);
+/// Provision the PQ.DevID identity, obtain its CSR (verifying it is self-signed
+/// by the PQ.DevID key), and issue a CA-rooted DevID certificate certifying that
+/// key. Shared first-run setup for every workflow test.
+fn provision_and_build_devid_chain(model: &mut DefaultHwModel) -> DevidChain {
+    provision_pq_seed(model);
 
-    // 2. Obtain the PQ.DevID CSR and confirm it is self-signed by the PQ.DevID key.
-    let csr_bytes = get_pq_csr(&mut model);
+    let csr_bytes = get_pq_csr(model);
     let csr = X509Req::from_der(&csr_bytes).unwrap();
     let devid_pubkey = csr.public_key().unwrap();
     assert!(
@@ -218,7 +231,6 @@ fn test_mldsa_full_attestation_workflow() {
         "DevID cert ({} bytes) must fit the PQ cert chain buffer",
         devid_der.len()
     );
-    // The DevID cert is CA-signed and certifies the PQ.DevID key.
     assert!(
         devid_cert.verify(ca.key()).unwrap(),
         "DevID cert must be signed by the Root CA"
@@ -228,47 +240,71 @@ fn test_mldsa_full_attestation_workflow() {
         devid_pubkey_raw
     );
 
-    // 4. Populate the ML-DSA cert chain with the DevID cert.
-    populate_pq_cert_blob(&mut model, &devid_der);
+    DevidChain {
+        ca,
+        devid_pubkey,
+        devid_pubkey_raw,
+        devid_der,
+    }
+}
 
-    // 5. SPDM GET_CERTIFICATE: retrieve the chain, validate Root CA -> DevID.
-    let chain = get_certificate_chain(&mut model);
+/// (Re)populate the ML-DSA cert chain with the DevID cert and retrieve it via
+/// GET_CERTIFICATE_CHAIN (SPDM GET_CERTIFICATE), validating that the chain is the
+/// DevID cert verbatim, verifies under the Root CA, and certifies the PQ.DevID
+/// key. The chain is not persistent, so this runs once per firmware boot.
+fn populate_and_validate_chain(model: &mut DefaultHwModel, chain: &DevidChain) {
+    populate_pq_cert_blob(model, &chain.devid_der);
+
+    let returned = get_certificate_chain(model);
     assert_eq!(
-        chain, devid_der,
+        returned, chain.devid_der,
         "GET_CERTIFICATE_CHAIN must return the populated DevID cert verbatim"
     );
-    let chain_devid = X509::from_der(&chain).unwrap();
+    let chain_devid = X509::from_der(&returned).unwrap();
     assert!(
-        chain_devid.verify(ca.key()).unwrap(),
+        chain_devid.verify(chain.ca.key()).unwrap(),
         "DevID cert in the chain must verify under the Root CA"
     );
     assert_eq!(
         raw_mldsa_pubkey(&chain_devid.public_key().unwrap()),
-        devid_pubkey_raw,
+        chain.devid_pubkey_raw,
         "DevID cert in the chain must certify the PQ.DevID key"
     );
+    assert_eq!(
+        name_cn(chain_devid.subject_name()).as_deref(),
+        Some(DEVID_SUBJECT_CN)
+    );
+}
 
-    // 6. Derive a measured context (an attested component). MAKE_DEFAULT makes it
-    //    the current context; INPUT_ALLOW_X509 lets it be certified as an X.509 leaf.
+/// Run the leaf half of the attestation workflow against the currently-running
+/// firmware: (re)populate + validate the DevID chain, derive a measured context,
+/// certify its leaf (signed directly by the PQ.DevID key), and challenge the leaf
+/// key. `round` distinguishes the measured context so repeated rounds (e.g. across
+/// a firmware update) do not collide on tci_type.
+fn run_leaf_attestation_round(model: &mut DefaultHwModel, chain: &DevidChain, round: u8) {
+    populate_and_validate_chain(model, chain);
+
+    // Derive a measured context. MAKE_DEFAULT makes it the current context;
+    // INPUT_ALLOW_X509 lets it be certified as an X.509 leaf.
     let derive_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
-        data: TciMeasurement([0xaa; TCI_SIZE]),
+        data: TciMeasurement([0xa0 | round; TCI_SIZE]),
         flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
-        tci_type: u32::from_be_bytes(*b"TEST"),
+        tci_type: u32::from_be_bytes([b'T', b'S', b'T', round]),
         target_locality: 0,
         ..Default::default()
     };
     let Some(Response::DeriveContext(_)) = execute_dpe_cmd(
         PROFILE,
-        &mut model,
+        model,
         &mut Command::DeriveContext(&derive_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected DeriveContext response");
     };
 
-    // 7. CERTIFY_KEY the measured context: the leaf is signed directly by the
-    //    PQ.DevID key (the ML-DSA DPE profile has no intermediate alias).
+    // CERTIFY_KEY the measured context: the leaf is signed directly by the
+    // PQ.DevID key (the ML-DSA DPE profile has no intermediate alias).
     let certify_cmd = CertifyKeyMldsa87Cmd {
         handle: ContextHandle::default(),
         label: TEST_LABEL,
@@ -277,7 +313,7 @@ fn test_mldsa_full_attestation_workflow() {
     };
     let Some(Response::CertifyKey(CertifyKeyResp::Mldsa87(certify_resp))) = execute_dpe_cmd(
         PROFILE,
-        &mut model,
+        model,
         &mut Command::from(&certify_cmd),
         DpeResult::Success,
     ) else {
@@ -287,7 +323,7 @@ fn test_mldsa_full_attestation_workflow() {
     let leaf_der = &certify_resp.cert[..certify_resp.header.cert_size as usize];
     let leaf = X509::from_der(leaf_der).unwrap();
     assert!(
-        leaf.verify(&devid_pubkey).unwrap(),
+        leaf.verify(&chain.devid_pubkey).unwrap(),
         "DPE leaf cert must be signed by the PQ.DevID key certified in the DevID cert"
     );
     // Name chaining: the leaf's Issuer CN matches the DevID cert's Subject CN.
@@ -295,14 +331,10 @@ fn test_mldsa_full_attestation_workflow() {
         name_cn(leaf.issuer_name()).as_deref(),
         Some(DEVID_SUBJECT_CN)
     );
-    assert_eq!(
-        name_cn(chain_devid.subject_name()).as_deref(),
-        Some(DEVID_SUBJECT_CN)
-    );
 
     let leaf_pubkey = certify_resp.header.pubkey;
 
-    // 8. SPDM CHALLENGE: sign a nonce with the leaf key; verify under the leaf pubkey.
+    // SPDM CHALLENGE: sign a nonce with the leaf key; verify under the leaf pubkey.
     let nonce = TEST_DIGEST_MLDSA;
     let sign_cmd = SignMldsa87Cmd {
         handle: ContextHandle::default(),
@@ -312,13 +344,12 @@ fn test_mldsa_full_attestation_workflow() {
     };
     let Some(Response::Sign(SignResp::Mldsa87(sign_resp))) = execute_dpe_cmd(
         PROFILE,
-        &mut model,
+        model,
         &mut Command::from(&sign_cmd),
         DpeResult::Success,
     ) else {
         panic!("expected Sign Mldsa87 response");
     };
-
     assert_eq!(
         caliptra_mldsa::Mldsa87::verify_mu(&leaf_pubkey, &sign_resp.sig, &nonce),
         caliptra_mldsa::Mldsa87Result::Success,
@@ -353,17 +384,50 @@ fn sign_with_exported(
         .expect("expected a SIGN_WITH_EXPORTED_MLDSA response")
 }
 
+/// Perform an impactless ("hitless") firmware update: same FMC, same runtime
+/// image, but a bumped app version, loaded via FIRMWARE_LOAD.
+fn hitless_update_bumped_version(model: &mut DefaultHwModel) {
+    // Let the in-flight mailbox flow settle before loading new firmware.
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().mailbox_flow_done());
+
+    let mut opts = ImageOptions::default();
+    opts.vendor_config.pl0_pauser = Some(0x1);
+    opts.fmc_version = DEFAULT_FMC_VERSION;
+    opts.app_version = DEFAULT_APP_VERSION + 1;
+    let image =
+        caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_MLDSA_ATTESTATION, opts)
+            .unwrap()
+            .to_bytes()
+            .unwrap();
+
+    model
+        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &image)
+        .unwrap();
+    model.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+}
+
+/// The leaf attestation workflow: provision the PQ.DevID identity, build its
+/// CA-rooted DevID chain, then certify and challenge a measured DPE leaf.
+#[test]
+fn test_mldsa_full_attestation_workflow() {
+    let mut model = run_pqc_rt_test();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let chain = provision_and_build_devid_chain(&mut model);
+    run_leaf_attestation_round(&mut model, &chain, 0);
+}
+
 /// The exported-CDI variant of the attestation workflow.
 ///
-/// Steps 1-5 build the same CA-rooted DevID chain as
-/// `test_mldsa_full_attestation_workflow`. Then, instead of a CERTIFY_KEY leaf,
-/// it exercises the exported-CDI leg:
-///   6. DeriveContext { EXPORT_CDI | CREATE_CERTIFICATE } produces an exported
-///      CDI handle and its certificate, signed by the PQ.DevID key.
-///   7. The exported cert chains to PQ.DevID (and thus to the CA-rooted DevID).
-///   8. SIGN_WITH_EXPORTED_MLDSA (SPDM CHALLENGE) signs a nonce with the exported
-///      key; the returned key matches the exported cert's subject key and the
-///      signature verifies under it.
+/// After the shared DevID-chain setup it exercises the exported-CDI leg:
+///   * DeriveContext { EXPORT_CDI | CREATE_CERTIFICATE } produces an exported CDI
+///     handle and its certificate, signed by the PQ.DevID key.
+///   * The exported cert chains to PQ.DevID (and thus to the CA-rooted DevID).
+///   * SIGN_WITH_EXPORTED_MLDSA (SPDM CHALLENGE) signs a nonce with the exported
+///     key; the returned key matches the exported cert's subject key and the
+///     signature verifies under it.
 #[test]
 fn test_mldsa_exported_cdi_attestation_workflow() {
     let mut model = run_pqc_rt_test();
@@ -371,41 +435,10 @@ fn test_mldsa_exported_cdi_attestation_workflow() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // 1. Provision the PQ.DevID identity.
-    provision_pq_seed(&mut model);
+    let chain = provision_and_build_devid_chain(&mut model);
+    populate_and_validate_chain(&mut model, &chain);
 
-    // 2. Obtain the PQ.DevID CSR and confirm it is self-signed by the PQ.DevID key.
-    let csr_bytes = get_pq_csr(&mut model);
-    let csr = X509Req::from_der(&csr_bytes).unwrap();
-    let devid_pubkey = csr.public_key().unwrap();
-    assert!(
-        csr.verify(&devid_pubkey).unwrap(),
-        "PQ.DevID CSR must be self-signed by the PQ.DevID key"
-    );
-    let devid_pubkey_raw = mldsa_csr_public_key(&csr_bytes);
-
-    // 3. Stand up a test Root CA and issue a DevID cert over the PQ.DevID key.
-    let ca = TestPqCa::new();
-    let devid_cert = ca.issue_devid_cert(&devid_pubkey);
-    let devid_der = devid_cert.to_der().unwrap();
-
-    // 4. Populate the ML-DSA cert chain with the DevID cert.
-    populate_pq_cert_blob(&mut model, &devid_der);
-
-    // 5. SPDM GET_CERTIFICATE: retrieve the chain and validate Root CA -> DevID.
-    let chain = get_certificate_chain(&mut model);
-    let chain_devid = X509::from_der(&chain).unwrap();
-    assert!(
-        chain_devid.verify(ca.key()).unwrap(),
-        "DevID cert in the chain must verify under the Root CA"
-    );
-    assert_eq!(
-        raw_mldsa_pubkey(&chain_devid.public_key().unwrap()),
-        devid_pubkey_raw,
-        "DevID cert in the chain must certify the PQ.DevID key"
-    );
-
-    // 6. Export a CDI with a certificate (a measured, exportable component).
+    // Export a CDI with a certificate (a measured, exportable component).
     let derive_cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
         data: TciMeasurement([0xbb; TCI_SIZE]),
@@ -428,10 +461,10 @@ fn test_mldsa_exported_cdi_attestation_workflow() {
         &export_resp.new_certificate[..export_resp.header.certificate_size as usize];
     let exported_cert = X509::from_der(exported_cert_der).unwrap();
 
-    // 7. The exported certificate is signed by the PQ.DevID key, so it chains to
-    //    the CA-rooted DevID cert.
+    // The exported certificate is signed by the PQ.DevID key, so it chains to
+    // the CA-rooted DevID cert.
     assert!(
-        exported_cert.verify(&devid_pubkey).unwrap(),
+        exported_cert.verify(&chain.devid_pubkey).unwrap(),
         "exported cert must be signed by the PQ.DevID key"
     );
     assert_eq!(
@@ -440,8 +473,8 @@ fn test_mldsa_exported_cdi_attestation_workflow() {
     );
     let exported_cert_pubkey_raw = raw_mldsa_pubkey(&exported_cert.public_key().unwrap());
 
-    // 8. SPDM CHALLENGE: sign a nonce with the exported key via
-    //    SIGN_WITH_EXPORTED_MLDSA and verify it against the exported cert's key.
+    // SPDM CHALLENGE: sign a nonce with the exported key via SIGN_WITH_EXPORTED_MLDSA
+    // and verify it against the exported cert's key.
     let nonce = b"spdm exported-cdi challenge nonce";
     let resp_bytes = sign_with_exported(
         &mut model,
@@ -463,4 +496,62 @@ fn test_mldsa_exported_cdi_attestation_workflow() {
         caliptra_mldsa::Mldsa87Result::Success,
         "challenge signature must verify under the exported key"
     );
+}
+
+/// The full attestation workflow must keep working across a hitless firmware
+/// update, reusing the PQ.DevID identity provisioned before the update. Only the
+/// first run performs SET_PQ_SEED / GET_PQ_CSR; the identity persists, while the
+/// (non-persistent) cert chain is re-populated after the update.
+#[test]
+fn test_mldsa_attestation_survives_hitless_update() {
+    let mut model = run_pqc_rt_test();
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // First run: provision the PQ.DevID identity, build its DevID chain, and run
+    // the full leaf attestation workflow.
+    let chain = provision_and_build_devid_chain(&mut model);
+    run_leaf_attestation_round(&mut model, &chain, 0);
+
+    // Hitless update to a bumped firmware version.
+    hitless_update_bumped_version(&mut model);
+
+    // The PQ.DevID CDI is write-once persistent data: attempting SET_PQ_SEED now
+    // is rejected as already-set, proving the seed survived the update.
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: PQ_SEED,
+    });
+    cmd.populate_chksum().unwrap();
+    let err = model
+        .mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap())
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_SET_PQ_SEED_ALREADY_SET,
+        err,
+    );
+
+    // The populated cert chain is NOT persistent: GET_CERTIFICATE_CHAIN fails
+    // until the chain is re-populated after the update.
+    let empty_chain_cmd = GetCertificateChainCmd {
+        offset: 0,
+        size: MAX_CHUNK_SIZE as u32,
+    };
+    let resp = execute_dpe_cmd(
+        PROFILE,
+        &mut model,
+        &mut Command::GetCertificateChain(&empty_chain_cmd),
+        DpeResult::DpeCmdFailure,
+    );
+    assert!(
+        matches!(resp, Some(Response::Error(_))),
+        "GET_CERTIFICATE_CHAIN should fail before the chain is re-populated after the update"
+    );
+
+    // Second run: WITHOUT SET_PQ_SEED / GET_PQ_CSR. Reuse the persisted PQ.DevID
+    // identity (and the DevID cert built from its run-1 CSR), re-populate the
+    // chain, and re-run the full workflow.
+    run_leaf_attestation_round(&mut model, &chain, 1);
 }


### PR DESCRIPTION
Add a test validating the hitless update functionality of PQ SEED.  This means the PQ SEED and the relevant CSR remain valid across reboots, the Cert has to be populated on both starts.

As part of this add some utility code to reduce duplication between tests.