### PR TITLE
drivers: Reduce PersistentData size

### DIFF
--- a/drivers/src/memory_layout.rs
+++ b/drivers/src/memory_layout.rs
@@ -24,9 +24,9 @@ pub const CFI_STATE_ORG: u32 = 0x500003E4; // size = 6 words
 pub const BOOT_STATUS_ORG: u32 = 0x500003FC;
 pub const PERSISTENT_DATA_ORG: u32 = 0x50000400;
 
-pub const DATA_ORG: u32 = 0x50009C00;
+pub const DATA_ORG: u32 = 0x50009400;
 
-pub const STACK_ORG: u32 = 0x5000A400;
+pub const STACK_ORG: u32 = 0x50009C00;
 pub const ROM_STACK_ORG: u32 = 0x5001C000;
 
 pub const ESTACK_ORG: u32 = 0x5001F800;
@@ -45,7 +45,7 @@ pub const ROM_NSTACK_ORG: u32 = 0x5001FC00;
 // reserved for future use and then allocating the rest of the DCCM.
 //
 // The `DATA_SIZE` variable reflects the leftover space.
-pub const PERSISTENT_DATA_SIZE: u32 = 38 * 1024;
+pub const PERSISTENT_DATA_SIZE: u32 = 36 * 1024;
 
 pub const ROM_RELAXATION_PADDING: u32 = 4 * 1024;
 pub const ROM_SIZE: u32 = 48 * 1024;
@@ -54,7 +54,7 @@ pub const ICCM_SIZE: u32 = 128 * 1024;
 pub const DCCM_SIZE: u32 = 128 * 1024;
 pub const ROM_DATA_SIZE: u32 = 996;
 pub const DATA_SIZE: u32 = 2 * 1024;
-pub const STACK_SIZE: u32 = 85 * 1024;
+pub const STACK_SIZE: u32 = 87 * 1024;
 pub const ROM_STACK_SIZE: u32 = 14 * 1024;
 pub const ESTACK_SIZE: u32 = 1024;
 pub const ROM_ESTACK_SIZE: u32 = 1024;

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -53,7 +53,7 @@ pub const PQ_DEVID_PUB_KEY_DIGEST_SIZE: u32 = 32;
 pub const PQC_STATUS_FLAGS_SIZE: u32 = 1;
 #[cfg(feature = "mldsa_attestation")]
 pub const PQC_MODE_ENABLED_FLAG: u8 = 1;
-pub const RESERVED_MEMORY_SIZE: u32 = (3 * 1024)
+pub const RESERVED_MEMORY_SIZE: u32 = 1024
     - 2
     - PQ_DEVID_CDI_SIZE
     - PQ_DEVID_PUB_KEY_DIGEST_SIZE


### PR DESCRIPTION
Reduce the reserved area of PersistentData by 4Kb.  This can be utilized for MLDSA optimization operations.

This also removes sparse space reservations for a number of data types, which are defined either through the ROM, Hardware or FMC.

Note:  This does change the location of some runtime specific Persistent Data fields.  This is acceptable since Hitless Update cannot be supported for this release due to the changes FMC.