### PR TITLE
mldsa: Increase pqc watchdog timer

### DIFF
--- a/runtime/src/certify_key_extended_mldsa.rs
+++ b/runtime/src/certify_key_extended_mldsa.rs
@@ -34,12 +34,10 @@ impl CertifyKeyExtendedMldsa87Cmd {
             return Err(CaliptraError::RUNTIME_PQC_NOT_INITIALIZED);
         }
 
-        // The mldsa variant of the certify key extended can be quite long, the current longest
-        // measurement over 400_000_000 cycles. As such support 800_000_000 cycles prior to timeout.
-        caliptra_common::wdt::start_wdt(
-            &mut drivers.soc_ifc,
-            caliptra_common::WdtTimeout::new_const(800_000_000),
-        );
+        // The mldsa variant of the certify key extended can be quite long (the
+        // current longest measurement is over 400_000_000 cycles), well past the
+        // default 20M-cycle command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
 
         // The certify-key logic is shared with the ECDSA variant; only the DPE
         // profile (and thus identity / signature algorithm) differs.

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -908,6 +908,29 @@ impl Drivers {
         dice::derive_devid_seed(&cdi, seed, &mut self.hmac384, &mut self.trng)
     }
 
+    /// Re-arm the per-command watchdog with the extended PQC budget for the
+    /// duration of a long-running ML-DSA-87 mailbox command (key generation
+    /// and/or signing).
+    ///
+    /// The runtime arms a 20M-cycle watchdog before each mailbox command (see
+    /// `run` in `lib.rs`). A single ML-DSA-87 keygen or sign -- and the
+    /// multi-operation CERTIFY_KEY_EXTENDED_MLDSA87 path -- exceeds that budget,
+    /// so the PQC commands re-arm the watchdog here first. `PQC_MLDSA_WDT_TIMEOUT`
+    /// mirrors the CERTIFY_KEY_EXTENDED_MLDSA87 budget (longest measurement
+    /// ~400M cycles). A no-op unless the device is debug-locked (see
+    /// `caliptra_common::wdt::start_wdt`).
+    #[cfg(feature = "mldsa_attestation")]
+    pub(crate) fn extend_wdt_for_pqc(&mut self) {
+        /// Extended command-watchdog budget, in cycles, for long-running
+        /// ML-DSA-87 mailbox commands. Matches CERTIFY_KEY_EXTENDED_MLDSA87.
+        const PQC_MLDSA_WDT_TIMEOUT: u64 = 800_000_000;
+
+        caliptra_common::wdt::start_wdt(
+            &mut self.soc_ifc,
+            caliptra_common::WdtTimeout::new_const(PQC_MLDSA_WDT_TIMEOUT),
+        );
+    }
+
     #[cfg(feature = "mldsa_attestation")]
     #[inline(never)]
     pub fn compute_mldsa_key_material(

--- a/runtime/src/get_pq_csr.rs
+++ b/runtime/src/get_pq_csr.rs
@@ -36,6 +36,10 @@ impl GetPqCsrCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         copy_from_mbox(drivers, GetPqCsrReq::new_zeroed().as_mut_bytes())?;
 
+        // Re-deriving the key material and signing the CSR below exceed the
+        // default 20M-cycle command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
+
         // Re-derive the PQ.DevID ML-DSA-87 seed and public key from the PQ.DevID CDI (held in
         // persistent data). The seed is transient and zeroized as soon as the key pair operations
         // are done.

--- a/runtime/src/get_pq_info.rs
+++ b/runtime/src/get_pq_info.rs
@@ -31,6 +31,10 @@ impl GetPqInfoCmd {
     pub(crate) fn execute(drivers: &mut Drivers) -> CaliptraResult<()> {
         copy_from_mbox(drivers, GetPqInfoReq::new_zeroed().as_mut_bytes())?;
 
+        // Computing the ML-DSA-87 public key below exceeds the default 20M-cycle
+        // command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
+
         let mut seed = Mldsa87Seed::default();
         drivers.derive_devid_seed(&mut seed)?;
 

--- a/runtime/src/invoke_dpe.rs
+++ b/runtime/src/invoke_dpe.rs
@@ -113,6 +113,11 @@ impl InvokeDpeMldsa87Cmd {
 
         let mut cmd = InvokeDpeMldsa87Req::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+
+        // ML-DSA-87 DPE operations (e.g. CertifyKey / Sign) can exceed the
+        // default 20M-cycle command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
+
         execute(
             drivers,
             CaliptraDpeProfile::Mldsa,

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -31,6 +31,10 @@ impl SetPqSeedCmd {
         let mut cmd = SetPqSeedReq::new_zeroed();
         crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
 
+        // Deriving the PQ.DevID CDI and computing the ML-DSA-87 key material
+        // below exceeds the default 20M-cycle command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
+
         let mut out = Array4x12::default();
         Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)?;
 

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -53,6 +53,10 @@ impl SignWithExportedMldsaCmd {
             _ => return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_INVALID_PARAMS),
         };
 
+        // The ML-DSA-87 key derivation and signing below exceed the default
+        // 20M-cycle command watchdog budget; extend it.
+        drivers.extend_wdt_for_pqc();
+
         let pdata = drivers.persistent_data.get_mut();
         let root_cdi = pdata.pq_devid_cdi()?;
         let mut crypto = DpeCrypto::new_mldsa87(

--- a/runtime/tests/runtime_integration_tests/test_mldsa_attestation_workflow.rs
+++ b/runtime/tests/runtime_integration_tests/test_mldsa_attestation_workflow.rs
@@ -28,7 +28,7 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel};
-use caliptra_runtime::{CaliptraDpeProfile, RtBootStatus};
+use caliptra_runtime::CaliptraDpeProfile;
 use dpe::{
     commands::{
         CertifyKeyCommand, CertifyKeyFlags, CertifyKeyMldsa87Cmd, Command, DeriveContextCmd,
@@ -52,7 +52,7 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
     assert_error, execute_dpe_cmd, get_pq_csr, mldsa_csr_public_key, provision_pq_seed,
-    run_pqc_rt_test, DpeResult, DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQ_SEED,
+    run_pqc_rt_test_wdt, DpeResult, DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQ_SEED,
     TEST_DIGEST_MLDSA, TEST_LABEL,
 };
 
@@ -408,12 +408,14 @@ fn hitless_update_bumped_version(model: &mut DefaultHwModel) {
 
 /// The leaf attestation workflow: provision the PQ.DevID identity, build its
 /// CA-rooted DevID chain, then certify and challenge a measured DPE leaf.
+///
+/// Boots debug-locked via `run_pqc_rt_test_wdt` so the firmware arms the
+/// per-command watchdog; the test fails if any PQC command exceeds its WDT
+/// budget. The helper already waits until the runtime is ready for commands, so
+/// no further boot-status polling is needed here.
 #[test]
 fn test_mldsa_full_attestation_workflow() {
-    let mut model = run_pqc_rt_test();
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+    let mut model = run_pqc_rt_test_wdt();
 
     let chain = provision_and_build_devid_chain(&mut model);
     run_leaf_attestation_round(&mut model, &chain, 0);
@@ -428,12 +430,12 @@ fn test_mldsa_full_attestation_workflow() {
 ///   * SIGN_WITH_EXPORTED_MLDSA (SPDM CHALLENGE) signs a nonce with the exported
 ///     key; the returned key matches the exported cert's subject key and the
 ///     signature verifies under it.
+///
+/// Boots debug-locked (`run_pqc_rt_test_wdt`) so the per-command watchdog is
+/// armed for the duration of the workflow.
 #[test]
 fn test_mldsa_exported_cdi_attestation_workflow() {
-    let mut model = run_pqc_rt_test();
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+    let mut model = run_pqc_rt_test_wdt();
 
     let chain = provision_and_build_devid_chain(&mut model);
     populate_and_validate_chain(&mut model, &chain);
@@ -502,12 +504,12 @@ fn test_mldsa_exported_cdi_attestation_workflow() {
 /// update, reusing the PQ.DevID identity provisioned before the update. Only the
 /// first run performs SET_PQ_SEED / GET_PQ_CSR; the identity persists, while the
 /// (non-persistent) cert chain is re-populated after the update.
+///
+/// Boots debug-locked (`run_pqc_rt_test_wdt`) so the per-command watchdog is
+/// armed across both firmware versions.
 #[test]
 fn test_mldsa_attestation_survives_hitless_update() {
-    let mut model = run_pqc_rt_test();
-    model.step_until(|m| {
-        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
-    });
+    let mut model = run_pqc_rt_test_wdt();
 
     // First run: provision the PQ.DevID identity, build its DevID chain, and run
     // the full leaf attestation workflow.


### PR DESCRIPTION
The PQC operations can take extensive amounts of time due to their performing software calculations.  For MLDSA commands which can trigger this behavior, increase the Watchdog timer to appropriately handle it.

Also adjust the workflow tests so similar issues will be detected automatically.