### PR TITLE
mldsa: cache polys

### DIFF
--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -54,6 +54,17 @@ const K_GAMMA_2: u32 = (K_PRIME - 1) / 32;
 const BETA: u32 = 120;
 const OMEGA: usize = 75;
 
+/// Number of ML-DSA-87 matrix A polynomials cached across the signing rejection
+/// loop. A is 8 rows x 7 columns = 56 polynomials and depends only on `rho`, so
+/// caching avoids re-expanding these via SHAKE128 on every iteration — the
+/// dominant per-iteration cost. Each cached polynomial is 24-bit packed (768
+/// bytes vs 1024 unpacked) and the cache lives on the sign stack.
+const A_CACHE_POLYS: usize = 50;
+/// Bytes per 24-bit-packed cached polynomial (256 coeffs * 3 bytes).
+const A_CACHE_POLY_BYTES: usize = K_DEGREE * 3;
+/// Total A-cache size in bytes.
+const A_CACHE_BYTES: usize = A_CACHE_POLYS * A_CACHE_POLY_BYTES;
+
 /* Fundamental types. */
 
 #[derive(Clone, Copy)]
@@ -658,9 +669,43 @@ fn expand_s1_or_s2_ntt_mul_scalar(
     scalar_mul_assign(out, rhs);
 }
 
