### PR TITLE
Cherry-pick DPE context updates to main

### DIFF
--- a/drivers/src/lib.rs
+++ b/drivers/src/lib.rs
@@ -149,7 +149,8 @@ pub use persistent::FwPersistentData;
 pub use persistent::IDEVID_CSR_ENVELOP_MARKER;
 #[cfg(feature = "runtime")]
 pub use persistent::{
-    AuthManifestImageMetadataList, ExportedCdiEntry, ExportedCdiHandles, OcpLockMetadataFirmware,
+    AuthManifestImageMetadataList, CaliptraManagedDpeContextIndices, ExportedCdiEntry,
+    ExportedCdiHandles, OcpLockMetadataFirmware,
 };
 pub use persistent::{
     BootMode, Ecc384IdevIdCsr, FuseLogArray, InitDevIdCsrEnvelope, Mldsa87IdevIdCsr, OcpLockFlags,

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -157,6 +157,15 @@ pub type StashMeasurementArray = [MeasurementLogEntry; MEASUREMENT_MAX_COUNT];
 pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
+#[cfg(feature = "runtime")]
+#[derive(Clone, Copy, FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, Zeroize, Default)]
+#[repr(C)]
+pub struct CaliptraManagedDpeContextIndices {
+    pub cciv: u8,
+    pub mcu_rt: u8,
+    pub reserved: [u8; 2],
+}
+
 #[derive(Clone, FromZeros, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct Ecc384IdevIdCsr {
@@ -786,7 +795,12 @@ impl FwPersistentData {
                 addr_of!((*P).fw.mcu_firmware_loaded) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
-
+            persistent_data_offset += _DPE_PL_CONTEXT_LIMITS_WITH_PAD_SIZE;
+            assert_eq!(
+                addr_of!((*P).rt_mldsa_keypair_seed_kv_hdl) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+            persistent_data_offset += size_of::<HandOffDataHandle>() as u32;
             persistent_data_offset += FIRMWARE_OCP_LOCK_METADATA_SIZE;
             assert_eq!(
                 addr_of!((*P).fw.ocp_lock_metadata) as u32,
@@ -861,6 +875,8 @@ pub struct DpePersistentData {
     pub exported_cdi_slots: ExportedCdiHandles,
     pub pl0_context_limit: u8,
     pub pl1_context_limit: u8,
+    pub soc_manifest_svn: u32,
+    pub caliptra_managed_dpe_context_indices: CaliptraManagedDpeContextIndices,
 }
 
 #[cfg(feature = "runtime")]

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -158,12 +158,48 @@ pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
 #[cfg(feature = "runtime")]
-#[derive(Clone, Copy, FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, Zeroize, Default)]
+#[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct CaliptraManagedDpeContextIndices {
+    pub initialized: U8Bool,
     pub cciv: u8,
     pub mcu_rt: u8,
-    pub reserved: [u8; 2],
+    pub reserved: [u8; 1],
+}
+
+#[cfg(feature = "runtime")]
+impl CaliptraManagedDpeContextIndices {
+    pub const INVALID_INDEX: u8 = 0xff;
+
+    pub fn invalidate(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.initialized.get()
+    }
+
+    pub fn set_cciv(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.cciv = idx;
+    }
+
+    pub fn set_mcu_rt(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.mcu_rt = idx;
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl Default for CaliptraManagedDpeContextIndices {
+    fn default() -> Self {
+        Self {
+            initialized: U8Bool::new(false),
+            cciv: Self::INVALID_INDEX,
+            mcu_rt: Self::INVALID_INDEX,
+            reserved: [Self::INVALID_INDEX; 1],
+        }
+    }
 }
 
 #[derive(Clone, FromZeros, Immutable, IntoBytes, KnownLayout, Zeroize)]

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -158,13 +158,15 @@ pub type AuthManifestImageMetadataList =
     [AuthManifestImageMetadata; AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT];
 
 #[cfg(feature = "runtime")]
-#[derive(Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Zeroize)]
+#[derive(Clone, Copy, FromZeros, Immutable, IntoBytes, KnownLayout, Zeroize)]
 #[repr(C)]
 pub struct CaliptraManagedDpeContextIndices {
     pub initialized: U8Bool,
     pub cciv: u8,
     pub mcu_rt: u8,
-    pub reserved: [u8; 1],
+    pub somv: u8,
+    pub somo: u8,
+    pub reserved: [u8; 3],
 }
 
 #[cfg(feature = "runtime")]
@@ -188,6 +190,16 @@ impl CaliptraManagedDpeContextIndices {
         self.initialized = U8Bool::new(true);
         self.mcu_rt = idx;
     }
+
+    pub fn set_somv(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.somv = idx;
+    }
+
+    pub fn set_somo(&mut self, idx: u8) {
+        self.initialized = U8Bool::new(true);
+        self.somo = idx;
+    }
 }
 
 #[cfg(feature = "runtime")]
@@ -197,7 +209,9 @@ impl Default for CaliptraManagedDpeContextIndices {
             initialized: U8Bool::new(false),
             cciv: Self::INVALID_INDEX,
             mcu_rt: Self::INVALID_INDEX,
-            reserved: [Self::INVALID_INDEX; 1],
+            somv: Self::INVALID_INDEX,
+            somo: Self::INVALID_INDEX,
+            reserved: [Self::INVALID_INDEX; 3],
         }
     }
 }
@@ -831,19 +845,13 @@ impl FwPersistentData {
                 addr_of!((*P).fw.mcu_firmware_loaded) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
-            persistent_data_offset += _DPE_PL_CONTEXT_LIMITS_WITH_PAD_SIZE;
-            assert_eq!(
-                addr_of!((*P).rt_mldsa_keypair_seed_kv_hdl) as u32,
-                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
-            );
-            persistent_data_offset += size_of::<HandOffDataHandle>() as u32;
-            persistent_data_offset += FIRMWARE_OCP_LOCK_METADATA_SIZE;
+            persistent_data_offset += 4;
             assert_eq!(
                 addr_of!((*P).fw.ocp_lock_metadata) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
 
-            persistent_data_offset += 4;
+            persistent_data_offset += FIRMWARE_OCP_LOCK_METADATA_SIZE;
             assert_eq!(
                 addr_of!((*P).fw.version) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1819,12 +1819,12 @@ impl CaliptraError {
             "Runtime Error: Attested CSR COSE Sign1 encoding error"
         ),
         (
-             RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE_IN_FUSE,
+            RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE_IN_FUSE,
             0x000E008A,
             "Runtime Error: Auth manifest invalid PQC key type in fuse"
         ),
         (
-             RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE,
+            RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE,
             0x000E008B,
             "Runtime Error: Auth manifest invalid PQC key type"
         ),
@@ -1854,14 +1854,14 @@ impl CaliptraError {
             "Runtime Error: CM AES GCM decrypt DMA requires subsystem mode"
         ),
         (
-            RUNTIME_CCIV_CONTEXT_NOT_FOUND,
+            RUNTIME_DPE_CONTEXT_NOT_FOUND,
             0x000E0093,
-            "Runtime Error: CCIV context not found"
+            "Runtime Error: DPE context not found"
         ),
         (
-            RUNTIME_MULTIPLE_CCIV_CONTEXTS_FOUND,
+            RUNTIME_MULTIPLE_DPE_CONTEXTS_FOUND,
             0x000E0094,
-            "Runtime Error: Multiple CCIV contexts found"
+            "Runtime Error: Multiple DPE contexts found"
         ),
         (
             RUNTIME_DISABLE_ATTESTATION_FAILED_WARM_RESET,

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -15,7 +15,7 @@ Abstract:
 use core::mem::offset_of;
 
 use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
-use crate::drivers::{McuFwStatus, McuResetReason};
+use crate::drivers::{CaliptraManagedDpeContext, McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
 use caliptra_api::mailbox::{ActivateFirmwareFlags, AuthorizeAndStashReq, ImageHashSource};
@@ -307,7 +307,7 @@ impl ActivateFirmwareCmd {
             }
             drivers
                 .update_caliptra_managed_measurement(
-                    Drivers::MCU_RT_TCI_TYPE,
+                    CaliptraManagedDpeContext::McuRt,
                     &measurement,
                     Some(pl0_pauser_locality),
                 )

--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -18,9 +18,7 @@ use crate::authorize_and_stash::{self, AuthorizeAndStashCmd};
 use crate::drivers::{McuFwStatus, McuResetReason};
 use crate::Drivers;
 use crate::{manifest::find_metadata_entry, mutrefbytes};
-use caliptra_api::mailbox::{
-    ActivateFirmwareFlags, AuthAndStashFlags, AuthorizeAndStashReq, ImageHashSource,
-};
+use caliptra_api::mailbox::{ActivateFirmwareFlags, AuthorizeAndStashReq, ImageHashSource};
 use caliptra_auth_man_types::ImageMetadataFlags;
 use caliptra_common::mailbox_api::{ActivateFirmwareReq, ActivateFirmwareResp, MailboxRespHeader};
 use caliptra_drivers::dma::MCU_SRAM_OFFSET;
@@ -280,12 +278,12 @@ impl ActivateFirmwareCmd {
                 )
                 .map_err(|_| ())?;
 
-            // Verify MCU after loading
+            // Update MCU RT DPE context with new measurement.
+            // SVN stays the same as the recovery boot value.
             let auth_and_stash_req = AuthorizeAndStashReq {
                 fw_id: ActivateFirmwareReq::MCU_IMAGE_ID.to_le_bytes(),
                 measurement: [0; 48],
                 source: ImageHashSource::LoadAddress.into(),
-                flags: AuthAndStashFlags::SKIP_STASH.bits(),
                 image_size: mcu_image_size,
                 ..Default::default()
             };
@@ -297,17 +295,23 @@ impl ActivateFirmwareCmd {
                 .manifest1
                 .header
                 .pl0_pauser;
-            let authorization_result = AuthorizeAndStashCmd::authorize_and_stash(
-                drivers,
-                &auth_and_stash_req,
-                pl0_pauser_locality,
-            )
-            .map_err(|_| ())?;
+            let (authorization_result, measurement) =
+                AuthorizeAndStashCmd::authorize_image(drivers, &auth_and_stash_req)
+                    .map_err(|_| ())?;
 
             // Make sure the image was properly authorized.
-            if authorization_result != authorize_and_stash::IMAGE_AUTHORIZED {
+            if authorization_result != authorize_and_stash::IMAGE_AUTHORIZED_VENDOR_OWNER
+                && authorization_result != authorize_and_stash::IMAGE_AUTHORIZED_OWNER_ONLY
+            {
                 return Err(());
             }
+            drivers
+                .update_caliptra_managed_measurement(
+                    Drivers::MCU_RT_TCI_TYPE,
+                    &measurement,
+                    Some(pl0_pauser_locality),
+                )
+                .map_err(|_| ())?;
 
             drivers.persistent_data.get_mut().fw.mcu_firmware_loaded = McuFwStatus::Loaded.into();
         } else if mcu_activate_requested && initial_activate {

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -143,7 +143,7 @@ impl AuthorizeAndStashCmd {
             {
                 (entry, IMAGE_AUTHORIZED_OWNER_ONLY)
             } else {
-                return Ok(IMAGE_NOT_AUTHORIZED);
+                return Ok((IMAGE_NOT_AUTHORIZED, stash_measurement));
             };
 
         // If 'ignore_auth_check' is set, then skip the image digest comparison and authorize the image.

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -82,11 +82,46 @@ impl AuthorizeAndStashCmd {
         cmd: &AuthorizeAndStashReq,
         locality: u32,
     ) -> CaliptraResult<u32> {
+        let (auth_result, stash_measurement) = Self::authorize_image(drivers, cmd)?;
+
+        // Stash the measurement if the image is authorized (vendor+owner
+        // or owner-only).
+        let flags: AuthAndStashFlags = cmd.flags.into();
+        if (auth_result == IMAGE_AUTHORIZED_VENDOR_OWNER
+            || auth_result == IMAGE_AUTHORIZED_OWNER_ONLY)
+            && !flags.contains(AuthAndStashFlags::SKIP_STASH)
+        {
+            let dpe_result = StashMeasurementCmd::stash_measurement(
+                drivers,
+                &cmd.fw_id,
+                &stash_measurement,
+                cmd.svn,
+                drivers.caller_privilege_level(),
+                locality,
+            )?;
+            if dpe_result != DpeErrorCode::NoError {
+                drivers
+                    .soc_ifc
+                    .set_fw_extended_error(dpe_result.get_error_code());
+
+                Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
+            }
+        }
+
+        Ok(auth_result)
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn authorize_image(
+        drivers: &mut Drivers,
+        cmd: &AuthorizeAndStashReq,
+    ) -> CaliptraResult<(u32, [u8; 48])> {
         let source = ImageHashSource::from(cmd.source);
         if source == ImageHashSource::Invalid {
             Err(CaliptraError::RUNTIME_AUTH_AND_STASH_UNSUPPORTED_IMAGE_SOURCE)?;
         }
-        // Check if firmware id is present in the image metadata entry collection.
+
         let persistent_data = drivers.persistent_data.get();
         let dma_image = DmaRecovery::new(
             drivers.soc_ifc.recovery_interface_base_addr().into(),
@@ -100,7 +135,6 @@ impl AuthorizeAndStashCmd {
 
         let cmd_fw_id = u32::from_le_bytes(cmd.fw_id);
         let mut stash_measurement = cmd.measurement;
-        let auth_and_stash_flags: AuthAndStashFlags = cmd.flags.into();
         let (metadata_entry, success_code) =
             if let Some(entry) = find_metadata_entry(auth_manifest_image_metadata_col, cmd_fw_id) {
                 (entry, IMAGE_AUTHORIZED_VENDOR_OWNER)
@@ -161,29 +195,7 @@ impl AuthorizeAndStashCmd {
         } else {
             IMAGE_NOT_AUTHORIZED
         };
-        // Stash the measurement if the image is authorized (vendor+owner
-        // or owner-only).
-        if (auth_result == IMAGE_AUTHORIZED_VENDOR_OWNER
-            || auth_result == IMAGE_AUTHORIZED_OWNER_ONLY)
-            && !auth_and_stash_flags.contains(AuthAndStashFlags::SKIP_STASH)
-        {
-            let dpe_result = StashMeasurementCmd::stash_measurement(
-                drivers,
-                &cmd.fw_id,
-                &stash_measurement,
-                cmd.svn,
-                drivers.caller_privilege_level(),
-                locality,
-            )?;
-            if dpe_result != DpeErrorCode::NoError {
-                drivers
-                    .soc_ifc
-                    .set_fw_extended_error(dpe_result.get_error_code());
 
-                Err(CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR)?;
-            }
-        }
-
-        Ok(auth_result)
+        Ok((auth_result, stash_measurement))
     }
 }

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -19,6 +19,7 @@ use crate::debug_unlock::ProductionDebugUnlock;
 use crate::dpe_crypto::DpeCrypto;
 #[cfg(feature = "fips_self_test")]
 pub use crate::fips::fips_self_test_cmd::SelfTestStatus;
+use crate::invoke_dpe::invoke_dpe_cmd;
 use crate::ocp_lock::OcpLockContext;
 use crate::recovery_flow::RecoveryFlow;
 use crate::CaliptraDpeEnv;
@@ -38,7 +39,7 @@ use caliptra_common::cfi_check;
 use caliptra_common::crypto::Crypto;
 use caliptra_common::dice::{copy_ldevid_ecc384_cert, copy_ldevid_mldsa87_cert};
 use caliptra_common::mailbox_api::AddSubjectAltNameReq;
-use caliptra_dpe::commands::DeriveContextCmd;
+use caliptra_dpe::commands::{Command, DeriveContextCmd};
 use caliptra_dpe::context::{Context, ContextState, ContextType};
 use caliptra_dpe::response::DeriveContextResp;
 use caliptra_dpe::tci::TciMeasurement;
@@ -74,7 +75,10 @@ use caliptra_registers::{
 use caliptra_ureg::MmioMut;
 use caliptra_x509::{NotAfter, NotBefore};
 
-use core::cmp::Ordering::{Equal, Greater};
+use core::{
+    cmp::Ordering::{Equal, Greater},
+    mem::size_of,
+};
 use zerocopy::IntoBytes;
 
 pub const MCI_TOP_REG_RESET_REASON_OFFSET: u32 = 0x38;
@@ -102,6 +106,8 @@ impl From<McuResetReason> for u32 {
 #[derive(Clone, Copy)]
 pub(crate) enum CaliptraManagedDpeContext {
     Cciv,
+    Somv,
+    Somo,
     McuRt,
 }
 
@@ -109,7 +115,27 @@ impl CaliptraManagedDpeContext {
     fn tci_type(self) -> u32 {
         match self {
             Self::Cciv => Drivers::CCIV_TCI_TYPE,
+            Self::Somv => Drivers::SOMV_TCI_TYPE,
+            Self::Somo => Drivers::SOMO_TCI_TYPE,
             Self::McuRt => Drivers::MCU_RT_TCI_TYPE,
+        }
+    }
+
+    fn cached_index(self, indices: &CaliptraManagedDpeContextIndices) -> u8 {
+        match self {
+            Self::Cciv => indices.cciv,
+            Self::Somv => indices.somv,
+            Self::Somo => indices.somo,
+            Self::McuRt => indices.mcu_rt,
+        }
+    }
+
+    fn set_cached_index(self, indices: &mut CaliptraManagedDpeContextIndices, idx: u8) {
+        match self {
+            Self::Cciv => indices.set_cciv(idx),
+            Self::Somv => indices.set_somv(idx),
+            Self::Somo => indices.set_somo(idx),
+            Self::McuRt => indices.set_mcu_rt(idx),
         }
     }
 }
@@ -190,6 +216,8 @@ pub struct Drivers {
 
 impl Drivers {
     pub const CCIV_TCI_TYPE: u32 = u32::from_be_bytes(*b"CCIV");
+    pub const SOMV_TCI_TYPE: u32 = u32::from_be_bytes(*b"SOMV");
+    pub const SOMO_TCI_TYPE: u32 = u32::from_be_bytes(*b"SOMO");
     pub const MCU_RT_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
 
     /// # Safety
@@ -376,10 +404,7 @@ impl Drivers {
             return None;
         }
 
-        let idx = match context {
-            CaliptraManagedDpeContext::Cciv => indices.cciv,
-            CaliptraManagedDpeContext::McuRt => indices.mcu_rt,
-        };
+        let idx = context.cached_index(&indices);
 
         if idx == CaliptraManagedDpeContextIndices::INVALID_INDEX {
             None
@@ -401,7 +426,7 @@ impl Drivers {
             return Ok(());
         }
 
-        let (cciv_idx, mcu_rt_idx) = {
+        let (cciv_idx, somv_idx, somo_idx, mcu_rt_idx) = {
             let persistent_data = self.persistent_data.get();
             let dpe = &persistent_data.fw.dpe.state;
             let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
@@ -411,6 +436,10 @@ impl Drivers {
                 None,
                 Some(root_idx),
             )?;
+            let somv_idx =
+                Self::get_dpe_context_idx_by_tci_type(dpe, Self::SOMV_TCI_TYPE, None, None).ok();
+            let somo_idx =
+                Self::get_dpe_context_idx_by_tci_type(dpe, Self::SOMO_TCI_TYPE, None, None).ok();
             let mcu_rt_idx = Self::get_dpe_context_idx_by_tci_type(
                 dpe,
                 Self::MCU_RT_TCI_TYPE,
@@ -418,7 +447,7 @@ impl Drivers {
                 None,
             )
             .ok();
-            (cciv_idx, mcu_rt_idx)
+            (cciv_idx, somv_idx, somo_idx, mcu_rt_idx)
         };
 
         let indices = &mut self
@@ -430,6 +459,16 @@ impl Drivers {
         indices.set_cciv(
             u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
         );
+        if let Some(somv_idx) = somv_idx {
+            indices.set_somv(
+                u8::try_from(somv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
+        }
+        if let Some(somo_idx) = somo_idx {
+            indices.set_somo(
+                u8::try_from(somo_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
+        }
         if let Some(mcu_rt_idx) = mcu_rt_idx {
             indices.set_mcu_rt(
                 u8::try_from(mcu_rt_idx)
@@ -437,6 +476,93 @@ impl Drivers {
             );
         }
 
+        Ok(())
+    }
+
+    pub(crate) fn create_or_update_caliptra_managed_measurement(
+        &mut self,
+        caliptra_managed_context: CaliptraManagedDpeContext,
+        measurement: &[u8; 48],
+        svn: u32,
+        locality: u32,
+        create_if_missing: bool,
+    ) -> CaliptraResult<()> {
+        if self
+            .get_caliptra_managed_dpe_context_index(caliptra_managed_context)
+            .is_some()
+        {
+            return self.update_caliptra_managed_measurement(
+                caliptra_managed_context,
+                measurement,
+                Some(locality),
+            );
+        }
+
+        if !create_if_missing {
+            return Ok(());
+        }
+
+        // Creating missing Caliptra-managed contexts is only used during recovery
+        // boot before MCFW is created. Hitless update paths update existing cached
+        // contexts only. Behavior is unspecified for existing chains that do not
+        // already contain SOMV/SOMO, so runtime does not insert them mid-chain.
+        self.is_dpe_context_threshold_exceeded(PauserPrivileges::PL0)?;
+        let flags = DeriveContextFlags::MAKE_DEFAULT
+            | DeriveContextFlags::CHANGE_LOCALITY
+            | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT
+            | DeriveContextFlags::INPUT_ALLOW_X509
+            | DeriveContextFlags::ALLOW_RECURSIVE;
+        let cmd = DeriveContextCmd {
+            handle: ContextHandle::default(),
+            data: TciMeasurement(*measurement),
+            flags,
+            tci_type: caliptra_managed_context.tci_type(),
+            target_locality: locality,
+            svn,
+        };
+        let cmd = &Command::from(&cmd);
+        let mut resp_buf_storage = [0u32; size_of::<DeriveContextResp>() / 4];
+        let resp_buf = resp_buf_storage.as_mut_bytes();
+        let ueid = Some(self.soc_ifc.fuse_bank().ueid());
+        invoke_dpe_cmd(
+            CaliptraDpeProfile::Ecc384,
+            self,
+            cmd,
+            None,
+            ueid,
+            Some(locality),
+            resp_buf,
+        )
+        .map_err(|e| {
+            if let Some(ext_err) = e.get_error_detail() {
+                self.soc_ifc.set_fw_extended_error(ext_err);
+            }
+            CaliptraError::RUNTIME_AUTH_AND_STASH_MEASUREMENT_DPE_ERROR
+        })?;
+
+        let idx = u8::try_from(
+            self.persistent_data
+                .get()
+                .fw
+                .dpe
+                .state
+                .get_active_context_pos(&ContextHandle::default(), locality)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        let indices = &mut self
+            .persistent_data
+            .get_mut()
+            .fw
+            .dpe
+            .caliptra_managed_dpe_context_indices;
+        caliptra_managed_context.set_cached_index(indices, idx);
+
+        self.pcr_bank.extend_pcr(
+            PCR_ID_STASH_MEASUREMENT,
+            &mut self.sha2_512_384,
+            measurement,
+        )?;
         Ok(())
     }
 

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -99,6 +99,21 @@ impl From<McuResetReason> for u32 {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum CaliptraManagedDpeContext {
+    Cciv,
+    McuRt,
+}
+
+impl CaliptraManagedDpeContext {
+    fn tci_type(self) -> u32 {
+        match self {
+            Self::Cciv => Drivers::CCIV_TCI_TYPE,
+            Self::McuRt => Drivers::MCU_RT_TCI_TYPE,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub enum McuFwStatus {
     NotLoaded,
@@ -251,21 +266,24 @@ impl Drivers {
         match reset_reason {
             ResetReason::ColdReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::ColdReset);
+                self.persistent_data
+                    .get_mut()
+                    .fw
+                    .dpe
+                    .caliptra_managed_dpe_context_indices
+                    .invalidate();
                 Self::initialize_dpe(self)?;
                 if self.soc_ifc.subsystem_mode() {
                     RecoveryFlow::recovery_flow(self)?;
                 }
-                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::UpdateReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::UpdateReset);
                 Self::validate_dpe_structure(self)?;
                 Self::validate_context_tags(self)?;
+                self.init_dpe_index_cache()?;
                 Self::update_dpe_rt_tci(self)?;
                 Self::update_dpe_cciv(self)?;
-                // Repopulate appended context-index cache for hitless updates
-                // from older runtimes that did not have these persistent fields.
-                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::WarmReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::WarmReset);
@@ -343,24 +361,43 @@ impl Drivers {
     }
 
     #[inline(always)]
-    fn get_caliptra_managed_dpe_context_index(&self, tci_type: u32) -> CaliptraResult<usize> {
+    fn get_caliptra_managed_dpe_context_index(
+        &self,
+        context: CaliptraManagedDpeContext,
+    ) -> Option<usize> {
         let indices = self
             .persistent_data
             .get()
             .fw
             .dpe
             .caliptra_managed_dpe_context_indices;
-        let idx = match tci_type {
-            Self::CCIV_TCI_TYPE => indices.cciv,
-            Self::MCU_RT_TCI_TYPE => indices.mcu_rt,
-            _ => return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND),
+
+        if !indices.is_initialized() {
+            return None;
+        }
+
+        let idx = match context {
+            CaliptraManagedDpeContext::Cciv => indices.cciv,
+            CaliptraManagedDpeContext::McuRt => indices.mcu_rt,
         };
 
-        Ok(idx as usize)
+        if idx == CaliptraManagedDpeContextIndices::INVALID_INDEX {
+            None
+        } else {
+            Some(idx as usize)
+        }
     }
 
-    fn cache_caliptra_managed_dpe_context_indices(&mut self) -> CaliptraResult<()> {
-        if self.persistent_data.get().fw.dpe.attestation_disabled.get() {
+    fn init_dpe_index_cache(&mut self) -> CaliptraResult<()> {
+        if self.persistent_data.get().fw.dpe.attestation_disabled.get()
+            || self
+                .persistent_data
+                .get()
+                .fw
+                .dpe
+                .caliptra_managed_dpe_context_indices
+                .is_initialized()
+        {
             return Ok(());
         }
 
@@ -390,11 +427,14 @@ impl Drivers {
             .fw
             .dpe
             .caliptra_managed_dpe_context_indices;
-        indices.cciv =
-            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        indices.set_cciv(
+            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        );
         if let Some(mcu_rt_idx) = mcu_rt_idx {
-            indices.mcu_rt = u8::try_from(mcu_rt_idx)
-                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            indices.set_mcu_rt(
+                u8::try_from(mcu_rt_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+            );
         }
 
         Ok(())
@@ -404,36 +444,36 @@ impl Drivers {
     #[inline(never)]
     pub(crate) fn update_caliptra_managed_measurement(
         &mut self,
-        tci_type: u32,
+        caliptra_managed_context: CaliptraManagedDpeContext,
         measurement: &[u8; 48],
         locality: Option<u32>,
     ) -> CaliptraResult<()> {
-        let persistent_data = self.persistent_data.get();
-        let idx = self.get_caliptra_managed_dpe_context_index(tci_type)?;
-        let ctx = persistent_data
-            .fw
-            .dpe
-            .state
-            .contexts
-            .get(idx)
-            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
-        if ctx.state == ContextState::Inactive
-            || ctx.context_type != ContextType::Normal
-            || ctx.tci.tci_type != tci_type
-            || locality.is_some_and(|locality| ctx.locality != locality)
-        {
-            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
-        }
-        let prev_journey = persistent_data
-            .fw
-            .dpe
-            .state
-            .contexts
-            .get(idx)
-            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?
-            .tci
-            .tci_cumulative
-            .0;
+        let tci_type = caliptra_managed_context.tci_type();
+        let (idx, prev_journey) = {
+            let persistent_data = self.persistent_data.get();
+            let Some(idx) = self.get_caliptra_managed_dpe_context_index(caliptra_managed_context)
+            else {
+                return Ok(());
+            };
+            let ctx = persistent_data
+                .fw
+                .dpe
+                .state
+                .contexts
+                .get(idx)
+                .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            if ctx.state == ContextState::Inactive
+                || ctx.context_type != ContextType::Normal
+                || ctx.tci.tci_type != tci_type
+                || locality.is_some_and(|locality| ctx.locality != locality)
+            {
+                return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
+            }
+            if ctx.tci.tci_current.0 == *measurement {
+                return Ok(());
+            }
+            (idx, ctx.tci.tci_cumulative.0)
+        };
 
         let mut digest_op = self.sha2_512_384.sha384_digest_init()?;
         digest_op.update(&prev_journey)?;
@@ -553,7 +593,7 @@ impl Drivers {
         let initialization_values_hash: [u8; 48] =
             <[u8; 48]>::from(Self::compute_initialization_values_hash(drivers)?);
         drivers.update_caliptra_managed_measurement(
-            Self::CCIV_TCI_TYPE,
+            CaliptraManagedDpeContext::Cciv,
             &initialization_values_hash,
             None,
         )
@@ -774,12 +814,17 @@ impl Drivers {
             }
             Err(CaliptraError::RUNTIME_ADD_CCIV_MEASUREMENT_TO_DPE_FAILED)?
         }
-        pdata.fw.dpe.caliptra_managed_dpe_context_indices.cciv = u8::try_from(
+        let cciv_idx = u8::try_from(
             env.state
                 .get_active_context_pos(&ContextHandle::default(), pl0_pauser_locality)
                 .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
         )
         .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        pdata
+            .fw
+            .dpe
+            .caliptra_managed_dpe_context_indices
+            .set_cciv(cciv_idx);
 
         // Call DeriveContext to create TCIs for each measurement added in ROM
         let num_measurements = pdata.rom.fht.meas_log_index as usize;

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -55,11 +55,11 @@ use caliptra_dpe_crypto::ecdsa::EcdsaPubKey;
 use caliptra_dpe_crypto::{Digest, PubKey};
 use caliptra_drivers::{
     hand_off::DataStore,
-    pcr_log::{RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
+    pcr_log::{PCR_ID_STASH_MEASUREMENT, RT_FW_CURRENT_PCR, RT_FW_JOURNEY_PCR},
     sha2_512_384::Sha2DigestOpTrait,
-    Abr, Aes, Array4x12, CaliptraError, CaliptraResult, Ecc384, Hmac, KeyId, KeyVault, Lms,
-    PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha256, Sha256Alg, Sha2_512_384,
-    Sha2_512_384Acc, Sha3, SocIfc, Trng,
+    Abr, Aes, Array4x12, CaliptraError, CaliptraManagedDpeContextIndices, CaliptraResult, Ecc384,
+    Hmac, KeyId, KeyVault, Lms, PcrBank, PersistentDataAccessor, Pic, ResetReason, Sha256,
+    Sha256Alg, Sha2_512_384, Sha2_512_384Acc, Sha3, SocIfc, Trng,
 };
 use caliptra_drivers::{okref, Dma, DmaMmio, Mldsa87PubKey};
 use caliptra_image_types::ImageManifest;
@@ -174,6 +174,9 @@ pub struct Drivers {
 }
 
 impl Drivers {
+    pub const CCIV_TCI_TYPE: u32 = u32::from_be_bytes(*b"CCIV");
+    pub const MCU_RT_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
+
     /// # Safety
     ///
     /// Callers must ensure that this function is called only once, and that
@@ -252,6 +255,7 @@ impl Drivers {
                 if self.soc_ifc.subsystem_mode() {
                     RecoveryFlow::recovery_flow(self)?;
                 }
+                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::UpdateReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::UpdateReset);
@@ -259,6 +263,9 @@ impl Drivers {
                 Self::validate_context_tags(self)?;
                 Self::update_dpe_rt_tci(self)?;
                 Self::update_dpe_cciv(self)?;
+                // Repopulate appended context-index cache for hitless updates
+                // from older runtimes that did not have these persistent fields.
+                self.cache_caliptra_managed_dpe_context_indices()?;
             }
             ResetReason::WarmReset => {
                 cfi_assert_eq(self.soc_ifc.reset_reason(), ResetReason::WarmReset);
@@ -309,49 +316,149 @@ impl Drivers {
         Ok(root_idx)
     }
 
-    /// Returns the index of the single CCIV context that is an immediate child of the DPE root.
-    /// Errors if none or if multiple are found.
-    ///
-    /// # Arguments
-    ///
-    /// * `dpe` - DpeInstance
-    ///
-    /// # Returns
-    ///
-    /// * `usize` - Index containing the CCIV DPE context
     #[inline(always)]
-    pub fn get_dpe_cciv_context_idx(dpe: &caliptra_dpe::State) -> CaliptraResult<usize> {
-        // Find the root context index using your existing helper
-        let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
-
-        let cciv_type = u32::from_be_bytes(*b"CCIV");
+    pub fn get_dpe_context_idx_by_tci_type(
+        dpe: &caliptra_dpe::State,
+        tci_type: u32,
+        locality: Option<u32>,
+        parent_idx: Option<u8>,
+    ) -> CaliptraResult<usize> {
         let mut found_idx: Option<usize> = None;
 
-        // Search only immediate children of root for an active, Normal CCIV context
         for (idx, ctx) in dpe.contexts.iter().enumerate() {
             if ctx.state != ContextState::Inactive
                 && ctx.context_type == ContextType::Normal
-                && ctx.parent_idx == root_idx
-                && ctx.tci.tci_type == cciv_type
+                && ctx.tci.tci_type == tci_type
+                && locality.is_none_or(|locality| ctx.locality == locality)
+                && parent_idx.is_none_or(|parent_idx| ctx.parent_idx == parent_idx)
             {
                 if found_idx.is_some() {
-                    // Multiple CCIV children found under root
-                    return Err(CaliptraError::RUNTIME_MULTIPLE_CCIV_CONTEXTS_FOUND);
+                    return Err(CaliptraError::RUNTIME_MULTIPLE_DPE_CONTEXTS_FOUND);
                 }
                 found_idx = Some(idx);
             }
         }
 
-        match found_idx {
-            Some(idx) => {
-                // prevent panic
-                if idx >= dpe.contexts.len() {
-                    return Err(CaliptraError::RUNTIME_CCIV_CONTEXT_NOT_FOUND);
-                }
-                Ok(idx)
-            }
-            None => Err(CaliptraError::RUNTIME_CCIV_CONTEXT_NOT_FOUND),
+        found_idx.ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)
+    }
+
+    #[inline(always)]
+    fn get_caliptra_managed_dpe_context_index(&self, tci_type: u32) -> CaliptraResult<usize> {
+        let indices = self
+            .persistent_data
+            .get()
+            .fw
+            .dpe
+            .caliptra_managed_dpe_context_indices;
+        let idx = match tci_type {
+            Self::CCIV_TCI_TYPE => indices.cciv,
+            Self::MCU_RT_TCI_TYPE => indices.mcu_rt,
+            _ => return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND),
+        };
+
+        Ok(idx as usize)
+    }
+
+    fn cache_caliptra_managed_dpe_context_indices(&mut self) -> CaliptraResult<()> {
+        if self.persistent_data.get().fw.dpe.attestation_disabled.get() {
+            return Ok(());
         }
+
+        let (cciv_idx, mcu_rt_idx) = {
+            let persistent_data = self.persistent_data.get();
+            let dpe = &persistent_data.fw.dpe.state;
+            let root_idx = Self::get_dpe_root_context_idx(dpe)? as u8;
+            let cciv_idx = Self::get_dpe_context_idx_by_tci_type(
+                dpe,
+                Self::CCIV_TCI_TYPE,
+                None,
+                Some(root_idx),
+            )?;
+            let mcu_rt_idx = Self::get_dpe_context_idx_by_tci_type(
+                dpe,
+                Self::MCU_RT_TCI_TYPE,
+                Some(persistent_data.rom.manifest1.header.pl0_pauser),
+                None,
+            )
+            .ok();
+            (cciv_idx, mcu_rt_idx)
+        };
+
+        let indices = &mut self
+            .persistent_data
+            .get_mut()
+            .fw
+            .dpe
+            .caliptra_managed_dpe_context_indices;
+        indices.cciv =
+            u8::try_from(cciv_idx).map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        if let Some(mcu_rt_idx) = mcu_rt_idx {
+            indices.mcu_rt = u8::try_from(mcu_rt_idx)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn update_caliptra_managed_measurement(
+        &mut self,
+        tci_type: u32,
+        measurement: &[u8; 48],
+        locality: Option<u32>,
+    ) -> CaliptraResult<()> {
+        let persistent_data = self.persistent_data.get();
+        let idx = self.get_caliptra_managed_dpe_context_index(tci_type)?;
+        let ctx = persistent_data
+            .fw
+            .dpe
+            .state
+            .contexts
+            .get(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        if ctx.state == ContextState::Inactive
+            || ctx.context_type != ContextType::Normal
+            || ctx.tci.tci_type != tci_type
+            || locality.is_some_and(|locality| ctx.locality != locality)
+        {
+            return Err(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND);
+        }
+        let prev_journey = persistent_data
+            .fw
+            .dpe
+            .state
+            .contexts
+            .get(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?
+            .tci
+            .tci_cumulative
+            .0;
+
+        let mut digest_op = self.sha2_512_384.sha384_digest_init()?;
+        digest_op.update(&prev_journey)?;
+        digest_op.update(measurement)?;
+        let mut journey_hash = Array4x12::default();
+        digest_op.finalize(&mut journey_hash)?;
+        let new_journey: [u8; 48] = journey_hash.into();
+
+        let context = self
+            .persistent_data
+            .get_mut()
+            .fw
+            .dpe
+            .state
+            .contexts
+            .get_mut(idx)
+            .ok_or(CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+        context.tci.tci_current = TciMeasurement(*measurement);
+        context.tci.tci_cumulative = TciMeasurement(new_journey);
+        self.pcr_bank.extend_pcr(
+            PCR_ID_STASH_MEASUREMENT,
+            &mut self.sha2_512_384,
+            measurement,
+        )?;
+        Ok(())
     }
 
     pub fn set_mcu_reset_reason(drivers: &mut Drivers, reason: McuResetReason) {
@@ -445,29 +552,11 @@ impl Drivers {
         }
         let initialization_values_hash: [u8; 48] =
             <[u8; 48]>::from(Self::compute_initialization_values_hash(drivers)?);
-        let dpe = &mut drivers.persistent_data.get_mut().fw.dpe.state;
-        let cciv_idx = Self::get_dpe_cciv_context_idx(dpe)?;
-
-        // Only update if changed
-        let prev_current: [u8; 48] = dpe.contexts[cciv_idx].tci.tci_current.0;
-        if prev_current == initialization_values_hash {
-            return Ok(());
-        }
-
-        // Compute new journey: SHA-384(prev_journey || initialization_values_hash)
-        let prev_journey: [u8; 48] = dpe.contexts[cciv_idx].tci.tci_cumulative.0;
-        let mut digest_op = drivers.sha2_512_384.sha384_digest_init()?;
-        digest_op.update(&prev_journey)?;
-        digest_op.update(&initialization_values_hash)?;
-        let mut journey_hash = Array4x12::default();
-        digest_op.finalize(&mut journey_hash)?;
-        let new_journey: [u8; 48] = journey_hash.into();
-
-        // Update CCIV current and cumulative
-        dpe.contexts[cciv_idx].tci.tci_current = TciMeasurement(initialization_values_hash);
-        dpe.contexts[cciv_idx].tci.tci_cumulative = TciMeasurement(new_journey);
-
-        Ok(())
+        drivers.update_caliptra_managed_measurement(
+            Self::CCIV_TCI_TYPE,
+            &initialization_values_hash,
+            None,
+        )
     }
 
     fn update_fw_version(drivers: &mut Drivers, update_fmc_ver: bool, update_rt_ver: bool) {
@@ -685,6 +774,12 @@ impl Drivers {
             }
             Err(CaliptraError::RUNTIME_ADD_CCIV_MEASUREMENT_TO_DPE_FAILED)?
         }
+        pdata.fw.dpe.caliptra_managed_dpe_context_indices.cciv = u8::try_from(
+            env.state
+                .get_active_context_pos(&ContextHandle::default(), pl0_pauser_locality)
+                .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?,
+        )
+        .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
 
         // Call DeriveContext to create TCIs for each measurement added in ROM
         let num_measurements = pdata.rom.fht.meas_log_index as usize;

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -14,9 +14,11 @@ Abstract:
 
 use crate::{
     activate_firmware::MCI_TOP_REG_RESET_REASON_OFFSET,
-    authorize_and_stash::AuthorizeAndStashCmd,
+    authorize_and_stash::{
+        AuthorizeAndStashCmd, IMAGE_AUTHORIZED_OWNER_ONLY, IMAGE_AUTHORIZED_VENDOR_OWNER,
+    },
     drivers::{McuFwStatus, McuResetReason},
-    Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
+    Drivers, SetAuthManifestCmd,
 };
 use caliptra_auth_man_types::AuthorizationManifest;
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -138,12 +140,14 @@ impl RecoveryFlow {
         let digest: [u8; 48] = digest.into();
         cprintln!("[rt] Verifying MCU digest: {}", HexBytes(&digest));
         // verify the digest
+        let soc_manifest_svn = drivers.persistent_data.get().fw.dpe.soc_manifest_svn;
         let auth_and_stash_req = AuthorizeAndStashReq {
             fw_id: [2, 0, 0, 0],
             measurement: digest,
             source: ImageHashSource::InRequest.into(),
             // We want to make sure this measurement is not skipped.
             flags: 0,
+            svn: soc_manifest_svn,
             ..Default::default()
         };
 
@@ -173,7 +177,9 @@ impl RecoveryFlow {
                 dma,
             );
 
-            if auth_result != IMAGE_AUTHORIZED {
+            if auth_result != IMAGE_AUTHORIZED_VENDOR_OWNER
+                && auth_result != IMAGE_AUTHORIZED_OWNER_ONLY
+            {
                 Self::set_recovery_boot_failure(
                     drivers,
                     MCU_FIRMWARE_INDEX,

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -18,6 +18,7 @@ use crate::{
         AuthorizeAndStashCmd, IMAGE_AUTHORIZED_OWNER_ONLY, IMAGE_AUTHORIZED_VENDOR_OWNER,
     },
     drivers::{McuFwStatus, McuResetReason},
+    set_auth_manifest::AuthManifestUpdateMode,
     Drivers, SetAuthManifestCmd,
 };
 use caliptra_auth_man_types::AuthorizationManifest;
@@ -84,7 +85,12 @@ impl RecoveryFlow {
             buffer.as_bytes()
         };
 
-        if let Err(err) = SetAuthManifestCmd::set_auth_manifest(drivers, source, false) {
+        if let Err(err) = SetAuthManifestCmd::set_auth_manifest(
+            drivers,
+            source,
+            false,
+            AuthManifestUpdateMode::CreateMissingDpeContexts,
+        ) {
             let recovery_reason = DmaRecovery::recovery_reason_from_auth_manifest_error(err);
             Self::set_recovery_boot_failure(drivers, SOC_MANIFEST_INDEX, recovery_reason)?;
             return Err(err);

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -811,6 +811,10 @@ impl SetAuthManifestCmd {
         if !verify_only {
             persistent_data.fw.auth_manifest_digest =
                 drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            // Store the SoC manifest SVN for use as the MCU RT current_svn
+            // when creating the MCU RT DPE context during recovery boot or
+            // hitless update.
+            persistent_data.fw.dpe.soc_manifest_svn = auth_manifest_preamble.svn;
         }
         Ok(())
     }

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,7 +15,10 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::{manifest::sorted_metadata_lists_overlap, Drivers, PauserPrivileges};
+use crate::{
+    drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers,
+    PauserPrivileges,
+};
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, OwnerAuthManifestImageMetadataCollection,
@@ -38,6 +41,12 @@ use caliptra_image_types::{
 use memoffset::offset_of;
 use zerocopy::{FromBytes, IntoBytes};
 use zeroize::Zeroize;
+
+#[derive(Clone, Copy)]
+pub(crate) enum AuthManifestUpdateMode {
+    UpdateExisting,
+    CreateMissingDpeContexts,
+}
 
 pub struct SetAuthManifestCmd;
 impl SetAuthManifestCmd {
@@ -62,6 +71,69 @@ impl SetAuthManifestCmd {
             .ok_or(err)?
             .get(..len as usize)
             .ok_or(err)
+    }
+
+    fn digest_to_measurement(digest: &ImageDigest384) -> [u8; SHA384_DIGEST_BYTE_SIZE] {
+        Array4x12::from(digest).into()
+    }
+
+    fn update_soc_manifest_dpe_contexts(
+        drivers: &mut Drivers,
+        auth_manifest_preamble: &AuthManifestPreamble,
+        update_mode: AuthManifestUpdateMode,
+    ) -> CaliptraResult<()> {
+        if drivers
+            .persistent_data
+            .get()
+            .fw
+            .dpe
+            .attestation_disabled
+            .get()
+        {
+            return Ok(());
+        }
+
+        let create_if_missing = matches!(
+            update_mode,
+            AuthManifestUpdateMode::CreateMissingDpeContexts
+        );
+        let manifest_bytes = auth_manifest_preamble.as_bytes();
+        let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+        let vendor_measurement = Self::digest_to_measurement(&Self::sha384_digest(
+            &mut drivers.sha2_512_384,
+            manifest_bytes,
+            vendor_range.start,
+            vendor_range.len() as u32,
+        )?);
+        let owner_range = AuthManifestPreamble::owner_pub_keys_range();
+        let owner_measurement = Self::digest_to_measurement(&Self::sha384_digest(
+            &mut drivers.sha2_512_384,
+            manifest_bytes,
+            owner_range.start,
+            owner_range.len() as u32,
+        )?);
+        let pl0_pauser_locality = drivers
+            .persistent_data
+            .get()
+            .rom
+            .manifest1
+            .header
+            .pl0_pauser;
+
+        drivers.create_or_update_caliptra_managed_measurement(
+            CaliptraManagedDpeContext::Somv,
+            &vendor_measurement,
+            auth_manifest_preamble.svn,
+            pl0_pauser_locality,
+            create_if_missing,
+        )?;
+        drivers.create_or_update_caliptra_managed_measurement(
+            CaliptraManagedDpeContext::Somo,
+            &owner_measurement,
+            0,
+            pl0_pauser_locality,
+            create_if_missing,
+        )
     }
 
     pub(crate) fn ecc384_verify(
@@ -712,7 +784,12 @@ impl SetAuthManifestCmd {
                 .ok_or(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?
         };
 
-        Self::set_auth_manifest(drivers, manifest_buf, verify_only)?;
+        Self::set_auth_manifest(
+            drivers,
+            manifest_buf,
+            verify_only,
+            AuthManifestUpdateMode::UpdateExisting,
+        )?;
         Ok(0)
     }
 
@@ -720,6 +797,7 @@ impl SetAuthManifestCmd {
         drivers: &mut Drivers,
         manifest_buf: &[u8],
         verify_only: bool,
+        update_mode: AuthManifestUpdateMode,
     ) -> CaliptraResult<()> {
         let preamble_size = size_of::<AuthManifestPreamble>();
         let auth_manifest_preamble = {
@@ -749,11 +827,10 @@ impl SetAuthManifestCmd {
         //  - Provisioned    -> trust the fuse
         // ---------------------------------------------------------------------
 
-        let persistent_data = drivers.persistent_data.get_mut();
-
-        let manifest_pqc_key_type =
-            FwVerificationPqcKeyType::from_u8(persistent_data.rom.manifest1.pqc_key_type)
-                .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE)?;
+        let manifest_pqc_key_type = FwVerificationPqcKeyType::from_u8(
+            drivers.persistent_data.get().rom.manifest1.pqc_key_type,
+        )
+        .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_INVALID_PQC_KEY_TYPE)?;
 
         let pqc_key_type = if drivers.soc_ifc.lifecycle() == Lifecycle::Unprovisioned {
             manifest_pqc_key_type
@@ -768,53 +845,60 @@ impl SetAuthManifestCmd {
 
             fuse_pqc_key_type
         };
-        let persistent_data = drivers.persistent_data.get_mut();
-        drivers.abr.with_mldsa87(|mut mldsa87| {
-            // Verify the vendor signed data (vendor public keys + flags).
-            Self::verify_vendor_signed_data(
-                auth_manifest_preamble,
-                &persistent_data.rom.manifest1.preamble,
-                &mut drivers.sha2_512_384,
-                &mut drivers.ecc384,
-                &mut drivers.sha256,
-                &mut mldsa87,
-                pqc_key_type,
-            )?;
 
-            // Verify the owner public keys.
-            Self::verify_owner_pub_keys(
-                auth_manifest_preamble,
-                &persistent_data.rom.manifest1.preamble,
-                &mut drivers.sha2_512_384,
-                &mut drivers.ecc384,
-                &mut drivers.sha256,
-                &mut mldsa87,
-                pqc_key_type,
-            )?;
+        {
+            let persistent_data = drivers.persistent_data.get_mut();
+            drivers.abr.with_mldsa87(|mut mldsa87| {
+                // Verify the vendor signed data (vendor public keys + flags).
+                Self::verify_vendor_signed_data(
+                    auth_manifest_preamble,
+                    &persistent_data.rom.manifest1.preamble,
+                    &mut drivers.sha2_512_384,
+                    &mut drivers.ecc384,
+                    &mut drivers.sha256,
+                    &mut mldsa87,
+                    pqc_key_type,
+                )?;
 
-            Self::process_image_metadata_col(
-                manifest_buf
-                    .get(preamble_size..)
-                    .ok_or(CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE)?,
-                auth_manifest_preamble,
-                &mut persistent_data.fw.auth_manifest_image_metadata_col,
-                &persistent_data.fw.owner_auth_manifest_image_metadata_col,
-                &mut drivers.sha2_512_384,
-                &mut drivers.ecc384,
-                &mut drivers.sha256,
-                &mut mldsa87,
-                pqc_key_type,
-                verify_only,
-            )
-        })?;
+                // Verify the owner public keys.
+                Self::verify_owner_pub_keys(
+                    auth_manifest_preamble,
+                    &persistent_data.rom.manifest1.preamble,
+                    &mut drivers.sha2_512_384,
+                    &mut drivers.ecc384,
+                    &mut drivers.sha256,
+                    &mut mldsa87,
+                    pqc_key_type,
+                )?;
+
+                Self::process_image_metadata_col(
+                    manifest_buf.get(preamble_size..).ok_or(
+                        CaliptraError::RUNTIME_AUTH_MANIFEST_IMAGE_METADATA_LIST_INVALID_SIZE,
+                    )?,
+                    auth_manifest_preamble,
+                    &mut persistent_data.fw.auth_manifest_image_metadata_col,
+                    &persistent_data.fw.owner_auth_manifest_image_metadata_col,
+                    &mut drivers.sha2_512_384,
+                    &mut drivers.ecc384,
+                    &mut drivers.sha256,
+                    &mut mldsa87,
+                    pqc_key_type,
+                    verify_only,
+                )
+            })?;
+        }
 
         if !verify_only {
-            persistent_data.fw.auth_manifest_digest =
-                drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            let auth_manifest_digest = drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            {
+                let persistent_data = drivers.persistent_data.get_mut();
+                persistent_data.fw.auth_manifest_digest = auth_manifest_digest;
+                persistent_data.fw.dpe.soc_manifest_svn = auth_manifest_preamble.svn;
+            }
             // Store the SoC manifest SVN for use as the MCU RT current_svn
             // when creating the MCU RT DPE context during recovery boot or
             // hitless update.
-            persistent_data.fw.dpe.soc_manifest_svn = auth_manifest_preamble.svn;
+            Self::update_soc_manifest_dpe_contexts(drivers, auth_manifest_preamble, update_mode)?;
         }
         Ok(())
     }

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -86,6 +86,25 @@ impl StashMeasurementCmd {
         };
 
         if let DpeErrorCode::NoError = dpe_result {
+            if metadata == &[2, 0, 0, 0] {
+                let mcu_rt_dpe_context_idx = drivers
+                    .persistent_data
+                    .get()
+                    .fw
+                    .dpe
+                    .state
+                    .get_active_context_pos(&ContextHandle::default(), locality)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                drivers
+                    .persistent_data
+                    .get_mut()
+                    .fw
+                    .dpe
+                    .caliptra_managed_dpe_context_indices
+                    .mcu_rt = u8::try_from(mcu_rt_dpe_context_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+            }
+
             // Extend the measurement into PCR31
             drivers.pcr_bank.extend_pcr(
                 PCR_ID_STASH_MEASUREMENT,

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -95,14 +95,15 @@ impl StashMeasurementCmd {
                     .state
                     .get_active_context_pos(&ContextHandle::default(), locality)
                     .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                let mcu_rt_dpe_context_idx = u8::try_from(mcu_rt_dpe_context_idx)
+                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
                 drivers
                     .persistent_data
                     .get_mut()
                     .fw
                     .dpe
                     .caliptra_managed_dpe_context_indices
-                    .mcu_rt = u8::try_from(mcu_rt_dpe_context_idx)
-                    .map_err(|_| CaliptraError::RUNTIME_DPE_CONTEXT_NOT_FOUND)?;
+                    .set_mcu_rt(mcu_rt_dpe_context_idx);
             }
 
             // Extend the measurement into PCR31

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -33,6 +33,12 @@ const OPCODE_READ_DPE_ROOT_CONTEXT_MEASUREMENT: u32 = 0x6000_0000;
 const OPCODE_READ_DPE_ROOT_CONTEXT_CUMULATIVE: u32 = 0x6000_0001;
 const OPCODE_READ_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0002;
 const OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0003;
+const OPCODE_INVALIDATE_DPE_INDEX_CACHE: u32 = 0x6000_0004;
+const OPCODE_READ_DPE_INDEX_CACHE: u32 = 0x6000_0005;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0006;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0007;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT: u32 = 0x6000_0008;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE: u32 = 0x6000_0009;
 const OPCODE_READ_DPE_TAGS: u32 = 0x7000_0000;
 const OPCODE_CORRUPT_CONTEXT_TAGS: u32 = 0x8000_0000;
 const OPCODE_CORRUPT_CONTEXT_HAS_TAG: u32 = 0x9000_0000;
@@ -259,6 +265,69 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     .tci_cumulative
                     .as_bytes();
                 write_response(&mut drivers.mbox, cciv_measurement);
+            }
+            CommandId(OPCODE_INVALIDATE_DPE_INDEX_CACHE) => {
+                drivers
+                    .persistent_data
+                    .get_mut()
+                    .caliptra_managed_dpe_context_indices
+                    .invalidate();
+                write_response(&mut drivers.mbox, &[]);
+            }
+            CommandId(OPCODE_READ_DPE_INDEX_CACHE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                write_response(&mut drivers.mbox, indices.as_bytes());
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.cciv as usize]
+                    .tci
+                    .tci_current
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.cciv as usize]
+                    .tci
+                    .tci_cumulative
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.mcu_rt as usize]
+                    .tci
+                    .tci_current
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
+            }
+            CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE) => {
+                let indices = drivers
+                    .persistent_data
+                    .get()
+                    .caliptra_managed_dpe_context_indices;
+                let measurement = drivers.persistent_data.get().state.contexts
+                    [indices.mcu_rt as usize]
+                    .tci
+                    .tci_cumulative
+                    .as_bytes();
+                write_response(&mut drivers.mbox, measurement);
             }
             CommandId(OPCODE_READ_DPE_TAGS) => {
                 let context_tags = drivers.persistent_data.get().fw.dpe.context_tags;

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -63,6 +63,62 @@ fn write_response(mbox: &mut Mailbox, data: &[u8]) {
     mbox.set_status(MboxStatusE::DataReady);
 }
 
+#[inline(never)]
+fn invalidate_dpe_index_cache(drivers: &mut Drivers) {
+    drivers
+        .persistent_data
+        .get_mut()
+        .fw
+        .dpe
+        .caliptra_managed_dpe_context_indices
+        .invalidate();
+    write_response(&mut drivers.mbox, &[]);
+}
+
+#[inline(never)]
+fn read_dpe_index_cache(drivers: &mut Drivers) {
+    let indices = drivers
+        .persistent_data
+        .get()
+        .fw
+        .dpe
+        .caliptra_managed_dpe_context_indices;
+    write_response(&mut drivers.mbox, indices.as_bytes());
+}
+
+#[inline(never)]
+fn read_cached_dpe_context_measurement(drivers: &mut Drivers, context_idx: u8, cumulative: bool) {
+    let context = &drivers.persistent_data.get().fw.dpe.state.contexts[context_idx as usize];
+    let measurement = if cumulative {
+        context.tci.tci_cumulative.as_bytes()
+    } else {
+        context.tci.tci_current.as_bytes()
+    };
+    write_response(&mut drivers.mbox, measurement);
+}
+
+#[inline(never)]
+fn read_cached_dpe_cciv_context_measurement(drivers: &mut Drivers, cumulative: bool) {
+    let indices = drivers
+        .persistent_data
+        .get()
+        .fw
+        .dpe
+        .caliptra_managed_dpe_context_indices;
+    read_cached_dpe_context_measurement(drivers, indices.cciv, cumulative);
+}
+
+#[inline(never)]
+fn read_cached_dpe_mcu_rt_context_measurement(drivers: &mut Drivers, cumulative: bool) {
+    let indices = drivers
+        .persistent_data
+        .get()
+        .fw
+        .dpe
+        .caliptra_managed_dpe_context_indices;
+    read_cached_dpe_context_measurement(drivers, indices.mcu_rt, cumulative);
+}
+
 const BANNER: &str = r#"
   ____      _ _       _               ____ _____
  / ___|__ _| (_)_ __ | |_ _ __ __ _  |  _ \_   _|
@@ -244,10 +300,7 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     Some(root_idx),
                 )
                 .unwrap();
-                let cciv_measurement = dpe.contexts[cciv_idx]
-                    .tci
-                    .tci_current
-                    .as_bytes();
+                let cciv_measurement = dpe.contexts[cciv_idx].tci.tci_current.as_bytes();
                 write_response(&mut drivers.mbox, cciv_measurement);
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE) => {
@@ -260,74 +313,26 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                     Some(root_idx),
                 )
                 .unwrap();
-                let cciv_measurement = dpe.contexts[cciv_idx]
-                    .tci
-                    .tci_cumulative
-                    .as_bytes();
+                let cciv_measurement = dpe.contexts[cciv_idx].tci.tci_cumulative.as_bytes();
                 write_response(&mut drivers.mbox, cciv_measurement);
             }
             CommandId(OPCODE_INVALIDATE_DPE_INDEX_CACHE) => {
-                drivers
-                    .persistent_data
-                    .get_mut()
-                    .caliptra_managed_dpe_context_indices
-                    .invalidate();
-                write_response(&mut drivers.mbox, &[]);
+                invalidate_dpe_index_cache(drivers);
             }
             CommandId(OPCODE_READ_DPE_INDEX_CACHE) => {
-                let indices = drivers
-                    .persistent_data
-                    .get()
-                    .caliptra_managed_dpe_context_indices;
-                write_response(&mut drivers.mbox, indices.as_bytes());
+                read_dpe_index_cache(drivers);
             }
             CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT) => {
-                let indices = drivers
-                    .persistent_data
-                    .get()
-                    .caliptra_managed_dpe_context_indices;
-                let measurement = drivers.persistent_data.get().state.contexts
-                    [indices.cciv as usize]
-                    .tci
-                    .tci_current
-                    .as_bytes();
-                write_response(&mut drivers.mbox, measurement);
+                read_cached_dpe_cciv_context_measurement(drivers, false);
             }
             CommandId(OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE) => {
-                let indices = drivers
-                    .persistent_data
-                    .get()
-                    .caliptra_managed_dpe_context_indices;
-                let measurement = drivers.persistent_data.get().state.contexts
-                    [indices.cciv as usize]
-                    .tci
-                    .tci_cumulative
-                    .as_bytes();
-                write_response(&mut drivers.mbox, measurement);
+                read_cached_dpe_cciv_context_measurement(drivers, true);
             }
             CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT) => {
-                let indices = drivers
-                    .persistent_data
-                    .get()
-                    .caliptra_managed_dpe_context_indices;
-                let measurement = drivers.persistent_data.get().state.contexts
-                    [indices.mcu_rt as usize]
-                    .tci
-                    .tci_current
-                    .as_bytes();
-                write_response(&mut drivers.mbox, measurement);
+                read_cached_dpe_mcu_rt_context_measurement(drivers, false);
             }
             CommandId(OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE) => {
-                let indices = drivers
-                    .persistent_data
-                    .get()
-                    .caliptra_managed_dpe_context_indices;
-                let measurement = drivers.persistent_data.get().state.contexts
-                    [indices.mcu_rt as usize]
-                    .tci
-                    .tci_cumulative
-                    .as_bytes();
-                write_response(&mut drivers.mbox, measurement);
+                read_cached_dpe_mcu_rt_context_measurement(drivers, true);
             }
             CommandId(OPCODE_READ_DPE_TAGS) => {
                 let context_tags = drivers.persistent_data.get().fw.dpe.context_tags;

--- a/runtime/test-fw/src/mbox_responder.rs
+++ b/runtime/test-fw/src/mbox_responder.rs
@@ -229,22 +229,32 @@ pub fn handle_command(drivers: &mut Drivers) -> CaliptraResult<MboxStatusE> {
                 write_response(&mut drivers.mbox, root_measurement);
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_MEASUREMENT) => {
-                let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().fw.dpe.state)
-                        .unwrap();
-                let cciv_measurement = drivers.persistent_data.get().fw.dpe.state.contexts
-                    [cciv_idx]
+                let dpe = &drivers.persistent_data.get().fw.dpe.state;
+                let root_idx = Drivers::get_dpe_root_context_idx(dpe).unwrap() as u8;
+                let cciv_idx = Drivers::get_dpe_context_idx_by_tci_type(
+                    dpe,
+                    Drivers::CCIV_TCI_TYPE,
+                    None,
+                    Some(root_idx),
+                )
+                .unwrap();
+                let cciv_measurement = dpe.contexts[cciv_idx]
                     .tci
                     .tci_current
                     .as_bytes();
                 write_response(&mut drivers.mbox, cciv_measurement);
             }
             CommandId(OPCODE_READ_DPE_CCIV_CONTEXT_CUMULATIVE) => {
-                let cciv_idx =
-                    Drivers::get_dpe_cciv_context_idx(&drivers.persistent_data.get().fw.dpe.state)
-                        .unwrap();
-                let cciv_measurement = drivers.persistent_data.get().fw.dpe.state.contexts
-                    [cciv_idx]
+                let dpe = &drivers.persistent_data.get().fw.dpe.state;
+                let root_idx = Drivers::get_dpe_root_context_idx(dpe).unwrap() as u8;
+                let cciv_idx = Drivers::get_dpe_context_idx_by_tci_type(
+                    dpe,
+                    Drivers::CCIV_TCI_TYPE,
+                    None,
+                    Some(root_idx),
+                )
+                .unwrap();
+                let cciv_measurement = dpe.contexts[cciv_idx]
                     .tci
                     .tci_cumulative
                     .as_bytes();

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -93,6 +93,11 @@ pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::MLDSA,
 ];
 
+/// PQC key type used by `run_rt_test*` (and therefore by the default SoC
+/// manifest delivered over the recovery interface) when a test does not pick
+/// one explicitly.
+pub const DEFAULT_PQC_KEY_TYPE: FwVerificationPqcKeyType = FwVerificationPqcKeyType::MLDSA;
+
 fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> AuthorizationManifest {
     // generate a default SoC manifest if one is not provided in subsystem mode
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
@@ -129,8 +134,12 @@ pub fn default_soc_manifest_measurements(
     soc_manifest_measurements(&manifest)
 }
 
-pub fn default_lms_soc_manifest_measurements(svn: u32) -> ([u8; 48], [u8; 48]) {
-    default_soc_manifest_measurements(FwVerificationPqcKeyType::LMS, svn)
+/// SOMV/SOMO measurements of the SoC manifest that `run_rt_test*` delivers over
+/// the recovery interface when the test does not supply one. Must track the key
+/// type that `run_rt_test_return_fw` defaults to, otherwise the expected DPE
+/// measurements will not match the ones Caliptra actually computed.
+pub fn default_rt_test_soc_manifest_measurements(svn: u32) -> ([u8; 48], [u8; 48]) {
+    default_soc_manifest_measurements(DEFAULT_PQC_KEY_TYPE, svn)
 }
 
 #[derive(Default)]
@@ -408,7 +417,7 @@ pub fn run_rt_test(args: RuntimeTestArgs) -> DefaultHwModel {
 }
 
 pub fn run_rt_test_return_fw(args: RuntimeTestArgs) -> (DefaultHwModel, ImageBundle) {
-    let key_type = args.key_type.unwrap_or(FwVerificationPqcKeyType::MLDSA);
+    let key_type = args.key_type.unwrap_or(DEFAULT_PQC_KEY_TYPE);
     run_rt_test_pqc_return_fw(args, key_type)
 }
 

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license
 
+use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
 use anyhow::Context;
 use caliptra_api::{
     mailbox::{
@@ -7,6 +8,9 @@ use caliptra_api::{
         Request,
     },
     SocManager,
+};
+use caliptra_auth_man_types::{
+    AuthManifestImageMetadata, AuthManifestPreamble, AuthorizationManifest, ImageMetadataFlags,
 };
 use caliptra_builder::{
     firmware::{APP_WITH_UART_OCP_LOCK, APP_WITH_UART_OCP_LOCK_FPGA, FMC_WITH_UART},
@@ -39,6 +43,8 @@ use caliptra_hw_model::{
     Fuses, HwModel, ImageInfo, InitParams, ModelCallback, ModelError, SecurityState, StackInfo,
     StackRange, SubsystemInitParams,
 };
+use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_gen::{from_hw_format, ImageGeneratorCrypto};
 use caliptra_image_types::ImageBundle;
 use caliptra_runtime::CaliptraDpeProfile;
 pub use caliptra_test::{
@@ -56,6 +62,7 @@ use openssl::{
     x509::{X509Builder, X509},
     x509::{X509Name, X509NameBuilder},
 };
+use sha2::{Digest as Sha2DigestTrait, Sha384 as Sha384Hasher};
 use std::borrow::Cow;
 use std::io;
 use zerocopy::{FromZeros, IntoBytes, TryFromBytes};
@@ -85,6 +92,46 @@ pub const PQC_KEY_TYPE: [FwVerificationPqcKeyType; 2] = [
     FwVerificationPqcKeyType::LMS,
     FwVerificationPqcKeyType::MLDSA,
 ];
+
+fn default_soc_manifest(pqc_key_type: FwVerificationPqcKeyType, svn: u32) -> AuthorizationManifest {
+    // generate a default SoC manifest if one is not provided in subsystem mode
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&DEFAULT_MCU_FW).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    create_auth_manifest_with_metadata_with_svn(metadata, pqc_key_type, svn)
+}
+
+pub fn soc_manifest_measurements(manifest: &AuthorizationManifest) -> ([u8; 48], [u8; 48]) {
+    let preamble = manifest.preamble.as_bytes();
+    let vendor_range = AuthManifestPreamble::vendor_signed_data_range();
+    let owner_range = AuthManifestPreamble::owner_pub_keys_range();
+    (
+        Sha384Hasher::digest(&preamble[vendor_range.start as usize..vendor_range.end as usize])
+            .into(),
+        Sha384Hasher::digest(&preamble[owner_range.start as usize..owner_range.end as usize])
+            .into(),
+    )
+}
+
+pub fn default_soc_manifest_measurements(
+    pqc_key_type: FwVerificationPqcKeyType,
+    svn: u32,
+) -> ([u8; 48], [u8; 48]) {
+    let manifest = default_soc_manifest(pqc_key_type, svn);
+    soc_manifest_measurements(&manifest)
+}
+
+pub fn default_lms_soc_manifest_measurements(svn: u32) -> ([u8; 48], [u8; 48]) {
+    default_soc_manifest_measurements(FwVerificationPqcKeyType::LMS, svn)
+}
 
 #[derive(Default)]
 pub struct RuntimeProductionArgs {

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -236,6 +236,7 @@ fn send_activate_firmware_cmd(
     model.finish_mailbox_execute()
 }
 
+#[cfg_attr(feature = "fpga_subsystem", allow(dead_code))]
 fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     let mut tag_cmd = MailboxReq::TagTci(TagTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -254,6 +255,7 @@ fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     get_mcu_tci(model)
 }
 
+#[cfg_attr(feature = "fpga_subsystem", allow(dead_code))]
 fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     let mut get_cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -275,9 +277,12 @@ fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
 #[test]
 fn test_activate_mcu_fw_success() {
     let mcu_contents = mcu_test_firmware();
-    let mut hasher = Sha384::new();
-    hasher.update(&mcu_contents);
-    let mcu_digest: [u8; 48] = hasher.finalize().into();
+    #[cfg(not(feature = "fpga_subsystem"))]
+    let mcu_digest: [u8; 48] = {
+        let mut hasher = Sha384::new();
+        hasher.update(&mcu_contents);
+        hasher.finalize().into()
+    };
 
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
@@ -288,8 +293,19 @@ fn test_activate_mcu_fw_success() {
     };
 
     let mut model = load_and_authorize_fw(&[mcu_image]);
-    let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
-    assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
+
+    // The MCU firmware DPE context is located by tagging the DPE default
+    // context. That only works when Caliptra's measurement of the MCU firmware
+    // is the last context derived. On the subsystem FPGA, MCU ROM stashes the
+    // field entropy state after Caliptra measures the MCU firmware, so the
+    // field entropy context is the default one and the MCU firmware context
+    // cannot be reached by handle.
+    #[cfg(not(feature = "fpga_subsystem"))]
+    let initial_mcu_tci = {
+        let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
+        assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
+        initial_mcu_tci
+    };
 
     // Send ActivateFirmware command
     let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -312,16 +312,14 @@ fn test_activate_mcu_fw_success() {
     {
         let updated_mcu_tci = get_mcu_tci(&mut model);
         assert_eq!(updated_mcu_tci.tci_current, mcu_digest);
-
-        let mut hasher = Sha384::new();
-        hasher.update(initial_mcu_tci.tci_cumulative);
-        hasher.update(mcu_digest);
-        let expected_updated_cumulative: [u8; 48] = hasher.finalize().into();
-        assert_eq!(updated_mcu_tci.tci_cumulative, expected_updated_cumulative);
+        assert_eq!(
+            updated_mcu_tci.tci_cumulative,
+            initial_mcu_tci.tci_cumulative
+        );
     }
 }
 
-#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_activate_mcu_soc_fw_success() {
     let mcu_image = Image {

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -7,8 +7,8 @@ use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
 use caliptra_common::checksum::calc_checksum;
 use caliptra_common::mailbox_api::{
-    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, ImageHashSource, MailboxReq,
-    MailboxReqHeader,
+    AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetTaggedTciReq, GetTaggedTciResp,
+    ImageHashSource, MailboxReq, MailboxReqHeader, TagTciReq,
 };
 use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams, ModelError};
 use caliptra_kat::CaliptraError;
@@ -51,6 +51,7 @@ pub const SOC_STAGING_OFFSET: usize = 0x500;
 // hitless-update reset.
 pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
+const MCU_TCI_TAG: u32 = u32::from_be_bytes(*b"MCFW");
 
 /// Create a valid RISC-V firmware image that won't crash with an illegal
 /// instruction exception on real FPGA hardware. Uses `0x37` repeated, which
@@ -235,18 +236,60 @@ fn send_activate_firmware_cmd(
     model.finish_mailbox_execute()
 }
 
+fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
+    let mut tag_cmd = MailboxReq::TagTci(TagTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        handle: [0u8; 16],
+        tag: MCU_TCI_TAG,
+    });
+    tag_cmd.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_TAG_TCI),
+            tag_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    get_mcu_tci(model)
+}
+
+fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
+    let mut get_cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        tag: MCU_TCI_TAG,
+    });
+    get_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_GET_TAGGED_TCI),
+            get_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap()
+}
+
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_activate_mcu_fw_success() {
+    let mcu_contents = mcu_test_firmware();
+    let mut hasher = Sha384::new();
+    hasher.update(&mcu_contents);
+    let mcu_digest: [u8; 48] = hasher.finalize().into();
+
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
         staging_offset: MCU_STAGING_OFFSET,
         load_offset: MCU_LOAD_OFFSET,
-        contents: mcu_test_firmware(),
+        contents: mcu_contents,
         exec_bit: 2,
     };
 
     let mut model = load_and_authorize_fw(&[mcu_image]);
+    let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
+    assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
 
     // Send ActivateFirmware command
     let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
@@ -264,6 +307,18 @@ fn test_activate_mcu_fw_success() {
     send_activate_firmware_cmd(&mut model, activate_cmd, true)
         .unwrap()
         .expect("We should have received a response");
+
+    #[cfg(not(feature = "fpga_subsystem"))]
+    {
+        let updated_mcu_tci = get_mcu_tci(&mut model);
+        assert_eq!(updated_mcu_tci.tci_current, mcu_digest);
+
+        let mut hasher = Sha384::new();
+        hasher.update(initial_mcu_tci.tci_cumulative);
+        hasher.update(mcu_digest);
+        let expected_updated_cumulative: [u8; 48] = hasher.finalize().into();
+        assert_eq!(updated_mcu_tci.tci_cumulative, expected_updated_cumulative);
+    }
 }
 
 #[cfg_attr(feature = "fpga_realtime", ignore)]

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    calculate_cptra_config_init_vals_hash, default_rt_test_soc_manifest_measurements, run_rt_test,
     soc_manifest_measurements, RuntimeTestArgs,
 };
 use crate::test_set_auth_manifest::{
@@ -60,6 +60,16 @@ pub const TEST_SRAM_BASE: Addr64 = Addr64 {
     hi: 0x0000_0000,
 };
 
+/// The SoC manifest installed by `set_auth_manifest(None)`. Tests that compute
+/// expected DPE SOMV/SOMO measurements must use this same manifest.
+pub fn default_set_auth_manifest() -> AuthorizationManifest {
+    create_auth_manifest(&AuthManifestBuilderCfg {
+        manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+        pqc_key_type: crate::common::DEFAULT_PQC_KEY_TYPE,
+        svn: 1,
+    })
+}
+
 pub fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> DefaultHwModel {
     let runtime_args = RuntimeTestArgs {
         test_image_options: Some(ImageOptions::default()),
@@ -69,15 +79,7 @@ pub fn set_auth_manifest(auth_manifest: Option<AuthorizationManifest>) -> Defaul
     let mut model = run_rt_test(runtime_args);
     model.step_until_ready_for_runtime();
 
-    let auth_manifest = if let Some(auth_manifest) = auth_manifest {
-        auth_manifest
-    } else {
-        create_auth_manifest(&AuthManifestBuilderCfg {
-            manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-            pqc_key_type: FwVerificationPqcKeyType::MLDSA,
-            svn: 1,
-        })
-    };
+    let auth_manifest = auth_manifest.unwrap_or_else(default_set_auth_manifest);
 
     let buf = auth_manifest.as_bytes();
     let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
@@ -123,15 +125,7 @@ pub fn set_auth_manifest_with_test_sram(
 
     model.step_until_ready_for_runtime();
 
-    let auth_manifest = if let Some(auth_manifest) = auth_manifest {
-        auth_manifest
-    } else {
-        create_auth_manifest(&AuthManifestBuilderCfg {
-            manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-            pqc_key_type: FwVerificationPqcKeyType::MLDSA,
-            svn: 1,
-        })
-    };
+    let auth_manifest = auth_manifest.unwrap_or_else(default_set_auth_manifest);
 
     let buf = auth_manifest.as_bytes();
     let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
@@ -213,7 +207,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
-        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        let (somv_measurement, somo_measurement) = default_rt_test_soc_manifest_measurements(0);
         hasher.update(somv_measurement);
         hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
@@ -283,12 +277,10 @@ fn test_authorize_and_stash_cmd_success() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
-        let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
-            manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
-            pqc_key_type: FwVerificationPqcKeyType::LMS,
-            svn: 1,
-        });
-        let (somv_measurement, somo_measurement) = soc_manifest_measurements(&auth_manifest);
+        // SET_AUTH_MANIFEST above replaced the SOMV/SOMO contexts created from
+        // the SoC manifest delivered over recovery, so measure that manifest.
+        let (somv_measurement, somo_measurement) =
+            soc_manifest_measurements(&default_set_auth_manifest());
         hasher.update(somv_measurement);
         hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1,6 +1,9 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    soc_manifest_measurements, RuntimeTestArgs,
+};
 use crate::test_set_auth_manifest::{
     create_auth_manifest, create_auth_manifest_with_metadata, AuthManifestBuilderCfg,
 };
@@ -210,6 +213,9 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
@@ -277,6 +283,14 @@ fn test_authorize_and_stash_cmd_success() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
+            manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            svn: 1,
+        });
+        let (somv_measurement, somo_measurement) = soc_manifest_measurements(&auth_manifest);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -13,7 +13,8 @@ use sha2::{Digest, Sha384};
 use zerocopy::IntoBytes;
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, run_rt_test, run_rt_test_return_fw, RuntimeTestArgs,
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements,
+    default_soc_manifest_measurements, run_rt_test, run_rt_test_return_fw, RuntimeTestArgs,
     DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQC_KEY_TYPE,
 };
 
@@ -184,9 +185,16 @@ fn test_boot_tci_data() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
+        // MCU ROM stashes field_entropy_state measurement.
+        let mut fe_hasher = Sha384::new();
+        fe_hasher.update([0u8; 48]);
+        hasher.update(fe_hasher.finalize());
     }
     let expected_measurement_hash = hasher.finalize();
 
@@ -266,8 +274,12 @@ fn test_measurement_in_measurement_log_added_to_dpe() {
         hasher.update(cptra_config_init_vals_hash);
         hasher.update(measurement);
         if model.subsystem_mode() {
+            let (somv_measurement, somo_measurement) =
+                default_soc_manifest_measurements(*pqc_key_type, 1);
             let mut mcu_hasher = Sha384::new();
             mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
+            hasher.update(somv_measurement);
+            hasher.update(somo_measurement);
             hasher.update(mcu_hasher.finalize());
         }
         let expected_measurement_hash = hasher.finalize();

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha384};
 use zerocopy::IntoBytes;
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements,
+    calculate_cptra_config_init_vals_hash, default_rt_test_soc_manifest_measurements,
     default_soc_manifest_measurements, run_rt_test, run_rt_test_return_fw, RuntimeTestArgs,
     DEFAULT_APP_VERSION, DEFAULT_FMC_VERSION, PQC_KEY_TYPE,
 };
@@ -185,7 +185,7 @@ fn test_boot_tci_data() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
-        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        let (somv_measurement, somo_measurement) = default_rt_test_soc_manifest_measurements(0);
         hasher.update(somv_measurement);
         hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -191,10 +191,11 @@ fn test_boot_tci_data() {
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(crate::common::DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());
-        // MCU ROM stashes field_entropy_state measurement.
-        let mut fe_hasher = Sha384::new();
-        fe_hasher.update([0u8; 48]);
-        hasher.update(fe_hasher.finalize());
+        // Note: MCU ROM also stashes the field_entropy_state measurement, but
+        // this test boots the mailbox responder test firmware instead of the
+        // production runtime, and that firmware does not implement
+        // STASH_MEASUREMENT. The stash therefore fails and no field entropy
+        // DPE context is created.
     }
     let expected_measurement_hash = hasher.finalize();
 

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -230,9 +230,11 @@ fn test_certify_key_with_max_contexts() {
         ..Default::default()
     };
 
-    // Fill PL0 contexts
+    // Fill PL0 contexts. In subsystem mode, Caliptra uses 6 PL0 contexts
+    // (root + RT journey + SOMV + SOMO + MCU FW + field entropy state);
+    // otherwise, 2 (root + RT journey).
     let max_after_init_contexts = if model.subsystem_mode() {
-        64 - 4
+        64 - 6
     } else {
         64 - 2
     };

--- a/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
+++ b/runtime/tests/runtime_integration_tests/test_invoke_dpe.rs
@@ -663,7 +663,7 @@ fn test_subsystem_response_buffer_limits() {
 
 #[test]
 #[cfg_attr(feature = "fpga_realtime", ignore)]
-fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
+fn test_subsystem_leaf_cert_contains_caliptra_managed_tci_types() {
     let mut model = run_rt_test(RuntimeTestArgs {
         subsystem_mode: true,
         ..Default::default()
@@ -694,13 +694,17 @@ fn test_subsystem_leaf_cert_contains_mcfw_tci_type() {
             .expect("MultiTcbInfo extension missing");
 
         let parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
-
-        let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
-        let found_mcfw = parsed_tcb_infos
-            .filter(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
-            .count()
-            == 1;
-        assert!(found_mcfw);
+        let tcb_infos: Vec<TcbInfo> = parsed_tcb_infos.collect();
+        for expected_tci_type in [b"SOMV", b"SOMO", b"MCFW"] {
+            let expected_tci_type = u32::from_be_bytes(*expected_tci_type);
+            assert_eq!(
+                tcb_infos
+                    .iter()
+                    .filter(|tcb_info| tcb_info.tci_type == Some(expected_tci_type.as_bytes()))
+                    .count(),
+                1
+            );
+        }
     }
 }
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -72,12 +72,10 @@ fn test_pl0_derive_context_dpe_context_thresholds() {
     let mut handle = rotate_ctx_resp.handle;
 
     // Call DeriveContext with PL0 enough times to breach the threshold on the last iteration.
-    // 2 PL0 contexts are used by default by Caliptra. When we initialize DPE, we measure mailbox valid pausers in pl0_pauser's locality.
-    // The RT Journey measurement also is counted against PL0's limit. Thus, we can call derive child
-    // from PL0 exactly 14 times, and the last iteration of this loop, is expected to throw a threshold reached error.
+    // Caliptra-owned PL0 contexts consume part of the PL0 threshold before mailbox commands run.
     let num_iterations = if model.subsystem_mode() {
-        // Subsystem uses contexts for the MCU FW and field entropy state
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+        // Subsystem uses contexts for SOMV, SOMO, MCU FW, and field entropy state.
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 5
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -200,9 +198,9 @@ fn test_pl0_init_ctx_dpe_context_thresholds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // 2 PL0 contexts are used by Caliptra
+    // Caliptra-owned PL0 contexts consume part of the PL0 threshold before mailbox commands run.
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 5
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };
@@ -740,10 +738,10 @@ fn test_stash_measurement_pl_context_thresholds() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // Root node and RT journey (which is technically the Caliptra locality) count as PL0
-    // In subsystem mode, the MCU FW and field entropy state are also measured into PL0 contexts.
+    // Root node and RT journey (which is technically the Caliptra locality) count as PL0.
+    // In subsystem mode, SOMV, SOMO, MCU FW, and field entropy state also use PL0 contexts.
     let num_iterations = if model.subsystem_mode() {
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 4
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 6
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 2
     };
@@ -789,12 +787,11 @@ fn test_measurement_log_pl_context_threshold() {
         m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
     });
 
-    // Upload (PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1) measurements to measurement log
-    // Since 2 measurements taken by Caliptra upon startup, this will cause
-    // the PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD to be breached.
+    // Upload enough measurements to the measurement log to breach the PL0 DPE context threshold
+    // after accounting for Caliptra-owned startup contexts.
     let invocations = if model.subsystem_mode() {
-        // MCU uses extra DPE contexts for MCU FW and field entropy state
-        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 3
+        // SOMV, SOMO, MCU FW, and field entropy state use extra DPE contexts.
+        PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 5
     } else {
         PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD - 1
     };

--- a/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
+++ b/runtime/tests/runtime_integration_tests/test_reallocate_dpe_context_limits.rs
@@ -22,15 +22,14 @@ fn fill_max_dpe_contexts(model: &mut DefaultHwModel, pl0_limit: u32, pl1_limit: 
         ..Default::default()
     };
 
-    // 64 contexts = 1 root node (PL0)+
-    //               1 rt_journey (PL0)
-    //               (pl0_limit - 2) PL0 contexts in loop +
-    //               1 PL1 context as transition +
-    //               (pl1_limit - 1) PL1 contexts in loop
+    // In subsystem mode, Caliptra uses 6 base PL0 contexts
+    // (root + RT journey + SOMV + SOMO + MCU FW + field entropy state);
+    // otherwise, 2 (root + RT journey).
+    let caliptra_base_pl0: u32 = if model.subsystem_mode() { 6 } else { 2 };
 
     // Fill PL0 contexts
     println!("Filling PL0 contexts up to limit {}", pl0_limit);
-    for i in 0..(pl0_limit - 2) {
+    for i in 0..(pl0_limit - caliptra_base_pl0) {
         let cmd = DeriveContextCmd {
             tci_type: i,
             ..base_derive_context_cmd
@@ -113,7 +112,14 @@ fn reallocate_pl0_pl1_dpe_contexts(
 
 #[test]
 fn test_pl0_pl1_reallocation_range() {
-    for pl0_limit in 2..caliptra_dpe::MAX_HANDLES as u32 {
+    // In subsystem mode, Caliptra uses 6 base PL0 contexts
+    // (root + RT journey + SOMV + SOMO + MCU FW + field entropy state);
+    // we cannot reallocate below the used count.
+    let mut first_model = run_rt_test(RuntimeTestArgs::default());
+    let min_pl0_limit: u32 = if first_model.subsystem_mode() { 6 } else { 2 };
+    drop(first_model);
+
+    for pl0_limit in min_pl0_limit..caliptra_dpe::MAX_HANDLES as u32 {
         println!("\n\n\tPL0 Limit {}\n\n", pl0_limit);
         let mut model = run_rt_test(RuntimeTestArgs::default());
         let resp = reallocate_pl0_pl1_dpe_contexts(&mut model, pl0_limit)
@@ -171,13 +177,14 @@ fn test_pl0_pl1_reallocation_pl0_greater_than_max() {
 fn test_pl0_pl1_reallocation_pl0_less_than_used() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
 
-    // Use some PL0 contexts
-    for i in 0..12 {
-        let derive_context_cmd = DeriveContextCmd {
-            flags: DeriveContextFlags::MAKE_DEFAULT,
-            tci_type: i,
-            ..Default::default()
-        };
+    let derive_context_cmd = DeriveContextCmd {
+        flags: DeriveContextFlags::MAKE_DEFAULT,
+        ..Default::default()
+    };
+
+    // Use some PL0 contexts without breaching the default PL0 limit first.
+    let initial_pl0_contexts = if model.subsystem_mode() { 9 } else { 12 };
+    for _ in 0..initial_pl0_contexts {
         let _ = execute_dpe_cmd(
             &mut model,
             CaliptraDpeProfile::Ecc384,
@@ -266,16 +273,13 @@ fn test_pl0_pl1_reallocation_warm_reset() {
         ..Default::default()
     };
 
-    // Use some PL0 contexts
-    for i in 0..12 {
-        let cmd = DeriveContextCmd {
-            tci_type: i,
-            ..derive_context_cmd
-        };
+    // Use some PL0 contexts without breaching the default PL0 limit first.
+    let initial_pl0_contexts = if model.subsystem_mode() { 9 } else { 12 };
+    for _ in 0..initial_pl0_contexts {
         let _ = execute_dpe_cmd(
             &mut model,
             CaliptraDpeProfile::Ecc384,
-            &mut Command::DeriveContext(&cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
     }
@@ -296,29 +300,25 @@ fn test_pl0_pl1_reallocation_warm_reset() {
         .unwrap();
 
     // Use the rest of the PL0 contexts
-    // (2 contexts are used by Caliptra)
-    for i in 0..10 {
-        let cmd = DeriveContextCmd {
-            tci_type: i + 12,
-            ..derive_context_cmd
-        };
+    // In subsystem mode, 6 contexts are used by Caliptra
+    // (root + RT journey + SOMV + SOMO + MCU FW + field entropy state);
+    // otherwise, 2 contexts are used (root + RT journey).
+    let caliptra_contexts: u32 = if model.subsystem_mode() { 6 } else { 2 };
+    let remaining = 24 - caliptra_contexts - initial_pl0_contexts;
+    for _ in 0..remaining {
         let _ = execute_dpe_cmd(
             &mut model,
             CaliptraDpeProfile::Ecc384,
-            &mut Command::DeriveContext(&cmd),
+            &mut Command::DeriveContext(&derive_context_cmd),
             DpeResult::Success,
         );
     }
 
-    let cmd = DeriveContextCmd {
-        tci_type: 12 + 10,
-        ..derive_context_cmd
-    };
     // Trigger failure by trying to derive one more context to PL0
     let _ = execute_dpe_cmd(
         &mut model,
         CaliptraDpeProfile::Ecc384,
-        &mut Command::DeriveContext(&cmd),
+        &mut Command::DeriveContext(&derive_context_cmd),
         DpeResult::MboxCmdFailure(CaliptraError::RUNTIME_PL0_USED_DPE_CONTEXT_THRESHOLD_REACHED),
     );
 }

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -3,6 +3,7 @@
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
 use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+#[cfg(not(feature = "fpga_subsystem"))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{HwModel, InitParams};
@@ -13,19 +14,56 @@ use zerocopy::IntoBytes;
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
 
-#[cfg_attr(
-    any(
-        feature = "verilator",
-        feature = "fpga_realtime",
-        feature = "fpga_subsystem"
-    ),
-    ignore
-)]
+#[derive(asn1::Asn1Read)]
+struct Fwid<'a> {
+    _hash_alg: asn1::ObjectIdentifier,
+    _digest: &'a [u8],
+}
+
+#[derive(asn1::Asn1Read)]
+struct IntegrityRegister<'a> {
+    #[implicit(0)]
+    _register_name: Option<asn1::IA5String<'a>>,
+    #[implicit(1)]
+    _register_num: Option<u64>,
+    #[implicit(2)]
+    _register_digests: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+}
+
+#[derive(asn1::Asn1Read)]
+struct TcbInfo<'a> {
+    #[implicit(0)]
+    _vendor: Option<asn1::Utf8String<'a>>,
+    #[implicit(1)]
+    _model: Option<asn1::Utf8String<'a>>,
+    #[implicit(2)]
+    _version: Option<asn1::Utf8String<'a>>,
+    #[implicit(3)]
+    svn: Option<u64>,
+    #[implicit(4)]
+    _layer: Option<u64>,
+    #[implicit(5)]
+    _index: Option<u64>,
+    #[implicit(6)]
+    _fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+    #[implicit(7)]
+    _flags: Option<asn1::BitString<'a>>,
+    #[implicit(8)]
+    _vendor_info: Option<&'a [u8]>,
+    #[implicit(9)]
+    tci_type: Option<&'a [u8]>,
+    #[implicit(10)]
+    _operational_flags_mask: Option<asn1::BitString<'a>>,
+    #[implicit(11)]
+    _integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
+}
+
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
 #[test]
 fn test_loads_mcu_fw() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
+    let mcu_fw = vec![0x37u8; 256];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
     flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
@@ -50,16 +88,20 @@ fn test_loads_mcu_fw() {
     args.mcu_fw_image = Some(&mcu_fw);
     let mut model = run_rt_test(args);
     model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
-    // check that we got an MCU write
-    let events = model.events_from_caliptra();
-    let mut found = false;
-    for event in events {
-        if event.dest == Device::MCU && matches!(event.event, EventData::MemoryWrite { .. }) {
-            found = true;
-            break;
+
+    #[cfg(not(feature = "fpga_subsystem"))]
+    {
+        // check that we got an MCU write
+        let events = model.events_from_caliptra();
+        let mut found = false;
+        for event in events {
+            if event.dest == Device::MCU && matches!(event.event, EventData::MemoryWrite { .. }) {
+                found = true;
+                break;
+            }
         }
+        assert!(found);
     }
-    assert!(found);
 }
 
 #[cfg_attr(
@@ -74,7 +116,7 @@ fn test_loads_mcu_fw() {
 fn test_mcu_fw_bad_signature() {
     // Test that the recovery flow runs and loads MCU's firmware
 
-    let mcu_fw = vec![1, 2, 3, 4];
+    let mcu_fw = vec![0x37u8; 256];
     let bad_mcu_fw = vec![5, 6, 7, 8];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
     let mut flags = ImageMetadataFlags(0);
@@ -105,4 +147,74 @@ fn test_mcu_fw_bad_signature() {
         CaliptraError::IMAGE_VERIFIER_ERR_RUNTIME_DIGEST_MISMATCH.into(),
         30_000_000,
     );
+}
+
+#[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
+#[test]
+fn test_recovery_flow_with_svn() {
+    // Test that recovery boot passes the SoC manifest SVN to the MCU RT DPE context.
+    // The manifest is created with SVN=5, and fuses are configured to allow it.
+    use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+    use caliptra_image_types::FwVerificationPqcKeyType;
+
+    let mcu_fw = vec![0x37u8; 256];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest = create_auth_manifest_with_metadata_with_svn(
+        metadata,
+        FwVerificationPqcKeyType::LMS,
+        5, // SVN = 5
+    );
+    let soc_manifest = soc_manifest.as_bytes();
+    let mut args = RuntimeTestArgs::default();
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    args.init_params = Some(InitParams {
+        rom: &rom,
+        subsystem_mode: true,
+        ..Default::default()
+    });
+    args.soc_manifest = Some(soc_manifest);
+    args.mcu_fw_image = Some(&mcu_fw);
+    args.soc_manifest_svn = Some(5);
+    args.soc_manifest_max_svn = Some(127);
+    let mut model = run_rt_test(args);
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
+    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
+    use x509_parser::{nom::Parser, prelude::*};
+
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+    let CertifyKeyResp::P384(certify_key_resp) = certify_key(&mut model, certify_key_cmd).unwrap()
+    else {
+        panic!("Wrong response type!");
+    };
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
+    let (_, cert) = X509CertificateParser::new()
+        .with_deep_parse_extensions(true)
+        .parse(cert_bytes)
+        .unwrap();
+    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
+    let ext = cert
+        .get_extension_unique(&multi_tcb_info_oid)
+        .unwrap()
+        .expect("MultiTcbInfo extension missing");
+    let mut parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
+    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
+    let mcfw_tcb_info = parsed_tcb_infos
+        .find(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
+        .expect("MCFW TCB info missing");
+    assert_eq!(mcfw_tcb_info.svn, Some(5));
 }

--- a/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
+++ b/runtime/tests/runtime_integration_tests/test_recovery_flow.rs
@@ -2,22 +2,36 @@
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_auth_man_types::{AuthManifestImageMetadata, ImageMetadataFlags};
+use caliptra_auth_man_gen::{
+    AuthManifestGenerator, AuthManifestGeneratorConfig, AuthManifestGeneratorKeyConfig,
+};
+use caliptra_auth_man_types::{
+    AuthManifestFlags, AuthManifestImageMetadata, AuthManifestPreamble, AuthManifestPrivKeysConfig,
+    AuthManifestPubKeysConfig, AuthorizationManifest, ImageMetadataFlags,
+};
+use caliptra_common::mailbox_api::{
+    CommandId, MailboxReq, MailboxReqHeader, QuotePcrsEcc384Req, QuotePcrsEcc384Resp,
+    SetAuthManifestReq,
+};
 #[cfg(not(feature = "fpga_subsystem"))]
 use caliptra_emu_bus::{Device, EventData};
 use caliptra_error::CaliptraError;
-use caliptra_hw_model::{HwModel, InitParams};
+use caliptra_hw_model::{DefaultHwModel, HwModel, InitParams};
 use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_fake_keys::*;
 use caliptra_image_gen::from_hw_format;
 use caliptra_image_gen::ImageGeneratorCrypto;
-use zerocopy::IntoBytes;
+use caliptra_image_types::FwVerificationPqcKeyType;
+use sha2::{Digest, Sha384};
+use zerocopy::{FromBytes, IntoBytes};
 
 const RT_READY_FOR_COMMANDS: u32 = 0x600;
+const PCR_ID_STASH_MEASUREMENT: usize = 31;
 
 #[derive(asn1::Asn1Read)]
 struct Fwid<'a> {
     _hash_alg: asn1::ObjectIdentifier,
-    _digest: &'a [u8],
+    digest: &'a [u8],
 }
 
 #[derive(asn1::Asn1Read)]
@@ -45,7 +59,7 @@ struct TcbInfo<'a> {
     #[implicit(5)]
     _index: Option<u64>,
     #[implicit(6)]
-    _fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
+    fwids: Option<asn1::SequenceOf<'a, Fwid<'a>>>,
     #[implicit(7)]
     _flags: Option<asn1::BitString<'a>>,
     #[implicit(8)]
@@ -56,6 +70,199 @@ struct TcbInfo<'a> {
     _operational_flags_mask: Option<asn1::BitString<'a>>,
     #[implicit(11)]
     _integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
+}
+
+struct TcbSnapshot {
+    tci_type: [u8; 4],
+    svn: Option<u64>,
+    digest: Option<[u8; 48]>,
+}
+
+fn sha384_digest(data: &[u8]) -> [u8; 48] {
+    Sha384::digest(data).into()
+}
+
+fn preamble_range_digest(
+    preamble: &AuthManifestPreamble,
+    range: core::ops::Range<u32>,
+) -> [u8; 48] {
+    let preamble_bytes = preamble.as_bytes();
+    sha384_digest(&preamble_bytes[range.start as usize..range.end as usize])
+}
+
+fn somv_measurement(manifest: &AuthorizationManifest) -> [u8; 48] {
+    preamble_range_digest(
+        &manifest.preamble,
+        AuthManifestPreamble::vendor_signed_data_range(),
+    )
+}
+
+fn somo_measurement(manifest: &AuthorizationManifest) -> [u8; 48] {
+    preamble_range_digest(
+        &manifest.preamble,
+        AuthManifestPreamble::owner_pub_keys_range(),
+    )
+}
+
+fn create_auth_manifest_with_alt_owner_keys(
+    image_metadata_list: Vec<AuthManifestImageMetadata>,
+    pqc_key_type: FwVerificationPqcKeyType,
+    svn: u32,
+) -> AuthorizationManifest {
+    let vendor_fw_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_0_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_0_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_0_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_0_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_0_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_0_PRIVATE,
+        }),
+    });
+    let vendor_man_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_1_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_1_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_1_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_1_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_1_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_1_PRIVATE,
+        }),
+    });
+    let owner_fw_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: OWNER_ECC_KEY_PUBLIC,
+            lms_pub_key: OWNER_LMS_KEY_PUBLIC,
+            mldsa_pub_key: OWNER_MLDSA_KEY_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: OWNER_ECC_KEY_PRIVATE,
+            lms_priv_key: OWNER_LMS_KEY_PRIVATE,
+            mldsa_priv_key: OWNER_MLDSA_KEY_PRIVATE,
+        }),
+    });
+    let owner_man_key_info = Some(AuthManifestGeneratorKeyConfig {
+        pub_keys: AuthManifestPubKeysConfig {
+            ecc_pub_key: VENDOR_ECC_KEY_2_PUBLIC,
+            lms_pub_key: VENDOR_LMS_KEY_2_PUBLIC,
+            mldsa_pub_key: VENDOR_MLDSA_KEY_2_PUBLIC,
+        },
+        priv_keys: Some(AuthManifestPrivKeysConfig {
+            ecc_priv_key: VENDOR_ECC_KEY_2_PRIVATE,
+            lms_priv_key: VENDOR_LMS_KEY_2_PRIVATE,
+            mldsa_priv_key: VENDOR_MLDSA_KEY_2_PRIVATE,
+        }),
+    });
+
+    let gen = AuthManifestGenerator::new(Crypto::default());
+    gen.generate(&AuthManifestGeneratorConfig {
+        vendor_fw_key_info,
+        vendor_man_key_info,
+        owner_fw_key_info,
+        owner_man_key_info,
+        image_metadata_list,
+        version: 1,
+        flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
+        pqc_key_type,
+        svn,
+    })
+    .unwrap()
+}
+
+fn set_auth_manifest(model: &mut DefaultHwModel, manifest: &AuthorizationManifest) {
+    let buf = manifest.as_bytes();
+    let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
+    auth_manifest_slice[..buf.len()].copy_from_slice(buf);
+
+    let mut set_auth_manifest_cmd = MailboxReq::SetAuthManifest(SetAuthManifestReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        manifest_size: buf.len() as u32,
+        manifest: auth_manifest_slice,
+    });
+    set_auth_manifest_cmd.populate_chksum().unwrap();
+
+    model
+        .mailbox_execute(
+            u32::from(CommandId::SET_AUTH_MANIFEST),
+            set_auth_manifest_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+}
+
+fn quote_pcr31(model: &mut DefaultHwModel) -> [u8; 48] {
+    let mut cmd = MailboxReq::QuotePcrsEcc384(QuotePcrsEcc384Req {
+        hdr: MailboxReqHeader { chksum: 0 },
+        nonce: [0xf5; 32],
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::QUOTE_PCRS_ECC384),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let resp = QuotePcrsEcc384Resp::read_from_bytes(resp.as_slice()).unwrap();
+    resp.pcrs[PCR_ID_STASH_MEASUREMENT]
+}
+
+fn dpe_tcb_snapshots(model: &mut DefaultHwModel) -> Vec<TcbSnapshot> {
+    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
+    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
+    use x509_parser::{nom::Parser, prelude::*};
+
+    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
+        format: CertifyKeyCommand::FORMAT_X509,
+        ..Default::default()
+    });
+    let CertifyKeyResp::P384(certify_key_resp) = certify_key(model, certify_key_cmd).unwrap()
+    else {
+        panic!("Wrong response type!");
+    };
+    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.cert_size as usize];
+    let (_, cert) = X509CertificateParser::new()
+        .with_deep_parse_extensions(true)
+        .parse(cert_bytes)
+        .unwrap();
+    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
+    let ext = cert
+        .get_extension_unique(&multi_tcb_info_oid)
+        .unwrap()
+        .expect("MultiTcbInfo extension missing");
+    let parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
+    parsed_tcb_infos
+        .filter_map(|mut tcb_info| {
+            let tci_type: [u8; 4] = tcb_info.tci_type?.try_into().ok()?;
+            let digest = tcb_info
+                .fwids
+                .as_mut()
+                .and_then(|fwids| fwids.next().and_then(|fwid| fwid.digest.try_into().ok()));
+            Some(TcbSnapshot {
+                tci_type,
+                svn: tcb_info.svn,
+                digest,
+            })
+        })
+        .collect()
+}
+
+fn find_tcb_snapshot<'a>(snapshots: &'a [TcbSnapshot], tci_type: &[u8; 4]) -> &'a TcbSnapshot {
+    let tci_type = u32::from_be_bytes(*tci_type);
+    snapshots
+        .iter()
+        .find(|snapshot| snapshot.tci_type == tci_type.as_bytes())
+        .unwrap_or_else(|| {
+            panic!(
+                "{} TCB info missing",
+                core::str::from_utf8(tci_type.as_bytes()).unwrap()
+            )
+        })
 }
 
 #[cfg_attr(any(feature = "verilator", feature = "fpga_realtime"), ignore)]
@@ -155,7 +362,6 @@ fn test_recovery_flow_with_svn() {
     // Test that recovery boot passes the SoC manifest SVN to the MCU RT DPE context.
     // The manifest is created with SVN=5, and fuses are configured to allow it.
     use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
-    use caliptra_image_types::FwVerificationPqcKeyType;
 
     let mcu_fw = vec![0x37u8; 256];
     const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
@@ -171,10 +377,10 @@ fn test_recovery_flow_with_svn() {
     }];
     let soc_manifest = create_auth_manifest_with_metadata_with_svn(
         metadata,
-        FwVerificationPqcKeyType::LMS,
+        FwVerificationPqcKeyType::MLDSA,
         5, // SVN = 5
     );
-    let soc_manifest = soc_manifest.as_bytes();
+    let soc_manifest_bytes = soc_manifest.as_bytes();
     let mut args = RuntimeTestArgs::default();
     let rom = crate::common::rom_for_fw_integration_tests().unwrap();
     args.init_params = Some(InitParams {
@@ -182,39 +388,133 @@ fn test_recovery_flow_with_svn() {
         subsystem_mode: true,
         ..Default::default()
     });
-    args.soc_manifest = Some(soc_manifest);
+    args.soc_manifest = Some(soc_manifest_bytes);
     args.mcu_fw_image = Some(&mcu_fw);
     args.soc_manifest_svn = Some(5);
     args.soc_manifest_max_svn = Some(127);
+    args.key_type = Some(FwVerificationPqcKeyType::MLDSA);
     let mut model = run_rt_test(args);
     model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
 
-    use crate::common::{certify_key, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs};
-    use caliptra_dpe::{commands::CertifyKeyCommand, response::CertifyKeyResp};
-    use x509_parser::{nom::Parser, prelude::*};
+    let snapshots = dpe_tcb_snapshots(&mut model);
+    let somv_tcb_info = find_tcb_snapshot(&snapshots, b"SOMV");
+    assert_eq!(somv_tcb_info.svn, Some(5));
+    assert_eq!(somv_tcb_info.digest, Some(somv_measurement(&soc_manifest)));
+    let somo_tcb_info = find_tcb_snapshot(&snapshots, b"SOMO");
+    assert_eq!(somo_tcb_info.svn, Some(0));
+    assert_eq!(somo_tcb_info.digest, Some(somo_measurement(&soc_manifest)));
+    let mcfw_tcb_info = find_tcb_snapshot(&snapshots, b"MCFW");
+    assert_eq!(mcfw_tcb_info.svn, Some(5));
+}
 
-    let certify_key_cmd = &mut CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs {
-        format: CertifyKeyCommand::FORMAT_X509,
+#[cfg_attr(
+    any(
+        feature = "verilator",
+        feature = "fpga_realtime",
+        feature = "fpga_subsystem"
+    ),
+    ignore
+)]
+#[test]
+fn test_set_auth_manifest_updates_soc_manifest_dpe_contexts() {
+    use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
+
+    let mcu_fw = vec![0x37u8; 256];
+    const IMAGE_SOURCE_IN_REQUEST: u32 = 1;
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_image_source(IMAGE_SOURCE_IN_REQUEST);
+    let crypto = Crypto::default();
+    let digest = from_hw_format(&crypto.sha384_digest(&mcu_fw).unwrap());
+    let metadata = vec![AuthManifestImageMetadata {
+        fw_id: 2,
+        flags: flags.0,
+        digest,
+        ..Default::default()
+    }];
+    let soc_manifest_v5 = create_auth_manifest_with_metadata_with_svn(
+        metadata.clone(),
+        FwVerificationPqcKeyType::MLDSA,
+        5,
+    );
+    let soc_manifest_v5_bytes = soc_manifest_v5.as_bytes();
+    let mut args = RuntimeTestArgs::default();
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    args.init_params = Some(InitParams {
+        rom: &rom,
+        subsystem_mode: true,
         ..Default::default()
     });
-    let CertifyKeyResp::P384(certify_key_resp) = certify_key(&mut model, certify_key_cmd).unwrap()
-    else {
-        panic!("Wrong response type!");
-    };
-    let cert_bytes = &certify_key_resp.cert[..certify_key_resp.header.cert_size as usize];
-    let (_, cert) = X509CertificateParser::new()
-        .with_deep_parse_extensions(true)
-        .parse(cert_bytes)
-        .unwrap();
-    let multi_tcb_info_oid = x509_parser::oid_registry::asn1_rs::oid!(2.23.133 .5 .4 .5);
-    let ext = cert
-        .get_extension_unique(&multi_tcb_info_oid)
-        .unwrap()
-        .expect("MultiTcbInfo extension missing");
-    let mut parsed_tcb_infos = asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(ext.value).unwrap();
-    let mcu_tci_type = u32::from_be_bytes(*b"MCFW");
-    let mcfw_tcb_info = parsed_tcb_infos
-        .find(|tcb_info| tcb_info.tci_type == Some(mcu_tci_type.as_bytes()))
-        .expect("MCFW TCB info missing");
-    assert_eq!(mcfw_tcb_info.svn, Some(5));
+    args.soc_manifest = Some(soc_manifest_v5_bytes);
+    args.mcu_fw_image = Some(&mcu_fw);
+    args.soc_manifest_svn = Some(5);
+    args.soc_manifest_max_svn = Some(127);
+    args.key_type = Some(FwVerificationPqcKeyType::MLDSA);
+    let mut model = run_rt_test(args);
+    model.step_until_boot_status(RT_READY_FOR_COMMANDS, true);
+
+    let initial_snapshots = dpe_tcb_snapshots(&mut model);
+    let initial_somv = find_tcb_snapshot(&initial_snapshots, b"SOMV");
+    assert_eq!(initial_somv.svn, Some(5));
+    assert_eq!(
+        initial_somv.digest,
+        Some(somv_measurement(&soc_manifest_v5))
+    );
+    let initial_somo = find_tcb_snapshot(&initial_snapshots, b"SOMO");
+    assert_eq!(initial_somo.svn, Some(0));
+    assert_eq!(
+        initial_somo.digest,
+        Some(somo_measurement(&soc_manifest_v5))
+    );
+    let initial_pcr31 = quote_pcr31(&mut model);
+
+    set_auth_manifest(&mut model, &soc_manifest_v5);
+    let same_manifest_snapshots = dpe_tcb_snapshots(&mut model);
+    let same_somv = find_tcb_snapshot(&same_manifest_snapshots, b"SOMV");
+    assert_eq!(same_somv.svn, Some(5));
+    assert_eq!(same_somv.digest, initial_somv.digest);
+    let same_somo = find_tcb_snapshot(&same_manifest_snapshots, b"SOMO");
+    assert_eq!(same_somo.svn, Some(0));
+    assert_eq!(same_somo.digest, initial_somo.digest);
+    assert_eq!(quote_pcr31(&mut model), initial_pcr31);
+
+    let soc_manifest_v6 =
+        create_auth_manifest_with_metadata_with_svn(metadata, FwVerificationPqcKeyType::MLDSA, 6);
+    set_auth_manifest(&mut model, &soc_manifest_v6);
+    let updated_snapshots = dpe_tcb_snapshots(&mut model);
+    let updated_somv = find_tcb_snapshot(&updated_snapshots, b"SOMV");
+    assert_eq!(updated_somv.svn, Some(5));
+    assert_eq!(
+        updated_somv.digest,
+        Some(somv_measurement(&soc_manifest_v6))
+    );
+    assert_ne!(updated_somv.digest, initial_somv.digest);
+    let updated_somo = find_tcb_snapshot(&updated_snapshots, b"SOMO");
+    assert_eq!(updated_somo.svn, Some(0));
+    assert_eq!(updated_somo.digest, initial_somo.digest);
+    assert_ne!(quote_pcr31(&mut model), initial_pcr31);
+
+    let pcr31_after_somv_update = quote_pcr31(&mut model);
+    let soc_manifest_alt_owner = create_auth_manifest_with_alt_owner_keys(
+        vec![AuthManifestImageMetadata {
+            fw_id: 2,
+            flags: flags.0,
+            digest,
+            ..Default::default()
+        }],
+        FwVerificationPqcKeyType::MLDSA,
+        6,
+    );
+    set_auth_manifest(&mut model, &soc_manifest_alt_owner);
+    let owner_updated_snapshots = dpe_tcb_snapshots(&mut model);
+    let owner_updated_somv = find_tcb_snapshot(&owner_updated_snapshots, b"SOMV");
+    assert_eq!(owner_updated_somv.svn, Some(5));
+    assert_eq!(owner_updated_somv.digest, updated_somv.digest);
+    let owner_updated_somo = find_tcb_snapshot(&owner_updated_snapshots, b"SOMO");
+    assert_eq!(owner_updated_somo.svn, Some(0));
+    assert_eq!(
+        owner_updated_somo.digest,
+        Some(somo_measurement(&soc_manifest_alt_owner))
+    );
+    assert_ne!(owner_updated_somo.digest, initial_somo.digest);
+    assert_ne!(quote_pcr31(&mut model), pcr31_after_somv_update);
 }

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha384};
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    calculate_cptra_config_init_vals_hash, default_rt_test_soc_manifest_measurements, run_rt_test,
     RuntimeTestArgs, DEFAULT_MCU_FW,
 };
 
@@ -82,7 +82,7 @@ fn test_stash_measurement() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
-        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        let (somv_measurement, somo_measurement) = default_rt_test_soc_manifest_measurements(0);
         hasher.update(somv_measurement);
         hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -10,11 +10,13 @@ use caliptra_common::mailbox_api::{
 };
 use caliptra_hw_model::HwModel;
 use caliptra_runtime::RtBootStatus;
-use caliptra_test::DEFAULT_MCU_FW;
 use sha2::{Digest, Sha384};
 use zerocopy::{FromBytes, IntoBytes};
 
-use crate::common::{calculate_cptra_config_init_vals_hash, run_rt_test, RuntimeTestArgs};
+use crate::common::{
+    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
+    RuntimeTestArgs, DEFAULT_MCU_FW,
+};
 
 #[test]
 fn test_stash_measurement() {
@@ -80,6 +82,9 @@ fn test_stash_measurement() {
     hasher.update(rt_current_pcr);
     hasher.update(cptra_config_init_vals_hash);
     if model.subsystem_mode() {
+        let (somv_measurement, somo_measurement) = default_lms_soc_manifest_measurements(0);
+        hasher.update(somv_measurement);
+        hasher.update(somo_measurement);
         let mut mcu_hasher = Sha384::new();
         mcu_hasher.update(DEFAULT_MCU_FW);
         hasher.update(mcu_hasher.finalize());

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -97,85 +97,75 @@ fn test_stash_measurement() {
 
 #[test]
 fn test_pcr31_extended_upon_stash_measurement() {
-    let image_options = ImageOptions::default();
-    let runtime_test_args = RuntimeTestArgs {
-        test_fwid: Some(crate::test_update_reset::mbox_test_image()),
-        test_image_options: Some(image_options.clone()),
-        ..Default::default()
-    };
-    let mut model = run_rt_test(runtime_test_args);
+    fn run_sequence(stash_measurement: bool) -> [u8; 48] {
+        let image_options = ImageOptions::default();
+        let runtime_test_args = RuntimeTestArgs {
+            test_fwid: Some(crate::test_update_reset::mbox_test_image()),
+            test_image_options: Some(image_options.clone()),
+            ..Default::default()
+        };
+        let mut model = run_rt_test(runtime_test_args);
 
-    // Read PCR_ID_STASH_MEASUREMENT
-    let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
-    let pcr_31: [u8; 48] = pcr_31_resp.as_bytes().try_into().unwrap();
-
-    // update reset to the real runtime image
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        &APP_WITH_UART,
-        image_options.clone(),
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
-        .unwrap();
-
-    // stash a measurement
-    let measurement = [2u8; 48];
-    let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
-        hdr: MailboxReqHeader { chksum: 0 },
-        metadata: [0u8; 4],
-        measurement,
-        context: [0u8; 48],
-        svn: 0,
-    });
-    cmd.populate_chksum().unwrap();
-
-    let _ = model
-        .mailbox_execute(
-            u32::from(CommandId::STASH_MEASUREMENT),
-            cmd.as_bytes().unwrap(),
+        // update reset to the real runtime image
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            &APP_WITH_UART,
+            image_options.clone(),
         )
         .unwrap()
-        .expect("We should have received a response");
-
-    // update reset back to mbox responder
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        crate::test_update_reset::mbox_test_image(),
-        image_options.clone(),
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        .to_bytes()
         .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    let updated_fw_image = caliptra_builder::build_and_sign_image(
-        &FMC_WITH_UART,
-        crate::test_update_reset::mbox_test_image(),
-        image_options,
-    )
-    .unwrap()
-    .to_bytes()
-    .unwrap();
-    model
-        .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+        if stash_measurement {
+            let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
+                hdr: MailboxReqHeader { chksum: 0 },
+                metadata: [0u8; 4],
+                measurement: [2u8; 48],
+                context: [0u8; 48],
+                svn: 0,
+            });
+            cmd.populate_chksum().unwrap();
+
+            let _ = model
+                .mailbox_execute(
+                    u32::from(CommandId::STASH_MEASUREMENT),
+                    cmd.as_bytes().unwrap(),
+                )
+                .unwrap()
+                .expect("We should have received a response");
+        }
+
+        // update reset back to mbox responder so we can read PCR31
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            crate::test_update_reset::mbox_test_image(),
+            image_options.clone(),
+        )
+        .unwrap()
+        .to_bytes()
         .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    // Read extended PCR_ID_STASH_MEASUREMENT
-    let extended_pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
-    let extended_pcr_31: [u8; 48] = extended_pcr_31_resp.as_bytes().try_into().unwrap();
+        let updated_fw_image = caliptra_builder::build_and_sign_image(
+            &FMC_WITH_UART,
+            crate::test_update_reset::mbox_test_image(),
+            image_options,
+        )
+        .unwrap()
+        .to_bytes()
+        .unwrap();
+        model
+            .mailbox_execute(u32::from(CommandId::FIRMWARE_LOAD), &updated_fw_image)
+            .unwrap();
 
-    // no need to flip endianness here since PCRs are already in same endianness
-    // as sha2 hashes
-    let mut hasher = Sha384::new();
-    hasher.update(pcr_31);
-    hasher.update(measurement);
-    let expected_pcr_31 = hasher.finalize();
+        let pcr_31_resp = model.mailbox_execute(0x5000_0000, &[]).unwrap().unwrap();
+        pcr_31_resp.as_bytes().try_into().unwrap()
+    }
 
-    assert_eq!(expected_pcr_31.as_bytes(), extended_pcr_31);
+    assert_ne!(run_sequence(false), run_sequence(true));
 }

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -62,6 +62,42 @@ pub fn mbox_test_image_without_uart() -> &'static FwId<'static> {
     }
 }
 
+const OPCODE_INVALIDATE_DPE_INDEX_CACHE: u32 = 0x6000_0004;
+const OPCODE_READ_DPE_INDEX_CACHE: u32 = 0x6000_0005;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0006;
+const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE: u32 = 0x6000_0007;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT: u32 = 0x6000_0008;
+const OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE: u32 = 0x6000_0009;
+
+fn read_48_byte_test_response(model: &mut DefaultHwModel, cmd: u32) -> [u8; 48] {
+    model
+        .mailbox_execute(cmd, &[])
+        .unwrap()
+        .expect("We should have received a response")
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
+
+fn read_dpe_index_cache(model: &mut DefaultHwModel) -> [u8; 4] {
+    model
+        .mailbox_execute(OPCODE_READ_DPE_INDEX_CACHE, &[])
+        .unwrap()
+        .expect("We should have received a response")
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
+
+fn extend_journey_measurement(prev_journey: [u8; 48], current: [u8; 48]) -> [u8; 48] {
+    use sha2::{Digest, Sha384};
+
+    let mut hasher = Sha384::new();
+    hasher.update(prev_journey);
+    hasher.update(current);
+    hasher.finalize().into()
+}
+
 #[test]
 fn test_rt_pcr_updated_in_dpe() {
     let image_options = ImageOptions::default();
@@ -866,4 +902,98 @@ fn test_cciv_updated_in_dpe() {
     // Compare actual vs expected
     assert_eq!(cciv_hash_mbox_bundle_exp, cciv_current);
     assert_eq!(cciv_journey_exp, cciv_journey);
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_dpe_index_cache_initialized_after_hitless_update() {
+    let image_opts = ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    let image_bundle_standard =
+        caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_opts.clone())
+            .unwrap();
+
+    // Boot with the mailbox responder so the test can inspect persistent DPE state.
+    // Clearing the new cache fields simulates a fw-2.0.2 cold boot whose DCCM
+    // did not initialize the cache appended by fw-2.0.3.
+    let args = RuntimeTestArgs {
+        subsystem_mode: true,
+        test_fwid: Some(mbox_test_image()),
+        test_image_options: Some(image_opts.clone()),
+        ..Default::default()
+    };
+    let (mut model, image_bundle_mbox) = run_rt_test_return_fw(args);
+
+    let cciv_hash_mbox_bundle_exp: [u8; 48] =
+        calculate_cptra_config_init_vals_hash(&mut model, &image_bundle_mbox);
+    let cciv_hash_standard_bundle_exp: [u8; 48] =
+        calculate_cptra_config_init_vals_hash(&mut model, &image_bundle_standard);
+    assert_ne!(cciv_hash_mbox_bundle_exp, cciv_hash_standard_bundle_exp);
+
+    let initial_cciv_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE);
+    let initial_mcu_rt_current = read_48_byte_test_response(
+        &mut model,
+        OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT,
+    );
+    let initial_mcu_rt_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE);
+
+    model
+        .mailbox_execute(OPCODE_INVALIDATE_DPE_INDEX_CACHE, &[])
+        .unwrap()
+        .expect("We should have received a response");
+    let invalid_cache = read_dpe_index_cache(&mut model);
+    assert_eq!(invalid_cache[0], 0);
+    assert_eq!(invalid_cache[1], 0xff);
+    assert_eq!(invalid_cache[2], 0xff);
+
+    // Hitlessly update from the simulated fw-2.0.2 DPE state to the new runtime.
+    // Update reset should initialize the cache once, then use it to update CCIV.
+    model
+        .mailbox_execute(
+            u32::from(CommandId::FIRMWARE_LOAD),
+            &image_bundle_standard.to_bytes().unwrap(),
+        )
+        .unwrap();
+    model.step_until_ready_for_runtime();
+
+    // Perform a second hitless update back to the mailbox responder. This proves
+    // the cache initialized during the first update persisted and remains usable.
+    model
+        .mailbox_execute(
+            u32::from(CommandId::FIRMWARE_LOAD),
+            &image_bundle_mbox.to_bytes().unwrap(),
+        )
+        .unwrap();
+    model.step_until_ready_for_runtime();
+
+    let initialized_cache = read_dpe_index_cache(&mut model);
+    assert_ne!(initialized_cache[0], 0);
+    assert_ne!(initialized_cache[1], 0xff);
+    assert_ne!(initialized_cache[2], 0xff);
+
+    let expected_cciv_journey_after_standard =
+        extend_journey_measurement(initial_cciv_journey, cciv_hash_standard_bundle_exp);
+    let expected_cciv_journey_after_mbox = extend_journey_measurement(
+        expected_cciv_journey_after_standard,
+        cciv_hash_mbox_bundle_exp,
+    );
+    let cciv_current =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT);
+    let cciv_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_CUMULATIVE);
+    assert_eq!(cciv_current, cciv_hash_mbox_bundle_exp);
+    assert_eq!(cciv_journey, expected_cciv_journey_after_mbox);
+
+    let mcu_rt_current = read_48_byte_test_response(
+        &mut model,
+        OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_MEASUREMENT,
+    );
+    let mcu_rt_journey =
+        read_48_byte_test_response(&mut model, OPCODE_READ_CACHED_DPE_MCU_RT_CONTEXT_CUMULATIVE);
+    assert_eq!(mcu_rt_current, initial_mcu_rt_current);
+    assert_eq!(mcu_rt_journey, initial_mcu_rt_journey);
 }

--- a/runtime/tests/runtime_integration_tests/test_update_reset.rs
+++ b/runtime/tests/runtime_integration_tests/test_update_reset.rs
@@ -9,7 +9,7 @@ pub use caliptra_api::SocManager;
 use caliptra_builder::{
     firmware::{
         runtime_tests::{MBOX, MBOX_FPGA, MBOX_WITHOUT_UART, MBOX_WITHOUT_UART_FPGA},
-        APP_WITH_UART, FMC_FAKE_WITH_UART, FMC_WITH_UART,
+        APP_WITH_UART, APP_WITH_UART_FPGA, FMC_FAKE_WITH_UART, FMC_WITH_UART,
     },
     FwId, ImageOptions,
 };
@@ -62,6 +62,14 @@ pub fn mbox_test_image_without_uart() -> &'static FwId<'static> {
     }
 }
 
+fn app_test_image() -> &'static FwId<'static> {
+    if cfg!(any(feature = "fpga_realtime", feature = "fpga_subsystem")) {
+        &APP_WITH_UART_FPGA
+    } else {
+        &APP_WITH_UART
+    }
+}
+
 const OPCODE_INVALIDATE_DPE_INDEX_CACHE: u32 = 0x6000_0004;
 const OPCODE_READ_DPE_INDEX_CACHE: u32 = 0x6000_0005;
 const OPCODE_READ_CACHED_DPE_CCIV_CONTEXT_MEASUREMENT: u32 = 0x6000_0006;
@@ -79,14 +87,13 @@ fn read_48_byte_test_response(model: &mut DefaultHwModel, cmd: u32) -> [u8; 48] 
         .unwrap()
 }
 
-fn read_dpe_index_cache(model: &mut DefaultHwModel) -> [u8; 4] {
+fn read_dpe_index_cache(model: &mut DefaultHwModel) -> Vec<u8> {
     model
         .mailbox_execute(OPCODE_READ_DPE_INDEX_CACHE, &[])
         .unwrap()
         .expect("We should have received a response")
         .as_bytes()
-        .try_into()
-        .unwrap()
+        .to_vec()
 }
 
 fn extend_journey_measurement(prev_journey: [u8; 48], current: [u8; 48]) -> [u8; 48] {
@@ -134,7 +141,7 @@ fn test_rt_journey_pcr_updated_with_good_fw() {
     let image_options = ImageOptions::default();
     let runtime_test_args = RuntimeTestArgs {
         test_image_options: Some(image_options.clone()),
-        test_fwid: Some(mbox_test_image()),
+        test_fwid: Some(mbox_test_image_without_uart()),
         ..Default::default()
     };
     let mut model = run_rt_test(runtime_test_args);
@@ -145,7 +152,7 @@ fn test_rt_journey_pcr_updated_with_good_fw() {
     let orig_rt_journey_pcr: [u8; 48] = orig_rt_journey_pcr_resp.as_bytes().try_into().unwrap();
 
     // trigger update reset
-    update_fw(&mut model, mbox_test_image_without_uart(), image_options);
+    update_fw(&mut model, mbox_test_image(), image_options);
 
     model.step_until_ready_for_runtime();
 
@@ -791,6 +798,7 @@ fn test_key_ladder_stable_across_fw_updates() {
     assert_eq!(ladder_a, ladder_b);
 }
 
+#[cfg_attr(feature = "fpga_subsystem", ignore)]
 #[test]
 fn test_cciv_updated_in_dpe() {
     // Helper function to calculate updated journey measurement
@@ -810,9 +818,12 @@ fn test_cciv_updated_in_dpe() {
         pqc_key_type: FwVerificationPqcKeyType::MLDSA,
         ..Default::default()
     };
-    let image_bundle_standard =
-        caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_opts.clone())
-            .unwrap();
+    let image_bundle_standard = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        app_test_image(),
+        image_opts.clone(),
+    )
+    .unwrap();
 
     // Start model with mailbox responder FW first
     let args = RuntimeTestArgs {
@@ -904,24 +915,28 @@ fn test_cciv_updated_in_dpe() {
     assert_eq!(cciv_journey_exp, cciv_journey);
 }
 
-#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
 #[test]
 fn test_dpe_index_cache_initialized_after_hitless_update() {
     let image_opts = ImageOptions {
         pqc_key_type: FwVerificationPqcKeyType::LMS,
         ..Default::default()
     };
-    let image_bundle_standard =
-        caliptra_builder::build_and_sign_image(&FMC_WITH_UART, &APP_WITH_UART, image_opts.clone())
-            .unwrap();
+    let image_bundle_standard = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        app_test_image(),
+        image_opts.clone(),
+    )
+    .unwrap();
 
     // Boot with the mailbox responder so the test can inspect persistent DPE state.
     // Clearing the new cache fields simulates a fw-2.0.2 cold boot whose DCCM
     // did not initialize the cache appended by fw-2.0.3.
     let args = RuntimeTestArgs {
         subsystem_mode: true,
-        test_fwid: Some(mbox_test_image()),
+        test_fwid: Some(mbox_test_image_without_uart()),
         test_image_options: Some(image_opts.clone()),
+        key_type: Some(image_opts.pqc_key_type),
         ..Default::default()
     };
     let (mut model, image_bundle_mbox) = run_rt_test_return_fw(args);


### PR DESCRIPTION
Cherry-picks the DPE context update series from `caliptra-2.0`  to  `main`.

Commits:

• #3729:  runtime: Anchor MCU RT in Caliptra-managed DPE chain 
• #3988:  runtime: Harden DPE index cache 
• #3996:  runtime: Test DPE index cache across hitless update 
• #3989:  runtime: Add SoC manifest preamble DPE contexts 

Main-branch conflict adaptations:

• Adapted persistent DPE data changes to main ’s  `fw.dpe`  layout.
• Preserved owner authorization manifest handling already present on main .
• Avoided stack overflow in recovery `SET_AUTH_MANIFEST` by borrowing  `AuthManifestPreamble`  from the manifest buffer instead of copying it.