### PR TITLE
mldsa: Optimize the stack for sign exported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=75226a859d9fb009371dfe4b2fd8d4adeafcaa42#75226a859d9fb009371dfe4b2fd8d4adeafcaa42"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
 dependencies = [
  "arrayvec",
  "asn1",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=75226a859d9fb009371dfe4b2fd8d4adeafcaa42#75226a859d9fb009371dfe4b2fd8d4adeafcaa42"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=75226a859d9fb009371dfe4b2fd8d4adeafcaa42#75226a859d9fb009371dfe4b2fd8d4adeafcaa42"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
 dependencies = [
  "arrayvec",
  "caliptra-dpe-crypto",
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-response-buffer"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=75226a859d9fb009371dfe4b2fd8d4adeafcaa42#75226a859d9fb009371dfe4b2fd8d4adeafcaa42"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
 
 [[package]]
 name = "caliptra-drivers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,10 +145,10 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", package = "caliptra-dpe", features = ["hybrid", "arbitrary_max_handles"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", package = "caliptra-dpe-crypto", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", package = "caliptra-dpe-platform", default-features = false }
-caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "75226a859d9fb009371dfe4b2fd8d4adeafcaa42", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe", features = ["hybrid", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe-crypto", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe-platform", default-features = false }
+caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", default-features = false }
 # Older version for backwards compatibility logic
 dpe-runtime-1-2 = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "e63241cebad7c96ff954ec7d33207fc96b3323ef", package = "dpe", default-features = false, features = ["dpe_profile_p384_sha384", "arbitrary_max_handles"] }
 elf = "0.7.2"

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -20,7 +20,7 @@ Abstract:
 use crate::CaliptraResult;
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 use core::ops::{Deref, DerefMut};
-use zerocopy::{FromBytes, Immutable, KnownLayout};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub use caliptra_mldsa::{
@@ -46,7 +46,7 @@ pub struct Mldsa87PrivKey([u8; MLDSA87_PRIVATE_KEY_BYTES]);
 
 /// ML-DSA-87 encoded signature (4,627 bytes).
 #[repr(transparent)]
-#[derive(KnownLayout, Immutable, FromBytes)]
+#[derive(KnownLayout, Immutable, FromBytes, IntoBytes)]
 pub struct Mldsa87Signature([u8; MLDSA87_SIGNATURE_BYTES]);
 
 #[repr(transparent)]

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -95,10 +95,14 @@ pub(crate) fn new_ec_dpe_crypto<'a>(
     exported_cdi_slots: &'a mut ExportedCdiHandles,
 ) -> CaliptraResult<DpeCrypto<'a>> {
     // The RT alias public key and both KeyIds all come from the FHT.
-    let rt_pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+    // Store the RT alias key as the concrete ECDSA type, not the `PubKey` enum:
+    // the enum is sized by its 2,592-byte ML-DSA variant, so wrapping this ~96-byte
+    // P-384 key in it would bloat the `Signer` enum (and thus the live DPE env on
+    // the sign stack) by ~2.5 KB for a variant that is never used here.
+    let rt_pub_key = EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
         &fht.rt_dice_pub_key.x.into(),
         &fht.rt_dice_pub_key.y.into(),
-    )));
+    ));
     DpeCrypto::new_ec(
         CryptoEngines {
             hasher: DpeHasher::new(sha384)?,
@@ -117,7 +121,7 @@ pub(crate) fn new_ec_dpe_crypto<'a>(
 impl<'a> DpeCrypto<'a> {
     pub fn new_ec(
         engines: CryptoEngines<'a>,
-        rt_pub_key: PubKey,
+        rt_pub_key: EcdsaPubKey,
         key_id_rt_cdi: KeyId,
         key_id_rt_priv_key: KeyId,
         exported_cdi_slots: &'a mut ExportedCdiHandles,
@@ -258,7 +262,7 @@ impl<'a> DpeCrypto<'a> {
         label: &[u8],
         info: &[u8],
         key_id: KeyId,
-    ) -> Result<(KeyId, PubKey), CryptoError> {
+    ) -> Result<(KeyId, EcdsaPubKey), CryptoError> {
         let mut usage: KeyUsage = KeyUsage::default();
         let usage = usage.set_ecc_key_gen_seed_en();
 
@@ -285,10 +289,10 @@ impl<'a> DpeCrypto<'a> {
                             .into(),
                     )
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                let pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
+                let pub_key = EcdsaPubKey::Ecdsa384(EcdsaPub384::from_slice(
                     &pub_key.x.into(),
                     &pub_key.y.into(),
-                )));
+                ));
                 Ok((key_id, pub_key))
             }
             #[cfg(feature = "mldsa_attestation")]
@@ -303,12 +307,13 @@ impl<'a> DpeCrypto<'a> {
         trng: &mut Trng,
         data: &SignData,
         priv_key: &KeyId,
-        pub_key: &PubKey,
-    ) -> Result<Signature, CryptoError> {
+        pub_key: &EcdsaPubKey,
+        out: &mut Signature,
+    ) -> Result<(), CryptoError> {
         let priv_key_args = KeyReadArgs::new(*priv_key);
         let ecc_priv_key = Ecc384PrivKeyIn::Key(priv_key_args);
 
-        let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })) = pub_key else {
+        let EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y }) = pub_key else {
             return Err(CryptoError::MismatchedAlgorithm);
         };
         let ecc_pub_key = Ecc384PubKey {
@@ -341,17 +346,20 @@ impl<'a> DpeCrypto<'a> {
             Ok(s) => s,
             Err(e) => Err(*e)?,
         };
-        Ok(Signature::Ecdsa(EcdsaSignature::Ecdsa384(
-            EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into()),
-        )))
+        let Signature::Ecdsa(EcdsaSignature::Ecdsa384(out_sig)) = out else {
+            return Err(CryptoError::MismatchedAlgorithm);
+        };
+        *out_sig = EcdsaSignature384::from_slice(&sig.r.into(), &sig.s.into());
+        Ok(())
     }
 
     fn sign_helper_ec(
         engines: &mut CryptoEngines,
         data: &SignData,
-        pub_key: &PubKey,
+        pub_key: &EcdsaPubKey,
         priv_key: &KeyId,
-    ) -> Result<Signature, CryptoError> {
+        out: &mut Signature,
+    ) -> Result<(), CryptoError> {
         Self::sign_ec(
             engines.ecc384,
             engines.hasher.driver(),
@@ -359,28 +367,39 @@ impl<'a> DpeCrypto<'a> {
             data,
             priv_key,
             pub_key,
+            out,
         )
     }
 
     #[cfg(feature = "mldsa_attestation")]
-    fn sign_helper_mldsa(data: &SignData, seed: &Mldsa87Seed) -> Result<Signature, CryptoError> {
-        let mut sig = Mldsa87Signature::default();
+    fn sign_helper_mldsa(
+        data: &SignData,
+        seed: &Mldsa87Seed,
+        out: &mut Signature,
+    ) -> Result<(), CryptoError> {
+        // Sign directly into the caller-owned signature buffer so the 4,627-byte
+        // signature lives in exactly one stack slot on the (stack-tight) sign path.
+        let Signature::Mldsa(MldsaSignature(buf)) = out else {
+            return Err(CryptoError::MismatchedAlgorithm);
+        };
+        let sig =
+            Mldsa87Signature::mut_from_bytes(buf.as_mut_slice()).map_err(|_| CryptoError::Size)?;
         match data {
-            SignData::ResponseBuffer(buf, range) => {
-                Mldsa87::generate_sign_mu_deterministic(seed, *buf, range.clone(), &mut sig)
+            SignData::ResponseBuffer(b, range) => {
+                Mldsa87::generate_sign_mu_deterministic(seed, *b, range.clone(), sig)
                     .map_err(|_| CryptoError::HashError(0))
             }
-            SignData::Raw(msg) => Mldsa87::sign_deterministic(seed, msg, &mut sig)
+            SignData::Raw(msg) => Mldsa87::sign_deterministic(seed, msg, sig)
                 .map_err(|e| CryptoError::CryptoLibError(u32::from(e))),
             SignData::Mu(mu) => {
                 let mu = Mldsa87Mu::ref_from_bytes(&mu.0).map_err(|_| CryptoError::Size)?;
-                Mldsa87::sign_mu_deterministic(seed, mu, &mut sig)
+                Mldsa87::sign_mu_deterministic(seed, mu, sig)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))
             }
             _ => return Err(CryptoError::MismatchedAlgorithm),
         }?;
 
-        Ok(Signature::Mldsa(MldsaSignature(*sig)))
+        Ok(())
     }
 }
 