+/// Pack a scalar's coefficients — each is `< K_PRIME < 2^23` — as little-endian
+/// 24-bit values, 3 bytes each. The top bit is always zero (1 wasted bit per
+/// coefficient), traded for a trivial byte-aligned encoding.
+fn scalar_pack_24(out: &mut [u8], s: &Scalar) {
+    for (coeff, chunk) in s.c.iter().zip(out.chunks_exact_mut(3)) {
+        chunk[0] = *coeff as u8;
+        chunk[1] = (*coeff >> 8) as u8;
+        chunk[2] = (*coeff >> 16) as u8;
+    }
+}
+
+/// Inverse of [`scalar_pack_24`].
+fn scalar_unpack_24(out: &mut Scalar, in_bytes: &[u8]) {
+    for (coeff, chunk) in out.c.iter_mut().zip(in_bytes.chunks_exact(3)) {
+        *coeff = (chunk[0] as u32) | ((chunk[1] as u32) << 8) | ((chunk[2] as u32) << 16);
+    }
+}
+
+/// Expand and 24-bit-pack the first `A_CACHE_POLYS` polynomials of matrix A once,
+/// in the same column-major `(j, i)` order [`matrix87_expand_mul_mask`] visits
+/// them, so the rejection loop can reuse them instead of re-running SHAKE128.
+fn matrix87_cache_expand(cache: &mut [u8; A_CACHE_BYTES], rho: &[u8; K_RHO_BYTES]) {
+    let mut derived_seed = [0u8; K_RHO_BYTES + 2];
+    derived_seed[..K_RHO_BYTES].copy_from_slice(rho);
+    let mut m = Scalar::default();
+    for (idx, slot) in cache.chunks_exact_mut(A_CACHE_POLY_BYTES).enumerate() {
+        derived_seed[K_RHO_BYTES] = (idx / 8) as u8; // column j
+        derived_seed[K_RHO_BYTES + 1] = (idx % 8) as u8; // row i
+        scalar_from_keccak_vartime(&mut m, &derived_seed);
+        scalar_pack_24(slot, &m);
+    }
+}
+
 fn matrix87_expand_mul_mask(
     out: &mut Vector8,
     rho: &[u8; K_RHO_BYTES],
+    a_cache: &[u8; A_CACHE_BYTES],
     rho_prime: &[u8; K_RHO_PRIME_BYTES],
     kappa: usize,
 ) {
@@ -680,9 +725,17 @@ fn matrix87_expand_mul_mask(
 
         for (i, out_scalar) in out.v.iter_mut().enumerate() {
             let mut m_ij = Scalar::default();
-            derived_seed[K_RHO_BYTES + 1] = i as u8;
-            derived_seed[K_RHO_BYTES] = j as u8;
-            scalar_from_keccak_vartime(&mut m_ij, &derived_seed);
+            let idx = j * 8 + i;
+            if idx < A_CACHE_POLYS {
+                scalar_unpack_24(
+                    &mut m_ij,
+                    &a_cache[idx * A_CACHE_POLY_BYTES..(idx + 1) * A_CACHE_POLY_BYTES],
+                );
+            } else {
+                derived_seed[K_RHO_BYTES + 1] = i as u8;
+                derived_seed[K_RHO_BYTES] = j as u8;
+                scalar_from_keccak_vartime(&mut m_ij, &derived_seed);
+            }
             scalar_mul_add_assign(out_scalar, &m_ij, &y_j);
         }
     }
@@ -971,10 +1024,16 @@ fn sign_internal_with_mu(
     shake256.absorb(mu);
     shake256.squeeze(&mut rho_prime);
 
+    // Expand the (rho-derived, kappa-independent) prefix of matrix A once and
+    // reuse it across every rejection-loop iteration instead of re-running
+    // SHAKE128 for it each time.
+    let mut a_cache = [0u8; A_CACHE_BYTES];
+    matrix87_cache_expand(&mut a_cache, &priv_key.rho);
+
     let mut kappa = 0;
     loop {
         let mut tmp = Vector8::default();
-        matrix87_expand_mul_mask(&mut tmp, &priv_key.rho, &rho_prime, kappa);
+        matrix87_expand_mul_mask(&mut tmp, &priv_key.rho, &a_cache, &rho_prime, kappa);
         vector8_inverse_ntt(&mut tmp);
 
         let mut c_tilde = [0u8; 2 * LAMBDA_BYTES];

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -124,6 +124,20 @@ impl ModelEmulated {
         self.cpu.stack_min_sp()
     }
 
+    /// Drain the `(pc, sp)` recorded for each new stack high-water mark since the
+    /// last reset. Empty unless `CALIPTRA_EMU_STACK_WATERMARK_LOG` was set when
+    /// the model was built.
+    pub fn take_stack_watermark_events(&mut self) -> Vec<(u32, u32)> {
+        self.cpu.take_stack_watermark_events()
+    }
+
+    /// Drain the full `(pc, sp)` stack-pointer-change trace (allocations and
+    /// frees) since the last reset. Empty unless `CALIPTRA_EMU_STACK_SP_TRACE`
+    /// was set when the model was built.
+    pub fn take_stack_sp_events(&mut self) -> Vec<(u32, u32)> {
+        self.cpu.take_stack_sp_events()
+    }
+
     /// Return the total number of simulated clock cycles elapsed since the
     /// model was created. Subtract two snapshots to measure the cost of a
     /// code region.
@@ -303,6 +317,17 @@ impl HwModel for ModelEmulated {
             let mut cpu = Cpu::new(BusLogger::new(root_bus), clock);
             if let Some(stack_info) = params.stack_info {
                 cpu.with_stack_info(stack_info);
+                // Opt-in, env-gated: record the (pc, sp) that set each stack
+                // high-water mark so the peak can be attributed to functions.
+                if std::env::var_os("CALIPTRA_EMU_STACK_WATERMARK_LOG").is_some() {
+                    cpu.enable_stack_watermark_log();
+                }
+                // Opt-in, env-gated: record every SP change so any call sub-chain
+                // (e.g. ML-DSA sign) can be reconstructed frame-by-frame, even when
+                // it is not the globally deepest path.
+                if std::env::var_os("CALIPTRA_EMU_STACK_SP_TRACE").is_some() {
+                    cpu.enable_stack_sp_trace();
+                }
             }
             if params.sample_stack_traces {
                 cpu.stack_sampler = Some(StackSampler::new(params.stack_sample_rate));

--- a/runtime/tests/runtime_integration_tests/test_command_timing.rs
+++ b/runtime/tests/runtime_integration_tests/test_command_timing.rs
@@ -15,7 +15,10 @@
 //! firmware and additionally measures the ML-DSA-87 commands via
 //! `run_pqc_command_suite` (`SET_PQ_SEED`, `GET_PQ_CSR`,
 //! `CERTIFY_KEY_EXTENDED_MLDSA87`, `MLDSA87_SIGNATURE_VERIFY`, `GET_PQ_CERT`,
-//! `POPULATE_PQ_CERT`).
+//! `POPULATE_PQ_CERT`) and every ML-DSA-87 `INVOKE_DPE` subcommand via
+//! `measure_mldsa_dpe_subcommands` (InitCtx, DeriveContext, CertifyKey, Sign,
+//! RotateCtx, DestroyCtx, GetProfile, GetCertificateChain,
+//! UpdateContextMeasurement).
 //!
 //! The mechanism relies on `DefaultHwModel::cycle_count()`, which reads the
 //! emulated CPU's clock counter. It is therefore only meaningful against the
@@ -29,7 +32,7 @@ use caliptra_hw_model::{DefaultHwModel, HwModel};
 use caliptra_runtime::RtBootStatus;
 
 #[cfg(feature = "mldsa_attestation")]
-use crate::test_measurements_common::run_pqc_command_suite;
+use crate::test_measurements_common::{measure_mldsa_dpe_subcommands, run_pqc_command_suite};
 #[cfg(feature = "mldsa_attestation")]
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 
@@ -89,12 +92,29 @@ fn measure_timing(args: RuntimeTestArgs) {
         &mut CycleSampler { start: 0 },
     ));
 
+    // The ML-DSA INVOKE_DPE subcommands are measured against their own dedicated
+    // model (see measure_mldsa_dpe_subcommands): the full set can't be sequenced in
+    // this shared model (default-context retirement + DISABLE_ATTESTATION conflicts).
+    #[cfg(feature = "mldsa_attestation")]
+    results.extend(measure_mldsa_dpe_subcommands(&mut CycleSampler {
+        start: 0,
+    }));
+
+    // Size the name column to the widest command name (some INVOKE_DPE_MLDSA87(..)
+    // subcommands are >40 chars) so the cycles column stays aligned instead of
+    // being pushed out by long names.
     results.sort_by_key(|b| std::cmp::Reverse(b.1));
+    let name_w = results
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap_or(0)
+        .max("command".len());
     println!("\nRuntime command cycle cost (emulated clock cycles):");
-    println!("{:<32} {:>12}", "command", "cycles");
-    println!("{}", "-".repeat(46));
+    println!("{:<name_w$} {:>12}", "command", "cycles");
+    println!("{}", "-".repeat(name_w + 13));
     for (name, cycles) in &results {
-        println!("{name:<32} {cycles:>12}");
+        println!("{name:<name_w$} {cycles:>12}");
     }
 
     for (name, cycles) in &results {
@@ -110,4 +130,183 @@ fn measure_runtime_command_timing() {
 #[test]
 fn measure_runtime_command_timing_and_sample_stack_traces() {
     measure_timing(test_args(true, None));
+}
+
+/// Profile the cycle-cost distribution of `CERTIFY_KEY_EXTENDED_MLDSA87` across
+/// many distinct labels.
+///
+/// ML-DSA-87 signing uses rejection sampling, so the number of loop iterations —
+/// and hence the cycle cost — depends on the data being signed. The DPE
+/// `CertifyKey` label seeds leaf-key derivation, so each distinct label yields a
+/// different derived key, a different certificate TBS, a different `mu`, and thus
+/// a different rejection-loop count. Leaf key generation itself is rejection-free
+/// (constant work), so the spread measured here reflects the signing loop.
+///
+/// Marked `#[ignore]`: this runs the full keygen+sign path 50 times and is a
+/// profiling aid, not a pass/fail gate. Run with:
+///   cargo test -p caliptra-runtime --features mldsa_attestation \
+///     measure_certify_key_mldsa_timing_distribution -- --ignored --nocapture
+#[cfg(feature = "mldsa_attestation")]
+#[test]
+#[ignore = "50x CERTIFY_KEY_EXTENDED_MLDSA87 profiling run; invoke with --ignored"]
+fn measure_certify_key_mldsa_timing_distribution() {
+    /// Number of distinct-label CERTIFY_KEY calls to sample.
+    const N: usize = 50;
+
+    CERTIFY_DONE.store(0, std::sync::atomic::Ordering::Relaxed);
+    let samples = sample_certify_worker(0, N, N);
+    print_timing_stats("CERTIFY_KEY_EXTENDED_MLDSA87", &samples);
+}
+
+/// Compute and print summary statistics (mean, sample std dev, spread,
+/// percentiles) over a set of cycle-count samples, and assert none are zero.
+#[cfg(feature = "mldsa_attestation")]
+fn print_timing_stats(title: &str, samples: &[u64]) {
+    let n = samples.len();
+    assert!(n > 1, "need at least 2 samples");
+    let mean = samples.iter().sum::<u64>() as f64 / n as f64;
+    // Sample variance (n-1 denominator).
+    let variance = samples
+        .iter()
+        .map(|&c| {
+            let d = c as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / (n - 1) as f64;
+    let std_dev = variance.sqrt();
+    let cv = std_dev / mean;
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    let pct = |p: f64| -> u64 { sorted[((p * (n as f64 - 1.0)).round() as usize).min(n - 1)] };
+    let median = if n.is_multiple_of(2) {
+        (sorted[n / 2 - 1] + sorted[n / 2]) as f64 / 2.0
+    } else {
+        sorted[n / 2] as f64
+    };
+
+    println!("\n{title} timing over {n} distinct labels (emulated clock cycles):");
+    println!("  n         = {n}");
+    println!("  mean      = {mean:.1}");
+    println!("  std dev   = {std_dev:.1}  (sample, n-1)");
+    println!("  cv        = {:.2}%  (std/mean)", cv * 100.0);
+    println!("  min       = {}", sorted[0]);
+    println!("  p25       = {}", pct(0.25));
+    println!("  median    = {median:.1}");
+    println!("  p75       = {}", pct(0.75));
+    println!("  p90       = {}", pct(0.90));
+    println!("  p99       = {}", pct(0.99));
+    println!("  max       = {}", sorted[n - 1]);
+    println!("  range     = {}", sorted[n - 1] - sorted[0]);
+
+    for (i, c) in samples.iter().enumerate() {
+        assert!(*c > 0, "sample {i} reported zero cycles");
+    }
+}
+
+/// Global progress counter shared by the CERTIFY_KEY sampling workers. Reset by
+/// each test before spawning its workers.
+#[cfg(feature = "mldsa_attestation")]
+static CERTIFY_DONE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Same distribution as `measure_certify_key_mldsa_timing_distribution`, but
+/// gathers 1000 samples by running several emulators in parallel worker threads
+/// (each over a disjoint label range) and combining them. The firmware-build
+/// cache is process-global and thread-safe (each worker reads the same cached
+/// ELF), so the workers share one build and only the emulation runs in parallel.
+#[cfg(feature = "mldsa_attestation")]
+#[test]
+#[ignore = "1000x CERTIFY_KEY_EXTENDED_MLDSA87 across parallel emulators; invoke with --ignored"]
+fn measure_certify_key_mldsa_timing_distribution_1000() {
+    use std::sync::atomic::Ordering;
+
+    const TOTAL: usize = 1000;
+    // One single-threaded emulator per worker; leave a couple of cores free.
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get().saturating_sub(2).max(1))
+        .unwrap_or(8)
+        .min(TOTAL);
+    let per = TOTAL / workers;
+    let total = per * workers;
+    CERTIFY_DONE.store(0, Ordering::Relaxed);
+
+    // Warm the thread-safe, process-global firmware build cache once so the
+    // workers read the cached ELF rather than racing to build it.
+    let _ = caliptra_builder::build_firmware_elf(&APP_MLDSA_ATTESTATION);
+
+    let handles: Vec<_> = (0..workers)
+        .map(|w| std::thread::spawn(move || sample_certify_worker(w * per, per, total)))
+        .collect();
+
+    let mut samples: Vec<u64> = Vec::with_capacity(total);
+    for h in handles {
+        samples.extend(h.join().expect("worker thread panicked"));
+    }
+    print_timing_stats("CERTIFY_KEY_EXTENDED_MLDSA87 (parallel)", &samples);
+}
+
+/// Boot one emulator, provision PQC, and time `count` CERTIFY_KEY calls whose
+/// labels start at `label_start`. Returns the per-call cycle counts.
+#[cfg(feature = "mldsa_attestation")]
+fn sample_certify_worker(label_start: usize, count: usize, total: usize) -> Vec<u64> {
+    use caliptra_common::mailbox_api::{
+        CertifyKeyExtendedFlags, CertifyKeyExtendedMldsa87Req, CommandId, MailboxReq,
+        MailboxReqHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE,
+    };
+    use dpe::{
+        commands::{CertifyKeyCommand, CertifyKeyFlags, CertifyKeyMldsa87Cmd},
+        context::ContextHandle,
+    };
+    use std::sync::atomic::Ordering;
+    use zerocopy::IntoBytes;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        test_fwid: Some(&APP_MLDSA_ATTESTATION),
+        ..Default::default()
+    });
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+    let mut seed_req = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        seed: [0x5a; SET_PQ_SEED_SEED_SIZE],
+    });
+    seed_req.populate_chksum().unwrap();
+    model
+        .mailbox_execute(
+            u32::from(CommandId::SET_PQ_SEED),
+            seed_req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("SET_PQ_SEED failed");
+
+    let mut samples = Vec::with_capacity(count);
+    for i in 0..count {
+        let mut label = [0u8; 48];
+        label[..8].copy_from_slice(&((label_start + i) as u64).to_le_bytes());
+        let certify_key_cmd = CertifyKeyMldsa87Cmd {
+            handle: ContextHandle::default(),
+            flags: CertifyKeyFlags::empty(),
+            format: CertifyKeyCommand::FORMAT_X509,
+            label,
+        };
+        let mut req = MailboxReq::CertifyKeyExtendedMldsa87(CertifyKeyExtendedMldsa87Req {
+            hdr: MailboxReqHeader { chksum: 0 },
+            flags: CertifyKeyExtendedFlags::empty(),
+            certify_key_req: certify_key_cmd.as_bytes().try_into().unwrap(),
+        });
+        req.populate_chksum().unwrap();
+        let bytes = req.as_bytes().unwrap().to_vec();
+        let start = model.cycle_count();
+        model
+            .mailbox_execute(u32::from(CommandId::CERTIFY_KEY_EXTENDED_MLDSA87), &bytes)
+            .unwrap()
+            .expect("CERTIFY_KEY_EXTENDED_MLDSA87 failed");
+        samples.push(model.cycle_count() - start);
+        let d = CERTIFY_DONE.fetch_add(1, Ordering::Relaxed) + 1;
+        if d.is_multiple_of(10) || d == total {
+            eprintln!("  {d}/{total} done");
+        }
+    }
+    samples
 }

--- a/runtime/tests/runtime_integration_tests/test_measurements_common.rs
+++ b/runtime/tests/runtime_integration_tests/test_measurements_common.rs
@@ -29,7 +29,7 @@ use caliptra_runtime::CaliptraDpeProfile;
 use dpe::{
     commands::{
         CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP384Cmd, Command, DeriveContextCmd,
-        DeriveContextFlags, GetProfileCmd,
+        DeriveContextFlags, GetProfileCmd, SignFlags, SignP384Cmd,
     },
     context::ContextHandle,
     response::Response,
@@ -90,14 +90,23 @@ fn measure_req(
     measure_raw(sampler, model, u32::from(cmd_id), &bytes)
 }
 
+fn measure_dpe_profile(
+    sampler: &mut dyn CommandSampler,
+    model: &mut DefaultHwModel,
+    profile: CaliptraDpeProfile,
+    cmd: &mut Command,
+) -> u64 {
+    sampler.before(model);
+    let _ = execute_dpe_cmd(profile, model, cmd, DpeResult::Success);
+    sampler.after(model)
+}
+
 fn measure_dpe(
     sampler: &mut dyn CommandSampler,
     model: &mut DefaultHwModel,
     cmd: &mut Command,
 ) -> u64 {
-    sampler.before(model);
-    let _ = execute_dpe_cmd(PROFILE, model, cmd, DpeResult::Success);
-    sampler.after(model)
+    measure_dpe_profile(sampler, model, PROFILE, cmd)
 }
 
 /// Drive every runtime command through `sampler` in state-dependency order and
@@ -224,6 +233,18 @@ pub fn run_command_suite(
                 format: CertifyKeyCommand::FORMAT_X509,
             })),
         ),
+    ));
+    // INVOKE_DPE(Sign) — sign a digest with the default context. `roll_onetime`
+    // is a no-op on the default handle, so the default context survives.
+    let sign_cmd = SignP384Cmd {
+        handle: ContextHandle::default(),
+        label: TEST_LABEL,
+        flags: SignFlags::empty(),
+        digest: TEST_DIGEST,
+    };
+    results.push((
+        "INVOKE_DPE(Sign)",
+        measure_dpe(sampler, model, &mut Command::from(&sign_cmd)),
     ));
 
     // --- DPE context tagging ---
