### PR TITLE
Add PR CI sanity check with legacy 1.x ROMs

### DIFF
--- a/.github/workflows/fw-test-emu-legacy-rom.yml
+++ b/.github/workflows/fw-test-emu-legacy-rom.yml
@@ -1,0 +1,32 @@
+# Run smoke_test against older ROM versions using the SW emulator.
+# This catches regressions in backward compatibility with older ROMs on every PR.
+
+name: Build and Test Firmware (legacy ROM, in emulator)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  sw-emulator-smoke-rom-1_0:
+    name: sw-emulator smoke (ROM 1.0)
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -pr-smoke-rom-1.0
+      # hw-1.0 selects the 1.0 hardware model; sw_emu_stack_check_disable is needed
+      # because the 1.0.x ROM overflows the stack into unused space.
+      extra-features: hw-1.0,sw_emu_stack_check_disable
+      rom-version: "1.0"
+      test-filter: "test(=smoke_test::smoke_test)"
+      branch: ${{ github.sha }}
+
+  sw-emulator-smoke-rom-1_1:
+    name: sw-emulator smoke (ROM 1.1)
+    uses: ./.github/workflows/fw-test-emu.yml
+    with:
+      artifact-suffix: -pr-smoke-rom-1.1
+      extra-features: ""
+      rom-version: "1.1"
+      test-filter: "test(=smoke_test::smoke_test)"
+      branch: ${{ github.sha }}

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -22,6 +22,10 @@ on:
       runner:
         default: '["ubuntu-22.04"]'
         type: string
+      test-filter:
+        default: ""
+        type: string
+        description: "nextest -E filter expression; empty means run all tests"
 
 jobs:
   build_and_test:
@@ -89,7 +93,8 @@ jobs:
           cargo-nextest nextest run \
             --features="${{ inputs.extra-features }}" \
             --no-fail-fast \
-            --profile=nightly
+            --profile=nightly \
+            ${{ inputs.test-filter != '' && format('-E ''{0}''', inputs.test-filter) || '' }}
 
       - name: 'Upload test results'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Previously, legacy ROM testing was not performed until the nightly release. This allows basic compatibility issues to be caught prior to merging a PR without adding too much testing overhead.