@@ -578,13 +597,13 @@ impl Crypto for DpeCrypto<'_> {
         Ok(self)
     }
 
-    fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
+    fn sign_with_alias(&mut self, data: &SignData, out: &mut Signature) -> Result<(), CryptoError> {
         match &self.signer {
             Signer::Ec {
                 rt_pub_key,
                 rt_priv_key,
                 ..
-            } => Self::sign_helper_ec(&mut self.engines, data, rt_pub_key, rt_priv_key),
+            } => Self::sign_helper_ec(&mut self.engines, data, rt_pub_key, rt_priv_key, out),
 
             #[cfg(feature = "mldsa_attestation")]
             Signer::Mldsa { .. } => {
@@ -595,7 +614,7 @@ impl Crypto for DpeCrypto<'_> {
                 let mut seed = Mldsa87Seed::default();
                 dice::derive_devid_seed(&cdi, &mut seed, self.engines.hmac384, self.engines.trng)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                Self::sign_helper_mldsa(data, &seed)
+                Self::sign_helper_mldsa(data, &seed, out)
             }
         }
     }
@@ -645,13 +664,13 @@ impl CdiManager for DpeCrypto<'_> {
 }
 
 impl crypto::Signer for DpeCrypto<'_> {
-    fn sign(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
+    fn sign(&mut self, data: &SignData, out: &mut Signature) -> Result<(), CryptoError> {
         match self.signer {
             Signer::Ec { .. } => {
                 let Some(DerivedKey::Ec((priv_key, pub_key))) = &self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
-                Self::sign_helper_ec(&mut self.engines, data, pub_key, priv_key)
+                Self::sign_helper_ec(&mut self.engines, data, pub_key, priv_key, out)
             }
 
             #[cfg(feature = "mldsa_attestation")]
@@ -659,14 +678,14 @@ impl crypto::Signer for DpeCrypto<'_> {
                 let Some(DerivedKey::Mldsa(seed)) = &self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
-                Self::sign_helper_mldsa(data, seed)
+                Self::sign_helper_mldsa(data, seed, out)
             }
         }
     }
 
     fn public_key(&mut self) -> Result<PubKey, CryptoError> {
         match &self.derived_key {
-            Some(DerivedKey::Ec((_, pub_key))) => Ok(pub_key.clone()),
+            Some(DerivedKey::Ec((_, pub_key))) => Ok(PubKey::Ecdsa(pub_key.clone())),
             #[cfg(feature = "mldsa_attestation")]
             Some(DerivedKey::Mldsa(seed)) => {
                 let mut pub_key = Mldsa87PubKey::default();
@@ -683,7 +702,7 @@ impl crypto::Signer for DpeCrypto<'_> {
 #[allow(clippy::large_enum_variant)]
 enum Signer<'a> {
     Ec {
-        rt_pub_key: PubKey,
+        rt_pub_key: EcdsaPubKey,
         rt_priv_key: KeyId,
         // The ECC engine lives in `DpeCrypto::engines`; this keeps `'a` used when
         // the ML-DSA variant (the only other `'a` borrow) is compiled out.
@@ -700,7 +719,10 @@ enum Signer<'a> {
 // The mldsa key is significantly larger than ecdsa.  Allow a large enum variant to support it.
 #[allow(clippy::large_enum_variant)]
 enum DerivedKey {
-    Ec((KeyId, PubKey)),
+    // Store the concrete ECDSA type, not the `PubKey` enum: the enum is sized by
+    // its 2,592-byte ML-DSA variant, so this ~96-byte P-384 key would otherwise
+    // bloat the live DPE env on the sign stack by ~2.5 KB for an unused variant.
+    Ec((KeyId, EcdsaPubKey)),
     #[cfg(feature = "mldsa_attestation")]
     Mldsa(Mldsa87Seed),
 }

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -15,7 +15,7 @@ use crypto::{
         curve_384::{EcdsaPub384, EcdsaSignature384},
         EcdsaPubKey, EcdsaSignature,
     },
-    Crypto, CryptoError, Digest, PubKey, SignData, Signature,
+    Crypto, CryptoError, Digest, PubKey, SignData, Signature, SignatureType,
 };
 use dpe::MAX_EXPORTED_CDI_SIZE;
 use zerocopy::{FromZeros, IntoBytes};
@@ -43,21 +43,29 @@ impl SignWithExportedEcdsaCmd {
         )?;
 
         let data = Digest::Sha384(crypto::Sha384(cmd.tbs)).into();
-        let (
-            Signature::Ecdsa(EcdsaSignature::Ecdsa384(EcdsaSignature384 { r, s })),
-            PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })),
-        ) = sign_exported(
+        let mut sig = Signature::zeroed(crypto.signature_algorithm());
+        let mut pub_key = PubKey::default();
+        sign_exported(
             &mut crypto,
             &data,
             &cmd.exported_cdi_handle,
             b"Exported ECC",
+            &mut sig,
+            &mut pub_key,
         )
         .map_err(|e| match e {
             ExportedSignError::Signature => {
                 CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_SIGNATURE_FAILED
             }
             _ => CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_KEY_DERIVIATION_FAILED,
-        })?
+        })?;
+
+        // Match by reference so the (large) signature/pubkey stay in their single
+        // caller-owned slots instead of being moved out into a fresh tuple.
+        let (
+            Signature::Ecdsa(EcdsaSignature::Ecdsa384(EcdsaSignature384 { r, s })),
+            PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })),
+        ) = (&sig, &pub_key)
         else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_ECDSA_INVALID_SIGNATURE);
         };
