### PR TITLE
runtime: fix metadata entry binary search bounds

### DIFF
--- a/runtime/src/authorize_and_stash.rs
+++ b/runtime/src/authorize_and_stash.rs
@@ -115,6 +115,7 @@ impl AuthorizeAndStashCmd {
     ) -> Option<&AuthManifestImageMetadata> {
         auth_manifest_image_metadata_col
             .image_metadata_list
+            .get(..auth_manifest_image_metadata_col.entry_count as usize)?
             .binary_search_by(|metadata| metadata.fw_id.cmp(&cmd_fw_id))
             .ok()
             .and_then(|index| {
@@ -122,5 +123,34 @@ impl AuthorizeAndStashCmd {
                     .image_metadata_list
                     .get(index)
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use caliptra_auth_man_types::{AuthManifestImageMetadata, AuthManifestImageMetadataCollection};
+
+    fn make_metadata_collection(fw_ids: &[u32]) -> AuthManifestImageMetadataCollection {
+        let mut collection = AuthManifestImageMetadataCollection {
+            entry_count: fw_ids.len() as u32,
+            ..Default::default()
+        };
+        collection.entry_count = fw_ids.len() as u32;
+        for (i, &id) in fw_ids.iter().enumerate() {
+            collection.image_metadata_list[i] = AuthManifestImageMetadata {
+                fw_id: id,
+                flags: 0,
+                digest: [0u8; 48],
+            };
+        }
+        collection
+    }
+
+    #[test]
+    fn test_find_metadata_entry_with_sentinel_fw_id() {
+        let collection = make_metadata_collection(&[1, 2, 3]);
+        let result = AuthorizeAndStashCmd::find_metadata_entry(&collection, u32::MAX);
+        assert!(result.is_none());
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -904,3 +904,32 @@ fn test_authorize_and_stash_after_update_reset_multiple_set_manifest() {
         IMAGE_NOT_AUTHORIZED
     );
 }
+
+#[test]
+fn test_authorize_and_stash_cmd_without_set_auth_manifest() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: [0; 4],
+        measurement: IMAGE_DIGEST1,
+        source: ImageHashSource::InRequest as u32,
+        flags: 0, // Don't skip stash
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            authorize_and_stash_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        authorize_and_stash_resp.auth_req_result,
+        IMAGE_NOT_AUTHORIZED
+    );
+}


### PR DESCRIPTION
While handling `AUTHORIZE_AND_STASH`, restrict the bounds of binary search for a metadata entry within `[0..entry_count]` instead of the entire list of `AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT` elements. This prevents uninitialized or sentinel entries from being found. Tests are added.