### PR TITLE
libcaliptra: check INVOKE_DPE request data size

### DIFF
--- a/libcaliptra/inc/caliptra_types.h
+++ b/libcaliptra/inc/caliptra_types.h
@@ -654,6 +654,7 @@ struct caliptra_invoke_dpe_req
     };
 };
 
+#define INVOKE_DPE_DATA_MAX_SIZE 512
 struct caliptra_invoke_dpe_resp
 {
     struct caliptra_resp_header cpl;
@@ -670,7 +671,7 @@ struct caliptra_invoke_dpe_resp
         struct dpe_rotate_context_handle_response rotate_context_handle_resp;
         struct dpe_destroy_context_response destroy_context_resp;
         struct dpe_get_certificate_chain_response get_certificate_chain_resp;
-        uint8_t data[0];
+        uint8_t data[INVOKE_DPE_DATA_MAX_SIZE];
     };
 };
 

--- a/libcaliptra/src/caliptra_api.c
+++ b/libcaliptra/src/caliptra_api.c
@@ -1134,6 +1134,11 @@ int caliptra_invoke_dpe_command(struct caliptra_invoke_dpe_req *req, struct cali
         return INVALID_PARAMS;
     }
 
+    if (req->data_size > INVOKE_DPE_DATA_MAX_SIZE)
+    {
+        return INVALID_PARAMS;
+    }
+
     // While it will likely cause no harm, there's no sense in writing more
     // to the FIFO than is absolutely required. This command can have a variable
     // data buffer.


### PR DESCRIPTION
For the `INVOKE_DPE` command, define `INVOKE_DPE_DATA_MAX_SIZE` and check the request data size against it, keeping the behavior consistent with the `INVOKE_DPE_MLDSA87` path.