@@ -105,15 +113,26 @@ pub(crate) enum ExportedSignError {
 }
 
 /// Derive the key pair bound to `exported_cdi_handle` (using `label`) and sign
-/// `data`, returning the signature and the derived public key. Shared by the
-/// SIGN_WITH_EXPORTED_{ECDSA,MLDSA} commands.
+/// `data`, writing the signature and derived public key into the caller-provided
+/// `sig`/`pub_key` buffers. Shared by the SIGN_WITH_EXPORTED_{ECDSA,MLDSA}
+/// commands.
+///
+/// The results are returned via out-params rather than by value: `Signature` and
+/// `PubKey` are large (the ML-DSA variants are ~4.6 KB and ~2.6 KB), and
+/// returning them by value materialized the pair ~3× on the caller's frame as it
+/// threaded them through `.map_err(...)?`. Out-params keep exactly one copy on
+/// the caller's stack — the dominant term of the SIGN_WITH_EXPORTED_MLDSA frame.
+/// `sig` must already be zeroed to the caller's signature algorithm (via
+/// [`Signature::zeroed`]); `pub_key` is fully overwritten on success.
 #[cfg_attr(feature = "cfi", cfi_mod_fn)]
 pub(crate) fn sign_exported(
     env: &mut DpeCrypto,
     data: &SignData,
     exported_cdi_handle: &[u8; MAX_EXPORTED_CDI_SIZE],
     label: &[u8],
-) -> Result<(Signature, PubKey), ExportedSignError> {
+    sig: &mut Signature,
+    pub_key: &mut PubKey,
+) -> Result<(), ExportedSignError> {
     let key_pair = env.derive_key_pair_exported(exported_cdi_handle, label, label);
     if cfi_launder(key_pair.is_ok()) {
         #[cfg(feature = "cfi")]
@@ -127,11 +146,11 @@ pub(crate) fn sign_exported(
         CryptoError::InvalidExportedCdiHandle => ExportedSignError::NotFound,
         _ => ExportedSignError::KeyDerivation,
     })?;
-    let pub_key = signer
+    *pub_key = signer
         .public_key()
         .map_err(|_| ExportedSignError::KeyDerivation)?;
-    let sig = signer
-        .sign(data)
+    signer
+        .sign(data, sig)
         .map_err(|_| ExportedSignError::Signature)?;
-    Ok((sig, pub_key))
+    Ok(())
 }

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -16,7 +16,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
     ml_dsa::{MldsaPublicKey, MldsaSignature},
