### PR TITLE
[update] runtime: expose manifest SVN state in FW_INFO

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1996,6 +1996,7 @@ pub struct FwInfoResp {
     pub soc_manifest_current_svn: u32,
     pub soc_manifest_min_svn: u32,
     pub owner_auth_manifest_current_svn: u32,
+    pub owner_auth_manifest_min_svn: u32,
 }
 
 // CAPABILITIES

--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1993,6 +1993,9 @@ pub struct FwInfoResp {
     pub image_manifest_pqc_type: u32,
     pub vendor_ecc384_pub_key_index: u32,
     pub vendor_pqc_pub_key_index: u32,
+    pub soc_manifest_current_svn: u32,
+    pub soc_manifest_min_svn: u32,
+    pub owner_auth_manifest_current_svn: u32,
 }
 
 // CAPABILITIES

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -671,8 +671,11 @@ pub struct FwPersistentData {
     #[cfg(feature = "runtime")]
     pub auth_manifest_digest: [u32; SHA384_HASH_SIZE / 4],
     #[cfg(feature = "runtime")]
+    // Survives warm and update resets and is cleared on cold reset with the manifest metadata.
+    pub auth_manifest_svn: u32,
+    #[cfg(feature = "runtime")]
     reserved9: [u8; AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize
-        - (SHA384_HASH_SIZE + size_of::<AuthManifestImageMetadataCollection>())],
+        - (SHA384_HASH_SIZE + size_of::<AuthManifestImageMetadataCollection>() + size_of::<u32>())],
 
     #[cfg(not(feature = "runtime"))]
     pub auth_manifest_image_metadata_col: [u8; AUTH_MAN_PERSISTENT_DATA_SIZE as usize],
