### PR TITLE
dpe_crypto: make public key an output argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=990fa31c851409633df41da7268edc677360e605#990fa31c851409633df41da7268edc677360e605"
 dependencies = [
  "arrayvec",
  "asn1",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-crypto"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=990fa31c851409633df41da7268edc677360e605#990fa31c851409633df41da7268edc677360e605"
 dependencies = [
  "arrayvec",
  "caliptra-cfi-derive",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-platform"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=990fa31c851409633df41da7268edc677360e605#990fa31c851409633df41da7268edc677360e605"
 dependencies = [
  "arrayvec",
  "caliptra-dpe-crypto",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "caliptra-dpe-response-buffer"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=c03749e003c18e63bd37e4fb7287c00dab591fce#c03749e003c18e63bd37e4fb7287c00dab591fce"
+source = "git+https://github.com/chipsalliance/caliptra-dpe.git?rev=990fa31c851409633df41da7268edc677360e605#990fa31c851409633df41da7268edc677360e605"
 
 [[package]]
 name = "caliptra-drivers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,10 +145,10 @@ clap = { version = "3.2.14", default-features = false, features = ["std"] }
 cms = "0.2.2"
 constant_time_eq = "0.3.0"
 convert_case = "0.6.0"
-dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe", features = ["hybrid", "arbitrary_max_handles"] }
-crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe-crypto", default-features = false }
-platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", package = "caliptra-dpe-platform", default-features = false }
-caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "c03749e003c18e63bd37e4fb7287c00dab591fce", default-features = false }
+dpe = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "990fa31c851409633df41da7268edc677360e605", package = "caliptra-dpe", features = ["hybrid", "arbitrary_max_handles"] }
+crypto = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "990fa31c851409633df41da7268edc677360e605", package = "caliptra-dpe-crypto", default-features = false }
+platform = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "990fa31c851409633df41da7268edc677360e605", package = "caliptra-dpe-platform", default-features = false }
+caliptra-dpe-response-buffer = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "990fa31c851409633df41da7268edc677360e605", default-features = false }
 # Older version for backwards compatibility logic
 dpe-runtime-1-2 = { git = "https://github.com/chipsalliance/caliptra-dpe.git", rev = "e63241cebad7c96ff954ec7d33207fc96b3323ef", package = "dpe", default-features = false, features = ["dpe_profile_p384_sha384", "arbitrary_max_handles"] }
 elf = "0.7.2"

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -36,7 +36,7 @@ pub struct Mldsa87Seed([u8; MLDSA87_PRIVATE_SEED_BYTES]);
 
 /// ML-DSA-87 encoded public key (2,592 bytes).
 #[repr(transparent)]
-#[derive(KnownLayout, Immutable, FromBytes)]
+#[derive(KnownLayout, Immutable, FromBytes, IntoBytes)]
 pub struct Mldsa87PubKey([u8; MLDSA87_PUBLIC_KEY_BYTES]);
 
 /// ML-DSA-87 FIPS 204 encoded private key (4,896 bytes).

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -683,15 +683,22 @@ impl crypto::Signer for DpeCrypto<'_> {
         }
     }
 
-    fn public_key(&mut self) -> Result<PubKey, CryptoError> {
+    fn public_key(&mut self, out: &mut PubKey) -> Result<(), CryptoError> {
         match &self.derived_key {
-            Some(DerivedKey::Ec((_, pub_key))) => Ok(PubKey::Ecdsa(pub_key.clone())),
+            Some(DerivedKey::Ec((_, pub_key))) => {
+                *out = PubKey::Ecdsa(pub_key.clone());
+                Ok(())
+            }
             #[cfg(feature = "mldsa_attestation")]
             Some(DerivedKey::Mldsa(seed)) => {
-                let mut pub_key = Mldsa87PubKey::default();
-                Mldsa87::pub_from_seed(seed, &mut pub_key, None)
+                let PubKey::Mldsa(MldsaPublicKey(bytes)) = out else {
+                    return Err(CryptoError::MismatchedAlgorithm);
+                };
+                let pub_key = Mldsa87PubKey::mut_from_bytes(bytes.as_mut_slice())
+                    .map_err(|_| CryptoError::Size)?;
+                Mldsa87::pub_from_seed(seed, pub_key, None)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                Ok(PubKey::Mldsa(MldsaPublicKey(*pub_key)))
+                Ok(())
             }
             _ => Err(CryptoError::CryptoLibError(4)),
         }

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -12,7 +12,7 @@ use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
     ecdsa::{
-        curve_384::{EcdsaPub384, EcdsaSignature384},
+        curve_384::{EcdsaPub384, EcdsaSignature384, CURVE_SIZE},
         EcdsaPubKey, EcdsaSignature,
     },
     Crypto, CryptoError, Digest, PubKey, SignData, Signature, SignatureType,
@@ -44,7 +44,10 @@ impl SignWithExportedEcdsaCmd {
 
         let data = Digest::Sha384(crypto::Sha384(cmd.tbs)).into();
         let mut sig = Signature::zeroed(crypto.signature_algorithm());
-        let mut pub_key = PubKey::default();
+        let mut pub_key = PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 {
+            x: [0u8; CURVE_SIZE],
+            y: [0u8; CURVE_SIZE],
+        }));
         sign_exported(
             &mut crypto,
             &data,
@@ -146,8 +149,8 @@ pub(crate) fn sign_exported(
         CryptoError::InvalidExportedCdiHandle => ExportedSignError::NotFound,
         _ => ExportedSignError::KeyDerivation,
     })?;
-    *pub_key = signer
-        .public_key()
+    signer
+        .public_key(pub_key)
         .map_err(|_| ExportedSignError::KeyDerivation)?;
     signer
         .sign(data, sig)

--- a/runtime/src/sign_with_exported_mldsa.rs
+++ b/runtime/src/sign_with_exported_mldsa.rs
@@ -15,7 +15,7 @@ use caliptra_drivers::MLDSA87_MU_BYTES;
 use caliptra_error::{CaliptraError, CaliptraResult};
 
 use crypto::{
-    ml_dsa::{MldsaPublicKey, MldsaSignature},
+    ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature},
     Mu, PubKey, SignData, Signature, SignatureType,
 };
 use zerocopy::{FromZeros, IntoBytes};
@@ -73,7 +73,9 @@ impl SignWithExportedMldsaCmd {
         )?;
 
         let mut sig = Signature::zeroed(crypto.signature_algorithm());
-        let mut pub_key = PubKey::default();
+        let mut pub_key = PubKey::Mldsa(MldsaPublicKey(
+            [0u8; MldsaAlgorithm::Mldsa87.public_key_size()],
+        ));
         sign_exported(
             &mut crypto,
             &data,


### PR DESCRIPTION
Avoid returning the public key by-value from Signer::public_key, saving stack space for ML-DSA signing path.

This is the caliptra-sw side changes following https://github.com/chipsalliance/caliptra-dpe/pull/623.