### PR TITLE
runtime: allow PL1 callers to use AUTHORIZE_AND_STASH with SKIP_STASH

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1529,7 +1529,7 @@ Command Code: `0x4154_5348` ("ATSH")
 | context     | u8[48]   | Context field for `svn`; e.g., a hash of the public key that authenticated the SVN. |
 | svn         | u32      | The version of the image |
 | flags       | u32      | See AUTHORIZE_AND_STASH_FLAGS below |
-| source      | u32      | This field identifies the source of the digest to be used to compare with the SoC's<br />SHA digest in the SoC Manifest<br /><br />Values<br />1 - InRequest - Use the hash in the 'measurement' field of this command<br /><br />3 - LoadAddress - The image located in the `ImageLoadAddress` will be streamed to the SHA Accelerator to <br />               retrieve the digest that will be used for authorization.<br />4 - ImageStagingAddress - The image located in the `StagingAddress` will be streamed to the SHA Accelerator to<br />               retrieve the digest that will be used for authorization |
+| source      | u32      | This field identifies the source of the digest to be used to compare with the SoC's<br />SHA digest in the SoC Manifest<br /><br />Values<br />1 - InRequest - Use the hash in the 'measurement' field of this command<br /><br />2 - LoadAddress - The image located in the `ImageLoadAddress` will be streamed to the SHA Accelerator to <br />               retrieve the digest that will be used for authorization.<br />3 - ImageStagingAddress - The image located in the `StagingAddress` will be streamed to the SHA Accelerator to<br />               retrieve the digest that will be used for authorization |
 | image_size   | u32      | The size of the image to hash. Only valid if source is `ImageLoadAddress` or `StagingAddress` |
 
 *Table: `AUTHORIZE_AND_STASH_FLAGS` input flags*

--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -56,16 +56,17 @@ impl AuthorizeAndStashCmd {
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let caller_privilege_level = drivers.caller_privilege_level();
-        match caller_privilege_level {
-            // Only PL0 can call STASH_MEASUREMENT
-            PauserPrivileges::PL0 => (),
-            PauserPrivileges::PL1 => {
-                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-            }
-        }
         let locality = drivers.mbox.id();
 
         if let Ok(cmd) = AuthorizeAndStashReq::ref_from_bytes(cmd_args) {
+            let auth_and_stash_flags: AuthAndStashFlags = cmd.flags.into();
+            // PL1 callers may only use AUTHORIZE_AND_STASH with SKIP_STASH set;
+            // stashing into DPE requires PL0.
+            if caller_privilege_level == PauserPrivileges::PL1
+                && !auth_and_stash_flags.contains(AuthAndStashFlags::SKIP_STASH)
+            {
+                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
+            }
             let resp = mutrefbytes::<AuthorizeAndStashResp>(resp)?;
             resp.hdr = MailboxRespHeader::default();
             resp.auth_req_result = Self::authorize_and_stash(drivers, cmd, locality)?;

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -18,7 +18,7 @@ use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetTaggedTciReq, GetTaggedTciResp,
     ImageHashSource, MailboxReq, MailboxReqHeader, SetAuthManifestReq, TagTciReq,
 };
-use caliptra_hw_model::{DefaultHwModel, HwModel};
+use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
 use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::{IMAGE_AUTHORIZED, IMAGE_HASH_MISMATCH, IMAGE_NOT_AUTHORIZED};
 use sha2::{Digest, Sha384};
@@ -1688,5 +1688,65 @@ fn test_verify_invalid_manifest() {
         .expect("We should have received a response");
 
     let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
+}
+
+#[test]
+fn test_authorize_and_stash_pl1_without_skip_stash_fails() {
+    let mut model = set_auth_manifest(None);
+
+    // Switch to a non-PL0 pauser (AXI user 2 is not the pl0_pauser).
+    model.set_axi_user(2);
+
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: FW_ID_1,
+        measurement: IMAGE_DIGEST1,
+        source: ImageHashSource::InRequest as u32,
+        flags: 0, // SKIP_STASH not set
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let result = model.mailbox_execute(
+        u32::from(CommandId::AUTHORIZE_AND_STASH),
+        authorize_and_stash_cmd.as_bytes().unwrap(),
+    );
+
+    assert_eq!(
+        result.unwrap_err(),
+        ModelError::MailboxCmdFailed(
+            caliptra_error::CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL.into()
+        )
+    );
+}
+
+#[test]
+fn test_authorize_and_stash_pl1_with_skip_stash_success() {
+    let mut model = set_auth_manifest(None);
+
+    // Switch to a non-PL0 pauser (AXI user 2 is not the pl0_pauser).
+    model.set_axi_user(2);
+
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: FW_ID_1,
+        measurement: IMAGE_DIGEST1,
+        source: ImageHashSource::InRequest as u32,
+        flags: 1, // SKIP_STASH is set
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let result = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            authorize_and_stash_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should ahe received a response");
+
+    let authorize_and_stash_resp =
+        AuthorizeAndStashResp::read_from_bytes(result.as_slice()).unwrap();
     assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
 }


### PR DESCRIPTION
Previously, PL1 callers were rejected unconditionally. Now PL1 is permitted when the SKIP_STASH flag is set, since stashing into DPE is the only PL0-exclusive operation. Adds a test covering the PL1 rejection path when SKIP_STASH is not set.

Also fixes README: LoadAddress and ImageStagingAddress source values were documented as 3/4 but are actually 2/3.