### PR TITLE
Backport DMA/SHA endianness fix from main

### DIFF
--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -13,7 +13,7 @@ Abstract:
 --*/
 
 use crate::dma::recovery::RecoveryRegisterInterface;
-use crate::helpers::words_from_bytes_be_vec;
+use crate::helpers::words_from_bytes_le_vec;
 use crate::SocRegistersInternal;
 use crate::{dma::otp_fc::FuseController, mci::Mci, Sha512Accelerator};
 use caliptra_emu_bus::{
@@ -414,7 +414,7 @@ impl AxiRootBus {
                     || event.src == Device::ExternalTestSram
                     || Device::RecoveryIntf == event.src
                 {
-                    self.dma_result = Some(words_from_bytes_be_vec(&data.clone()));
+                    self.dma_result = Some(words_from_bytes_le_vec(&data.clone()));
                 }
             }
             EventData::RecoveryFifoStatusResponse { status } => {

--- a/sw-emulator/lib/periph/src/helpers.rs
+++ b/sw-emulator/lib/periph/src/helpers.rs
@@ -92,6 +92,15 @@ pub fn words_from_bytes_be_vec(arr: &[u8]) -> Vec<u32> {
     result
 }
 
+pub fn words_from_bytes_le_vec(arr: &[u8]) -> Vec<u32> {
+    assert_eq!(arr.len() % 4, 0);
+    let mut result = vec![0u32; arr.len() / 4];
+    for i in 0..result.len() {
+        result[i] = u32::from_le_bytes(arr[i * 4..][..4].try_into().unwrap())
+    }
+    result
+}
+
 pub fn bytes_from_words_le<A: U32Array>(arr: &A) -> A::ByteArray {
     let mut result = A::default_result();
     for i in 0..arr.as_ref().len() {

--- a/sw-emulator/lib/periph/src/sha512_acc.rs
+++ b/sw-emulator/lib/periph/src/sha512_acc.rs
@@ -333,8 +333,16 @@ impl Sha512AcceleratorRegs {
             Err(BusError::StoreAccessFault)?
         }
 
+        // Check ENDIAN_TOGGLE bit. If set to 1, data from the mailbox is in big-endian format.
+        // Convert it to little-endian for padding operation.
+        let val = if self.mode.reg.read(ShaMode::ENDIAN_TOGGLE) == 1 {
+            val.to_be_bytes()
+        } else {
+            val.to_le_bytes()
+        };
+
         self.sha_stream
-            .update_bytes(&val.to_be_bytes(), Some(self.dlen.reg.get()));
+            .update_bytes(&val, Some(self.dlen.reg.get()));
 
         Ok(())
     }


### PR DESCRIPTION
Cherry-picks the emulator subset of 4b8e5bb3 ("Download Caliptra firmware to MCU SRAM in subsystem mode", PR #2709) onto the 2.0 line.

AxiRootBus decoded incoming DMA MemoryReadResponse payloads as big-endian (words_from_bytes_be_vec) while AxiRootBus::write emits val.to_le_bytes(). Any AXI-to-AXI copy whose source is an event-backed device (MCU SRAM, MCU MBOX0/MBOX1, ExternalTestSram) therefore byte-swapped every 32-bit word.

This corrupts the ACTIVATE_FIRMWARE staging->MCU SRAM copy, so Caliptra hashes a word-swapped image, authorize_image returns IMAGE_HASH_MISMATCH, and activate_fw returns early without restoring FW_EXEC_CTRL[2] - leaving the MCU halted forever.

Fix decodes responses little-endian and makes the SHA accelerator honor ENDIAN_TOGGLE so the copy path and the hash path stay consistent.