@@ -502,11 +523,237 @@ pub fn run_command_suite(
 /// these have side effects that break the standard suite (unlike `SHUTDOWN`), a
 /// caller should measure this suite *before* `run_command_suite`.
 ///
-/// Two `mldsa_attestation` commands are intentionally excluded: `INVOKE_DPE_MLDSA87`
-/// is a stub that unconditionally returns `RUNTIME_UNIMPLEMENTED_COMMAND`, and
-/// `SIGN_WITH_EXPORTED_MLDSA` cannot reach its ML-DSA sign path because nothing
-/// yet populates the exported ML-DSA CDI slot — both would only measure an early
-/// return, not a representative ML-DSA flow.
+/// Exercise the ML-DSA variant of every `INVOKE_DPE_MLDSA87` subcommand, returning
+/// one `("INVOKE_DPE_MLDSA87(<Subcommand>)", measurement)` per DPE `Command`.
+///
+/// Boots a DEDICATED model (rather than sharing the standard suite's) because the
+/// full set can't be sequenced in a shared model: DeriveContext (regular child)
+/// must retire the RT default context — the DPE "one default per locality" rule
+/// (`safe_to_make_child`) rejects any other regular child-derive — which the
+/// standard suite needs; and the standard suite's `DISABLE_ATTESTATION` clears PQC
+/// mode, which `INVOKE_DPE_MLDSA87` requires. A fresh model (attestation on,
+/// untouched default context) sidesteps both. Order: default-context commands
+/// (Sign/CertifyKey) first, simulation-context commands (InitCtx/DestroyCtx/
+/// RotateCtx) next, then DeriveContext retires the default to create a child from
+/// which UpdateContextMeasurement's parent-with-child tree is built.
+#[cfg(feature = "mldsa_attestation")]
+pub fn measure_mldsa_dpe_subcommands(sampler: &mut dyn CommandSampler) -> Vec<(&'static str, u64)> {
+    use crate::common::{
+        export_mldsa_cdi, populate_pq_cert, provision_pq_seed, run_pqc_rt_test, TEST_DIGEST_MLDSA,
+    };
+    use caliptra_common::mailbox_api::SignWithExportedMldsaReq;
+    use caliptra_drivers::MLDSA87_MU_BYTES;
+    use dpe::commands::{
+        CertifyKeyMldsa87Cmd, DestroyCtxCmd, GetCertificateChainCmd, InitCtxCmd, RotateCtxCmd,
+        RotateCtxFlags, SignMldsa87Cmd, UpdateContextMeasurementCmd,
+    };
+
+    const P: CaliptraDpeProfile = CaliptraDpeProfile::Mldsa;
+    const TCI_TYPE: u32 = 7;
+
+    // Dedicated model with the full ML-DSA provisioning the INVOKE_DPE_MLDSA87 path
+    // needs: enable PQC mode (SET_PQ_SEED) and populate the PQ cert chain
+    // (POPULATE_PQ_CERT) — the same sequence the test_invoke_dpe_mldsa tests use.
+    // A fresh model also keeps attestation on and the default context untouched, so
+    // DeriveContext can retire the default to build UpdateContextMeasurement's tree.
+    let mut owned_model = run_pqc_rt_test();
+    provision_pq_seed(&mut owned_model);
+    let _ = populate_pq_cert(&mut owned_model);
+    let model = &mut owned_model;
+
+    let mut results: Vec<(&'static str, u64)> = Vec::new();
+
+    // Run a setup command (unmeasured) and require success, returning its response.
+    fn setup(model: &mut DefaultHwModel, cmd: &mut Command) -> Response {
+        execute_dpe_cmd(P, model, cmd, DpeResult::Success).expect("DPE setup command failed")
+    }
+
+    // 1. GetProfile — stateless.
+    results.push((
+        "INVOKE_DPE_MLDSA87(GetProfile)",
+        measure_dpe_profile(sampler, model, P, &mut Command::GetProfile(&GetProfileCmd)),
+    ));
+
+    // 2. GetCertificateChain — stateless.
+    let chain_cmd = GetCertificateChainCmd {
+        offset: 0,
+        size: 2048,
+    };
+    results.push((
+        "INVOKE_DPE_MLDSA87(GetCertificateChain)",
+        measure_dpe_profile(
+            sampler,
+            model,
+            P,
+            &mut Command::GetCertificateChain(&chain_cmd),
+        ),
+    ));
+
+    // 3. Sign on the default context (before it is retired in step 8).
+    let sign_cmd = SignMldsa87Cmd {
+        handle: ContextHandle::default(),
+        label: TEST_LABEL,
+        flags: SignFlags::empty(),
+        digest: TEST_DIGEST_MLDSA,
+    };
+    results.push((
+        "INVOKE_DPE_MLDSA87(Sign)",
+        measure_dpe_profile(sampler, model, P, &mut Command::from(&sign_cmd)),
+    ));
+
+    // 4. CertifyKey / X509 on the default context.
+    let certify_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_X509,
+        label: TEST_LABEL,
+    };
+    results.push((
+        "INVOKE_DPE_MLDSA87(CertifyKey)",
+        measure_dpe_profile(sampler, model, P, &mut Command::from(&certify_cmd)),
+    ));
+
+    // 4b. SIGN_WITH_EXPORTED_MLDSA (data mode) — export an ML-DSA CDI first
+    //     (populates the exported-CDI slot; the export derives from the default
+    //     context, so this runs before the default is retired in step 8), then sign
+    //     a message. The handle is reused by 4c (signing does not consume it).
+    let exported_cdi = export_mldsa_cdi(model);
+    let mut sign_exported = Box::new(SignWithExportedMldsaReq::default());
+    sign_exported.exported_cdi_handle = exported_cdi;
+    const MSG: &[u8] = b"caliptra mldsa sign-with-exported measurement";
+    sign_exported.message[..MSG.len()].copy_from_slice(MSG);
+    sign_exported.message_size = MSG.len() as u32;
+    results.push((
+        "SIGN_WITH_EXPORTED_MLDSA(Data)",
+        measure_req(
+            sampler,
+            model,
+            CommandId::SIGN_WITH_EXPORTED_MLDSA,
+            MailboxReq::SignWithExportedMldsa(*sign_exported),
+        ),
+    ));
+
+    // 4c. SIGN_WITH_EXPORTED_MLDSA (external-mu mode) — same exported handle, but
+    //     the caller supplies mu directly (message[..MU] = mu, message_size = MU).
+    //     This exercises the sign_mu_deterministic variant of the sign path, which
+    //     the data mode above does not.
+    const MU: usize = MLDSA87_MU_BYTES;
+    let mut sign_exported_mu = Box::new(SignWithExportedMldsaReq::default());
+    sign_exported_mu.exported_cdi_handle = exported_cdi;
+    sign_exported_mu.sign_mode = SignWithExportedMldsaReq::SIGN_MODE_EXTERNAL_MU;
+    sign_exported_mu.message[..MU].copy_from_slice(&[0xA5u8; MU]);
+    sign_exported_mu.message_size = MU as u32;
+    results.push((
+        "SIGN_WITH_EXPORTED_MLDSA(ExternalMu)",
+        measure_req(
+            sampler,
+            model,
+            CommandId::SIGN_WITH_EXPORTED_MLDSA,
+            MailboxReq::SignWithExportedMldsa(*sign_exported_mu),
+        ),
+    ));
+
+    // 5. InitCtx (simulation) — creates a side context.
+    let init_measured = InitCtxCmd::new_simulation();
+    results.push((
+        "INVOKE_DPE_MLDSA87(InitCtx)",
+        measure_dpe_profile(sampler, model, P, &mut Command::InitCtx(&init_measured)),
+    ));
+
+    // 6. DestroyCtx against a throwaway simulation context.
+    {
+        let sim = InitCtxCmd::new_simulation();
+        let Response::InitCtx(r) = setup(model, &mut Command::InitCtx(&sim)) else {
+            panic!("DestroyCtx setup: unexpected InitCtx response");
+        };
+        let destroy_cmd = DestroyCtxCmd { handle: r.handle };
+        results.push((
+            "INVOKE_DPE_MLDSA87(DestroyCtx)",
+            measure_dpe_profile(sampler, model, P, &mut Command::DestroyCtx(&destroy_cmd)),
+        ));
+    }
+
+    // 7. RotateCtx against a throwaway simulation context.
+    {
+        let sim = InitCtxCmd::new_simulation();
+        let Response::InitCtx(r) = setup(model, &mut Command::InitCtx(&sim)) else {
+            panic!("RotateCtx setup: unexpected InitCtx response");
+        };
+        let rotate_cmd = RotateCtxCmd {
+            handle: r.handle,
+            flags: RotateCtxFlags::empty(),
+        };
+        results.push((
+            "INVOKE_DPE_MLDSA87(RotateCtx)",
+            measure_dpe_profile(sampler, model, P, &mut Command::RotateCtx(&rotate_cmd)),
+        ));
+    }
+
+    // 8. DeriveContext — the only way to create a regular child in a locality that
+    //    already has a default context is to retire that default (empty flags, no
+    //    RETAIN_PARENT). This consumes the RT default context, which is why the
+    //    whole suite runs last. Capture the child handle for step 9.
+    let derive_measured = DeriveContextCmd {
+        handle: ContextHandle::default(),
+        data: TciMeasurement([0u8; TCI_SIZE]),
+        flags: DeriveContextFlags::empty(),
+        tci_type: 1,
+        target_locality: 0,
+        ..Default::default()
+    };
+    sampler.before(model);
+    let derive_resp = execute_dpe_cmd(
+        P,
+        model,
+        &mut Command::DeriveContext(&derive_measured),
+        DpeResult::Success,
+    )
+    .expect("DeriveContext failed");
+    results.push(("INVOKE_DPE_MLDSA87(DeriveContext)", sampler.after(model)));
+    let Response::DeriveContext(dr) = derive_resp else {
+        panic!("DeriveContext: unexpected response");
+    };
+    let child_handle = dr.handle; // new non-default child; the default is now retired.
+
+    // 9. UpdateContextMeasurement — needs a non-default parent with an active child
+    //    of matching tci_type. With the default retired, derive a child from the
+    //    step-8 child (retaining it) to form that parent/child pair.
+    {
+        let derive = DeriveContextCmd {
+            handle: child_handle,
+            data: TciMeasurement([0u8; TCI_SIZE]),
+            flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+            tci_type: TCI_TYPE,
+            target_locality: 0,
+            ..Default::default()
+        };
+        let Response::DeriveContext(dr) = setup(model, &mut Command::DeriveContext(&derive)) else {
+            panic!("UpdateContextMeasurement setup: unexpected DeriveContext response");
+        };
+        let update_cmd = UpdateContextMeasurementCmd {
+            parent_handle: dr.parent_handle,
+            data: TciMeasurement([0u8; TCI_SIZE]),
+            reserved: 0,
+            tci_type: TCI_TYPE,
+            reserved_svn: 0,
+        };
+        results.push((
+            "INVOKE_DPE_MLDSA87(UpdateContextMeasurement)",
+            measure_dpe_profile(
+                sampler,
+                model,
+                P,
+                &mut Command::UpdateContextMeasurement(&update_cmd),
+            ),
+        ));
+    }
+
+    results
+}
+
+/// Every `mldsa_attestation` command is now exercised: each `INVOKE_DPE_MLDSA87`
+/// DPE subcommand plus `SIGN_WITH_EXPORTED_MLDSA` (which exports an ML-DSA CDI to
+/// populate the slot before signing) run via [`measure_mldsa_dpe_subcommands`].
 #[cfg(feature = "mldsa_attestation")]
 pub fn run_pqc_command_suite(
     model: &mut DefaultHwModel,

--- a/runtime/tests/runtime_integration_tests/test_stack_usage.rs
+++ b/runtime/tests/runtime_integration_tests/test_stack_usage.rs
@@ -39,7 +39,7 @@ use caliptra_hw_model::{DefaultHwModel, HwModel};
 use caliptra_runtime::RtBootStatus;
 
 #[cfg(feature = "mldsa_attestation")]
-use crate::test_measurements_common::run_pqc_command_suite;
+use crate::test_measurements_common::{measure_mldsa_dpe_subcommands, run_pqc_command_suite};
 #[cfg(feature = "mldsa_attestation")]
 use caliptra_builder::firmware::APP_MLDSA_ATTESTATION;
 
@@ -59,9 +59,42 @@ impl CommandSampler for StackSampler {
     }
 
     fn after(&mut self, model: &mut DefaultHwModel) -> u64 {
-        peak_stack_usage(model)
-            .expect("no stack activity observed; was the model built with stack_info?")
-            as u64
+        let peak = peak_stack_usage(model)
+            .expect("no stack activity observed; was the model built with stack_info?");
+        // When CALIPTRA_EMU_STACK_WATERMARK_LOG is set, append this command's
+        // high-water `(pc, sp)` events so they can be symbolized against the
+        // firmware ELF. Each block is labeled by peak so commands are distinguishable.
+        if let Some(path) = std::env::var_os("CALIPTRA_EMU_STACK_WATERMARK_LOG") {
+            use std::io::Write;
+            let events = model.take_stack_watermark_events();
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .expect("open stack watermark log");
+            writeln!(f, "# peak_bytes={} events={}", peak, events.len()).unwrap();
+            for (pc, sp) in events {
+                writeln!(f, "{pc:#010x} {sp:#010x}").unwrap();
+            }
+        }
+        // When CALIPTRA_EMU_STACK_SP_TRACE is set, append this command's full
+        // stack-pointer-change trace (allocs and frees). A post-processor replays
+        // it to reconstruct the live call stack and read off any sub-chain (e.g.
+        // ML-DSA sign) frame-by-frame, independent of the global peak path.
+        if let Some(path) = std::env::var_os("CALIPTRA_EMU_STACK_SP_TRACE") {
+            use std::io::Write;
+            let events = model.take_stack_sp_events();
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .expect("open stack sp trace");
+            writeln!(f, "# peak_bytes={} sp_events={}", peak, events.len()).unwrap();
+            for (pc, sp) in events {
+                writeln!(f, "{pc:#010x} {sp:#010x}").unwrap();
+            }
+        }
+        peak as u64
     }
 }
 
@@ -96,14 +129,32 @@ fn measure_runtime_command_stack_usage() {
             .map(|(name, v)| (name, v as u32)),
     );
 
-    // Report, highest stack usage first.
+    // The ML-DSA INVOKE_DPE subcommands are measured against their own dedicated
+    // model (see measure_mldsa_dpe_subcommands): the full set can't be sequenced in
+    // this shared model (default-context retirement + DISABLE_ATTESTATION conflicts).
+    #[cfg(feature = "mldsa_attestation")]
+    results.extend(
+        measure_mldsa_dpe_subcommands(&mut StackSampler)
+            .into_iter()
+            .map(|(name, v)| (name, v as u32)),
+    );
+
+    // Report, highest stack usage first. Size the name column to the widest
+    // command name (some INVOKE_DPE_MLDSA87(..) subcommands are >40 chars) so the
+    // bytes/% columns stay aligned instead of being pushed out by long names.
     results.sort_by_key(|b| std::cmp::Reverse(b.1));
+    let name_w = results
+        .iter()
+        .map(|(name, _)| name.len())
+        .max()
+        .unwrap_or(0)
+        .max("command".len());
     println!("\nRuntime command peak stack usage (runtime stack = {STACK_SIZE} bytes):");
-    println!("{:<32} {:>10} {:>8}", "command", "bytes", "% stack");
-    println!("{}", "-".repeat(52));
+    println!("{:<name_w$} {:>10} {:>8}", "command", "bytes", "% stack");
+    println!("{}", "-".repeat(name_w + 20));
     for (name, bytes) in &results {
         let pct = (*bytes as f64) * 100.0 / (STACK_SIZE as f64);
-        println!("{name:<32} {bytes:>10} {pct:>7.1}%");
+        println!("{name:<name_w$} {bytes:>10} {pct:>7.1}%");
     }
 
     // Sanity: every command must consume some stack and stay within the budget.

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -103,6 +103,26 @@ pub struct StackInfo {
     /// Stacks grow downward, so this is the high-water mark of stack usage.
     /// `None` means no stack-pointer activity has been observed yet.
     stack_watermark: Option<u32>,
+    /// When true, every time a new high-water mark is reached the `(pc, sp)` that
+    /// set it is appended to `watermark_events`, so the peak can be attributed to
+    /// the exact instructions (and thus functions) that grew the stack.
+    log_watermark: bool,
+    /// `(pc, sp)` for each new high-water mark since the last reset. Only the
+    /// deepest-so-far points are recorded, so this is bounded by the number of
+    /// frames on the deepest call path.
+    watermark_events: Vec<(u32, u32)>,
+    /// When true, every change to the stack pointer within a tracked image is
+    /// appended to `sp_events` — both decreases (frame allocation, prologue) and
+    /// increases (frame free, epilogue). Unlike `watermark_events`, which only
+    /// captures the monotonic descent to the single global minimum, this full
+    /// trace lets a post-processor reconstruct the live call stack at any instant
+    /// — so a sub-chain (e.g. ML-DSA sign) that is not the global deepest path
+    /// can still be attributed frame-by-frame.
+    log_sp_trace: bool,
+    /// `(pc, sp)` for every stack-pointer change since the last reset.
+    sp_events: Vec<(u32, u32)>,
+    /// Last stack pointer recorded into `sp_events`, used to drop no-op writes.
+    last_traced_sp: Option<u32>,
 }
 
 impl StackInfo {
@@ -114,18 +134,47 @@ impl StackInfo {
             max_stack_overflow: 0,
             has_overflowed: false,
             stack_watermark: None,
+            log_watermark: false,
+            watermark_events: Vec::new(),
+            log_sp_trace: false,
+            sp_events: Vec::new(),
+            last_traced_sp: None,
         }
     }
 
     /// Reset the high-water mark so a subsequent measurement window starts fresh.
     pub fn reset_min_sp(&mut self) {
         self.stack_watermark = None;
+        self.watermark_events.clear();
+        self.sp_events.clear();
+        self.last_traced_sp = None;
     }
 
     /// Fetch the lowest stack pointer observed since the last reset, or `None`
     /// if no stack-pointer activity has been observed within a tracked image.
     pub fn min_sp(&self) -> Option<u32> {
         self.stack_watermark
+    }
+
+    /// Enable recording of `(pc, sp)` for each new high-water mark.
+    pub fn enable_watermark_log(&mut self) {
+        self.log_watermark = true;
+    }
+
+    /// Drain the recorded high-water `(pc, sp)` events since the last reset.
+    pub fn take_watermark_events(&mut self) -> Vec<(u32, u32)> {
+        core::mem::take(&mut self.watermark_events)
+    }
+
+    /// Enable recording of every stack-pointer change (allocation and free).
+    pub fn enable_sp_trace(&mut self) {
+        self.log_sp_trace = true;
+    }
+
+    /// Drain the full `(pc, sp)` stack-pointer-change trace since the last reset.
+    pub fn take_sp_events(&mut self) -> Vec<(u32, u32)> {
+        self.last_traced_sp = None;
+        core::mem::take(&mut self.sp_events)
     }
 }
 
