### PR TITLE
Fix PopulateIdev privilege level (#3120)

### DIFF
--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -16,7 +16,7 @@ use caliptra_common::mailbox_api::{PopulateIdevEcc384CertReq, PopulateIdevMldsa8
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::FromBytes;
 
-use crate::{Drivers, PL0_PAUSER_FLAG};
+use crate::{Drivers, PauserPrivileges};
 
 pub struct PopulateIDevIdEcc384CertCmd;
 impl PopulateIDevIdEcc384CertCmd {
@@ -41,9 +41,8 @@ impl PopulateIDevIdEcc384CertCmd {
             return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
 
-        let flags = drivers.persistent_data.get().manifest1.header.flags;
         // PL1 cannot call this mailbox command
-        if flags & PL0_PAUSER_FLAG == 0 {
+        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
             return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
         }
 
@@ -124,9 +123,8 @@ impl PopulateIDevIdMldsa87CertCmd {
             return Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS);
         }
 
-        let flags = drivers.persistent_data.get().manifest1.header.flags;
         // PL1 cannot call this mailbox command
-        if flags & PL0_PAUSER_FLAG == 0 {
+        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
             return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
         }
 


### PR DESCRIPTION
Backport of #3120 from main.

`POPULATE_IDEV_CERT` checked the manifest's `PL0_PAUSER_FLAG` instead of the caller's privilege level, so a PL1 caller could invoke it whenever the manifest set that flag.