### PR TITLE
[nightly]: Fix smoke test failures caused by missing subsystem mode i…

### DIFF
--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -771,6 +771,7 @@ pub struct Pcr0Input {
     pub fw_svn: u8,
     pub vendor_ecc_pk_index: u8,
     pub vendor_pqc_pk_index: u8,
+    pub subsystem_mode: u8,
 }
 impl Pcr0Input {}
 
@@ -803,6 +804,7 @@ impl Pcr0 {
                 input.fw_svn,
                 input.vendor_ecc_pk_index,
                 input.vendor_pqc_pk_index,
+                input.subsystem_mode,
             ],
         );
         extend(
@@ -850,12 +852,13 @@ fn test_derive_pcr0() {
         fw_svn: 6,
         vendor_ecc_pk_index: 7,
         vendor_pqc_pk_index: 8,
+        subsystem_mode: 0,
     });
     assert_eq!(
         pcr0,
         Pcr0([
-            105088857, 944151149, 2604353809, 791137423, 1712852176, 1628755509, 3990671566,
-            2052346331, 640093718, 3145303069, 2197324478, 520085314
+            3663688547, 292490323, 2989019511, 1238385844, 3324789810, 1099712823, 752274733,
+            1844697096, 3223280379, 1397148399, 1640486654, 1743252165
         ])
     )
 }

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -479,6 +479,7 @@ fn smoke_test() {
             hasher.update(&[fw_svn as u8]);
             hasher.update(&[image.manifest.header.vendor_ecc_pub_key_idx as u8]);
             hasher.update(&[image.manifest.header.vendor_pqc_pub_key_idx as u8]);
+            hasher.update(&[hw.subsystem_mode() as u8]);
             let vendor_info_hash = hasher.finish();
 
             let fmc_expected_tcb_info = [
@@ -546,6 +547,7 @@ fn smoke_test() {
                     fw_svn: fw_svn as u8,
                     vendor_ecc_pk_index: image.manifest.header.vendor_ecc_pub_key_idx as u8,
                     vendor_pqc_pk_index: image.manifest.header.vendor_pqc_pub_key_idx as u8,
+                    subsystem_mode: hw.subsystem_mode() as u8,
                 }),
                 &expected_ldevid_key,
             );


### PR DESCRIPTION
…n TCB info and PCR0 derivation

Commit ed615f00d ("Record subsystem mode in ROM DeviceStatus measurement") added subsystem_mode to ROM DeviceStatus PCR measurement and common DICE vendor_device_info_hash. However, smoke_test.rs and test::Pcr0Input were not updated to include subsystem_mode when generating expected TCB Info and deriving expected FMC Alias key for PCR0 comparison.

This caused assertion panics in smoke_test::smoke_test during nightly release runs.

This change:
1. Adds subsystem_mode to vendor_info_hash calculation and Pcr0Input in smoke_test.rs.
2. Adds subsystem_mode field to Pcr0Input and Pcr0::derive in test/src/derive.rs.
3. Updates golden PCR0 test assertion in derive unit tests.