@@ -155,6 +204,15 @@ impl StackInfo {
                 // Record the high-water mark of stack usage for this window.
                 if self.stack_watermark.is_none_or(|min| stack_address < min) {
                     self.stack_watermark = Some(stack_address);
+                    if self.log_watermark {
+                        self.watermark_events.push((pc, stack_address));
+                    }
+                }
+                // Full trace: record every SP change (alloc *and* free), skipping
+                // no-op writes, so any call sub-chain can be reconstructed later.
+                if self.log_sp_trace && self.last_traced_sp != Some(stack_address) {
+                    self.sp_events.push((pc, stack_address));
+                    self.last_traced_sp = Some(stack_address);
                 }
                 if let Some(overflow_amount) = image.check_overflow(stack_address) {
                     self.max_stack_overflow = self.max_stack_overflow.max(overflow_amount);
@@ -435,6 +493,36 @@ impl<TBus: Bus> Cpu<TBus> {
     /// if stack tracking is disabled or no activity has been observed.
     pub fn stack_min_sp(&self) -> Option<u32> {
         self.stack_info.as_ref().and_then(StackInfo::min_sp)
+    }
+
+    /// Enable per-high-water-mark `(pc, sp)` logging, if stack tracking is on.
+    pub fn enable_stack_watermark_log(&mut self) {
+        if let Some(stack_info) = &mut self.stack_info {
+            stack_info.enable_watermark_log();
+        }
+    }
+
+    /// Drain the recorded high-water `(pc, sp)` events since the last reset.
+    pub fn take_stack_watermark_events(&mut self) -> Vec<(u32, u32)> {
+        self.stack_info
+            .as_mut()
+            .map(StackInfo::take_watermark_events)
+            .unwrap_or_default()
+    }
+
+    /// Enable full stack-pointer-change tracing, if stack tracking is on.
+    pub fn enable_stack_sp_trace(&mut self) {
+        if let Some(stack_info) = &mut self.stack_info {
+            stack_info.enable_sp_trace();
+        }
+    }
+
+    /// Drain the full `(pc, sp)` stack-pointer-change trace since the last reset.
+    pub fn take_stack_sp_events(&mut self) -> Vec<(u32, u32)> {
+        self.stack_info
+            .as_mut()
+            .map(StackInfo::take_sp_events)
+            .unwrap_or_default()
     }
 
     /// Read the RISCV CPU Program counter


### PR DESCRIPTION
Implement an algorithm for caching the `A` matrix during MLDSA signing operations.  This can greatly reduce the cost of Rejection loop processing, as it avoids duplicated calculation of the `A` matrix polynomials which relies on the Keccak algorithm.

As part of this include a series of tests validating the full functionality, and which can produce timing results.

Stack and Performance metrics:
<img width="635" height="944" alt="image" src="https://github.com/user-attachments/assets/60c3aae1-4c1e-404e-bc58-d919ba2c27fa" />

<img width="708" height="401" alt="image" src="https://github.com/user-attachments/assets/8f89c7a5-a579-4531-84fe-b3e524a3f0eb" />
