### PR TITLE
hw-model (1.x): drop cfi default-feature override for image-types/lms-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,10 +121,10 @@ caliptra-image-fake-keys = { path = "image/fake-keys" }
 caliptra-image-gen = { path = "image/gen" }
 caliptra-image-crypto = { path = "image/crypto" }
 caliptra-image-serde = { path = "image/serde" }
-caliptra-image-types = { path = "image/types", default-features = false, features = ["cfi"] }
+caliptra-image-types = { path = "image/types", default-features = false }
 caliptra-image-verify = { path = "image/verify", default-features = false, features = ["cfi"] }
 caliptra-kat = { path = "kat" }
-caliptra-lms-types = { path = "lms-types", features = ["cfi"] }
+caliptra-lms-types = { path = "lms-types" }
 caliptra-mldsa = { path = "common/crypto/mldsa" }
 caliptra-registers = { path = "registers" }
 caliptra-registers-1_0 = { path = "hw/1.0/registers" }


### PR DESCRIPTION
  **Summary**

  caliptra-1.x's workspace root still explicitly sets features = ["cfi"] on caliptra-image-types and caliptra-lms-types; main
  does not (and never has, going back before #4038/#4039). Since Cargo dependency features are purely additive and cannot be
  countermanded downstream, every consumer that pulls these crates in via the plain .workspace = true form — including
  caliptra-hw-model, which has no cfi feature of its own — unconditionally compiles caliptra-cfi-lib without cfi-test.

  Without cfi-test, caliptra-cfi-lib emits bare extern "C" declarations for CFI_STATE_ORG and cfi_panic_handler (lib.rs
  (https://github.com/chipsalliance/caliptra-cfi/blob/main/lib/src/lib.rs)/cfi.rs
  (https://github.com/chipsalliance/caliptra-cfi/blob/main/lib/src/cfi.rs)) that only a firmware link script satisfies. Any     external consumer building caliptra-hw-model as a library on caliptra-1.x hits an unresolved-external-symbol link error in    debug builds; release only avoids it because dead-code elimination drops the unused references.

  **Why #4039 didn't already fix this**

  #4039 (an ancestor of this branch) made caliptra-cfi-lib/caliptra-cfi-derive optional dependencies of image-types/lms-types,
  gated behind each crate's own cfi feature — correctly removing the unconditional dependency that existed before it. But
  that backport only ports the per-crate diff from main; it doesn't (and structurally can't) also revisit this workspace-root   override, which predates it and is untouched by it. This PR is the remaining piece: match main's already-clean root
  Cargo.toml so the feature #4039 made optional isn't immediately forced back on.

  **The fix**

  -caliptra-image-types = { path = "image/types", default-features = false, features = ["cfi"] }
  +caliptra-image-types = { path = "image/types", default-features = false }
   caliptra-image-verify = { path = "image/verify", default-features = false, features = ["cfi"] }
   caliptra-kat = { path = "kat" }
  -caliptra-lms-types = { path = "lms-types", features = ["cfi"] }
  +caliptra-lms-types = { path = "lms-types" }

  Scope: only caliptra-image-types and caliptra-lms-types are touched. caliptra-image-verify has the same explicit cfi
  override and diverges from main the same way, but caliptra-hw-model doesn't depend on it, so it's left as a separate,
  unrelated concern (happy to file/fix separately if useful).

  **Why this is safe for in-workspace builds**

  rom/dev and runtime — the actual firmware crates that need real CFI protection — already declare image-types/lms-types
  plainly (default-features = false, no cfi) and instead forward their own cfi feature explicitly (cfi = [...,
  "caliptra-image-types/cfi", ...]). Since Cargo unifies features workspace-wide within a single build, a whole-workspace
  build still gets cfi on image-types regardless of this change — confirmed via cargo check -p caliptra-image-types -p
  caliptra-lms-types, which still pulls in caliptra-cfi-lib through the rest of the workspace resolution.

  The only thing this changes is an isolated build — e.g. cargo check -p caliptra-hw-model (confirmed passing), or any
  external consumer pulling caliptra-hw-model in via a git dependency outside the caliptra-sw workspace. That's exactly the
  case this fixes.

  **Testing**

  cargo check -p caliptra-hw-model passes. cargo check -p caliptra-image-types -p caliptra-lms-types passes, confirming
  in-workspace cfi unification is unaffected. Validated end-to-end against a real external tool that consumes
  caliptra-hw-model as a git dependency: before this fix, cargo tree -i caliptra-cfi-lib showed it pulled in via
  image-types/lms-types; after, cargo tree -i caliptra-cfi-lib reports no matching packages at all. Full downstream build and
  regression suite passes.