### PR TITLE
runtime: Reject reserved MCU RT firmware ID on STASH_MEASUREMENT

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1699,6 +1699,11 @@ impl CaliptraError {
             0x000E00AE,
             "Runtime Error: Owner auth manifest owner public key does not match firmware-image owner pub key"
         ),
+        (
+            RUNTIME_STASH_MEASUREMENT_RESERVED_FW_ID,
+            0x000E00AF,
+            "Runtime Error: Stash measurement firmware ID is reserved for Caliptra internal use"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -13,6 +13,7 @@ Abstract:
 --*/
 
 use crate::manifest::{find_metadata_entry, find_owner_metadata_entry};
+use crate::stash_measurement::CaliptraManagedContextAccess;
 use crate::{mutrefbytes, Drivers, PauserPrivileges, StashMeasurementCmd};
 use caliptra_auth_man_types::ImageMetadataFlags;
 #[cfg(feature = "cfi")]
@@ -84,6 +85,10 @@ impl AuthorizeAndStashCmd {
                     cmd.svn,
                     drivers.caller_privilege_level(),
                     locality,
+                    // Only reachable once `authorize_image` matched this image
+                    // against the signed SoC manifest, so the measurement is
+                    // verified even when the request came from the mailbox.
+                    CaliptraManagedContextAccess::Allowed,
                 )?;
                 if dpe_result != DpeErrorCode::NoError {
                     drivers

--- a/runtime/src/recovery_flow.rs
+++ b/runtime/src/recovery_flow.rs
@@ -16,6 +16,7 @@ use crate::{
     authorize_and_stash::AuthorizeAndStashCmd,
     drivers::{McuFwStatus, McuResetReason},
     set_auth_manifest::{AuthManifestSource, AuthManifestUpdateMode},
+    stash_measurement::MCU_RT_RESERVED_FW_ID,
     Drivers, SetAuthManifestCmd, IMAGE_AUTHORIZED,
 };
 #[cfg(feature = "cfi")]
@@ -123,7 +124,7 @@ impl RecoveryFlow {
         // verify the digest
         let soc_manifest_svn = drivers.persistent_data.get().soc_manifest_svn;
         let auth_and_stash_req = AuthorizeAndStashReq {
-            fw_id: [2, 0, 0, 0],
+            fw_id: MCU_RT_RESERVED_FW_ID,
             measurement: digest,
             source: ImageHashSource::InRequest.into(),
             // We want to make sure this measurement is not skipped.

--- a/runtime/src/stash_measurement.rs
+++ b/runtime/src/stash_measurement.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::mailbox_api::{MailboxRespHeader, StashMeasurementReq, StashMeasurementResp};
+use caliptra_common::mailbox_api::{
+    ActivateFirmwareReq, MailboxRespHeader, StashMeasurementReq, StashMeasurementResp,
+};
 use caliptra_dpe::{
     commands::{Command, DeriveContextCmd, DeriveContextFlags},
     context::ContextHandle,
@@ -30,12 +32,39 @@ use zerocopy::{FromBytes, IntoBytes};
 
 const MCU_TCI_TYPE: u32 = u32::from_be_bytes(*b"MCFW");
 
+/// Firmware ID reserved for the Caliptra-managed MCU runtime DPE context.
+///
+/// Measurements stashed under this ID are tagged with the `MCFW` TCI type and
+/// re-point the cached MCU RT context index, so it may only be used with a
+/// measurement Caliptra has verified against the signed SoC manifest.
+pub(crate) const MCU_RT_RESERVED_FW_ID: [u8; 4] = ActivateFirmwareReq::MCU_IMAGE_ID.to_le_bytes();
+
+/// Whether a stash operation may create or update the Caliptra-managed MCU RT
+/// DPE context by stashing under [`MCU_RT_RESERVED_FW_ID`].
+///
+/// This deliberately has no `Default` impl and no conversion from raw mailbox
+/// bytes so that a mailbox caller cannot forge
+/// [`CaliptraManagedContextAccess::Allowed`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CaliptraManagedContextAccess {
+    /// The measurement was verified against the signed SoC manifest, or was
+    /// produced by a Caliptra-internal flow such as recovery.
+    Allowed,
+    /// The measurement was supplied verbatim by the SoC over the mailbox and
+    /// was not verified against the SoC manifest.
+    Denied,
+}
+
 pub struct StashMeasurementCmd;
 impl StashMeasurementCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     /// This function MUST ONLY be called by Caliptra.
     /// Mailbox commands MUST use the `execute` function.
+    ///
+    /// Callers passing a measurement Caliptra has not verified MUST pass
+    /// `CaliptraManagedContextAccess::Denied`; only verified measurements may
+    /// stash under `MCU_RT_RESERVED_FW_ID`.
     pub(crate) fn stash_measurement(
         drivers: &mut Drivers,
         metadata: &[u8; 4],
@@ -43,10 +72,20 @@ impl StashMeasurementCmd {
         svn: u32,
         caller_privilege_level: PauserPrivileges,
         locality: u32,
+        caliptra_managed_access: CaliptraManagedContextAccess,
     ) -> CaliptraResult<DpeErrorCode> {
+        // The reserved MCU RT firmware ID creates or re-points the
+        // Caliptra-managed MCFW context. Reject it for unverified measurements
+        // so the SoC cannot forge the MCU RT measurement or steal its cached
+        // context index via STASH_MEASUREMENT.
+        let is_mcu_rt = metadata == &MCU_RT_RESERVED_FW_ID;
+        if is_mcu_rt && caliptra_managed_access == CaliptraManagedContextAccess::Denied {
+            return Err(CaliptraError::RUNTIME_STASH_MEASUREMENT_RESERVED_FW_ID);
+        }
+
         let dpe_result = {
             // Check for MCU FW ID and swap it's TCI type
-            let tci_type = if metadata == &[2, 0, 0, 0] {
+            let tci_type = if is_mcu_rt {
                 MCU_TCI_TYPE
             } else {
                 u32::from_ne_bytes(*metadata)
@@ -98,7 +137,7 @@ impl StashMeasurementCmd {
         };
 
         if let DpeErrorCode::NoError = dpe_result {
-            if metadata == &[2, 0, 0, 0] {
+            if is_mcu_rt {
                 let mcu_rt_dpe_context_idx = drivers
                     .persistent_data
                     .get()
@@ -150,6 +189,7 @@ impl StashMeasurementCmd {
             cmd.svn,
             caller_privilege_level,
             locality,
+            CaliptraManagedContextAccess::Denied,
         )?;
 
         let resp = mutrefbytes::<StashMeasurementResp>(resp)?;

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache-2.0 license
 
 use crate::common::{
-    calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements, run_rt_test,
-    RuntimeTestArgs, DEFAULT_MCU_FW,
+    assert_error, calculate_cptra_config_init_vals_hash, default_lms_soc_manifest_measurements,
+    run_rt_test, RuntimeTestArgs, DEFAULT_MCU_FW,
 };
 use caliptra_api::SocManager;
 use caliptra_builder::{
@@ -10,13 +10,18 @@ use caliptra_builder::{
     ImageOptions,
 };
 use caliptra_common::mailbox_api::{
-    CommandId, MailboxReq, MailboxReqHeader, StashMeasurementReq, StashMeasurementResp,
+    ActivateFirmwareReq, CommandId, MailboxReq, MailboxReqHeader, StashMeasurementReq,
+    StashMeasurementResp,
 };
+use caliptra_error::CaliptraError;
 use caliptra_hw_model::HwModel;
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::RtBootStatus;
 use sha2::{Digest, Sha384};
 use zerocopy::{FromBytes, IntoBytes};
+
+/// Firmware ID reserved for the Caliptra-managed MCU RT DPE context.
+const MCU_RT_RESERVED_FW_ID: [u8; 4] = ActivateFirmwareReq::MCU_IMAGE_ID.to_le_bytes();
 
 #[test]
 fn test_stash_measurement() {
@@ -175,4 +180,49 @@ fn test_pcr31_extended_upon_stash_measurement() {
     }
 
     assert_ne!(run_sequence(false), run_sequence(true));
+}
+
+/// Metadata `[2, 0, 0, 0]` is reserved for the Caliptra-managed MCU RT DPE
+/// context: it tags the measurement with the `MCFW` TCI type and re-points the
+/// cached MCU RT context index. `STASH_MEASUREMENT` performs no authorization,
+/// so it must reject the reserved ID rather than let the SoC forge the MCU RT
+/// measurement. (`AUTHORIZE_AND_STASH` may still use it, since that path
+/// verifies the measurement against the signed SoC manifest.)
+#[test]
+fn test_stash_measurement_reserved_mcu_fw_id_rejected() {
+    let image_options = ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    let runtime_test_args = RuntimeTestArgs {
+        test_image_options: Some(image_options),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(runtime_test_args);
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        metadata: MCU_RT_RESERVED_FW_ID,
+        measurement: [0xAAu8; 48],
+        context: [0u8; 48],
+        svn: 0,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::STASH_MEASUREMENT),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_STASH_MEASUREMENT_RESERVED_FW_ID,
+        resp,
+    );
 }


### PR DESCRIPTION
Firmware ID 2 is reserved for the Caliptra-managed MCU RT DPE context. STASH_MEASUREMENT does no authorization, so MCU (the PL0 caller in subsystem mode) could stash under the reserved ID and update its own measurement.

Add StashAuthorization to distinguish measurements Caliptra has authorized from raw mailbox input, and reject the reserved ID for unauthorized ones.

AUTHORIZE_AND_STASH keeps working with firmware ID 2, since it only stashes after verifying the image against the signed SoC manifest and is required by the hitless MCU update flow.

Also replace the magic [2, 0, 0, 0] literals with MCU_RT_RESERVED_FW_ID.

Addresses review feedback on #4070.