-    Mu, PubKey, SignData, Signature,
+    Mu, PubKey, SignData, Signature, SignatureType,
 };
 use zerocopy::{FromZeros, IntoBytes};
 
@@ -72,24 +72,33 @@ impl SignWithExportedMldsaCmd {
             &mut pdata.mldsa_exported_cdi_slots,
         )?;
 
+        let mut sig = Signature::zeroed(crypto.signature_algorithm());
+        let mut pub_key = PubKey::default();
+        sign_exported(
+            &mut crypto,
+            &data,
+            &cmd.exported_cdi_handle,
+            b"Exported ML-DSA",
+            &mut sig,
+            &mut pub_key,
+        )
+        .map_err(|e| match e {
+            ExportedSignError::NotFound => {
+                CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND
+            }
+            ExportedSignError::KeyDerivation => {
+                CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED
+            }
+            ExportedSignError::Signature => {
+                CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED
+            }
+        })?;
+
+        // Match by reference: the ~4.6 KB signature and ~2.6 KB public key stay in
+        // their single caller-owned slots rather than being moved into a tuple,
+        // which is what keeps this frame off the runtime stack limit.
         let (Signature::Mldsa(MldsaSignature(sig)), PubKey::Mldsa(MldsaPublicKey(pub_key))) =
