### PR TITLE
[caliptra-2.0] runtime: report tagged DPE context SVN in DPE_GET_TAGGED_TCI

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1811,12 +1811,23 @@ pub struct GetTaggedTciReq {
     pub hdr: MailboxReqHeader,
     pub tag: u32,
 }
+/// Response to `DPE_GET_TAGGED_TCI`.
+///
+/// Fields are appended only; never insert, reorder, resize or remove a published
+/// field, since callers rely on the offsets of the ones already here.
+///
+/// Appending still changes the response length and therefore its checksum, so a
+/// caller built against an older layout cannot parse a response from newer
+/// firmware. As with `FW_INFO`, this command assumes the caller and firmware are
+/// updated in lockstep.
 #[repr(C)]
 #[derive(Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 pub struct GetTaggedTciResp {
     pub hdr: MailboxRespHeader,
     pub tci_cumulative: [u8; 48],
     pub tci_current: [u8; 48],
+    /// Security Version Number of the tagged DPE context.
+    pub svn: u32,
 }
 
 // INCREMENT_PCR_RESET_COUNTER request

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -238,6 +238,7 @@ struct caliptra_get_tagged_tci_resp
     struct caliptra_resp_header hdr;
     uint8_t tci_cumulative[48];
     uint8_t tci_current[48];
+    uint32_t svn;
 };
 
 struct caliptra_increment_pcr_reset_counter_req

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -975,6 +975,10 @@ Command Code: `0x5451_4754` ("TAGT")
 
 Retrieves the TCI measurements corresponding to the tagged DPE context.
 
+NOTE: Additional fields and info may be appended to the response in subsequent FW
+versions. Appending changes the response length and therefore its checksum, so
+the caller and firmware are expected to be updated in lockstep.
+
 Command Code: `0x4754_4744` ("GTGD")
 
 *Table: `DPE_GET_TAGGED_TCI` input arguments*
@@ -992,6 +996,7 @@ Command Code: `0x4754_4744` ("GTGD")
 | fips\_status     | u32       | Indicates if the command is FIPS approved or an error.
 | tci\_cumulative  | u8[48]    | Hash of all of the input data provided to the context.
 | tci\_current     | u8[48]    | Most recent measurement made into the context.
+| svn              | u32       | Security Version Number of the tagged DPE context.
 
 ### FW\_INFO
 

--- a/runtime/doc/test-coverage.md
+++ b/runtime/doc/test-coverage.md
@@ -143,6 +143,7 @@ Calls the dpe_get_tagged_tci mailbox command with a tag that does not exist and 
 Attempts to tag an inactive context and verifies that it fails | **test_tagging_inactive_context** | RUNTIME_TAGGING_FAILURE
 Tags the default context, destroys the default context, and checks that the dpe_get_tagged_tci mailbox command fails on the default context | **test_tagging_destroyed_context** | RUNTIME_TAGGING_FAILURE
 Tags the default context, retires the default context, and checks that the dpe_get_tagged_tci mailbox command fails on the default context | **test_tagging_retired_context** | RUNTIME_TAGGING_FAILURE
+Derives a context with a known SVN, tags it, and checks that the dpe_get_tagged_tci mailbox command reports that exact SVN | **test_get_tagged_tci_reports_context_svn** | N/A
 
 <br><br>
 # **Update Reset Tests**

--- a/runtime/src/tagging.rs
+++ b/runtime/src/tagging.rs
@@ -92,6 +92,7 @@ impl GetTaggedTciCmd {
         resp.hdr = MailboxRespHeader::default();
         resp.tci_cumulative = context.tci.tci_cumulative.0;
         resp.tci_current = context.tci.tci_current.0;
+        resp.svn = context.tci.svn;
         Ok(core::mem::size_of::<GetTaggedTciResp>())
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_tagging.rs
+++ b/runtime/tests/runtime_integration_tests/test_tagging.rs
@@ -14,6 +14,7 @@ use zerocopy::FromBytes;
 
 const TAG: u32 = 1;
 const INVALID_TAG: u32 = 2;
+const TEST_SVN: u32 = 0x5A5A_1234;
 const DEFAULT_HANDLE: [u8; 16] = [0u8; 16];
 const BAD_HANDLE: [u8; 16] = [1u8; 16];
 
@@ -46,7 +47,10 @@ fn test_tagging_default_context() {
         )
         .unwrap()
         .expect("We expected a response");
-    let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
+    let resp = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
+
+    // DPE creates the default context with SVN 0.
+    assert_eq!(resp.svn, 0);
 }
 
 #[test]
@@ -280,4 +284,59 @@ fn test_tagging_retired_context() {
         .unwrap()
         .expect("We expected a response");
     let _ = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
+}
+
+/// `svn` is the field this response was extended to expose, and every other test
+/// would still pass if firmware reported a wrong or defaulted one. Derive a
+/// context with a known SVN, tag it, and require that exact value back.
+#[test]
+fn test_get_tagged_tci_reports_context_svn() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    // Derive a child carrying a known, non-default SVN.
+    let derive_context_cmd = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        tci_type: 1,
+        svn: TEST_SVN,
+        ..Default::default()
+    };
+    let resp = execute_dpe_cmd(
+        &mut model,
+        &mut Command::from(&derive_context_cmd),
+        DpeResult::Success,
+    );
+    let Some(Response::DeriveContext(derive_context_resp)) = resp else {
+        panic!("Wrong response type!");
+    };
+
+    // Tag that child so the tag resolves to the context just derived.
+    let mut cmd = MailboxReq::TagTci(TagTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        handle: derive_context_resp.handle.0,
+        tag: TAG,
+    });
+    cmd.populate_chksum().unwrap();
+    let _ = model
+        .mailbox_execute(u32::from(CommandId::DPE_TAG_TCI), cmd.as_bytes().unwrap())
+        .unwrap()
+        .expect("We expected a response");
+
+    let mut cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        tag: TAG,
+    });
+    cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DPE_GET_TAGGED_TCI),
+            cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We expected a response");
+    let resp = GetTaggedTciResp::read_from_bytes(resp.as_slice()).unwrap();
+
+    assert_eq!(
+        resp.svn, TEST_SVN,
+        "must report the SVN the tagged context was derived with"
+    );
 }


### PR DESCRIPTION
Backport of #4083 to `caliptra-2.0`.

Cherry-picked with `-x` from def30f3c3990991119e84671132a2e3bccfce16d.

Extends `DPE_GET_TAGGED_TCI` by appending `svn` to `GetTaggedTciResp`, so callers can read the Security Version Number of the tagged DPE context. Appending changes the response length and therefore its checksum, so as with `FW_INFO` the caller and firmware are expected to be updated in lockstep.

## Porting note

One adjustment was needed on top of the cherry-pick: `execute_dpe_cmd` on this branch takes 3 arguments and does not take a `CaliptraDpeProfile`, so the profile argument was dropped from the new test. Everything else applied cleanly.
