### PR TITLE
[update] runtime: expose manifest SVN state in FW_INFO (#4082)

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -1668,6 +1668,10 @@ pub struct FwInfoResp {
     pub image_manifest_pqc_type: u32,
     pub vendor_ecc384_pub_key_index: u32,
     pub vendor_pqc_pub_key_index: u32,
+    pub soc_manifest_current_svn: u32,
+    pub soc_manifest_min_svn: u32,
+    pub owner_auth_manifest_current_svn: u32,
+    pub owner_auth_manifest_min_svn: u32,
 }
 
 // CAPABILITIES

--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -417,8 +417,11 @@ pub struct PersistentData {
     #[cfg(feature = "runtime")]
     pub auth_manifest_digest: [u32; SHA384_HASH_SIZE / 4],
     #[cfg(feature = "runtime")]
+    // Survives warm and update resets and is cleared on cold reset with the manifest metadata.
+    pub auth_manifest_svn: u32,
+    #[cfg(feature = "runtime")]
     reserved9: [u8; AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize
-        - (SHA384_HASH_SIZE + size_of::<AuthManifestImageMetadataCollection>())],
+        - (SHA384_HASH_SIZE + size_of::<AuthManifestImageMetadataCollection>() + size_of::<u32>())],
 
     #[cfg(not(feature = "runtime"))]
     pub auth_manifest_image_metadata_col: [u8; AUTH_MAN_PERSISTENT_DATA_SIZE as usize],
@@ -428,8 +431,12 @@ pub struct PersistentData {
     #[cfg(feature = "runtime")]
     pub owner_auth_manifest_digest: [u32; SHA384_HASH_SIZE / 4],
     #[cfg(feature = "runtime")]
+    pub owner_auth_manifest_svn: u32,
+    #[cfg(feature = "runtime")]
     reserved_owner_auth_manifest: [u8; OWNER_AUTH_MAN_IMAGE_METADATA_MAX_SIZE as usize
-        - (SHA384_HASH_SIZE + size_of::<OwnerAuthManifestImageMetadataCollection>())],
+        - (SHA384_HASH_SIZE
+            + size_of::<OwnerAuthManifestImageMetadataCollection>()
+            + size_of::<u32>())],
     #[cfg(feature = "runtime")]
     reserved_auth_manifests: [u8; (AUTH_MAN_PERSISTENT_DATA_SIZE
         - AUTH_MAN_IMAGE_METADATA_MAX_SIZE

--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -218,6 +218,10 @@ struct caliptra_fw_info_resp
     uint32_t image_manifest_pqc_type;
     uint32_t vendor_ecc384_pub_key_index;
     uint32_t vendor_pqc_pub_key_index;
+    uint32_t soc_manifest_current_svn;
+    uint32_t soc_manifest_min_svn;
+    uint32_t owner_auth_manifest_current_svn;
+    uint32_t owner_auth_manifest_min_svn;
 };
 
 struct caliptra_dpe_tag_tci_req

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1036,6 +1036,10 @@ Command Code: `0x494E_464F` ("INFO")
 | image_manifest_pqc_type     | u32      | PQC key type from image manifest. **Only present in FW 2.0.2+ and 2.1.1+.**                                                                         |
 | vendor_ecc384_pub_key_index | u32      | Index of the vendor ECC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
 | vendor_pqc_pub_key_index    | u32      | Index of the vendor PQC public key used for verification. **Only present in FW 2.0.2+ and 2.1.1+.**                                                 |
+| soc_manifest_current_svn    | u32      | SVN of the authorization manifest accepted by `SET_AUTH_MANIFEST`, or zero if none has been accepted.                                              |
+| soc_manifest_min_svn        | u32      | Minimum SoC manifest SVN encoded in `FUSE_SOC_MANIFEST_SVN` and enforced by `SET_AUTH_MANIFEST` when anti-rollback checks are enabled.               |
+| owner_auth_manifest_current_svn | u32   | SVN of the owner authorization manifest accepted by `SET_OWNER_AUTH_MANIFEST`, or zero if none has been accepted.                                  |
+| owner_auth_manifest_min_svn | u32      | Minimum owner authorization manifest SVN encoded in `SS_STRAP_GENERIC[3][15:8]` and enforced by `SET_OWNER_AUTH_MANIFEST` when anti-rollback checks are enabled. |
 
 ### VERSION
 

--- a/runtime/src/info.rs
+++ b/runtime/src/info.rs
@@ -54,6 +54,10 @@ impl FwInfoCmd {
         resp.image_manifest_pqc_type = pdata.manifest1.pqc_key_type as u32;
         resp.vendor_ecc384_pub_key_index = handoff.data_vault.vendor_ecc_pk_index();
         resp.vendor_pqc_pub_key_index = handoff.data_vault.vendor_pqc_pk_index();
+        resp.soc_manifest_current_svn = pdata.auth_manifest_svn;
+        resp.soc_manifest_min_svn = drivers.soc_ifc.fuse_bank().soc_manifest_fuse_svn();
+        resp.owner_auth_manifest_current_svn = pdata.owner_auth_manifest_svn;
+        resp.owner_auth_manifest_min_svn = drivers.soc_ifc.ss_owner_manifest_min_svn();
         resp.most_recent_fw_error = match get_fw_error_non_fatal() {
             0 => drivers.persistent_data.get().cleared_non_fatal_fw_error,
             e => e,

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -852,7 +852,11 @@ impl SetAuthManifestCmd {
 
         if !verify_only {
             let auth_manifest_digest = drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
-            drivers.persistent_data.get_mut().auth_manifest_digest = auth_manifest_digest;
+            {
+                let persistent_data = drivers.persistent_data.get_mut();
+                persistent_data.auth_manifest_digest = auth_manifest_digest;
+                persistent_data.auth_manifest_svn = auth_manifest_preamble.svn;
+            }
             // Store the SoC manifest SVN for use as the MCU RT current_svn
             // when creating the MCU RT DPE context during recovery boot or
             // hitless update.

--- a/runtime/src/set_owner_auth_manifest.rs
+++ b/runtime/src/set_owner_auth_manifest.rs
@@ -435,6 +435,7 @@ impl SetOwnerAuthManifestCmd {
         // Record the digest of the full manifest buffer for attestation.
         persistent_data.owner_auth_manifest_digest =
             drivers.sha2_512_384.sha384_digest(manifest_buf)?.0;
+        persistent_data.owner_auth_manifest_svn = preamble.svn;
 
         Ok(())
     }

--- a/runtime/tests/runtime_integration_tests/test_info.rs
+++ b/runtime/tests/runtime_integration_tests/test_info.rs
@@ -44,6 +44,12 @@ fn find_rom_info(rom: &[u8]) -> Option<RomInfo> {
 }
 
 pub fn get_fwinfo(model: &mut DefaultHwModel) -> FwInfoResp {
+    let info = get_fwinfo_allow_attestation_disabled(model);
+    assert_eq!(info.attestation_disabled, 0);
+    info
+}
+
+pub fn get_fwinfo_allow_attestation_disabled(model: &mut DefaultHwModel) -> FwInfoResp {
     let payload = MailboxReqHeader {
         chksum: caliptra_common::checksum::calc_checksum(u32::from(CommandId::FW_INFO), &[]),
     };
@@ -65,7 +71,6 @@ pub fn get_fwinfo(model: &mut DefaultHwModel) -> FwInfoResp {
         info.hdr.fips_status,
         MailboxRespHeader::FIPS_STATUS_APPROVED
     );
-    assert_eq!(info.attestation_disabled, 0);
     info
 }
 

--- a/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_auth_manifest.rs
@@ -3,7 +3,7 @@
 use crate::{
     common::{assert_error, run_rt_test_pqc, RuntimeTestArgs, PQC_KEY_TYPE},
     test_authorize_and_stash::IMAGE_DIGEST1,
-    test_info::get_fwinfo,
+    test_info::{get_fwinfo, get_fwinfo_allow_attestation_disabled},
 };
 use caliptra_api::mailbox::ImageHashSource;
 use caliptra_auth_man_gen::{
@@ -14,6 +14,7 @@ use caliptra_auth_man_types::{
     AuthManifestPubKeysConfig, AuthorizationManifest, ImageMetadataFlags,
     AUTH_MANIFEST_IMAGE_METADATA_MAX_COUNT,
 };
+use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::{CommandId, MailboxReq, MailboxReqHeader, SetAuthManifestReq};
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, DeviceLifecycle, HwModel, SecurityState};
@@ -385,14 +386,39 @@ fn test_set_auth_manifest_cmd_pqc_lms() {
 }
 
 #[test]
-fn test_set_auth_manifest_fw_info_digest() {
-    let mut model = run_rt_test_pqc(RuntimeTestArgs::default(), FwVerificationPqcKeyType::MLDSA);
+fn test_set_auth_manifest_fw_info() {
+    let mut security_state = SecurityState::default();
+    security_state.set_debug_locked(true);
+    security_state.set_device_lifecycle(DeviceLifecycle::Production);
+    let mut rt_args = RuntimeTestArgs {
+        security_state: Some(security_state),
+        ..Default::default()
+    };
+    rt_args.soc_manifest_svn = Some(2);
+    let subsystem_mode = !cfg!(feature = "fpga_realtime");
+    rt_args.subsystem_mode = subsystem_mode;
+    let mut image_options = ImageOptions {
+        fw_svn: 12,
+        pqc_key_type: FwVerificationPqcKeyType::MLDSA,
+        ..Default::default()
+    };
+    image_options.vendor_config.pl0_pauser = Some(0x1);
+    rt_args.test_image_options = Some(image_options);
+    let mut model = run_rt_test_pqc(rt_args, FwVerificationPqcKeyType::MLDSA);
     model.step_until_ready_for_runtime();
+
+    let info = get_fwinfo(&mut model);
+    assert_eq!(
+        info.soc_manifest_current_svn,
+        if subsystem_mode { 2 } else { 0 }
+    );
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
 
     let auth_manifest = create_auth_manifest(&AuthManifestBuilderCfg {
         manifest_flags: AuthManifestFlags::VENDOR_SIGNATURE_REQUIRED,
         pqc_key_type: FwVerificationPqcKeyType::MLDSA,
-        ..Default::default()
+        svn: 3,
     });
     let buf = auth_manifest.as_bytes();
     let mut auth_manifest_slice = [0u8; SetAuthManifestReq::MAX_MAN_SIZE];
@@ -428,6 +454,15 @@ fn test_set_auth_manifest_fw_info_digest() {
         .collect();
 
     assert_eq!(info.authman_sha384_digest, authman_digest.as_slice());
+    assert_eq!(info.soc_manifest_current_svn, 3);
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
+
+    model.warm_reset_flow().unwrap();
+    let info = get_fwinfo_allow_attestation_disabled(&mut model);
+    assert_eq!(info.soc_manifest_current_svn, 3);
+    assert_eq!(info.soc_manifest_min_svn, 2);
+    assert_eq!(info.fw_svn, 12);
 }
 
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
+++ b/runtime/tests/runtime_integration_tests/test_set_owner_auth_manifest.rs
@@ -5,6 +5,7 @@
 
 use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_authorize_and_stash::{set_auth_manifest, FW_ID_1, IMAGE_DIGEST1};
+use crate::test_info::get_fwinfo;
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata_with_svn;
 use crate::test_update_reset::update_fw;
 use caliptra_api::{mailbox::VerifyAuthManifestReq, SocManager};
@@ -264,6 +265,9 @@ fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
         ..Default::default()
     });
     model.step_until_ready_for_runtime();
+    let info = get_fwinfo(&mut model);
+    assert_eq!(info.owner_auth_manifest_current_svn, 0);
+    assert_eq!(info.owner_auth_manifest_min_svn, MIN_SVN);
 
     let below_floor = build_owner_manifest(
         vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
@@ -276,12 +280,17 @@ fn test_set_owner_auth_manifest_svn_floor_uses_strap_bits_15_8() {
         matches!(err, ModelError::MailboxCmdFailed(code) if code == expected),
         "expected owner manifest SVN below minimum, got {err:?}",
     );
+    assert_eq!(get_fwinfo(&mut model).owner_auth_manifest_current_svn, 0);
 
     let at_floor = build_owner_manifest(
         vec![make_entry(OWNER_ONLY_FW_ID, OWNER_ONLY_DIGEST)],
         MIN_SVN,
     );
     send_set_owner_auth_manifest(&mut model, &at_floor);
+    assert_eq!(
+        get_fwinfo(&mut model).owner_auth_manifest_current_svn,
+        MIN_SVN
+    );
 }
 
 #[test]


### PR DESCRIPTION
Report the current and minimum SoC authorization manifest SVN and the current owner authorization manifest SVN. Persist accepted manifest SVNs across warm and update resets, and update API bindings, documentation, and tests.

(cherry picked from commit 14a1fee5e2d06c0bc210d6fa1f2466469e16773f)