-            sign_exported(
-                &mut crypto,
-                &data,
-                &cmd.exported_cdi_handle,
-                b"Exported ML-DSA",
-            )
-            .map_err(|e| match e {
-                ExportedSignError::NotFound => {
-                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_NOT_FOUND
-                }
-                ExportedSignError::KeyDerivation => {
-                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_KEY_DERIVATION_FAILED
-                }
-                ExportedSignError::Signature => {
-                    CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED
-                }
-            })?
+            (&sig, &pub_key)
         else {
             return Err(CaliptraError::RUNTIME_SIGN_WITH_EXPORTED_MLDSA_SIGNATURE_FAILED);
         };
@@ -97,7 +106,7 @@ impl SignWithExportedMldsaCmd {
         // Explicitly drop crypto and pdata so the mutable borrow to drivers also ends.
         drop(crypto);
         let _ = pdata;
-        Self::send_response(drivers, &pub_key, &sig)
+        Self::send_response(drivers, pub_key, sig)
     }
 
     /// Assemble the response from `pub_key`/`sig` and send it. Kept in its own


### PR DESCRIPTION
Use an out parameter instead of a return value to represent the signature and public key for sign with exported commands.  This allows the compiler to remove 2 instantiations of them on the stack, saving ~14Kb for the MLDSA variant.