### PR TITLE
[CHERRY-PICK]: drivers: dynamic power handling of entropy_src (#4038)

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-17d50bd5ed7cde317840ee03c9a1c0dfc7ca0ba01fa196c7c505c6f83b4305ac2d1cc6f51173c7f5fffce72788c8c8dd  caliptra-rom-no-log.bin
-ef2d5df7802ff8bddb86e61aee09b0945c17391e169991e6fb80e98cba0344ce963ff1fb9d7b4ea2a21223c633678a02  caliptra-rom-with-log.bin
+78abe3dbd241b297361bdd265b97f435567bac1bad36019ee7bf89af2595a410d3cdc00f4909a12bf673caffd9097a70  caliptra-rom-no-log.bin
+10183747de91b80c8aed5d7e9331f03a619c5c15c5ca4595c8027150d9439b7522b30baa70b05cb15537c9e098480c10  caliptra-rom-with-log.bin

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -413,6 +413,17 @@ pub mod driver_tests {
         ..BASE_FWID
     };
 
+    pub const CSRNG_RESEED_TESTS: FwId = FwId {
+        bin_name: "csrng_reseed_tests",
+        ..BASE_FWID
+    };
+
+    pub const CSRNG_RESEED_HEALTH_FAIL_TESTS: FwId = FwId {
+        bin_name: "csrng_reseed_health_fail_tests",
+        // Enables the CSRNG_RESEED_FAILURE hook to simulate a reseed failure.
+        features: &["emu", "fips-test-hooks"],
+        ..BASE_FWID
+    };
     pub const TRNG_DRIVER_RESPONDER: FwId = FwId {
         bin_name: "trng_driver_responder",
         ..BASE_FWID
@@ -617,6 +628,8 @@ pub const REGISTERED_FW: &[&FwId] = &[
     &driver_tests::CSRNG_CONFIG_UNLOCK_TESTS,
     &driver_tests::CSRNG_SINGLE_BIT_MODE_TESTS,
     &driver_tests::CSRNG_RUNTIME_HEALTH_FAIL_TESTS,
+    &driver_tests::CSRNG_RESEED_TESTS,
+    &driver_tests::CSRNG_RESEED_HEALTH_FAIL_TESTS,
     &driver_tests::TRNG_DRIVER_RESPONDER,
     &driver_tests::PERSISTENT,
     &driver_tests::DMA_SHA384,

--- a/drivers/src/csrng.rs
+++ b/drivers/src/csrng.rs
@@ -26,8 +26,6 @@ use caliptra_registers::csrng::CsrngReg;
 use caliptra_registers::entropy_src::{self, regs::AlertFailCountsReadVal, EntropySrcReg};
 use caliptra_registers::soc_ifc::{self, SocIfcReg};
 
-use core::mem::MaybeUninit;
-
 // https://opentitan.org/book/hw/ip/csrng/doc/theory_of_operation.html#command-description
 pub const MAX_SEED_WORDS: usize = 12;
 const WORDS_PER_BLOCK: usize = 4;
@@ -86,30 +84,27 @@ impl Csrng {
         soc_ifc: &SocIfcReg,
         seed: Seed,
     ) -> CaliptraResult<Self> {
-        const FALSE: u32 = MultiBitBool::False as u32;
-        const TRUE: u32 = MultiBitBool::True as u32;
-
         let mut result = Self { csrng, entropy_src };
         let e = result.entropy_src.regs_mut();
 
         // Configure and enable entropy_src if not already enabled.
         // If already enabled, assume it was configured correctly by a previous call.
-        if e.module_enable().read().module_enable() == FALSE {
+        if e.module_enable().read().module_enable() == MULTIBIT_FALSE {
             // Configure entropy_src
             let entropy_cfg = read_entropy_configuration(&soc_ifc.regs());
             set_health_check_thresholds(e, &entropy_cfg);
 
             let rng_bit_enable = if entropy_cfg.rng_bit_enable {
-                TRUE
+                MULTIBIT_TRUE
             } else {
-                FALSE
+                MULTIBIT_FALSE
             };
             e.conf().write(|w| {
-                w.fips_enable(TRUE)
-                    .entropy_data_reg_enable(FALSE)
+                w.fips_enable(MULTIBIT_TRUE)
+                    .entropy_data_reg_enable(MULTIBIT_FALSE)
                     // THRESHOLD_SCOPE=FALSE so adaptive-proportion and Markov health
                     // tests score each of the 4 RNG bus lanes individually.
-                    .threshold_scope(FALSE)
+                    .threshold_scope(MULTIBIT_FALSE)
                     .rng_bit_enable(rng_bit_enable)
                     .rng_bit_sel(entropy_cfg.rng_bit_sel)
             });
@@ -121,9 +116,9 @@ impl Csrng {
                 & 1
                 == 1
             {
-                e.entropy_control().modify(|w| w.es_type(TRUE));
+                e.entropy_control().modify(|w| w.es_type(MULTIBIT_TRUE));
             }
-            e.module_enable().write(|w| w.module_enable(TRUE));
+            e.module_enable().write(|w| w.module_enable(MULTIBIT_TRUE));
             check_for_alert_state(result.entropy_src.regs())?;
 
             // Lock entropy_src configuration if not in debug mode.
@@ -136,18 +131,47 @@ impl Csrng {
                 e.sw_regupd().modify(|w| w.sw_regupd(false));
             }
         }
-
         let c = result.csrng.regs_mut();
 
-        if c.ctrl().read().enable() == FALSE {
-            c.ctrl()
-                .write(|w| w.enable(TRUE).sw_app_enable(TRUE).read_int_state(TRUE));
+        if c.ctrl().read().enable() == MULTIBIT_FALSE {
+            c.ctrl().write(|w| {
+                w.enable(MULTIBIT_TRUE)
+                    .sw_app_enable(MULTIBIT_TRUE)
+                    .read_int_state(MULTIBIT_TRUE)
+            });
         }
 
         send_command(&mut result.csrng, Command::Uninstantiate)?;
         send_command(&mut result.csrng, Command::Instantiate(seed))?;
 
         Ok(result)
+    }
+
+    /// Return 4 randomly generated [`u32`]s as a tuple.
+    ///
+    /// The return type is a tuple of 4 `u32`s which fits entirely in registers
+    /// on RV32, guaranteeing no hidden out-pointer and no `memcpy` on the
+    /// return path regardless of optimization level. Safe to call before CFI
+    /// counters are initialized.
+    pub fn generate4(&mut self) -> CaliptraResult<(u32, u32, u32, u32)> {
+        let token = self.manage_entropy_src_and_reseed()?;
+        self.do_generate4(token)
+    }
+
+    fn do_generate4(&mut self, _token: GenerateToken) -> CaliptraResult<(u32, u32, u32, u32)> {
+        send_command(
+            &mut self.csrng,
+            Command::Generate {
+                num_128_bit_blocks: 1,
+            },
+        )?;
+        wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
+        Ok((
+            self.csrng.regs().genbits().read(),
+            self.csrng.regs().genbits().read(),
+            self.csrng.regs().genbits().read(),
+            self.csrng.regs().genbits().read(),
+        ))
     }
 
     /// Return 12 randomly generated [`u32`]s.
@@ -168,41 +192,84 @@ impl Csrng {
     /// }
     /// ```
     pub fn generate12(&mut self) -> CaliptraResult<[u32; 12]> {
-        check_for_alert_state(self.entropy_src.regs())?;
-
-        send_command(
-            &mut self.csrng,
-            Command::Generate {
-                num_128_bit_blocks: 12 / WORDS_PER_BLOCK,
-            },
-        )?;
-
-        let mut result = MaybeUninit::<[u32; 12]>::uninit();
-        let dest = result.as_mut_ptr() as *mut u32;
-        unsafe {
-            wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
-            dest.add(0).write(self.csrng.regs().genbits().read());
-            dest.add(1).write(self.csrng.regs().genbits().read());
-            dest.add(2).write(self.csrng.regs().genbits().read());
-            dest.add(3).write(self.csrng.regs().genbits().read());
-            wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
-            dest.add(4).write(self.csrng.regs().genbits().read());
-            dest.add(5).write(self.csrng.regs().genbits().read());
-            dest.add(6).write(self.csrng.regs().genbits().read());
-            dest.add(7).write(self.csrng.regs().genbits().read());
-            wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
-            dest.add(8).write(self.csrng.regs().genbits().read());
-            dest.add(9).write(self.csrng.regs().genbits().read());
-            dest.add(10).write(self.csrng.regs().genbits().read());
-            dest.add(11).write(self.csrng.regs().genbits().read());
-            let out = result.assume_init();
-            #[cfg(feature = "fips-test-hooks")]
-            let out = crate::FipsTestHook::corrupt_data_if_hook_set(
+        let token = self.manage_entropy_src_and_reseed()?;
+        let result = self.do_generate::<12>(token, 12 / WORDS_PER_BLOCK)?;
+        #[cfg(feature = "fips-test-hooks")]
+        let result = unsafe {
+            crate::FipsTestHook::corrupt_data_if_hook_set(
                 crate::FipsTestHook::CSRNG_CORRUPT_OUTPUT,
-                &out,
-            );
-            Ok(out)
+                &result,
+            )
+        };
+        Ok(result)
+    }
+
+    /// Number of Generate calls before the reseed interval at which entropy_src
+    /// is pre-enabled, so it is ready by the time the reseed is needed.
+    /// Covers the ~2 ms entropy_src startup at typical generate cadence.
+    pub const ENTROPY_SRC_PRE_ENABLE_HEADROOM: u32 = 5;
+
+    /// Disable entropy_src.
+    ///
+    /// Must be called only after any in-flight Reseed has consumed its seed
+    /// from the esfinal FIFO; disabling mid-Reseed clears that FIFO and hangs
+    /// the CSRNG in `MainSmReseedPrep`. Pair with `wait_for_csrng_idle`.
+    pub(crate) fn disable_entropy_source(&mut self) {
+        self.entropy_src
+            .regs_mut()
+            .module_enable()
+            .write(|w| w.module_enable(MULTIBIT_FALSE));
+    }
+
+    pub(crate) fn enable_entropy_source(&mut self) {
+        self.entropy_src
+            .regs_mut()
+            .module_enable()
+            .write(|w| w.module_enable(MULTIBIT_TRUE));
+    }
+
+    /// Called before every Generate command. Keeps entropy_src disabled except
+    /// during a short window around each reseed:
+    ///
+    /// Phase 1 — pre-enable (`counter >= interval - HEADROOM`): enable
+    /// entropy_src in the background so its startup health checks overlap with
+    /// the next few Generates.
+    ///
+    /// Phase 2 — reseed (`counter >= interval`): reseed from entropy_src,
+    /// then disable it again. The Generate runs with entropy_src off.
+    fn manage_entropy_src_and_reseed(&mut self) -> CaliptraResult<GenerateToken> {
+        let interval = self.csrng.regs().reseed_interval().read();
+        let counter = self.csrng.regs().reseed_counter_2().read();
+        if counter >= interval {
+            self.ensure_entropy_src_enabled(&Seed::EntropySrc)?;
+            self.reseed(Seed::EntropySrc)?;
+            self.disable_entropy_source();
+            return Ok(GenerateToken(()));
         }
+
+        let pre_enable_threshold = interval.saturating_sub(Self::ENTROPY_SRC_PRE_ENABLE_HEADROOM);
+        if counter >= pre_enable_threshold {
+            self.enable_entropy_source();
+        }
+
+        Ok(GenerateToken(()))
+    }
+
+    fn do_generate<const N: usize>(
+        &mut self,
+        _token: GenerateToken,
+        num_128_bit_blocks: usize,
+    ) -> CaliptraResult<[u32; N]> {
+        send_command(&mut self.csrng, Command::Generate { num_128_bit_blocks })?;
+
+        let mut result = [0u32; N];
+        for block in result.chunks_mut(WORDS_PER_BLOCK) {
+            wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
+            for word in block.iter_mut() {
+                *word = self.csrng.regs().genbits().read();
+            }
+        }
+        Ok(result)
     }
 
     /// Return 16 randomly generated [`u32`]s (512 bits = four 128-bit GENBITS
@@ -218,22 +285,8 @@ impl Csrng {
     ///
     /// Returns an error if the internal generate command fails.
     pub fn generate16(&mut self) -> CaliptraResult<[u32; 16]> {
-        check_for_alert_state(self.entropy_src.regs())?;
-
-        send_command(
-            &mut self.csrng,
-            Command::Generate {
-                num_128_bit_blocks: 16 / WORDS_PER_BLOCK,
-            },
-        )?;
-
-        let mut result = [0u32; 16];
-        for block in result.chunks_mut(WORDS_PER_BLOCK) {
-            wait::until(|| self.csrng.regs().genbits_vld().read().genbits_vld());
-            for word in block.iter_mut() {
-                *word = self.csrng.regs().genbits().read();
-            }
-        }
+        let token = self.manage_entropy_src_and_reseed()?;
+        let result = self.do_generate::<16>(token, 16 / WORDS_PER_BLOCK)?;
         #[cfg(feature = "fips-test-hooks")]
         let result = unsafe {
             crate::FipsTestHook::corrupt_data_if_hook_set(
@@ -244,8 +297,23 @@ impl Csrng {
         Ok(result)
     }
 
+    /// Reseed the DRBG with the given seed. Returns only after the CSRNG has
+    /// fully processed the Reseed — `send_command` alone returns when the
+    /// command is accepted into the staging FIFO, not when the seed has been
+    /// consumed. Callers that disable entropy_src after this call need that
+    /// stronger guarantee.
     pub fn reseed(&mut self, seed: Seed) -> CaliptraResult<()> {
-        send_command(&mut self.csrng, Command::Reseed(seed))
+        self.ensure_entropy_src_enabled(&seed)?;
+        // FIPS test hook: inject a reseed failure for testing on platforms
+        // where the real TRNG cannot produce bad entropy (e.g. FPGA itrng).
+        // No-op unless `fips-test-hooks` is enabled and the host arms
+        // `CSRNG_RESEED_FAILURE` in `cptra_dbg_manuf_service_reg`.
+        #[cfg(feature = "fips-test-hooks")]
+        unsafe {
+            crate::FipsTestHook::error_if_hook_set(crate::FipsTestHook::CSRNG_RESEED_FAILURE)?;
+        }
+        send_command(&mut self.csrng, Command::Reseed(seed))?;
+        self.wait_for_csrng_idle()
     }
 
     /// Tear down the current DRBG instance and create a new one with the
@@ -263,8 +331,29 @@ impl Csrng {
     /// Returns an error if either the internal `Uninstantiate` or
     /// `Instantiate` command fails.
     pub fn reinstantiate(&mut self, seed: Seed) -> CaliptraResult<()> {
+        self.ensure_entropy_src_enabled(&seed)?;
         send_command(&mut self.csrng, Command::Uninstantiate)?;
         send_command(&mut self.csrng, Command::Instantiate(seed))
+    }
+
+    /// Enables entropy_src and waits for it to be ready if the seed source is
+    /// `EntropySrc` and the module is currently disabled. No-op for
+    /// `Seed::Constant` since entropy_src is not needed in that case.
+    fn ensure_entropy_src_enabled(&mut self, seed: &Seed) -> CaliptraResult<()> {
+        if matches!(seed, Seed::EntropySrc) {
+            if self
+                .entropy_src
+                .regs()
+                .module_enable()
+                .read()
+                .module_enable()
+                != MULTIBIT_TRUE
+            {
+                self.enable_entropy_source();
+            }
+            check_for_alert_state(self.entropy_src.regs())?;
+        }
+        Ok(())
     }
 
     pub fn update(&mut self, additional_data: &[u32]) -> CaliptraResult<()> {
@@ -291,6 +380,29 @@ impl Csrng {
 
     pub fn zeroize(&mut self) -> CaliptraResult<()> {
         send_command(&mut self.csrng, Command::Uninstantiate)
+    }
+
+    /// Wait for the CSRNG main SM to return to Idle. `send_command` returns
+    /// when the command is accepted into the staging FIFO, not when the CSRNG
+    /// finishes executing it.
+    fn wait_for_csrng_idle(&self) -> CaliptraResult<()> {
+        const MAIN_SM_IDLE: u32 = 0x4e;
+        const ALERT_HANG: u32 = 0x1fb;
+        loop {
+            let csrng_state = self.csrng.regs().main_sm_state().read().main_sm_state();
+            let es_state = self
+                .entropy_src
+                .regs()
+                .main_sm_state()
+                .read()
+                .main_sm_state();
+            if csrng_state == MAIN_SM_IDLE {
+                return Ok(());
+            }
+            if es_state == ALERT_HANG {
+                return check_for_alert_state(self.entropy_src.regs());
+            }
+        }
     }
 }
 
@@ -340,6 +452,9 @@ pub enum Seed<'a> {
     Constant(&'a [u32]),
 }
 
+/// Proof token that `manage_entropy_src_and_reseed` has been called.
+struct GenerateToken(());
+
 enum Command<'a> {
     Instantiate(Seed<'a>),
     Reseed(Seed<'a>),
@@ -353,6 +468,9 @@ enum MultiBitBool {
     False = 9,
     True = 6,
 }
+
+const MULTIBIT_FALSE: u32 = MultiBitBool::False as u32;
+const MULTIBIT_TRUE: u32 = MultiBitBool::True as u32;
 
 /// Contains counts of failing health checks.
 ///

--- a/drivers/src/trng.rs
+++ b/drivers/src/trng.rs
@@ -107,10 +107,7 @@ impl Trng {
         }
 
         match self {
-            Self::Internal(csrng) => {
-                let a = csrng.generate12()?;
-                Ok((a[0], a[1], a[2], a[3]))
-            }
+            Self::Internal(csrng) => csrng.generate4(),
             Self::External(trng_ext) => trng_ext.generate4(),
             Self::MfgMode() => {
                 unsafe {
@@ -156,6 +153,12 @@ impl Trng {
             _ => unsafe {
                 cfi_panic_handler(CaliptraError::ROM_CFI_PANIC_UNEXPECTED_MATCH_BRANCH.into())
             },
+        }
+    }
+
+    pub fn disable_entropy_source(&mut self) {
+        if let Self::Internal(csrng) = self {
+            csrng.disable_entropy_source()
         }
     }
 }

--- a/drivers/test-fw/Cargo.toml
+++ b/drivers/test-fw/Cargo.toml
@@ -24,6 +24,7 @@ caliptra-cfi-lib = { workspace = true, default-features = false, features = [
 emu = ["caliptra-test-harness/emu"]
 fpga_realtime = ["caliptra-drivers/fpga_realtime"]
 fpga_subsystem = ["caliptra-drivers/fpga_subsystem"]
+fips-test-hooks = ["caliptra-drivers/fips-test-hooks"]
 
 
 # This feature is used to filter all these binary targets during normal builds
@@ -232,4 +233,14 @@ required-features = ["riscv"]
 [[bin]]
 name = "csrng_runtime_health_fail_tests"
 path = "src/bin/csrng_runtime_health_fail_tests.rs"
+required-features = ["riscv"]
+
+[[bin]]
+name = "csrng_reseed_tests"
+path = "src/bin/csrng_reseed_tests.rs"
+required-features = ["riscv"]
+
+[[bin]]
+name = "csrng_reseed_health_fail_tests"
+path = "src/bin/csrng_reseed_health_fail_tests.rs"
 required-features = ["riscv"]

--- a/drivers/test-fw/src/bin/csrng_reseed_health_fail_tests.rs
+++ b/drivers/test-fw/src/bin/csrng_reseed_health_fail_tests.rs
@@ -1,0 +1,75 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    csrng_reseed_health_fail_tests.rs
+
+Abstract:
+
+    Firmware for TC-6: injects a reseed failure via the CSRNG_RESEED_FAILURE
+    FIPS test hook, for platforms where the real TRNG cannot produce bad
+    entropy (e.g. FPGA in itrng mode).
+
+    The host arms the hook by writing CSRNG_RESEED_FAILURE to bits 23:16 of
+    cptra_dbg_manuf_service_reg before boot. The driver's reseed() calls
+    FipsTestHook::error_if_hook_set(), returning FIPS_HOOKS_INJECTED_ERROR on
+    the next reseed.
+
+    This firmware:
+      1. Initialises CSRNG with live entropy (startup passes — the hook is
+         only checked on the reseed path).
+      2. Sets RESEED_INTERVAL = 1 so the next generate triggers a reseed.
+      3. Calls generate12() and expects the reseed to fail.
+
+    Built with the `fips-test-hooks` cargo feature.
+
+--*/
+#![no_std]
+#![no_main]
+
+use caliptra_drivers::Csrng;
+use caliptra_error::CaliptraError;
+use caliptra_registers::{csrng::CsrngReg, entropy_src::EntropySrcReg, soc_ifc::SocIfcReg};
+use caliptra_test_harness::test_suite;
+
+fn test_reseed_fails_on_health_check_failure() {
+    let csrng_reg = unsafe { CsrngReg::new() };
+    let entropy_src_reg = unsafe { EntropySrcReg::new() };
+    let soc_ifc_reg = unsafe { SocIfcReg::new() };
+
+    // Startup health checks pass — the hook is only checked on the reseed path.
+    let mut csrng = Csrng::new(csrng_reg, entropy_src_reg, &soc_ifc_reg)
+        .expect("CSRNG should pass startup health testing");
+
+    // Set a tight interval so the next generate triggers a reseed.
+    let mut csrng_reg2 = unsafe { CsrngReg::new() };
+    csrng_reg2.regs_mut().reseed_interval().write(|_| 1);
+
+    // First generate12() does not trigger Phase 2 (counter < interval);
+    // it succeeds and advances the counter to the interval.
+    csrng
+        .generate12()
+        .expect("first generate12 should succeed (counter < interval)");
+
+    // The next generate12() enters Phase 2 and calls reseed(); the FIPS hook
+    // fires there. send_command() maps the failure to DRIVER_CSRNG_RESEED,
+    // so either error is acceptable.
+    let result = csrng.generate12();
+    match result {
+        Err(CaliptraError::FIPS_HOOKS_INJECTED_ERROR) | Err(CaliptraError::DRIVER_CSRNG_RESEED) => {
+            // Expected: the injected hook caused the reseed to fail.
+        }
+        Err(e) => {
+            panic!("unexpected error {:?}", e);
+        }
+        Ok(_) => {
+            panic!("expected reseed failure from FIPS hook, but generate12 succeeded");
+        }
+    }
+}
+
+test_suite! {
+    test_reseed_fails_on_health_check_failure,
+}

--- a/drivers/test-fw/src/bin/csrng_reseed_tests.rs
+++ b/drivers/test-fw/src/bin/csrng_reseed_tests.rs
@@ -1,0 +1,216 @@
+/*++
+
+Licensed under the Apache-2.0 license.
+
+File Name:
+
+    csrng_reseed_tests.rs
+
+Abstract:
+
+    Firmware-side test cases for CSRNG reseed and entropy source power-saving
+    behaviour. Verifies:
+
+      - generate12() succeeds when RESEED_COUNTER is close to RESEED_INTERVAL
+        (driver triggers an automatic reseed before the counter overflows).
+      - generate12() succeeds normally when RESEED_COUNTER is near zero.
+      - generate12() succeeds when RESEED_INTERVAL is tightened below the
+        current RESEED_COUNTER (forces an immediate reseed).
+      - generate12() triggers a reseed from entropy_src after RESEED_INTERVAL
+        is changed while entropy_src is enabled.
+      - generate12() succeeds (auto-enables entropy_src and reseeds) even
+        when entropy_src was disabled before the call.
+
+--*/
+#![no_std]
+#![no_main]
+
+use caliptra_drivers::{Csrng, CsrngSeed};
+use caliptra_registers::{csrng::CsrngReg, entropy_src::EntropySrcReg, soc_ifc::SocIfcReg};
+use caliptra_test_harness::test_suite;
+
+// Deterministic seed so generate output is reproducible across all tests that
+// do not need live entropy.
+const FIXED_SEED: CsrngSeed = CsrngSeed::Constant(&[
+    0x73bec010, 0x9262474c, 0x16a30f76, 0x531b51de, 0x2ee494e5, 0xdfec9db3, 0xcb7a879d, 0x5600419c,
+    0xca79b0b0, 0xdda33b5c, 0xa468649e, 0xdf5d73fa,
+]);
+
+fn make_csrng_fixed() -> Csrng {
+    let csrng_reg = unsafe { CsrngReg::new() };
+    let entropy_src_reg = unsafe { EntropySrcReg::new() };
+    let soc_ifc_reg = unsafe { SocIfcReg::new() };
+    Csrng::with_seed(csrng_reg, entropy_src_reg, &soc_ifc_reg, FIXED_SEED)
+        .expect("construct CSRNG with fixed seed")
+}
+
+fn make_csrng_live() -> Csrng {
+    let csrng_reg = unsafe { CsrngReg::new() };
+    let entropy_src_reg = unsafe { EntropySrcReg::new() };
+    let soc_ifc_reg = unsafe { SocIfcReg::new() };
+    Csrng::new(csrng_reg, entropy_src_reg, &soc_ifc_reg).expect("construct CSRNG with live entropy")
+}
+
+// ---------------------------------------------------------------------------
+// TC-1: generate12() when RESEED_COUNTER is close to RESEED_INTERVAL
+//
+// Set RESEED_INTERVAL to a small value (10), advance RESEED_COUNTER to
+// RESEED_INTERVAL - 1 by calling generate12() nine times, then verify that
+// the tenth call (which would hit the interval) still succeeds — the driver
+// must trigger an automatic reseed before the counter overflows.
+// ---------------------------------------------------------------------------
+fn test_generate_reseed_counter_near_interval() {
+    let mut csrng = make_csrng_fixed();
+
+    // Set a small reseed interval so the test runs quickly.
+    const RESEED_INTERVAL: u32 = 10;
+    let mut csrng_reg = unsafe { CsrngReg::new() };
+    csrng_reg
+        .regs_mut()
+        .reseed_interval()
+        .write(|_| RESEED_INTERVAL);
+
+    // Advance counter to RESEED_INTERVAL - 1.
+    for i in 0..RESEED_INTERVAL - 1 {
+        csrng
+            .generate12()
+            .unwrap_or_else(|_| panic!("generate12 failed at iteration {}", i));
+    }
+
+    // This call lands exactly at RESEED_INTERVAL — driver should reseed and succeed.
+    csrng
+        .generate12()
+        .expect("generate12 at RESEED_INTERVAL should succeed via automatic reseed");
+}
+
+// ---------------------------------------------------------------------------
+// TC-2: generate12() when RESEED_COUNTER is near zero (normal early-use case)
+//
+// After fresh instantiation the counter is 0.  Verify that the very first
+// generate12() call succeeds without any reseed logic being triggered.
+//
+// Reads RESEED_COUNTER_2 (the SW application instance — NumApps=3, instance 2
+// is the SW app the driver uses). The emulator models all three counter
+// registers with the same internal CTR_DRBG counter.
+// ---------------------------------------------------------------------------
+fn test_generate_reseed_counter_near_zero() {
+    let mut csrng = make_csrng_fixed();
+
+    // Verify the reseed counter starts at 0 (or 1 after instantiate).
+    let csrng_reg = unsafe { CsrngReg::new() };
+    let counter = csrng_reg.regs().reseed_counter_2().read();
+    assert!(
+        counter <= 1,
+        "reseed_counter_2 should be <=1 after instantiate, got {}",
+        counter
+    );
+
+    csrng
+        .generate12()
+        .expect("generate12 near counter=0 should succeed");
+}
+
+// ---------------------------------------------------------------------------
+// TC-3: generate12() when RESEED_INTERVAL is tightened below current counter
+//
+// Advance the counter to 5, then set RESEED_INTERVAL = 3 (below the current
+// counter).  The next generate12() must detect counter > interval, perform a
+// reseed, and succeed.
+// ---------------------------------------------------------------------------
+fn test_generate_interval_shrunk_below_counter() {
+    let mut csrng = make_csrng_fixed();
+    let mut csrng_reg = unsafe { CsrngReg::new() };
+
+    // Advance counter to 5.
+    for _ in 0..5 {
+        csrng.generate12().expect("generate12 during setup");
+    }
+    let counter_before = csrng_reg.regs().reseed_counter_2().read();
+    assert!(
+        counter_before >= 5,
+        "expected counter >= 5, got {}",
+        counter_before
+    );
+
+    // Shrink interval below the current counter.
+    csrng_reg.regs_mut().reseed_interval().write(|_| 3);
+
+    // Driver should detect counter > interval, reseed, then complete.
+    csrng
+        .generate12()
+        .expect("generate12 should succeed after reseed triggered by shrunken interval");
+}
+
+// ---------------------------------------------------------------------------
+// TC-4: generate12() reseeds from entropy_src when interval changes while
+//       entropy_src is enabled
+//
+// Uses a live-entropy CSRNG.  Sets a tight interval so the counter reaches it
+// while entropy_src is active, confirming the automatic reseed draws from the
+// live entropy source (not a constant seed).
+// ---------------------------------------------------------------------------
+fn test_generate_reseed_from_entropy_src_after_interval_change() {
+    let mut csrng = make_csrng_live();
+    let mut csrng_reg = unsafe { CsrngReg::new() };
+
+    // Advance counter to 3 using live entropy.
+    for _ in 0..3 {
+        csrng.generate12().expect("generate12 during setup");
+    }
+
+    // Set interval to 3 — counter is now at the boundary.
+    csrng_reg.regs_mut().reseed_interval().write(|_| 3);
+
+    // entropy_src is currently enabled; reseed should pull from it.
+    csrng
+        .generate12()
+        .expect("generate12 should reseed from live entropy_src and succeed");
+}
+
+// ---------------------------------------------------------------------------
+// TC-5: generate12() succeeds (auto-enables entropy_src) when entropy_src is
+//       disabled at the time a reseed is required.
+//
+// The driver re-enables entropy_src on demand before issuing the Reseed
+// command, so disabling it externally before a boundary generate must not
+// cause generate12() to fail.
+// ---------------------------------------------------------------------------
+fn test_generate_reseed_auto_enables_entropy_src() {
+    let mut csrng = make_csrng_live();
+    let mut csrng_reg = unsafe { CsrngReg::new() };
+    let mut entropy_src_reg = unsafe { EntropySrcReg::new() };
+
+    // Set interval = 3, advance counter to 3 (boundary).
+    csrng_reg.regs_mut().reseed_interval().write(|_| 3);
+    for _ in 0..3 {
+        csrng.generate12().expect("generate12 during setup");
+    }
+
+    // Disable entropy_src externally. The driver must re-enable it before the
+    // reseed, so the next generate12() succeeds.
+    // MultiBitBool::False = 9 (same value used in csrng.rs).
+    entropy_src_reg
+        .regs_mut()
+        .module_enable()
+        .write(|w| w.module_enable(9));
+
+    csrng
+        .generate12()
+        .expect("generate12 should auto-enable entropy_src and succeed at the reseed boundary");
+}
+
+// ---------------------------------------------------------------------------
+// TC-6: generate12() fails with an injected error when the
+//       CSRNG_RESEED_FAILURE FIPS test hook is set
+//
+// This case lives in csrng_reseed_health_fail_tests.rs (separate firmware
+// binary built with the `fips-test-hooks` feature).
+// ---------------------------------------------------------------------------
+
+test_suite! {
+    test_generate_reseed_counter_near_zero,
+    test_generate_reseed_counter_near_interval,
+    test_generate_interval_shrunk_below_counter,
+    test_generate_reseed_from_entropy_src_after_interval_change,
+    test_generate_reseed_auto_enables_entropy_src,
+}

--- a/drivers/test-fw/src/bin/csrng_runtime_health_fail_tests.rs
+++ b/drivers/test-fw/src/bin/csrng_runtime_health_fail_tests.rs
@@ -21,7 +21,7 @@ Abstract:
 #![no_std]
 #![no_main]
 
-use caliptra_drivers::Csrng;
+use caliptra_drivers::{Csrng, CsrngSeed};
 use caliptra_error::CaliptraError;
 use caliptra_registers::{csrng::CsrngReg, entropy_src::EntropySrcReg, soc_ifc::SocIfcReg};
 use caliptra_test_harness::test_suite;
@@ -35,10 +35,10 @@ fn test_runtime_health_check_failure() {
     let mut csrng = Csrng::new(csrng_reg, entropy_src_reg, &soc_ifc_reg)
         .expect("CSRNG should pass startup health testing");
 
-    // First generate should start seeing bad entropy
-    // The emulator will be configured to provide good entropy for startup,
-    // then bad entropy for runtime operations
-    let result = csrng.generate12();
+    // Reseed from entropy_src — this enables entropy_src, consumes from it,
+    // and is where the health check fires. Bad entropy injected by the test
+    // harness will be detected here.
+    let result = csrng.reseed(CsrngSeed::EntropySrc);
 
     match result {
         Err(CaliptraError::DRIVER_CSRNG_REPCNT_HEALTH_CHECK_FAILED) => {
@@ -51,7 +51,7 @@ fn test_runtime_health_check_failure() {
             panic!("Expected health check failure error, got: {:?}", e);
         }
         Ok(_) => {
-            panic!("Expected generate12 to fail due to runtime health check failure");
+            panic!("Expected reseed to fail due to runtime health check failure");
         }
     }
 }

--- a/drivers/tests/drivers_integration_tests/main.rs
+++ b/drivers/tests/drivers_integration_tests/main.rs
@@ -1413,3 +1413,62 @@ fn test_dma_sha384() {
         run_driver_test(&firmware::driver_tests::DMA_SHA384);
     }
 }
+
+// ---------------------------------------------------------------------------
+// CSRNG reseed / power-saving tests
+//
+// TC-1..TC-5 run with normal good entropy.
+// TC-6 (health-check failure on reseed) needs bad entropy after startup.
+// ---------------------------------------------------------------------------
+
+/// TC-1..TC-5: reseed/counter/interval/disable tests with good entropy.
+/// Runs on all targets including FPGA itrng (TC-5 exercises auto-enable).
+#[test]
+fn test_csrng_reseed() {
+    let rom =
+        caliptra_builder::build_firmware_rom(&firmware::driver_tests::CSRNG_RESEED_TESTS).unwrap();
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            itrng_nibbles: Box::new(trng_nibbles()),
+            trng_mode: Some(TrngMode::Internal),
+            ..default_init_params()
+        },
+        BootParams::default(),
+    )
+    .unwrap();
+
+    model.step_until_exit_success().unwrap();
+}
+
+/// TC-6: injects a reseed failure via the CSRNG_RESEED_FAILURE FIPS hook
+/// (0x4D armed in `cptra_dbg_manuf_service_reg` before boot). Uses good
+/// entropy — the failure comes from the hook, not the TRNG — so it runs on
+/// every target including FPGA itrng.
+#[test]
+fn test_csrng_reseed_health_fail() {
+    let rom = caliptra_builder::build_firmware_rom(
+        &firmware::driver_tests::CSRNG_RESEED_HEALTH_FAIL_TESTS,
+    )
+    .unwrap();
+
+    const HOOK_CODE_OFFSET: u32 = 16;
+    const CSRNG_RESEED_FAILURE: u32 = 0x4D;
+
+    let mut model = caliptra_hw_model::new(
+        InitParams {
+            rom: &rom,
+            itrng_nibbles: Box::new(trng_nibbles()),
+            trng_mode: Some(TrngMode::Internal),
+            ..default_init_params()
+        },
+        BootParams {
+            initial_dbg_manuf_service_reg: CSRNG_RESEED_FAILURE << HOOK_CODE_OFFSET,
+            ..BootParams::default()
+        },
+    )
+    .unwrap();
+
+    model.step_until_exit_success().unwrap();
+}

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -74,6 +74,10 @@ pub extern "C" fn entry_point() -> ! {
         cprintln!("[rt] RT can't load FHT");
         handle_fatal_error(caliptra_drivers::CaliptraError::RUNTIME_HANDOFF_FHT_NOT_LOADED.into());
     }
+
+    cprintln!("[rt] Disable entropy source");
+    drivers.trng.disable_entropy_source();
+
     cprintln!("[rt] RT listening for mailbox commands...");
     if let Err(e) = caliptra_runtime::handle_mailbox_commands(&mut drivers) {
         handle_fatal_error(e.into());

--- a/sw-emulator/lib/periph/src/csrng.rs
+++ b/sw-emulator/lib/periph/src/csrng.rs
@@ -33,6 +33,13 @@ pub struct Csrng {
     #[register(offset = 0x18, write_fn = cmd_req_write)]
     cmd_req: WriteOnlyRegister<u32>,
 
+    #[register(offset = 0x1C, write_fn = reseed_interval_write)]
+    reseed_interval: u32,
+
+    // SW app instance counter (NumApps=3, instance 2 is what the driver reads).
+    #[register(offset = 0x28, read_fn = reseed_counter_read)]
+    reseed_counter_2: ReadOnlyRegister<u32>,
+
     #[register(offset = 0x2c)]
     sw_cmd_sts: ReadOnlyRegister<u32>,
 
@@ -41,6 +48,11 @@ pub struct Csrng {
 
     #[register(offset = 0x34, read_fn = genbits_read)]
     genbits: ReadOnlyRegister<u32>,
+
+    // MAIN_SM_STATE (0x5c): CSRNG main SM state. The emulator processes
+    // commands synchronously, so it always reads Idle (0x4e = MainSmIdle).
+    #[register(offset = 0x5c)]
+    main_sm_state_csrng: ReadOnlyRegister<u32>,
 
     #[register(offset = 0x54)]
     err_code: ReadOnlyRegister<u32>,
@@ -107,9 +119,12 @@ impl Csrng {
             // These reset values come from register definitions
             ctrl: 0x999,
             cmd_req: WriteOnlyRegister::new(0),
+            reseed_interval: 0xffffffff,
+            reseed_counter_2: ReadOnlyRegister::new(0),
             sw_cmd_sts: ReadOnlyRegister::new(0b110), // cmd_rdy=1, cmd_ack=1, cmd_sts=0
             genbits_vld: ReadOnlyRegister::new(0b01),
             genbits: ReadOnlyRegister::new(0),
+            main_sm_state_csrng: ReadOnlyRegister::new(0x4e), // MainSmIdle (csrng_pkg.sv)
             err_code: ReadOnlyRegister::new(0),
             me_regwen: 1, // Reset value: enabled (writable)
             sw_regupd: 1, // Reset value: enabled (writable)
@@ -173,6 +188,21 @@ impl Csrng {
             }
         }
         Ok(())
+    }
+
+    fn reseed_interval_write(&mut self, _: RvSize, data: RvData) -> Result<(), BusError> {
+        if self.sw_regupd == 0 {
+            return Ok(());
+        }
+        self.reseed_interval = data;
+
+        self.ctr_drbg.set_reseed_interval(data);
+        Ok(())
+    }
+
+    /// Read handler for RESEED_COUNTER_2 (SW app instance; NumApps=3).
+    fn reseed_counter_read(&mut self, _: RvSize) -> Result<RvData, BusError> {
+        Ok(self.ctr_drbg.reseed_counter())
     }
 
     fn genbits_vld_read(&mut self, _: RvSize) -> Result<RvData, BusError> {

--- a/sw-emulator/lib/periph/src/csrng/ctr_drbg.rs
+++ b/sw-emulator/lib/periph/src/csrng/ctr_drbg.rs
@@ -32,6 +32,8 @@ pub struct CtrDrbg {
     v: Block,
     key: Key,
     generated_bytes: Vec<Block>,
+    reseed_interval: u32,
+    reseed_counter: u32,
 }
 
 impl CtrDrbg {
@@ -40,6 +42,8 @@ impl CtrDrbg {
             v: [0; BLOCK_LEN_BYTES],
             key: [0; KEY_LEN_BYTES],
             generated_bytes: vec![],
+            reseed_interval: 0xffffffffu32,
+            reseed_counter: 0u32,
         }
     }
 
@@ -70,6 +74,8 @@ impl CtrDrbg {
         self.key = [0; KEY_LEN_BYTES];
         self.v = [0; BLOCK_LEN_BYTES];
         self.update(seed_material);
+        // Instantiate resets the reseed counter (RTL state_db resets to 0).
+        self.reseed_counter = 0;
     }
 
     pub fn reseed(&mut self, seed: Instantiate) {
@@ -81,10 +87,18 @@ impl CtrDrbg {
             Instantiate::Bytes(bytes) => *bytes,
         };
         self.update(seed_material);
+        // Reseed resets the reseed counter, matching the RTL state_db.
+        self.reseed_counter = 0;
     }
 
     pub fn generate(&mut self, num_128_bit_blocks: usize) {
         // Section 10.2.1.5 (page 55).
+        // The RTL NACKs with CMD_STS_RESEED_CNT_EXCEEDED when
+        // RESEED_COUNTER >= RESEED_INTERVAL; model that by producing no output.
+        if self.reseed_counter >= self.reseed_interval {
+            return;
+        }
+        self.reseed_counter += 1;
 
         let additional_input = [0; SEED_LEN_BYTES];
         self.generated_bytes.clear();
@@ -109,6 +123,16 @@ impl CtrDrbg {
 
     pub fn pop_block(&mut self) -> Option<Block> {
         self.generated_bytes.pop()
+    }
+
+    /// Store the reseed interval written to the CSRNG RESEED_INTERVAL register.
+    pub fn set_reseed_interval(&mut self, interval: u32) {
+        self.reseed_interval = interval;
+    }
+
+    /// Current reseed counter value, exposed for the RESEED_COUNTER_* registers.
+    pub fn reseed_counter(&self) -> u32 {
+        self.reseed_counter
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Keep entropy_src disabled outside of CSRNG Reseed windows to reduce power consumption, per RFC #2868. Caliptra RT leaves entropy_src MODULE_ENABLE=False by default and only enables it briefly around each Reseed, with a headroom so the health-test startup is ready when the Reseed fires. RESEED_INTERVAL stays at the hardware default — the saving comes from gating entropy_src, not from shortening the interval.

reseed() waits for the CSRNG main SM to reach MainSmIdle (and surfaces an entropy_src AlertHang as a health-check failure) before returning, since send_command returns when the Reseed is accepted into the staging FIFO, not when the CSRNG finishes it.

Also adds generate4() — four u32s returned in a tuple so they fit in registers on RV32 (no hidden out-pointer, safe before CFI counters are initialized).

Fixes #2868

(cherry picked from commit 4892e5bec3744c87b5f15648137ca71ce92154f8)