@@ -687,8 +690,12 @@ pub struct FwPersistentData {
     #[cfg(feature = "runtime")]
     pub owner_auth_manifest_digest: [u32; SHA384_HASH_SIZE / 4],
     #[cfg(feature = "runtime")]
+    pub owner_auth_manifest_svn: u32,
+    #[cfg(feature = "runtime")]
     reserved10: [u8; OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize
-        - (SHA384_HASH_SIZE + size_of::<OwnerAuthManifestImageMetadataCollection>())],
+        - (SHA384_HASH_SIZE
+            + size_of::<OwnerAuthManifestImageMetadataCollection>()
+            + size_of::<u32>())],
 
     #[cfg(feature = "runtime")]
     reserved11: [u8; (AUTH_MAN_PERSISTENT_DATA_SIZE
@@ -1031,7 +1038,11 @@ mod tests {
             (offset_of!(FwPersistentData, pcr_reset), 19992, "pcr_reset"),
             (offset_of!(FwPersistentData, auth_manifest_image_metadata_col), 21016, "auth_manifest_image_metadata_col"),
             #[cfg(feature = "runtime")]
+            (offset_of!(FwPersistentData, auth_manifest_svn), 27468, "auth_manifest_svn"),
+            #[cfg(feature = "runtime")]
             (offset_of!(FwPersistentData, owner_auth_manifest_image_metadata_col), 27672, "owner_auth_manifest_image_metadata_col"),
+            #[cfg(feature = "runtime")]
+            (offset_of!(FwPersistentData, owner_auth_manifest_svn), 30284, "owner_auth_manifest_svn"),
             (offset_of!(FwPersistentData, fmc_alias_csr), 31256, "fmc_alias_csr"),
             (offset_of!(FwPersistentData, mcu_firmware_loaded), 40472, "mcu_firmware_loaded"),
             (offset_of!(FwPersistentData, ocp_lock_metadata), 40476, "ocp_lock_metadata"),

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -223,6 +223,7 @@ struct caliptra_fw_info_resp
     uint32_t soc_manifest_current_svn;
     uint32_t soc_manifest_min_svn;
     uint32_t owner_auth_manifest_current_svn;
+    uint32_t owner_auth_manifest_min_svn;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -220,6 +220,9 @@ struct caliptra_fw_info_resp
     uint32_t image_manifest_pqc_type;
     uint32_t vendor_ecc384_pub_key_index;
     uint32_t vendor_pqc_pub_key_index;
+    uint32_t soc_manifest_current_svn;
+    uint32_t soc_manifest_min_svn;
+    uint32_t owner_auth_manifest_current_svn;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1196,6 +1196,7 @@ Command Code: `0x494E_464F` ("INFO")
 | soc_manifest_current_svn    | u32      | SVN of the authorization manifest accepted by `SET_AUTH_MANIFEST`, or zero if none has been accepted.                                              |
 | soc_manifest_min_svn        | u32      | Minimum SoC manifest SVN encoded in `FUSE_SOC_MANIFEST_SVN` and enforced by `SET_AUTH_MANIFEST` when anti-rollback checks are enabled.               |
 | owner_auth_manifest_current_svn | u32   | SVN of the owner authorization manifest accepted by `SET_OWNER_AUTH_MANIFEST`, or zero if none has been accepted.                                  |
+| owner_auth_manifest_min_svn | u32      | Minimum owner authorization manifest SVN encoded in `SS_STRAP_GENERIC[3][15:8]` and enforced by `SET_OWNER_AUTH_MANIFEST` when anti-rollback checks are enabled. |
 
 ### VERSION
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1193,6 +1193,9 @@ Command Code: `0x494E_464F` ("INFO")
 | image_manifest_pqc_type     | u32      | PQC key type from image manifest. **Only present in FW 2.0.2+ and 2.1.1+.**                                                                         |
 | vendor_ecc384_pub_key_index | u32      | Index of the vendor ECC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
 | vendor_pqc_pub_key_index    | u32      | Index of the vendor PQC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
+| soc_manifest_current_svn    | u32      | SVN of the authorization manifest accepted by `SET_AUTH_MANIFEST`, or zero if none has been accepted.                                              |
+| soc_manifest_min_svn        | u32      | Minimum SoC manifest SVN encoded in `FUSE_SOC_MANIFEST_SVN` and enforced by `SET_AUTH_MANIFEST` when anti-rollback checks are enabled.               |
+| owner_auth_manifest_current_svn | u32   | SVN of the owner authorization manifest accepted by `SET_OWNER_AUTH_MANIFEST`, or zero if none has been accepted.                                  |
 
 ### VERSION
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -57,6 +57,7 @@ impl FwInfoCmd {
         resp.soc_manifest_current_svn = pdata.fw.auth_manifest_svn;
         resp.soc_manifest_min_svn = drivers.soc_ifc.fuse_bank().soc_manifest_fuse_svn();
         resp.owner_auth_manifest_current_svn = pdata.fw.owner_auth_manifest_svn;
+        resp.owner_auth_manifest_min_svn = drivers.soc_ifc.ss_owner_manifest_min_svn();
         resp.most_recent_fw_error = match get_fw_error_non_fatal() {
             0 => drivers.persistent_data.get().rom.cleared_non_fatal_fw_error,
             e => e,

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -54,6 +54,9 @@ impl FwInfoCmd {
         resp.image_manifest_pqc_type = pdata.rom.manifest1.pqc_key_type as u32;
         resp.vendor_ecc384_pub_key_index = handoff.data_vault.vendor_ecc_pk_index();
         resp.vendor_pqc_pub_key_index = handoff.data_vault.vendor_pqc_pk_index();
+        resp.soc_manifest_current_svn = pdata.fw.auth_manifest_svn;
+        resp.soc_manifest_min_svn = drivers.soc_ifc.fuse_bank().soc_manifest_fuse_svn();
+        resp.owner_auth_manifest_current_svn = pdata.fw.owner_auth_manifest_svn;
         resp.most_recent_fw_error = match get_fw_error_non_fatal() {
             0 => drivers.persistent_data.get().rom.cleared_non_fatal_fw_error,
             e => e,

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -811,6 +811,7 @@ impl SetAuthManifestCmd {
         if !verify_only {
             persistent_data.fw.auth_manifest_digest =
                 drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+            persistent_data.fw.auth_manifest_svn = auth_manifest_preamble.svn;
         }
         Ok(())
     }

--- a/runtime/src/set_owner_auth_manifest.rs
+++ b/runtime/src/set_owner_auth_manifest.rs
@@ -442,6 +442,7 @@ impl SetOwnerAuthManifestCmd {
         // Record the digest of the full manifest buffer for attestation.
         persistent_data.fw.owner_auth_manifest_digest =
             drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+        persistent_data.fw.owner_auth_manifest_svn = preamble.svn;
 
         Ok(())
     }

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -47,6 +47,12 @@ fn find_rom_info(rom: &[u8]) -> Option<RomInfo> {
 }
 
 pub fn get_fwinfo(model: &mut DefaultHwModel) -> FwInfoResp {
+    let info = get_fwinfo_allow_attestation_disabled(model);
+    assert_eq!(info.attestation_disabled, 0);
+    info
+}
+
+pub fn get_fwinfo_allow_attestation_disabled(model: &mut DefaultHwModel) -> FwInfoResp {
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::FW_INFO), &[]),
     };
@@ -68,7 +74,6 @@ pub fn get_fwinfo(model: &mut DefaultHwModel) -> FwInfoResp {
         info.hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
     );
-    assert_eq!(info.attestation_disabled, 0);
     info
 }
 

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -4,7 +4,7 @@ use crate::test_activate_firmware::{TEST_SRAM_BASE, TEST_SRAM_SIZE};
 use crate::{
     common::{assert_error, run_rt_test_pqc, RuntimeTestArgs, PQC_KEY_TYPE},
     test_authorize_and_stash::IMAGE_DIGEST1,
-    test_info::get_fwinfo,
+    test_info::{get_fwinfo, get_fwinfo_allow_attestation_disabled},
 };
 use caliptra_api::mailbox::ExternalMailboxCmdReq;
 use caliptra_api::{mailbox::ImageHashSource, SocManager};
@@ -15,6 +15,7 @@ use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthorizationManifest, ImageMetadataFlags,
     AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT,
 };
+use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxReqHeader, SetAuthManifestReq};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, HwModel, SecurityState};
@@ -242,14 +243,29 @@ fn test_set_auth_manifest_cmd_pqc_lms() {
 }
 
 #[test]
-fn test_set_auth_manifest_fw_info_digest() {
-    let mut model = run_rt_test_pqc(RuntimeTestArgs::default(), FwVerificationPqcKeyType::MLDSA);
+fn test_set_auth_manifest_fw_info() {
+    let mut rt_args = RuntimeTestArgs::test_productions_args();
+    rt_args.soc_manifest_svn = Some(2);
+    rt_args.subsystem_mode = true;
+    let mut image_options = ImageOptions {
+        fw_svn: 12,
+        pqc_key_type: FwVerificationPqcKeyType::MLDSA,
+        ..Default::default()
+    };
+    image_options.vendor_config.pl0_pauser = Some(0x1);
+    rt_args.test_image_options = Some(image_options);
+    let mut model = run_rt_test_pqc(rt_args, FwVerificationPqcKeyType::MLDSA);
     model.step_until_ready_for_runtime();
+
+    let info = get_fwinfo(&mut model);
+    assert_eq!(info.soc_manifest_current_svn, 2);
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
 
     let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
         manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
         pqc_key_type: FwVerificationPqcKeyType::MLDSA,
-        ..Default::default()
+        svn: 3,
     });
     let buf = auth_manifest.as_bytes();
     let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
@@ -285,6 +301,15 @@ fn test_set_auth_manifest_fw_info_digest() {
         .collect();
 
     assert_eq!(info.authman_sha384_digest, authman_digest.as_slice());
+    assert_eq!(info.soc_manifest_current_svn, 3);
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
+
+    model.warm_reset_flow().unwrap();
+    let info = get_fwinfo_allow_attestation_disabled(&mut model);
+    assert_eq!(info.soc_manifest_current_svn, 3);
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -246,7 +246,8 @@ fn test_set_auth_manifest_cmd_pqc_lms() {
 fn test_set_auth_manifest_fw_info() {
     let mut rt_args = RuntimeTestArgs::test_productions_args();
     rt_args.soc_manifest_svn = Some(2);
-    rt_args.subsystem_mode = true;
+    let subsystem_mode = !cfg!(feature = "fpga_realtime");
+    rt_args.subsystem_mode = subsystem_mode;
     let mut image_options = ImageOptions {
         fw_svn: 12,
         pqc_key_type: FwVerificationPqcKeyType::MLDSA,
@@ -258,7 +259,10 @@ fn test_set_auth_manifest_fw_info() {
     model.step_until_ready_for_runtime();
 
     let info = get_fwinfo(&mut model);
-    assert_eq!(info.soc_manifest_current_svn, 2);
+    assert_eq!(
+        info.soc_manifest_current_svn,
+        if subsystem_mode { 2 } else { 0 }
+    );
     assert_eq!(info.soc_manifest_min_svn, 2);
     assert_eq!(info.fw_svn, 12);
 

--- a/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
@@ -5,6 +5,7 @@
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_authorize_and_stash::{set_auth_manifest, FW_ID_1, IMAGE_DIGEST1};
+use crate::test_info::get_fwinfo;
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
 use crate::test_update_reset::update_fw;
 use caliptra_api::{mailbox::VerifyAuthManifestReq, SocManager};
@@ -257,6 +258,7 @@ fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
         ..Default::default()
     });
     model.step_until_ready_for_runtime();
+    assert_eq!(get_fwinfo(&mut model).owner_auth_manifest_current_svn, 0);
 
     let below_floor = build_owner_manifest(
         vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
@@ -269,12 +271,17 @@ fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
         matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
         "expected owner manifest SVN below minimum, got {err:?}",
     );
+    assert_eq!(get_fwinfo(&mut model).owner_auth_manifest_current_svn, 0);
 
     let at_floor = build_owner_manifest(
         vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
         MIN_SVN,
     );
     send_set_owner_auth_manifest(&mut model, &at_floor);
+    assert_eq!(
+        get_fwinfo(&mut model).owner_auth_manifest_current_svn,
+        MIN_SVN
+    );
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
@@ -258,7 +258,9 @@ fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
         ..Default::default()
     });
     model.step_until_ready_for_runtime();
-    assert_eq!(get_fwinfo(&mut model).owner_auth_manifest_current_svn, 0);
+    let info = get_fwinfo(&mut model);
+    assert_eq!(info.owner_auth_manifest_current_svn, 0);
+    assert_eq!(info.owner_auth_manifest_min_svn, MIN_SVN);
 
     let below_floor = build_owner_manifest(
         vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],


### PR DESCRIPTION
Report the current and minimum SoC authorization manifest SVN and the current owner authorization manifest SVN. Persist accepted manifest SVNs across warm and update resets, and update API bindings, documentation, and tests.

Fixes #4042