### PR TITLE
Restricting set_auth_manifest to PL0 (#3734)

### DIFF
--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,7 +15,10 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::{drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers};
+use crate::{
+    drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers,
+    PauserPrivileges,
+};
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, OwnerAuthManifestImageMetadataCollection,
@@ -743,6 +746,11 @@ impl SetAuthManifestCmd {
         cmd_args: &[u8],
         verify_only: bool,
     ) -> CaliptraResult<usize> {
+        // Restrict to PL0
+        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
+            Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?
+        }
+
         // Validate cmd length
         let manifest_size: usize = {
             let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -15,7 +15,7 @@ use caliptra_builder::{
 };
 use caliptra_common::mailbox_api::{
     CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CommandId, MailboxReq, MailboxReqHeader,
-    PopulateIdevEcc384CertReq, StashMeasurementReq,
+    PopulateIdevEcc384CertReq, SetAuthManifestReq, StashMeasurementReq,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
@@ -377,6 +377,42 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
         let resp = model
             .mailbox_execute(
                 u32::from(CommandId::STASH_MEASUREMENT),
+                cmd.as_bytes().unwrap(),
+            )
+            .unwrap_err();
+        assert_error(
+            &mut model,
+            CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+            resp,
+        );
+    }
+}
+
+#[test]
+fn test_set_auth_manifest_cannot_be_called_from_pl1() {
+    for pqc_key_type in PQC_KEY_TYPE.iter() {
+        let mut image_opts = ImageOptions {
+            pqc_key_type: *pqc_key_type,
+            ..Default::default()
+        };
+        image_opts.vendor_config.pl0_pauser = None;
+
+        let args = RuntimeTestArgs {
+            test_image_options: Some(image_opts),
+            ..Default::default()
+        };
+        let mut model = run_rt_test_pqc(args, *pqc_key_type);
+
+        model.step_until(|m| {
+            m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+        });
+
+        let mut cmd = MailboxReq::SetAuthManifest(SetAuthManifestReq::default());
+        cmd.populate_chksum().unwrap();
+
+        let resp = model
+            .mailbox_execute(
+                u32::from(CommandId::SET_AUTH_MANIFEST),
                 cmd.as_bytes().unwrap(),
             )
             .unwrap_err();


### PR DESCRIPTION
Backport of #3734 from main.

SET_AUTH_MANIFEST/VERIFY_AUTH_MANIFEST currently have no privilege check on
caliptra-2.0, so a PL1 caller can install the authorization manifest that
AUTHORIZE_AND_STASH validates against.
