### PR TITLE
fpga: Adds a boot sequence for external I3C host

### DIFF
--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -217,6 +217,9 @@ pub struct SubsystemInitParams<'a> {
     // Initial contents of the primary flash memory (for flash-based boot testing)
     pub primary_flash_initial_contents: Option<&'a [u8]>,
 
+    // Whether to use external I3C host controller.
+    pub use_external_i3c_host: bool,
+
     // Override the lifecycle state provisioned into OTP. When set, this
     // takes priority over the security_state-derived lifecycle mapping.
     pub lc_state: Option<LifecycleControllerState>,
@@ -240,6 +243,7 @@ impl Default for SubsystemInitParams<'_> {
             num_prod_dbg_unlock_pk_hashes: Default::default(),
             prod_dbg_unlock_pk_hashes_offset: Default::default(),
             primary_flash_initial_contents: None,
+            use_external_i3c_host: false,
             lc_state: None,
             use_strap_secrets: false,
             target_provisioning_stage: Default::default(),
@@ -1568,6 +1572,12 @@ pub trait HwModel: SocManager {
         soc_manifest: Option<&[u8]>,
         mcu_firmware: Option<&[u8]>,
     ) -> Result<(), ModelError>;
+
+    fn enable_external_i3c_upload_firmware_rri(&mut self) -> Result<(), ModelError> {
+        unimplemented!(
+            "Firmware upload from an external I3C host is only supported with the FPGA setup."
+        )
+    }
 
     /// Upload fw image to RRI.
     fn upload_firmware_rri(

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -7,7 +7,7 @@ use crate::api_types::{DeviceLifecycle, Fuses};
 use crate::bmc::Bmc;
 use crate::fpga_regs::{
     Control, FifoData, FifoRegs, FifoStatus, FlashControl, FlashCtrlRegs, FlashOpStatus,
-    ItrngFifoStatus, WrapperRegs,
+    ItrngFifoStatus, SpareI3cControlSts, WrapperRegs,
 };
 use crate::keys::{DEFAULT_LIFECYCLE_RAW_TOKENS, DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN};
 use crate::mcu_boot_status::McuBootMilestones;
@@ -423,6 +423,8 @@ pub struct ModelFpgaSubsystem {
     pub secondary_flash: Vec<u8>,
     // whether or not to attempt flash boot instead of streaming boot
     pub flash_boot: bool,
+    // whether or not to use external I3C host instead of soft IP
+    pub use_external_i3c_host: bool,
     pub target_provisioning_stage: ProvisioningStage,
 
     // Saved init params needed for cold_reset re-initialization
@@ -1963,6 +1965,7 @@ impl HwModel for ModelFpgaSubsystem {
                 .ss_init_params
                 .primary_flash_initial_contents
                 .is_some(),
+            use_external_i3c_host: params.ss_init_params.use_external_i3c_host,
             target_provisioning_stage: params.ss_init_params.target_provisioning_stage,
 
             saved_input_wires,
@@ -1982,6 +1985,12 @@ impl HwModel for ModelFpgaSubsystem {
             saved_lc_state: params.ss_init_params.lc_state,
             saved_use_strap_secrets: params.ss_init_params.use_strap_secrets,
         };
+
+        if m.flash_boot && m.use_external_i3c_host {
+            eprintln!(
+                "Warning: `use_external_i3c_host` does not make sense when flash boot is enabled (`primary_flash_initial_contents` is some)."
+            );
+        }
 
         println!("AXI reset");
         m.axi_reset();
@@ -2230,6 +2239,8 @@ impl HwModel for ModelFpgaSubsystem {
                     );
                 }
             }
+        } else if self.use_external_i3c_host {
+            self.enable_external_i3c_upload_firmware_rri().unwrap();
         } else {
             self.upload_firmware_rri(
                 boot_params.fw_image.unwrap(),
@@ -2294,6 +2305,31 @@ impl HwModel for ModelFpgaSubsystem {
     fn subsystem_mode(&mut self) -> bool {
         // we only support subsystem mode
         true
+    }
+
+    fn enable_external_i3c_upload_firmware_rri(&mut self) -> Result<(), ModelError> {
+        println!("Wait for Caliptra I3C controller to come up.");
+        while !self.i3c_target_configured() {
+            self.step();
+        }
+        println!("Set mux to use external I3C host.");
+        self.wrapper
+            .regs()
+            .spare_i3c_control_sts
+            .modify(SpareI3cControlSts::UseExtI3cHost::SET);
+
+        // Call ROM callback before informing MCU ROM it can load firmware.
+        if let Some(cb) = self.rom_callback.take() {
+            cb(self);
+        }
+
+        // Notify MCU ROM it can start loading firmware.
+        let gpio = &self.wrapper.regs().mci_generic_input_wires[1];
+        let current = gpio.extract().get();
+        // MCU ROM will wait after reaching the mailbox for this bit before booting RT.
+        gpio.set(current | 1 << 31);
+
+        Ok(())
     }
 
     fn upload_firmware_rri(


### PR DESCRIPTION
Depending on the external I3C boot parameter, a configuration sequence will be executed that sets things up for Caliptra to boot from the external I3C device.