### PR TITLE
emu: fix mailbox lock panic

### DIFF
--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -969,11 +969,13 @@ impl SocRegistersImpl {
             Err(BusError::StoreAccessFault)?
         }
 
+        let was_ready_for_fw = self.cptra_flow_status.reg.is_set(FlowStatus::READY_FOR_FW);
         // Set the flow status register.
         self.cptra_flow_status.reg.set(val);
+        let is_ready_for_fw = self.cptra_flow_status.reg.is_set(FlowStatus::READY_FOR_FW);
 
-        // If ready_for_fw bit is set, run the op_fn_write_complete_cb.
-        if self.cptra_flow_status.reg.is_set(FlowStatus::READY_FOR_FW) {
+        // If ready_for_fw bit is set for the first time, run the op_fn_write_complete_cb.
+        if !was_ready_for_fw && is_ready_for_fw {
             let op_fw_write_complete_action = &mut self.op_fw_write_complete_action;
             let op_fw_write_complete_cb = &mut self.op_fw_write_complete_cb;
             let timer = &self.timer;


### PR DESCRIPTION
The write callback of `CPTRA_FLOW_STATUS` register schedules a firmware upload solely depending on the `READY_FOR_FW` bit. This could be problematic since the runtime modifies the same register to update the `MAILBOX_FLOW_DONE` bit, leaving the old `READY_FOR_FW` bit set. This would then trigger the write callback to schedule another firmware upload, but this spurious upload would now be handled by runtime, trying to upload the firmware specified with `--update-firmware`: but it will fail due to the mailbox being busy.

This commit checks if `READY_FOR_FW` is set for the first time, and only schedules a firmware upload in that case, preventing the spurious update from happening.

Full log and panic:
```
Running Caliptra ROM ...

[state] CFI On
[state] LcState = Unprov
[state] DbgLock = No
[state] WDT skip, dbg unlocked
[kat] SHA2-256
ROM Digest: 7111396CC918AEF8C9F164FF6498936C5794A11283AD80785F3DE9908AC37390
[kat] ++
[kat] sha1
[kat] SHA2-256
[kat] SHA2-384
[kat] SHA2-512-ACC
[kat] ECC-384
[kat] HMAC-384Kdf
[kat] LMS
[kat] --
[cold-reset] ++
[fht] FHT @ 0x50003400
[idev] ++
[idev] CDI.KEYID = 6
[idev] SUBJECT.KEYID = 7
[idev] UDS.KEYID = 0
[idev] Erasing UDS.KEYID = 0
[idev] Sha1 KeyId Algorithm
[idev] --
[ldev] ++
[ldev] CDI.KEYID = 6
[ldev] SUBJECT.KEYID = 5
[ldev] AUTHORITY.KEYID = 7
[ldev] FE.KEYID = 1
[ldev] Erasing FE.KEYID = 1
[ldev] Signing Cert w/ AUTHORITY.KEYID = 7
[ldev] PUB.X = 504D38CA45D997901F48BA333A149A2FB2668B973AAC64D3B79ECC09A663F02ED2FABA133F5FA499677AEB7687C99B25
[ldev] PUB.Y = A5CD31125698B3322C086E4398A591946BF20A3ECEA8EB7D7C23410D49FA877E7ECFBE47BD883BD53D7DA865AC217F1D
[ldev] SIG.R = A20EB096C15D7D29809559C2B3FB7508CBAA3385C3AE7F0452965F917F99C87C7232196F9D2D57A505C36FEAFCAB8E2A
[ldev] SIG.S = 3607393FA13FE0A4516A3E0F63F9CA0B9F1C2C184507063B3453FEF725394FA36534BB9B844B177687715855914B17C7
[ldev] --
[fwproc] Waiting...
[fwproc] Cmd 0x46574c44
[fwproc] Img size: 106344
[fwproc] ECC Key 0
[fwproc] FMC 0x40000000 len 20272
[fwproc] RT 0x40005400 len 80188
[afmc] ++
[afmc] CDI.KEYID = 6
[afmc] SUBJECT.KEYID = 7
[afmc] AUTHORITY.KEYID = 5
[afmc] Signing Cert w/ AUTHORITY.KEYID = 5
[afmc] Erase AUTHORITY.KEYID = 5
[afmc] PUB.X = E81E3099FB06BD3CD5D94106A483BCFD5A6C6B7C4AC601E5E44E918E080BC8BFDBBDFBEB0C274297A42CAA6276ACA36A
[afmc] PUB.Y = CC11851A14A52558483541C7A0B9F653659A4790560A12AAA7EC1F2BDA824104808817A6D3E50DC904EF1809FA3FA582
[afmc] SIG.R = 7BFECE96E557E4111862A2AA83DCD5A6E749416A0C0A766D70FD01C7EB0C80BB9EC46DF8086EC18D7CE7AE4FD9F8C0D3
[afmc] SIG.S = 3C59D3A3B06A7D090894699CC74C5CA0BCE441E6F5F8C0830F6C6B32E6B0503A1B7B6F17505ADDFA78EE5B2FB75B6666
[afmc] --
[cold-reset] --
[state] Lock Datavault
[state] Lock PCRs
[state] Lock ICCM
[exit] FMC @ 0x40000130

Running Caliptra FMC ...

[state] CFI Enabled
[fht] FMC Alias Private Key: 7
[art] Extend RT PCRs Done
[art] Lock RT PCRs Done
[art] Populate DV Done
[fht] FMC Alias Private Key: 7
[art] Derive CDI
[art] Store in slot 0x4
[art] Derive Key Pair
[art] Store priv key in slot 0x5
[art] Derive Key Pair - Done
[art] Signing Cert with AUTHORITY.KEYID = 7
[art] Erasing AUTHORITY.KEYID = 7
[art] PUB.X = 978C2C5722B257B3C3743C52A36923570BCAEFAC6A432ADB87CA70AEBC708A05FF50376DA81328E9F94746F100BED024
[art] PUB.Y = 035C46A445950758DC162DE38610C680578CF8193C7E032B5F7319CF24967EEEBBBA5335B8771844574472571D9EC1F4
[art] SIG.R = 942C0BA4E40B79AB09FA6CA16240D2BDB6E9F49C9604A4D778014C4E3CA3EDDDD92E1ED218464DBA7A79062FDBE7EE37
[art] SIG.S = C2C5EA9DE668C3EF25CA1389D77BD95BFB92C0997A8A687245BD0B60FE3E9E7981AFDEC68556469015CA8B5D9D31DF8C
Caliptra RT
[state] CFI Enabled
[rt] RT listening for mailbox commands...
handle_trap: cause=8000000b, mtval=0, next_pc=40005400
handle_trap: cause=8000000b, mtval=0, next_pc=40005400

thread 'main' (1280664) panicked at sw-emulator/app/src/main.rs:411:5:
assertion failed: !soc_mbox.lock().read().lock()
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/panicking.rs:80:14
   2: core::panicking::panic
             at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/panicking.rs:150:5
   3: caliptra_emu::upload_fw_to_mailbox
             at ./sw-emulator/app/src/main.rs:411:5
   4: caliptra_emu::main::{{closure}}
             at ./sw-emulator/app/src/main.rs:268:13
   5: <alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut
             at /data/x.home/.rustup/toolchains/1.95-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2247:9
   6: caliptra_emu_periph::soc_reg::SocRegistersImpl::bus_update_reset
             at ./sw-emulator/lib/periph/src/soc_reg.rs:1299:9
   7: <caliptra_emu_periph::soc_reg::SocRegistersInternal as caliptra_emu_types::bus::Bus>::update_reset
             at ./sw-emulator/lib/periph/src/soc_reg.rs:441:32
   8: <caliptra_emu_periph::root_bus::CaliptraRootBus as caliptra_emu_types::bus::Bus>::update_reset
             at ./sw-emulator/lib/periph/src/root_bus.rs:249:10
   9: caliptra_emu_bus::clock::Clock::increment_and_process_timer_actions
             at ./sw-emulator/lib/bus/src/clock.rs:180:25
  10: caliptra_emu_cpu::cpu::Cpu<TBus>::step
             at ./sw-emulator/lib/cpu/src/cpu.rs:608:14
  11: caliptra_emu::free_run
             at ./sw-emulator/app/src/main.rs:66:46
  12: caliptra_emu::main
             at ./sw-emulator/app/src/main.rs:393:13
  13: core::ops::function::FnOnce::call_once
             at /data/x.home/.rustup/toolchains/1.95-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
```