### PR TITLE
[rom] defer ready_for_mb_processing until mailbox polling loop

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-88f8569841d3bd8005048cbdbeae8479f267b4329b97010da9288f8dbfd386cc1728721fdf1012279102451c8ea537bd  caliptra-rom-no-log.bin
-942b91b96fc42b7c3cf82289b3633aead046e2ab3fceda446d8c9137ba8a8b0c237f8413035a797ca14bdbeee9bfda62  caliptra-rom-with-log.bin
+90fc90910263561d5c67bdd19fed8e93aa9b887c7e9b3747780854b37d45e2d067b9989d68e69e90ce7987496fc4c4cd  caliptra-rom-no-log.bin
+ec83a136e42744ed7ef37c6af177fac2d3d1c1e531068a565edf5dd76b9832d79b8d37424f2592fbc02330692d3deccd  caliptra-rom-with-log.bin

--- a/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mod.rs
@@ -284,6 +284,7 @@ impl FirmwareProcessor {
         let subsystem_mode = soc_ifc.subsystem_mode();
 
         cprintln!("[fwproc] Wait for Commands...");
+        soc_ifc.flow_status_set_ready_for_mb_processing();
         loop {
             // Random delay for CFI glitch protection.
             CfiCounter::delay();

--- a/rom/dev/src/flow/cold_reset/idev_id.rs
+++ b/rom/dev/src/flow/cold_reset/idev_id.rs
@@ -66,12 +66,6 @@ impl InitDevIdLayer {
         );
         cprintln!("[idev] UDS.KEYID = {}", KEY_ID_UDS as u8);
 
-        // If CSR is not requested, indicate to the SOC that it can start
-        // uploading the firmware image to the mailbox.
-        if !env.soc_ifc.mfg_flag_gen_idev_id_csr() {
-            env.soc_ifc.flow_status_set_ready_for_mb_processing();
-        }
-
         // Decrypt the UDS
         Self::decrypt_uds(env, KEY_ID_UDS)?;
 
@@ -130,11 +124,6 @@ impl InitDevIdLayer {
 
         // Generate the Initial DevID Certificate Signing Request (CSR)
         Self::generate_csrs(env, &output)?;
-
-        // Indicate (if not already done) to SOC that it can start uploading the firmware image to the mailbox.
-        if !env.soc_ifc.flow_status_ready_for_mb_processing() {
-            env.soc_ifc.flow_status_set_ready_for_mb_processing();
-        }
 
         // Write IDevID public key to FHT
         env.persistent_data

--- a/rom/dev/src/flow/fake.rs
+++ b/rom/dev/src/flow/fake.rs
@@ -61,8 +61,6 @@ impl FakeRomFlow {
                 // Zeroize the key vault in the fake ROM flow
                 unsafe { KeyVault::zeroize() };
 
-                env.soc_ifc.flow_status_set_ready_for_mb_processing();
-
                 fht::initialize_fht(env);
 
                 // SKIP Execute IDEVID layer


### PR DESCRIPTION
CPTRA_FLOW_STATUS.ready_for_mb_processing was previously asserted early during InitDevIdLayer::derive (and at the start of FakeRomFlow). In Caliptra 2.x subsystem mode, this causes the MCU ROM / SoC to send mailbox commands immediately upon observing the status bit.

However, Caliptra ROM continues executing time-consuming cryptographic derivations after InitDevIdLayer starts (DOE secret deobfuscation, Stable Owner Root Key derivation, LDevID CDI derivation, keypair generation, and certificate signing) before entering the mailbox polling loop in FirmwareProcessor. As a result, mailbox commands sent right after ready_for_mb_processing assertion sit unserviced, risking or triggering mailbox command timeouts on the sender side.

Fix this by removing the early assertions in InitDevIdLayer and FakeRomFlow, and setting ready_for_mb_processing inside FirmwareProcessor::process_mailbox_commands immediately prior to entering the command receive loop.

In Caliptra 1.x, this field was named ready_for_fw. It was asserted early so the SoC could begin streaming the large firmware bundle into Mailbox SRAM in parallel while Caliptra ROM computed DICE derivations.

Fixes #4107