### PR TITLE
Add execution of CSRNG KAT before usage in CFI init

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-3a4c575dd2805483e915c8c75162cf5990f137f14b9cd09856a9a8403d20e93bbcac65bb265e36595441477799b269d8  caliptra-rom-no-log.bin
-95c5cf3ebbaf40d7ca1725ae2d7f3814c841ee248cad7c681fc4ea7631b3f3033e3ae4ead9ef6766ef0edcff77373240  caliptra-rom-with-log.bin
+46dfa14678350d34c9769a8591bfd7aca9901c1291ba3ba9ffb674977ca9e086c85dd05ab39fc6a2b51e242904d45ba3  caliptra-rom-no-log.bin
+a2372767c2555b5cd38f18893fbce2e668a42635ead0a3ef0e79a626f52572f798edeeda8380d49bdddddea73cfcf0c4  caliptra-rom-with-log.bin

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -76,6 +76,12 @@ pub extern "C" fn rom_entry() -> ! {
         Err(e) => handle_fatal_error(e.into()),
     };
 
+    // Run CSRNG KAT before any CSRNG output is consumed
+    #[cfg(not(feature = "fake-rom"))]
+    if let Err(e) = CsrngKat::default().execute(&mut trng) {
+        handle_fatal_error(e.into());
+    }
+
     // Initialize CFI before creating the rest of the environment
     // (AesGcm::new runs KATs which have CFI annotations)
     if cfg!(feature = "cfi") {

--- a/rom/dev/tests/rom_integration_tests/test_cfi.rs
+++ b/rom/dev/tests/rom_integration_tests/test_cfi.rs
@@ -9,6 +9,7 @@ use caliptra_common::RomBootStatus;
 use caliptra_emu_cpu::CoverageBitmaps;
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
 
+#[allow(dead_code)]
 fn find_symbol<'a>(symbols: &'a [Symbol<'a>], name: &str) -> &'a Symbol<'a> {
     symbols
         .iter()
@@ -57,8 +58,7 @@ fn test_memcpy_not_called_before_cfi_init() {
 
         hw.step_until_boot_status(RomBootStatus::CfiInitialized.into(), true);
 
-        assert_symbol_not_called(&hw, find_symbol(&symbols, "memcpy"));
-        assert_symbol_not_called(&hw, find_symbol(&symbols, "memset"));
+        // Ideally we would also check for memcpy and memset, but the CSRNG KAT has to happen before the CFI init which uses it
         assert_symbol_not_called(&hw, find_symbol_containing(&symbols, "read_volatile_slice"));
         assert_symbol_not_called(
             &hw,


### PR DESCRIPTION
Run the CSRNG KAT prior to any use.

We believe the existing use before the KAT should be permitted given it is not a FIPS approved use case. But this change removes any debate or doubt during CMVP review.