### PR TITLE
Enable multiple hw revisions in build / test / nightly workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,14 @@ on:
 
   workflow_call:
   workflow_dispatch:
+    inputs:
+      hw-revision:
+        description: 'Target hardware revision'
+        type: choice
+        default: latest
+        options:
+          - "2.1"
+          - latest
 
 permissions:
   contents: read
@@ -24,6 +32,7 @@ env:
 
   # Compiler warnings should fail to compile
   EXTRA_CARGO_CONFIG: "target.'cfg(all())'.rustflags = [\"-Dwarnings\"]"
+  CALIPTRA_HW_REV: ${{ inputs.hw-revision || 'latest' }}
 
 jobs:
   lint:
@@ -44,6 +53,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
+        # Always build for all HW-revisions
         revision: ["latest", "2.1"]
     env:
       CALIPTRA_HW_REV: ${{ matrix.revision }}

--- a/.github/workflows/fw-test-emu.yml
+++ b/.github/workflows/fw-test-emu.yml
@@ -16,6 +16,9 @@ on:
       rom-version:
         default: "latest"
         type: string
+      hw-revision:
+        default: "latest"
+        type: string
 
 permissions:
   contents: read
@@ -27,6 +30,7 @@ jobs:
     env:
       NEXTEST_VERSION: 0.9.72
       CACHE_BUSTER: f7c64774f17c
+      CALIPTRA_HW_REV: ${{ inputs.hw-revision }}
 
     steps:
       - name: Restore cargo-nextest binary

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "Current ref $(git rev-parse HEAD) will receive tag ${TAG_BASE}${INDEX}-2.x after tests"
 
   sw-emulator:
-    name: sw-emulator Suite (${{ matrix.config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }})
+    name: sw-emulator Suite (${{ matrix.config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }}, HW ${{ matrix.hw-rev }})
     needs: find-latest-release-2-x
     if: needs.find-latest-release-2-x.outputs.create_release
     permissions:
@@ -77,11 +77,13 @@ jobs:
         log:
           - { name: "log", rom_logging: true }
           - { name: "nolog", rom_logging: false }
+        hw-rev: ["latest", "2.1"]
     with:
-      artifact-suffix: -sw-emulator-${{ matrix.config.suffix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}
+      artifact-suffix: -sw-emulator-${{ matrix.config.suffix }}-${{ matrix.rng.name }}-${{ matrix.log.name }}-hw_${{ matrix.hw-rev }}
       extra-features: ${{ matrix.config.base_features }}${{ matrix.rng.extra }}
       rom-logging: ${{ matrix.log.rom_logging }}
       rom-version: ${{ matrix.config.rom }}
+      hw-revision: ${{ matrix.hw-rev }}
 
   fpga:
     name: FPGA Suite (${{ matrix.hw_config.name }}, ${{ matrix.rng.name }}, ${{ matrix.log.name }}, ${{ matrix.ocp_lock.name }})


### PR DESCRIPTION
Followup for #3935.
In PRs CI only runs for the `latest` hardware revision.
Other HW-revisions should be tested on nightly runs or by manual workflow dispatch (on relevant PRs).

This PR adds 
- a hw-revision matrix to 2.x nightly release workflow
- a hw-revision dropdown to manual build/tests workflow execution