### PR TITLE
[BACKPORT] Apply post-fw-2.1.1 fixes to caliptra-2.0

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -75,7 +75,9 @@ not (package(/caliptra-emu-.*/) |
     binary_id(caliptra-test::fips_test_suite) |
     test(test_update_reset::test_update_reset_verify_image_failure) |
     test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_success) |
-    test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_failure))
+    test(test_debug_unlock::test_dbg_unlock_prod_unlock_levels_failure) |
+    test(test_device_status_mode::test_device_status_mode_passive) |
+    test(test_device_status_mode::test_device_status_mode_subsystem))
 """
 failure-output = "immediate-final"
 fail-fast = false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,14 +1,14 @@
 ##########################################
 #             Code Ownership
 ##########################################
-/rom/dev/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @zhalvorsen @timothytrippel
-/rom/dev/tests/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @jhand2 @zhalvorsen @timothytrippel
-/kat/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @zhalvorsen @timothytrippel
-/drivers/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @rusty1968 @swenson @zhalvorsen @timothytrippel
-/image/ @mhatrevi @ajisaxena @vsonims @korran @swenson @vsonims @jhand2 @zhalvorsen @timothytrippel
-/sw-emulator/ @korran @mhatrevi @ajisaxena @swenson @vsonims @jhand2 @zhalvorsen @timothytrippel
-/x509/ @mhatrevi @ajisaxena @vsonims @jlmahowa-amd @jhand2 @swenson @timothytrippel
-/fmc/ @FerralCoder @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims @zhalvorsen @timothytrippel
-/runtime/ @jhand2 @fdamato @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims @zhalvorsen @timothytrippel
-/hw-model/ @korran @fdamato @jlmahowa-amd @mhatrevi @jhand2 @swenson @vsonims @zhalvorsen @timothytrippel
-/libcaliptra/ @fdamato @wmaroneAMD @JohnTraverAmd @jlmahowa-amd @korran @mhatrevi @swenson @vsonims @nquarton @jhand2 @zhalvorsen @timothytrippel
+/rom/dev/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @zhalvorsen @timothytrippel @parvathib
+/rom/dev/tests/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @jhand2 @zhalvorsen @timothytrippel @parvathib
+/kat/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @swenson @zhalvorsen @timothytrippel @parvathib
+/drivers/ @mhatrevi @ajisaxena @vsonims @korran @JohnTraverAmd @rusty1968 @swenson @zhalvorsen @timothytrippel @parvathib
+/image/ @mhatrevi @ajisaxena @vsonims @korran @swenson @vsonims @jhand2 @zhalvorsen @timothytrippel @parvathib
+/sw-emulator/ @korran @mhatrevi @ajisaxena @swenson @vsonims @jhand2 @zhalvorsen @timothytrippel @parvathib
+/x509/ @mhatrevi @ajisaxena @vsonims @jlmahowa-amd @jhand2 @swenson @timothytrippel @parvathib
+/fmc/ @FerralCoder @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims @zhalvorsen @timothytrippel @parvathib
+/runtime/ @jhand2 @fdamato @rusty1968 @bluegate010 @mhatrevi @swenson @vsonims @zhalvorsen @timothytrippel @parvathib
+/hw-model/ @korran @fdamato @jlmahowa-amd @mhatrevi @jhand2 @swenson @vsonims @zhalvorsen @timothytrippel @parvathib
+/libcaliptra/ @fdamato @wmaroneAMD @JohnTraverAmd @jlmahowa-amd @korran @mhatrevi @swenson @vsonims @nquarton @jhand2 @zhalvorsen @timothytrippel @parvathib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -126,7 +132,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -152,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +174,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -221,10 +239,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "caliptra-api"
@@ -328,12 +372,14 @@ dependencies = [
  "hex",
  "memoffset 0.8.0",
  "once_cell",
+ "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2",
  "toml 0.7.8",
  "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -408,7 +454,7 @@ dependencies = [
  "caliptra-image-types",
  "elf",
  "hex",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -427,7 +473,7 @@ dependencies = [
 name = "caliptra-csrng-test-data-gen"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -442,7 +488,7 @@ dependencies = [
  "caliptra-dpe-platform",
  "caliptra-dpe-response-buffer",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "ufmt",
  "zerocopy",
  "zeroize",
@@ -457,7 +503,7 @@ dependencies = [
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
  "caliptra-dpe-response-buffer",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "zerocopy",
  "zeroize",
 ]
@@ -607,7 +653,7 @@ dependencies = [
  "const-random",
  "fips204",
  "lazy_static",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "sha3",
  "smlang",
@@ -685,7 +731,7 @@ dependencies = [
  "libc",
  "nix",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rustix",
  "scopeguard",
@@ -731,7 +777,7 @@ name = "caliptra-hw-model-types"
 version = "0.1.0"
 dependencies = [
  "caliptra-api-types",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -767,7 +813,7 @@ dependencies = [
  "fips204",
  "openssl",
  "p384",
- "rand",
+ "rand 0.8.5",
  "sec1",
  "sha2",
  "zerocopy",
@@ -805,7 +851,7 @@ dependencies = [
  "fips204",
  "memoffset 0.8.0",
  "p384",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "zerocopy",
@@ -884,7 +930,7 @@ dependencies = [
  "ecdsa",
  "minicbor",
  "p384",
- "rand",
+ "rand 0.8.5",
  "sha2",
 ]
 
@@ -944,7 +990,7 @@ dependencies = [
  "ml-dsa",
  "openssl",
  "p384",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "ufmt",
  "zerocopy",
@@ -1023,7 +1069,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cms",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "coset",
  "ctr",
  "fips204",
@@ -1033,7 +1079,7 @@ dependencies = [
  "ml-dsa",
  "openssl",
  "p384",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "spki",
  "ufmt",
@@ -1105,7 +1151,7 @@ dependencies = [
  "der",
  "elf",
  "openssl",
- "rand",
+ "rand 0.8.5",
  "regex",
  "zerocopy",
 ]
@@ -1151,7 +1197,7 @@ dependencies = [
 name = "caliptra-verilated"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1165,7 +1211,7 @@ dependencies = [
  "hex",
  "openssl",
  "quote",
- "rand",
+ "rand 0.8.5",
  "syn 1.0.109",
  "x509-parser",
  "zeroize",
@@ -1229,6 +1275,8 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1237,6 +1285,23 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1381,6 +1446,12 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
@@ -1420,10 +1491,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1438,7 +1533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1450,7 +1545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1604,7 +1699,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1644,7 +1739,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1654,7 +1749,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9fb5a367b9846933e271a3c2a992930743f82ae5e8cb7faa780715a80fa0b15"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "sha3",
  "zeroize",
@@ -1665,6 +1760,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1680,6 +1785,15 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -1819,8 +1933,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1831,8 +1947,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1861,7 +1991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1925,12 +2055,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1955,6 +2183,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1988,6 +2318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2337,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2018,7 +2364,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2040,6 +2386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2405,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "managed"
@@ -2111,6 +2469,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ml-dsa"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2499,7 @@ dependencies = [
  "hybrid-array",
  "num-traits",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha3",
  "signature",
 ]
@@ -2130,7 +2509,7 @@ name = "mldsa_key_pair_gen"
 version = "0.1.0"
 dependencies = [
  "fips204",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2298,10 +2677,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2311,6 +2713,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2347,9 +2755,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2409,6 +2826,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,6 +2897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,7 +2910,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2441,7 +2931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2451,6 +2941,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2492,6 +2997,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +3044,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2532,6 +3091,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +3116,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2627,6 +3227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,7 +3270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2669,7 +3281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2696,8 +3308,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2733,6 +3351,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +3369,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_morph"
@@ -2777,6 +3411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +3429,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2888,6 +3542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,6 +3560,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
@@ -2922,6 +3601,30 @@ dependencies = [
 name = "tock-registers"
 version = "0.9.0"
 source = "git+https://github.com/tock/tock.git?rev=release-2.2#9554639b17501a9f5940cef7a1770a0823e790c3"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
 
 [[package]]
 name = "toml"
@@ -2965,6 +3668,76 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3036,6 +3809,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3851,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -3097,6 +3903,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3945,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3217,6 +4065,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -3231,6 +4088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3380,6 +4246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "wycheproof"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +4294,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +4337,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure 0.13.2",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,4 +4375,86 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-78abe3dbd241b297361bdd265b97f435567bac1bad36019ee7bf89af2595a410d3cdc00f4909a12bf673caffd9097a70  caliptra-rom-no-log.bin
-10183747de91b80c8aed5d7e9331f03a619c5c15c5ca4595c8027150d9439b7522b30baa70b05cb15537c9e098480c10  caliptra-rom-with-log.bin
+a11e8bc61c80a462c67a78b936062bdfab258bc8fa4087d7378e3fb0c06718f926f3cbef7f4a509fad830450950c0d2b  caliptra-rom-no-log.bin
+f6b53df86db0b07935eb2c0f0caa12717652dabd233ebd11aff9a984439ba91261f4c8ee4275f8089f7f13fade8ec4ee  caliptra-rom-with-log.bin

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -23,9 +23,11 @@ once_cell.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 sha2.workspace = true
 toml.workspace = true
 zerocopy.workspace = true
+zip = "0.6"
 
 [features]
 default = ["openssl"]

--- a/builder/src/firmware.rs
+++ b/builder/src/firmware.rs
@@ -3,7 +3,7 @@
 // Centralized list of all firmware targets. This allows us to compile them all
 // ahead of time for executing tests on hosts that can't compile rust code.
 
-use crate::FwId;
+use crate::{FirmwareType, FwId};
 
 pub fn rom_from_env() -> &'static FwId<'static> {
     match std::env::var("CPTRA_ROM_TYPE").as_ref().map(|s| s.as_str()) {
@@ -42,105 +42,151 @@ pub fn fake_rom(fpga: bool) -> &'static FwId<'static> {
 pub const ROM: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &[],
+    fw_type: FirmwareType::Source { features: &[] },
 };
 
 pub const ROM_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fpga_realtime"],
+    fw_type: FirmwareType::Source {
+        features: &["fpga_realtime"],
+    },
 };
 
 pub const ROM_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu"],
+    fw_type: FirmwareType::Source { features: &["emu"] },
 };
 
 pub const ROM_FAKE_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fake-rom"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-rom"],
+    },
 };
 
 pub const ROM_FAKE_WITH_UART_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fake-rom", "fpga_realtime"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-rom", "fpga_realtime"],
+    },
 };
 
 pub const ROM_WITH_FIPS_TEST_HOOKS: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fips-test-hooks"],
+    fw_type: FirmwareType::Source {
+        features: &["fips-test-hooks"],
+    },
+};
+
+/// Pre-built 2.0.1 ROM release binary target identifier.
+pub const ROM_2_0_1_RELEASE: FwId = FwId {
+    crate_name: "caliptra-rom-2_0_1-release",
+    bin_name: "caliptra-rom-with-log.bin",
+    fw_type: FirmwareType::TaggedReleaseFromNetwork {
+        version_tag: "rom-2.0.1",
+        url: "https://github.com/chipsalliance/caliptra-sw/releases/download/rom-2.0.2/caliptra_release_v20260327_0-2.0.zip",
+    },
+};
+
+/// Pre-built 2.0.1 FMC and Runtime firmware bundle target identifier.
+pub const FW_2_0_1_RELEASE: FwId = FwId {
+    crate_name: "caliptra-fw-2_0_1-release",
+    bin_name: "image-bundle-mldsa.bin",
+    fw_type: FirmwareType::TaggedReleaseFromNetwork {
+        version_tag: "fw-2.0.1",
+        url: "https://github.com/chipsalliance/caliptra-sw/releases/download/fw-2.0.1/caliptra_release_v20260210_0-2.0.zip",
+    },
 };
 
 pub const ROM_WITH_FIPS_TEST_HOOKS_FPGA: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["fips-test-hooks", "fpga_realtime"],
+    fw_type: FirmwareType::Source {
+        features: &["fips-test-hooks", "fpga_realtime"],
+    },
 };
 
 // TODO: delete this when AXI DMA is fixed in the FPGA
 pub const ROM_FPGA_WITH_UART: FwId = FwId {
     crate_name: "caliptra-rom",
     bin_name: "caliptra-rom",
-    features: &["emu", "fpga_realtime"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fpga_realtime"],
+    },
 };
 
 pub const FMC_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "cfi"],
+    },
 };
 
 pub const FMC_FAKE_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "fake-fmc", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fake-fmc", "cfi"],
+    },
 };
 
 // TODO: delete this when AXI DMA is fixed in the FPGA
 pub const FMC_FPGA_WITH_UART: FwId = FwId {
     crate_name: "caliptra-fmc",
     bin_name: "caliptra-fmc",
-    features: &["emu", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const APP: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["fips_self_test", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["fips_self_test", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_FIPS_TEST_HOOKS: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "fips-test-hooks", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "fips-test-hooks", "cfi"],
+    },
 };
 
 pub const APP_WITH_UART_FPGA: FwId = FwId {
     crate_name: "caliptra-runtime",
     bin_name: "caliptra-runtime",
-    features: &["emu", "fips_self_test", "fpga_realtime", "cfi"],
+    fw_type: FirmwareType::Source {
+        features: &["emu", "fips_self_test", "fpga_realtime", "cfi"],
+    },
 };
 
 pub const APP_ZEROS: FwId = FwId {
     crate_name: "caliptra-zeros",
     bin_name: "caliptra-zeros",
-    features: &[],
+    fw_type: FirmwareType::Source { features: &[] },
 };
 
 pub const FMC_ZEROS: FwId = FwId {
     crate_name: "caliptra-zeros",
     bin_name: "caliptra-zeros",
-    features: &["fmc"],
+    fw_type: FirmwareType::Source { features: &["fmc"] },
 };
 
 pub mod caliptra_builder_tests {
@@ -149,7 +195,7 @@ pub mod caliptra_builder_tests {
     pub const FWID: FwId = FwId {
         crate_name: "caliptra-drivers-test-bin",
         bin_name: "test_success",
-        features: &[],
+        fw_type: FirmwareType::Source { features: &[] },
     };
 }
 
@@ -159,7 +205,7 @@ pub mod hw_model_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-hw-model-test-fw",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const MAILBOX_RESPONDER: FwId = FwId {
@@ -229,7 +275,7 @@ pub mod driver_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-drivers-test-bin",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const DOE: FwId = FwId {
@@ -269,7 +315,9 @@ pub mod driver_tests {
 
     pub const KEYVAULT_FPGA: FwId = FwId {
         bin_name: "keyvault",
-        features: &["emu", "fpga_realtime"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_realtime"],
+        },
         ..BASE_FWID
     };
 
@@ -421,7 +469,9 @@ pub mod driver_tests {
     pub const CSRNG_RESEED_HEALTH_FAIL_TESTS: FwId = FwId {
         bin_name: "csrng_reseed_health_fail_tests",
         // Enables the CSRNG_RESEED_FAILURE hook to simulate a reseed failure.
-        features: &["emu", "fips-test-hooks"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fips-test-hooks"],
+        },
         ..BASE_FWID
     };
     pub const TRNG_DRIVER_RESPONDER: FwId = FwId {
@@ -442,7 +492,9 @@ pub mod driver_tests {
     // TODO: delete this when AXI DMA is fixed in the FPGA
     pub const DMA_SHA384_FPGA: FwId = FwId {
         bin_name: "dma_sha384",
-        features: &["emu", "fpga_subsystem"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fpga_subsystem"],
+        },
         ..BASE_FWID
     };
 }
@@ -453,7 +505,7 @@ pub mod rom_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-rom",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const ASM_TESTS: FwId = FwId {
@@ -464,31 +516,41 @@ pub mod rom_tests {
     pub const TEST_FMC_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "cfi"],
+        },
     };
 
     pub const TEST_RT_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-rt",
         bin_name: "caliptra-rom-test-rt",
-        features: &["emu", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "cfi"],
+        },
     };
 
     pub const FAKE_TEST_FMC_WITH_UART: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "fake-fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "fake-fmc", "cfi"],
+        },
     };
 
     pub const TEST_FMC_INTERACTIVE: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "interactive_test_fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "interactive_test_fmc", "cfi"],
+        },
     };
 
     pub const FAKE_TEST_FMC_INTERACTIVE: FwId = FwId {
         crate_name: "caliptra-rom-test-fmc",
         bin_name: "caliptra-rom-test-fmc",
-        features: &["emu", "interactive_test_fmc", "fake-fmc", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "interactive_test_fmc", "fake-fmc", "cfi"],
+        },
     };
 
     pub const TEST_PMP_TESTS: FwId = FwId {
@@ -503,7 +565,9 @@ pub mod runtime_tests {
     const RUNTIME_TEST_FWID_BASE: FwId = FwId {
         crate_name: "caliptra-runtime-test-bin",
         bin_name: "",
-        features: &["emu", "riscv", "runtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "riscv", "runtime", "cfi"],
+        },
     };
 
     pub const BOOT: FwId = FwId {
@@ -518,20 +582,26 @@ pub mod runtime_tests {
 
     pub const MBOX_FPGA: FwId = FwId {
         bin_name: "mbox",
-        features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["emu", "riscv", "runtime", "fpga_realtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
     // Used to test updates between RT FW images.
     pub const MBOX_WITHOUT_UART: FwId = FwId {
         bin_name: "mbox",
-        features: &["riscv", "runtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["riscv", "runtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
     pub const MBOX_WITHOUT_UART_FPGA: FwId = FwId {
         bin_name: "mbox",
-        features: &["riscv", "runtime", "fpga_realtime", "cfi"],
+        fw_type: FirmwareType::Source {
+            features: &["riscv", "runtime", "fpga_realtime", "cfi"],
+        },
         ..RUNTIME_TEST_FWID_BASE
     };
 
@@ -552,7 +622,7 @@ pub mod api_tests {
     const BASE_FWID: FwId = FwId {
         crate_name: "caliptra-api-test-bin",
         bin_name: "",
-        features: &["emu"],
+        fw_type: FirmwareType::Source { features: &["emu"] },
     };
 
     pub const MAILBOX: FwId = FwId {
@@ -560,6 +630,8 @@ pub mod api_tests {
         ..BASE_FWID
     };
 }
+
+pub const PREBUILT_FW: &[&FwId] = &[&ROM_2_0_1_RELEASE, &FW_2_0_1_RELEASE];
 
 pub const REGISTERED_FW: &[&FwId] = &[
     &ROM,

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -27,6 +27,7 @@ use zerocopy::IntoBytes;
 
 mod elf_symbols;
 pub mod firmware;
+pub mod release_artifacts;
 mod sha256;
 pub mod version;
 
@@ -86,6 +87,18 @@ pub fn run_cmd_stdout(cmd: &mut Command, input: Option<&[u8]>) -> io::Result<Str
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub enum FirmwareType<'a> {
+    Source { features: &'a [&'a str] },
+    TaggedReleaseFromNetwork { version_tag: &'a str, url: &'a str },
+}
+
+impl Default for FirmwareType<'_> {
+    fn default() -> Self {
+        FirmwareType::Source { features: &[] }
+    }
+}
+
 // Represent the Cargo identity of a firmware binary.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct FwId<'a> {
@@ -96,11 +109,26 @@ pub struct FwId<'a> {
     // for a binary crate.
     pub bin_name: &'a str,
 
-    // The features to use the build the binary
-    pub features: &'a [&'a str],
+    // The type of firmware target
+    pub fw_type: FirmwareType<'a>,
 }
 
-impl FwId<'_> {
+type PrebuiltCacheMap = Lazy<Mutex<HashMap<FwId<'static>, &'static [u8]>>>;
+
+impl From<&'static FwId<'static>> for &'static [u8] {
+    fn from(id: &'static FwId<'static>) -> &'static [u8] {
+        get_prebuilt_firmware_static(id).expect("Failed to fetch prebuilt firmware artifact")
+    }
+}
+
+impl<'a> FwId<'a> {
+    pub fn features(&self) -> &'a [&'a str] {
+        match self.fw_type {
+            FirmwareType::Source { features } => features,
+            _ => &[],
+        }
+    }
+
     /// A reasonably unique filename to be used for saving elf files containing
     /// this firmware.
     pub fn elf_filename(&self) -> String {
@@ -111,8 +139,8 @@ impl FwId<'_> {
         if self.bin_name != self.crate_name {
             write!(&mut result, "--{}", self.bin_name).unwrap();
         }
-        if !self.features.is_empty() {
-            write!(&mut result, "--{}", self.features.join("-")).unwrap();
+        if !self.features().is_empty() {
+            write!(&mut result, "--{}", self.features().join("-")).unwrap();
         }
         write!(&mut result, ".elf").unwrap();
         result
@@ -261,8 +289,8 @@ fn cargo_invocations_from_fwids<'a>(
 
         remaining_fwids.retain(|&fwid| {
             let invocation = invocation_map
-                .entry((fwid.crate_name, fwid.features))
-                .or_insert_with(|| CargoInvocation::new(fwid.crate_name, fwid.features));
+                .entry((fwid.crate_name, fwid.features()))
+                .or_insert_with(|| CargoInvocation::new(fwid.crate_name, fwid.features()));
             if invocation
                 .fwids
                 .iter()
@@ -532,9 +560,49 @@ pub fn rom_for_fw_integration_tests_fpga(fpga: bool) -> io::Result<Cow<'static, 
     }
 }
 
+pub fn get_prebuilt_firmware(id: &FwId<'static>) -> io::Result<Vec<u8>> {
+    if !crate::firmware::PREBUILT_FW.contains(&id) {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("FwId {id:?} is not a registered prebuilt firmware target"),
+        ));
+    }
+
+    match id.fw_type {
+        FirmwareType::TaggedReleaseFromNetwork { version_tag, url } => {
+            let artifacts = release_artifacts::download_and_extract_release(version_tag, url)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            artifacts.get_file(id.bin_name)
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("FwId {id:?} is not a supported prebuilt firmware ID"),
+        )),
+    }
+}
+
+pub fn get_prebuilt_firmware_static(id: &FwId<'static>) -> io::Result<&'static [u8]> {
+    static CACHE: PrebuiltCacheMap = Lazy::new(|| Mutex::new(HashMap::new()));
+
+    let mut cache = CACHE.lock().unwrap();
+    if let Some(&bytes) = cache.get(id) {
+        return Ok(bytes);
+    }
+
+    let bytes = build_firmware_rom(id)?;
+    let leaked: &'static [u8] = Box::leak(bytes.into_boxed_slice());
+    cache.insert(*id, leaked);
+    Ok(leaked)
+}
+
 pub fn build_firmware_rom(id: &FwId<'static>) -> io::Result<Vec<u8>> {
-    let elf_bytes = build_firmware_elf(id)?;
-    elf2rom(&elf_bytes)
+    match id.fw_type {
+        FirmwareType::TaggedReleaseFromNetwork { .. } => get_prebuilt_firmware(id),
+        FirmwareType::Source { .. } => {
+            let elf_bytes = build_firmware_elf(id)?;
+            elf2rom(&elf_bytes)
+        }
+    }
 }
 
 pub fn elf2rom(elf_bytes: &[u8]) -> io::Result<Vec<u8>> {
@@ -699,7 +767,7 @@ mod test {
         static FWID: FwId = FwId {
             crate_name: "caliptra-drivers-test-bin",
             bin_name: "test_success2",
-            features: &[],
+            fw_type: FirmwareType::Source { features: &[] },
         };
         // Ensure that we can build the ELF and elf2rom can parse it
         let err = build_firmware_rom(&FWID).unwrap_err();
@@ -760,42 +828,58 @@ mod test {
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter", "uart"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter", "uart"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test1",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test2",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test2",
-                    features: &["pc-load-letter", "uart"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter", "uart"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw",
                     bin_name: "test3",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw2",
                     bin_name: "test1",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "test-fw2",
                     bin_name: "test4",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
             ];
 
@@ -808,17 +892,23 @@ mod test {
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test1",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test2",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw",
                                 bin_name: "test3",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                         ]
                     },
@@ -829,12 +919,16 @@ mod test {
                             &FwId {
                                 crate_name: "test-fw2",
                                 bin_name: "test1",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                             &FwId {
                                 crate_name: "test-fw2",
                                 bin_name: "test4",
-                                features: &["pc-load-letter",],
+                                fw_type: FirmwareType::Source {
+                                    features: &["pc-load-letter",]
+                                },
                             },
                         ],
                     },
@@ -844,7 +938,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "initech-firmware",
                             bin_name: "initech-firmware",
-                            features: &["pc-load-letter"],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter"]
+                            },
                         },],
                     },
                     CargoInvocation {
@@ -853,7 +949,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "initech-firmware",
                             bin_name: "initech-firmware",
-                            features: &["pc-load-letter", "uart",],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter", "uart",]
+                            },
                         },]
                     },
                     CargoInvocation {
@@ -862,7 +960,9 @@ mod test {
                         fwids: vec![&FwId {
                             crate_name: "test-fw",
                             bin_name: "test2",
-                            features: &["pc-load-letter", "uart",],
+                            fw_type: FirmwareType::Source {
+                                features: &["pc-load-letter", "uart",]
+                            },
                         },],
                     },
                 ],
@@ -876,12 +976,16 @@ mod test {
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
                 &FwId {
                     crate_name: "initech-firmware",
                     bin_name: "initech-firmware",
-                    features: &["pc-load-letter"],
+                    fw_type: FirmwareType::Source {
+                        features: &["pc-load-letter"],
+                    },
                 },
             ];
             assert!(cargo_invocations_from_fwids(&fwids)
@@ -897,7 +1001,7 @@ mod test {
             FwId {
                 crate_name: "caliptra-rom",
                 bin_name: "caliptra-rom",
-                features: &[]
+                fw_type: FirmwareType::Source { features: &[] },
             }
             .elf_filename(),
             "caliptra-rom.elf"
@@ -906,7 +1010,9 @@ mod test {
             FwId {
                 crate_name: "caliptra-rom",
                 bin_name: "caliptra-rom",
-                features: &["uart", "debug"]
+                fw_type: FirmwareType::Source {
+                    features: &["uart", "debug"]
+                },
             }
             .elf_filename(),
             "caliptra-rom--uart-debug.elf"
@@ -915,7 +1021,7 @@ mod test {
             &FwId {
                 crate_name: "caliptra-test",
                 bin_name: "smoke_test",
-                features: &[]
+                fw_type: FirmwareType::Source { features: &[] },
             }
             .elf_filename(),
             "caliptra-test--smoke_test.elf"
@@ -924,7 +1030,9 @@ mod test {
             &FwId {
                 crate_name: "caliptra-test",
                 bin_name: "smoke_test",
-                features: &["uart", "debug"]
+                fw_type: FirmwareType::Source {
+                    features: &["uart", "debug"]
+                },
             }
             .elf_filename(),
             "caliptra-test--smoke_test--uart-debug.elf"

--- a/builder/src/release_artifacts.rs
+++ b/builder/src/release_artifacts.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache-2.0 license
+
+use std::io::{self, Cursor};
+use std::path::PathBuf;
+
+pub struct ReleaseArtifacts {
+    pub cache_dir: PathBuf,
+}
+
+impl ReleaseArtifacts {
+    pub fn get_file(&self, bin_name: &str) -> io::Result<Vec<u8>> {
+        let file_path = self.cache_dir.join(bin_name);
+        std::fs::read(&file_path).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("Failed to read release binary {bin_name} from {file_path:?}: {e}"),
+            )
+        })
+    }
+}
+
+/// Downloads and extracts release artifacts from a GitHub release ZIP URL using `reqwest` and `zip::ZipArchive::extract`.
+/// Results are cached locally in the system temp directory under `caliptra_release_cache/{version_tag}`.
+pub fn download_and_extract_release(
+    version_tag: &str,
+    url: &str,
+) -> anyhow::Result<ReleaseArtifacts> {
+    let cache_dir = std::env::temp_dir()
+        .join("caliptra_release_cache")
+        .join(version_tag);
+
+    std::fs::create_dir_all(&cache_dir)?;
+
+    let rom_path = cache_dir.join("caliptra-rom-with-log.bin");
+    let fw_path = cache_dir.join("image-bundle-mldsa.bin");
+
+    if !rom_path.exists() && !fw_path.exists() {
+        let response = reqwest::blocking::get(url)?;
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Failed to download release zip from {}: HTTP status {}",
+                url,
+                response.status()
+            );
+        }
+
+        let bytes = response.bytes()?;
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes))?;
+        archive.extract(&cache_dir)?;
+    }
+
+    Ok(ReleaseArtifacts { cache_dir })
+}

--- a/ci-tools/fpga-image/build.sh
+++ b/ci-tools/fpga-image/build.sh
@@ -37,6 +37,7 @@ if [[ -z "${SKIP_DEBOOTSTRAP}" ]]; then
   chroot out/rootfs bash -c 'echo auto end0 > /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo allow-hotplug end0 >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo iface end0 inet dhcp >> /etc/network/interfaces'
+  chroot out/rootfs bash -c 'echo "    pre-up /usr/sbin/set-mac-address.sh end0" >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo iface end0 inet6 auto >> /etc/network/interfaces'
   chroot out/rootfs bash -c 'echo nameserver 8.8.8.8 > /etc/resolv.conf'
   chroot out/rootfs bash -c 'echo nameserver 2001:4860:4860::6464 > /etc/resolv.conf'
@@ -121,6 +122,8 @@ popd
 mv out/nextest/target/aarch64-unknown-linux-gnu/release/cargo-nextest out/rootfs/usr/bin/
 
 chroot out/rootfs bash -c 'echo ::1 caliptra-fpga >> /etc/hosts'
+cp set-mac-address.sh out/rootfs/usr/sbin/
+chmod 755 out/rootfs/usr/sbin/set-mac-address.sh
 cp startup-script.sh out/rootfs/usr/bin/
 chroot out/rootfs systemctl set-default multi-user.target
 chroot out/rootfs chmod 755 /usr/bin/startup-script.sh

--- a/ci-tools/fpga-image/set-mac-address.sh
+++ b/ci-tools/fpga-image/set-mac-address.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Licensed under the Apache-2.0 license
+
+# Generate and apply a deterministic, board-unique MAC address for network interfaces.
+# This prevents MAC address collisions on the local network between multiple FPGA boards
+# while ensuring the MAC address remains stable across reboots of the same board.
+
+set -e
+
+IFACE="${1:-end0}"
+
+get_hardware_seed() {
+    # SD Card CID (128-bit unique hardware card identification register on the boot SD card)
+    if [ -f /sys/block/mmcblk0/device/cid ]; then
+        local cid
+        cid=$(tr -d '\n\r\0' < /sys/block/mmcblk0/device/cid 2>/dev/null | xargs)
+        if [ -n "$cid" ]; then
+            echo "$cid"
+            return 0
+        fi
+    fi
+
+    # Fallback seed if SD card CID is unavailable (e.g. QEMU or container)
+    echo "caliptra-fpga-default-seed"
+}
+
+SEED=$(get_hardware_seed)
+HASH=$(echo -n "$SEED" | sha256sum | awk '{print $1}')
+
+# Construct locally administered unicast MAC address (02:xx:xx:xx:xx:xx)
+MAC="02:${HASH:0:2}:${HASH:2:2}:${HASH:4:2}:${HASH:6:2}:${HASH:8:2}"
+
+if [ "$1" = "--print" ]; then
+    echo "$MAC"
+    exit 0
+fi
+
+if ip link show "$IFACE" >/dev/null 2>&1; then
+    CURRENT_MAC=$(ip link show "$IFACE" | grep -oE 'link/ether [0-9a-fA-F:]+' | awk '{print $2}')
+    if [ "$CURRENT_MAC" != "$MAC" ]; then
+        echo "Setting MAC address for $IFACE to $MAC (seed: $SEED)"
+        ip link set dev "$IFACE" down 2>/dev/null || true
+        ip link set dev "$IFACE" address "$MAC"
+        ip link set dev "$IFACE" up 2>/dev/null || true
+    fi
+fi

--- a/ci-tools/fpga-image/startup-script.sh
+++ b/ci-tools/fpga-image/startup-script.sh
@@ -10,12 +10,6 @@ echo 3 > /proc/sys/kernel/printk
 
 # TODO(clundin): There are a lot of hacks that get cleaned up if using initrd.
 
-# The VCK-190 image currently always has the same MAC. Do this for now until 
-# a better option is found.
-ip link set dev end0 down
-macchanger -r end0 || true
-ip link set dev end0 up
-
 # Overlay exists so we can proceed.
 if [[ -f "/etc/no_overlayfs" ]]; then
     echo "Skipping overlayfs setup for development image."

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -440,6 +440,10 @@ pub struct DmaRecovery<'a> {
 impl<'a> DmaRecovery<'a> {
     const RECOVERY_REGISTER_OFFSET: usize = 0x100;
     const INDIRECT_FIFO_DATA_OFFSET: u32 = 0x68;
+
+    /// Max bytes per DMA transfer; mirrors `DMA_MAX_XFER_SIZE` in
+    /// `axi_dma_ctrl.sv`. A larger `byte_count` is rejected by the HW.
+    const DMA_MAX_XFER_SIZE: u32 = 0x10_0000; // 1 MiB
     const PROT_CAP2_DEVICE_ID_SUPPORT: u32 = 0x1; // Bit 0 in agent_caps
     const PROT_CAP2_DEVICE_STATUS_SUPPORT: u32 = 0x10; // Bit 4 in agent_caps
     const PROT_CAP2_RECOVERY_MEMORY_ACCESS_SUPPORT: u32 = 0x20; // Bit 5 in agent_caps
@@ -974,6 +978,23 @@ impl<'a> DmaRecovery<'a> {
         self.sha384_image(sha_acc, source, length)
     }
 
+    /// Feed `length` bytes from `source` into the SHA accelerator's `datain`
+    /// (`write_addr`) in <= [`DMA_MAX_XFER_SIZE`] chunks; the digest matches a
+    /// single transfer.
+    fn chunked_sha_datain(
+        &self,
+        source: AxiAddr,
+        length: u32,
+        write_addr: AxiAddr,
+    ) -> CaliptraResult<()> {
+        for offset in (0..length).step_by(Self::DMA_MAX_XFER_SIZE as usize) {
+            let chunk = (length - offset).min(Self::DMA_MAX_XFER_SIZE);
+            // `source` advances per chunk; `write_addr` (datain) stays fixed.
+            self.transfer_payload_to_axi(source + offset, chunk, write_addr, false, true)?;
+        }
+        Ok(())
+    }
+
     pub fn sha384_image(
         &self,
         sha_acc: &'a mut Sha2_512_384Acc,
@@ -1020,7 +1041,9 @@ impl<'a> DmaRecovery<'a> {
                 source.lo,
                 length
             );
-            self.transfer_payload_to_axi(source, length, write_addr, false, true)?;
+            // feed the data into the SHA accelerator (split into <= 1 MiB
+            // DMA transfers; dlen/execute cover the full length).
+            self.chunked_sha_datain(source, length, write_addr)?;
 
             dma_sha.execute().write(|w| w.execute(true));
 

--- a/drivers/src/pcr_log.rs
+++ b/drivers/src/pcr_log.rs
@@ -25,7 +25,7 @@ pub const PCR_ID_STASH_MEASUREMENT: PcrId = PcrId::PcrId31;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PcrLogEntryId {
     Invalid = 0,
-    DeviceStatus = 1,         // data size = 9 bytes
+    DeviceStatus = 1,         // data size = 10 bytes
     VendorPubKeyInfoHash = 2, // data size = 48 bytes
     OwnerPubKeyHash = 3,      // data size = 48 bytes
     FmcTci = 4,               // data size = 48 bytes
@@ -70,7 +70,7 @@ impl PcrLogEntry {
     pub fn measured_data(&self) -> &[u8] {
         let data_len = match PcrLogEntryId::from(self.id) {
             PcrLogEntryId::Invalid => 0,
-            PcrLogEntryId::DeviceStatus => 9,
+            PcrLogEntryId::DeviceStatus => 10,
             PcrLogEntryId::VendorPubKeyInfoHash => 48,
             PcrLogEntryId::OwnerPubKeyHash => 48,
             PcrLogEntryId::FmcTci => 48,

--- a/fmc/README.md
+++ b/fmc/README.md
@@ -515,4 +515,4 @@ Fake FMC should be used with the Fake ROM. Details can be found in the ROM readm
 - Current POR is for FIPS Crypto boundary to encompass all of Caliptra FW, including ROM, FMC, and Runtime. With this boundary, there is no need for any
   dedicated crypto module, and each layer of FW will include the library code it needs to access any required crypto functionality. In the future, if a more
   strict FIPS boundary is created, FMC will need to be changed to handle crypto operations differently. Depending on where it is implemented, it may or may not
-  have to initilize the FIPS Crypto module, and it may need to use a different calling convention.
+  have to initialize the FIPS Crypto module, and it may need to use a different calling convention.

--- a/fmc/src/flow/fmc_alias_csr.rs
+++ b/fmc/src/flow/fmc_alias_csr.rs
@@ -123,6 +123,7 @@ fn get_tbs_common_params(env: &mut FmcEnv) -> CaliptraResult<FmcAliasCsrTbsCommo
         data_vault.vendor_pqc_pk_index() as u8,
         env.soc_ifc.fuse_bank().pqc_key_type() as u8,
         owner_pub_keys_digest_in_fuses as u8,
+        env.soc_ifc.subsystem_mode() as u8,
     ])?;
     hasher.update(&<[u8; 48]>::from(
         env.soc_ifc.fuse_bank().vendor_pub_key_info_hash(),

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -28,6 +28,7 @@ caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
+caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }

--- a/hw-model/Cargo.toml
+++ b/hw-model/Cargo.toml
@@ -28,7 +28,6 @@ caliptra-emu-periph.workspace = true
 caliptra-emu-types.workspace = true
 caliptra-hw-model-types.workspace = true
 caliptra-api.workspace = true
-caliptra-builder.workspace = true
 caliptra-registers.workspace = true
 caliptra-image-fake-keys.workspace = true
 caliptra-verilated = { workspace = true, optional = true }

--- a/hw-model/src/lib.rs
+++ b/hw-model/src/lib.rs
@@ -169,6 +169,19 @@ impl TrngMode {
 
 const EXPECTED_CALIPTRA_BOOT_TIME_IN_CYCLES: u64 = 40_000_000; // 40 million cycles
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum ProvisioningStage {
+    /// Blank OTP memory.
+    Raw = 0,
+    /// Provision lifecycle-transition and manufacturing-debug-unlock tokens.
+    TestUnlocked = 1,
+    /// Provision through the manufacturing partitions.
+    Manuf = 2,
+    /// Provision all partitions (the default for runtime and production tests).
+    #[default]
+    Prod = 3,
+}
+
 pub struct SubsystemInitParams<'a> {
     // Optionally, provide MCU ROM; otherwise use the pre-built ROM image, if needed
     pub mcu_rom: Option<&'a [u8]>,
@@ -201,6 +214,9 @@ pub struct SubsystemInitParams<'a> {
     // from strap registers instead of OTP. This gives deterministic
     // IDevID on FPGA, required for attestation tests.
     pub use_strap_secrets: bool,
+
+    // Target stage through which the harness provisions OTP.
+    pub target_provisioning_stage: ProvisioningStage,
 }
 
 impl Default for SubsystemInitParams<'_> {
@@ -215,6 +231,7 @@ impl Default for SubsystemInitParams<'_> {
             primary_flash_initial_contents: None,
             lc_state: None,
             use_strap_secrets: false,
+            target_provisioning_stage: Default::default(),
         }
     }
 }

--- a/hw-model/src/model_emulated.rs
+++ b/hw-model/src/model_emulated.rs
@@ -137,6 +137,19 @@ impl ModelEmulated {
     }
 }
 
+impl ModelEmulated {
+    /// Returns true when the emulated CPU is halted via the VeeR MPMC
+    /// low-power CSR (not the RISC-V `wfi` instruction, which this emulator
+    /// treats as a no-op).
+    ///
+    /// This reflects the VeeR EL2 core-halt power-management state tracked by the
+    /// CPU (`Cpu::read_halted`), used by external schedulers to drop the core off
+    /// their event queue while it is idle.
+    pub fn cpu_halted(&self) -> bool {
+        self.cpu.read_halted()
+    }
+}
+
 fn hash_slice(slice: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
     std::hash::Hash::hash_slice(slice, &mut hasher);

--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -18,8 +18,8 @@ use crate::otp_provision::{
     LifecycleControllerState, OtpSwManufPartition,
 };
 use crate::xi3c::XI3cError;
-use crate::SecurityState;
 use crate::{xi3c, BootParams, Error, HwModel, InitParams, ModelError, Output, TrngMode};
+use crate::{ProvisioningStage, SecurityState};
 use anyhow::Result;
 use caliptra_api::SocManager;
 use caliptra_emu_bus::{Bus, BusError, BusMmio, Device, Event, EventData, RecoveryCommandCode};
@@ -440,6 +440,7 @@ pub struct ModelFpgaSubsystem {
     pub secondary_flash: Vec<u8>,
     // whether or not to attempt flash boot instead of streaming boot
     pub flash_boot: bool,
+    pub target_provisioning_stage: ProvisioningStage,
 
     // Init params saved at construction time so that `cold_reset()` can
     // re-program every FPGA wrapper register that AXI reset clears. Adapted
@@ -1528,98 +1529,106 @@ impl ModelFpgaSubsystem {
             otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
         }
 
-        // Provision default LC tokens.
-        println!("Provisioning SECRET_LC_TRANSITION partition.");
-        let tokens = &DEFAULT_LIFECYCLE_RAW_TOKENS;
-        let mem = otp_generate_lifecycle_tokens_mem(tokens)?;
-        let offset = OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+        let stage = self.target_provisioning_stage;
 
-        // Provision default SW_TEST_UNLOCK partition (manuf debug unlock token).
-        println!("Provisioning SW_TEST_UNLOCK partition.");
-        let mem = otp_generate_manuf_debug_unlock_token_mem(&DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN)?;
-        let offset = OTP_SW_TEST_UNLOCK_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+        if stage > ProvisioningStage::Raw {
+            println!("Provisioning SECRET_LC_TRANSITION partition.");
+            let tokens = &DEFAULT_LIFECYCLE_RAW_TOKENS;
+            let mem = otp_generate_lifecycle_tokens_mem(tokens)?;
+            let offset = OTP_SECRET_LC_TRANSITION_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-        // Provision default SW_MANUF partition.
-        // TODO(timothytrippel): enable provisioning prod debug unlock public key hashes for public
-        // keys passed in `prod_dbg_unlock_keypairs` field in InitParams.
-        println!("Provisioning SW_MANUF partition.");
-        let mem = otp_generate_sw_manuf_partition_mem(&OtpSwManufPartition {
-            anti_rollback_disable: u32::from(self.fuses.anti_rollback_disable),
-            ..Default::default()
-        })?;
-        let offset = OTP_SW_MANUF_PARTITION_OFFSET;
-        otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+            // Provision default SW_TEST_UNLOCK partition (manuf debug unlock token).
+            println!("Provisioning SW_TEST_UNLOCK partition.");
+            let mem =
+                otp_generate_manuf_debug_unlock_token_mem(&DEFAULT_MANUF_DEBUG_UNLOCK_RAW_TOKEN)?;
+            let offset = OTP_SW_TEST_UNLOCK_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
+        }
 
-        let vendor_pk_hash = self.fuses.vendor_pk_hash.as_bytes();
-        println!(
-            "Setting vendor public key hash to {:x?}",
-            HexSlice(vendor_pk_hash)
-        );
-        otp_data[FUSE_VENDOR_PKHASH_OFFSET..FUSE_VENDOR_PKHASH_OFFSET + vendor_pk_hash.len()]
-            .copy_from_slice(vendor_pk_hash);
+        if stage > ProvisioningStage::TestUnlocked {
+            // Provision default SW_MANUF partition.
+            // TODO(timothytrippel): enable provisioning prod debug unlock public key hashes for public
+            // keys passed in `prod_dbg_unlock_keypairs` field in InitParams.
+            println!("Provisioning SW_MANUF partition.");
+            let mem = otp_generate_sw_manuf_partition_mem(&OtpSwManufPartition {
+                anti_rollback_disable: u32::from(self.fuses.anti_rollback_disable),
+                ..Default::default()
+            })?;
+            let offset = OTP_SW_MANUF_PARTITION_OFFSET;
+            otp_data[offset..offset + mem.len()].copy_from_slice(&mem);
 
-        let vendor_pqc_type = FwVerificationPqcKeyType::from_u8(self.fuses.fuse_pqc_key_type as u8)
-            .unwrap_or(FwVerificationPqcKeyType::LMS);
-        println!(
-            "Setting vendor public key pqc type to {:x?}",
-            vendor_pqc_type
-        );
-        let encoded_pqc = otp_generate_linear_majority_vote(2, 3, vendor_pqc_type as u32)?;
-        otp_data[FUSE_PQC_OFFSET..FUSE_PQC_OFFSET + 4].copy_from_slice(&encoded_pqc.to_le_bytes());
+            let vendor_pk_hash = self.fuses.vendor_pk_hash.as_bytes();
+            println!(
+                "Setting vendor public key hash to {:x?}",
+                HexSlice(vendor_pk_hash)
+            );
+            otp_data[FUSE_VENDOR_PKHASH_OFFSET..FUSE_VENDOR_PKHASH_OFFSET + vendor_pk_hash.len()]
+                .copy_from_slice(vendor_pk_hash);
 
-        // Owner public key hash (48 bytes) lives in VENDOR_HASHES_PROD partition
-        let owner_pk_hash = self.fuses.owner_pk_hash.as_bytes();
-        println!(
-            "Setting owner public key hash to {:x?}",
-            HexSlice(owner_pk_hash)
-        );
-        otp_data[FUSE_OWNER_PKHASH_OFFSET..FUSE_OWNER_PKHASH_OFFSET + owner_pk_hash.len()]
-            .copy_from_slice(owner_pk_hash);
+            let vendor_pqc_type =
+                FwVerificationPqcKeyType::from_u8(self.fuses.fuse_pqc_key_type as u8)
+                    .unwrap_or(FwVerificationPqcKeyType::LMS);
+            println!(
+                "Setting vendor public key pqc type to {:x?}",
+                vendor_pqc_type
+            );
+            let encoded_pqc = otp_generate_linear_majority_vote(2, 3, vendor_pqc_type as u32)?;
+            otp_data[FUSE_PQC_OFFSET..FUSE_PQC_OFFSET + 4]
+                .copy_from_slice(&encoded_pqc.to_le_bytes());
 
-        // Owner revocation fields (ECC, LMS, MLDSA) in VENDOR_REVOCATIONS_PROD partition
-        // Note: ECC revocation in API is a 4-bit value; store in low bits of u32 here.
-        let vendor_ecc_revocation: u32 = (u32::from(self.fuses.fuse_ecc_revocation)) & 0xF;
-        let vendor_lms_revocation: u32 = self.fuses.fuse_lms_revocation;
-        let vendor_mldsa_revocation: u32 = self.fuses.fuse_mldsa_revocation;
-        println!(
-            "Setting owner revocations ecc={:#x} lms={:#x} mldsa={:#x}",
-            vendor_ecc_revocation, vendor_lms_revocation, vendor_mldsa_revocation
-        );
-        let encoded_ecc = otp_generate_linear_majority_vote(4, 3, vendor_ecc_revocation)?;
-        otp_data[FUSE_VENDOR_ECC_REVOCATION_OFFSET..FUSE_VENDOR_ECC_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_ecc.to_le_bytes());
-        let encoded_lms = otp_generate_linear_majority_vote(16, 2, vendor_lms_revocation)?;
-        otp_data[FUSE_VENDOR_LMS_REVOCATION_OFFSET..FUSE_VENDOR_LMS_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_lms.to_le_bytes());
-        let encoded_mldsa = otp_generate_linear_majority_vote(4, 3, vendor_mldsa_revocation)?;
-        otp_data[FUSE_VENDOR_REVOCATION_OFFSET..FUSE_VENDOR_REVOCATION_OFFSET + 4]
-            .copy_from_slice(&encoded_mldsa.to_le_bytes());
+            // Owner public key hash (48 bytes) lives in VENDOR_HASHES_PROD partition
+            let owner_pk_hash = self.fuses.owner_pk_hash.as_bytes();
+            println!(
+                "Setting owner public key hash to {:x?}",
+                HexSlice(owner_pk_hash)
+            );
+            otp_data[FUSE_OWNER_PKHASH_OFFSET..FUSE_OWNER_PKHASH_OFFSET + owner_pk_hash.len()]
+                .copy_from_slice(owner_pk_hash);
 
-        // Firmware/runtime SVN (16 bytes -> 4 words)
-        let fw_svn = self.fuses.fw_svn.as_bytes();
-        println!("Setting runtime FW SVN to {:x?}", HexSlice(fw_svn));
-        otp_data[OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET
-            ..OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET + fw_svn.len()]
-            .copy_from_slice(fw_svn);
+            // Owner revocation fields (ECC, LMS, MLDSA) in VENDOR_REVOCATIONS_PROD partition
+            // Note: ECC revocation in API is a 4-bit value; store in low bits of u32 here.
+            let vendor_ecc_revocation: u32 = (u32::from(self.fuses.fuse_ecc_revocation)) & 0xF;
+            let vendor_lms_revocation: u32 = self.fuses.fuse_lms_revocation;
+            let vendor_mldsa_revocation: u32 = self.fuses.fuse_mldsa_revocation;
+            println!(
+                "Setting owner revocations ecc={:#x} lms={:#x} mldsa={:#x}",
+                vendor_ecc_revocation, vendor_lms_revocation, vendor_mldsa_revocation
+            );
+            let encoded_ecc = otp_generate_linear_majority_vote(4, 3, vendor_ecc_revocation)?;
+            otp_data[FUSE_VENDOR_ECC_REVOCATION_OFFSET..FUSE_VENDOR_ECC_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_ecc.to_le_bytes());
+            let encoded_lms = otp_generate_linear_majority_vote(16, 2, vendor_lms_revocation)?;
+            otp_data[FUSE_VENDOR_LMS_REVOCATION_OFFSET..FUSE_VENDOR_LMS_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_lms.to_le_bytes());
+            let encoded_mldsa = otp_generate_linear_majority_vote(4, 3, vendor_mldsa_revocation)?;
+            otp_data[FUSE_VENDOR_REVOCATION_OFFSET..FUSE_VENDOR_REVOCATION_OFFSET + 4]
+                .copy_from_slice(&encoded_mldsa.to_le_bytes());
 
-        // SoC manifest SVN (16 bytes -> 4 words)
-        let soc_manifest_svn = self.fuses.soc_manifest_svn.as_bytes();
-        println!(
-            "Setting SoC manifest SVN to {:x?}",
-            HexSlice(soc_manifest_svn)
-        );
-        otp_data[OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET
-            ..OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET + soc_manifest_svn.len()]
-            .copy_from_slice(soc_manifest_svn);
+            // Firmware/runtime SVN (16 bytes -> 4 words)
+            let fw_svn = self.fuses.fw_svn.as_bytes();
+            println!("Setting runtime FW SVN to {:x?}", HexSlice(fw_svn));
+            otp_data[OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET
+                ..OTP_SVN_PARTITION_RUNTIME_SVN_FIELD_OFFSET + fw_svn.len()]
+                .copy_from_slice(fw_svn);
 
-        // Max SOC Manifest SVN (1 byte used)
-        println!(
-            "Burning fuse for SOC MAX SVN {}",
-            self.fuses.soc_manifest_max_svn
-        );
-        otp_data[OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET] = self.fuses.soc_manifest_max_svn;
+            // SoC manifest SVN (16 bytes -> 4 words)
+            let soc_manifest_svn = self.fuses.soc_manifest_svn.as_bytes();
+            println!(
+                "Setting SoC manifest SVN to {:x?}",
+                HexSlice(soc_manifest_svn)
+            );
+            otp_data[OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET
+                ..OTP_SVN_PARTITION_SOC_MANIFEST_SVN_FIELD_OFFSET + soc_manifest_svn.len()]
+                .copy_from_slice(soc_manifest_svn);
+
+            // Max SOC Manifest SVN (1 byte used)
+            println!(
+                "Burning fuse for SOC MAX SVN {}",
+                self.fuses.soc_manifest_max_svn
+            );
+            otp_data[OTP_SVN_PARTITION_SOC_MAX_SVN_FIELD_OFFSET] = self.fuses.soc_manifest_max_svn;
+        }
 
         self.otp_slice().copy_from_slice(&otp_data);
 
@@ -1882,6 +1891,7 @@ impl HwModel for ModelFpgaSubsystem {
                 .ss_init_params
                 .primary_flash_initial_contents
                 .is_some(),
+            target_provisioning_stage: params.ss_init_params.target_provisioning_stage,
 
             saved_input_wires: [(!params.uds_granularity_64 as u32) << 31, 0],
             saved_cptra_obf_key: params.cptra_obf_key,

--- a/hw-model/src/openocd/openocd_jtag_tap.rs
+++ b/hw-model/src/openocd/openocd_jtag_tap.rs
@@ -8,7 +8,7 @@
 
 #![allow(dead_code)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{bail, ensure, Context, Result};
@@ -200,6 +200,22 @@ impl OpenOcdJtagTap {
         let response = self.openocd.execute(cmd.as_str())?;
         if !response.is_empty() {
             bail!("unexpected response: '{response}'");
+        }
+        Ok(())
+    }
+
+    pub fn load_image(&mut self, path: &Path, addr: u32) -> Result<()> {
+        ensure!(
+            self.jtag_tap != JtagTap::NoTap,
+            JtagError::Tap(self.jtag_tap)
+        );
+        let cmd = format!("load_image {} 0x{:x} bin", path.display(), addr);
+        let response = self.openocd.execute(cmd.as_str())?;
+        if !response.contains("bytes written") {
+            return Err(anyhow::anyhow!(
+                "OpenOCD load_image failed or returned unexpected output: {}",
+                response
+            ));
         }
         Ok(())
     }

--- a/image/elf/src/lib.rs
+++ b/image/elf/src/lib.rs
@@ -17,6 +17,7 @@ use caliptra_image_gen::ImageGeneratorExecutable;
 use caliptra_image_types::ImageRevision;
 use elf::abi::PT_LOAD;
 use elf::endian::AnyEndian;
+use elf::segment::ProgramHeader;
 use elf::ElfBytes;
 use std::path::PathBuf;
 
@@ -48,6 +49,15 @@ fn load_into_image(
     Ok(())
 }
 
+// Check if `seg` includes ELF header data or program header table.
+// ELF files begin with the ELF header and the program header table.
+// A segment contains such metadata if its file size is above 0 and
+// its file offset falls within the range of such metadata tables.
+fn segment_has_elf_metadata(seg: &ProgramHeader, elf: &ElfBytes<AnyEndian>) -> bool {
+    let phdr_table_end = elf.ehdr.e_phoff + elf.ehdr.e_phentsize as u64 * elf.ehdr.e_phnum as u64;
+    seg.p_filesz > 0 && seg.p_offset < phdr_table_end
+}
+
 impl ElfExecutable {
     pub fn open(path: &PathBuf, version: u32, rev: ImageRevision) -> anyhow::Result<Self> {
         let file_data = std::fs::read(path).with_context(|| "Failed to read file")?;
@@ -64,9 +74,12 @@ impl ElfExecutable {
             bail!("ELF file has no segments");
         };
 
+        // To determine the base load address, find the minimum
+        // load address across the segments that are PT_LOAD and
+        // do not contain any ELF metadata.
         let Some(load_addr) = segments
             .iter()
-            .filter(|s| s.p_type == PT_LOAD)
+            .filter(|s| s.p_type == PT_LOAD && !segment_has_elf_metadata(s, &elf_file))
             .map(|s| s.p_paddr as u32)
             .min()
         else {
@@ -74,7 +87,8 @@ impl ElfExecutable {
         };
 
         for segment in segments {
-            if segment.p_type != PT_LOAD {
+            // Skip the segments using the same criterion as before.
+            if segment.p_type != PT_LOAD || segment_has_elf_metadata(&segment, &elf_file) {
                 continue;
             }
             let segment_data = elf_file.segment_data(&segment)?;

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -795,7 +795,7 @@ Following is the sequence of steps that are performed to download the firmware i
 9. Set RI `RECOVERY_STATUS` register `Device Recovery Status` field to 0x2 (`Booting recovery image`).
 10. Validate the image per the [Image Validation Process](#firmware-image-validation-process).
 11. Reset the `RECOVERY_CTRL` register `Activate Recovery Image` field by writing 0x1.
-12. If the validation is succesful, set the `DEVICE_STATUS` register `Device Status` field to 0x5 (`Running Recovery Image ( Recover Reason Code not populated)`)
+12. If the validation is successful, set the `DEVICE_STATUS` register `Device Status` field to 0x5 (`Running Recovery Image ( Recover Reason Code not populated)`)
 13. If the validation fails, set the `RECOVERY_STATUS` register `Device Recovery Status` field to 0xd (`Authentication Error`) and `DEVICE_STATUS` register `Device Status` field to 0xE (`Boot Failure`) with the `Recovery Reason Code` populated for the failure.
 14. Release the mailbox lock.
 

--- a/rom/dev/doc/svg/cm-derive-stable-key.svg
+++ b/rom/dev/doc/svg/cm-derive-stable-key.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="620" viewBox="0 0 1180 620" role="img" aria-labelledby="title desc">
+  <title id="title">CM_DERIVE_STABLE_KEY derivation</title>
+  <desc id="desc">Diagram showing how CM_DERIVE_STABLE_KEY derives wrapped stable key material from a ROM-populated stable root key.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2f3437"/>
+    </marker>
+    <style>
+      .title { font: 700 24px Arial, sans-serif; fill: #1f2528; }
+      .section { font: 700 18px Arial, sans-serif; fill: #1f2528; }
+      .label { font: 600 15px Arial, sans-serif; fill: #1f2528; }
+      .small { font: 13px Arial, sans-serif; fill: #3c4448; }
+      .tiny { font: 12px Arial, sans-serif; fill: #4d555a; }
+      .root { fill: #e8f5e8; stroke: #2f3437; stroke-width: 1.4; }
+      .input { fill: #f8f9fa; stroke: #2f3437; stroke-width: 1.4; }
+      .cmac { fill: #dff1f7; stroke: #2f3437; stroke-width: 1.4; }
+      .hmac { fill: #fff2c7; stroke: #2f3437; stroke-width: 1.4; }
+      .material { fill: #f7e5e2; stroke: #2f3437; stroke-width: 1.4; }
+      .wrap { fill: #eee7fa; stroke: #2f3437; stroke-width: 1.4; }
+      .note { fill: #ffffff; stroke: #8b949e; stroke-width: 1.2; }
+      .line { stroke: #2f3437; stroke-width: 1.6; fill: none; marker-end: url(#arrow); }
+      .soft-line { stroke: #6a737d; stroke-width: 1.3; fill: none; marker-end: url(#arrow); }
+      .dash { stroke-dasharray: 5 4; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="1180" height="620" fill="#ffffff"/>
+  <text x="40" y="44" class="title">CM_DERIVE_STABLE_KEY</text>
+  <text x="40" y="70" class="small">Runtime and ROM use the same mailbox command flow: select a stable root, derive key material, then return it as an encrypted CMK.</text>
+
+  <rect x="44" y="112" width="220" height="184" rx="8" class="root"/>
+  <text x="154" y="140" text-anchor="middle" class="section">Selected Stable Root</text>
+  <text x="154" y="170" text-anchor="middle" class="small">key_type = IDevId</text>
+  <text x="154" y="190" text-anchor="middle" class="tiny">KEY_ID_STABLE_IDEV / KeyId0</text>
+  <text x="154" y="216" text-anchor="middle" class="small">key_type = LDevId</text>
+  <text x="154" y="236" text-anchor="middle" class="tiny">KEY_ID_STABLE_LDEV / KeyId1</text>
+  <text x="154" y="262" text-anchor="middle" class="small">key_type = OwnerKey</text>
+  <text x="154" y="282" text-anchor="middle" class="tiny">KEY_ID_STABLE_OWNER / KeyId15</text>
+
+  <rect x="44" y="330" width="220" height="82" rx="8" class="input"/>
+  <text x="154" y="361" text-anchor="middle" class="section">Request Info</text>
+  <text x="154" y="386" text-anchor="middle" class="small">info[32]</text>
+
+  <polygon points="360,150 520,150 492,250 388,250" class="cmac"/>
+  <text x="440" y="185" text-anchor="middle" class="label">CMAC-KDF</text>
+  <text x="440" y="209" text-anchor="middle" class="label">AES-256</text>
+  <text x="440" y="232" text-anchor="middle" class="small">4 rounds</text>
+
+  <rect x="595" y="166" width="150" height="68" rx="8" class="material"/>
+  <text x="670" y="194" text-anchor="middle" class="label">K0</text>
+  <text x="670" y="216" text-anchor="middle" class="small">64 bytes</text>
+
+  <polygon points="830,150 990,150 962,250 858,250" class="hmac"/>
+  <text x="910" y="185" text-anchor="middle" class="label">KBKDF</text>
+  <text x="910" y="209" text-anchor="middle" class="label">HMAC-SHA512</text>
+  <text x="910" y="232" text-anchor="middle" class="small">final key material</text>
+
+  <rect x="770" y="300" width="220" height="132" rx="8" class="input"/>
+  <text x="880" y="328" text-anchor="middle" class="section">Domain Input</text>
+  <text x="880" y="354" text-anchor="middle" class="small">IDevId/LDevId:</text>
+  <text x="880" y="376" text-anchor="middle" class="tiny">"DOT Final" || info</text>
+  <text x="880" y="402" text-anchor="middle" class="small">OwnerKey:</text>
+  <text x="880" y="424" text-anchor="middle" class="tiny">"Stable Owner Key" || info</text>
+
+  <rect x="1014" y="150" width="126" height="100" rx="8" class="material"/>
+  <text x="1077" y="184" text-anchor="middle" class="label">Stable Key</text>
+  <text x="1077" y="207" text-anchor="middle" class="small">64 bytes</text>
+  <text x="1077" y="229" text-anchor="middle" class="tiny">HMAC CMK data</text>
+
+  <rect x="1014" y="338" width="126" height="72" rx="8" class="wrap"/>
+  <text x="1077" y="367" text-anchor="middle" class="label">Encrypted</text>
+  <text x="1077" y="389" text-anchor="middle" class="label">CMK</text>
+
+  <path d="M264 188 L360 188" class="line"/>
+  <text x="306" y="176" text-anchor="middle" class="tiny">AES key</text>
+  <path d="M264 371 L360 226" class="soft-line"/>
+  <text x="318" y="314" text-anchor="middle" class="tiny">label = info</text>
+  <path d="M520 200 L595 200" class="line"/>
+  <path d="M745 200 L830 200" class="line"/>
+  <text x="787" y="188" text-anchor="middle" class="tiny">HMAC key</text>
+  <path d="M880 300 L910 250" class="soft-line"/>
+  <text x="830" y="282" text-anchor="middle" class="tiny">label input</text>
+  <path d="M990 200 L1014 200" class="line"/>
+  <path d="M1077 250 L1077 338" class="line"/>
+
+  <rect x="44" y="472" width="1096" height="92" rx="8" class="note"/>
+  <text x="68" y="501" class="label">Derivation summary</text>
+  <text x="68" y="526" class="small">K0 = CMAC-KDF(selected stable root, label = info, context = None, rounds = 4)</text>
+  <text x="68" y="549" class="small">StableKey = KBKDF-HMAC-SHA512(K0, label = prefix || info, context = None); the response contains this material wrapped as a CMK.</text>
+</svg>

--- a/rom/dev/doc/svg/dice-diagram.svg
+++ b/rom/dev/doc/svg/dice-diagram.svg
@@ -470,7 +470,7 @@
 			<text x="71.33" y="1181.18" class="st25" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>SIGN</text>		</g>
 		<g id="shape1040-156" v:mID="1040" v:groupContext="shape" v:layerMember="2" transform="translate(310.62,-798.307)">
 			<title>Custom 2.1006</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -498,7 +498,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1041-160" v:mID="1041" v:groupContext="shape" v:layerMember="0" transform="translate(351.12,-798.307)">
 			<title>Dynamic connector.1008</title>
@@ -529,7 +529,7 @@
 			<text x="7.51" y="1123.1" class="st28" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>“idevid_cdi”</text>		</g>
 		<g id="shape1044-178" v:mID="1044" v:groupContext="shape" v:layerMember="2" transform="translate(274.62,-647.558)">
 			<title>Custom 2.1011</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -557,11 +557,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1045-182" v:mID="1045" v:groupContext="shape" v:layerMember="2" transform="translate(346.62,-647.558)">
 			<title>Custom 2.1012</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -589,7 +589,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1046-186" v:mID="1046" v:groupContext="shape" v:layerMember="0" transform="translate(342.12,-715.8)">
 			<title>Dynamic connector.1014</title>
@@ -873,7 +873,7 @@
 			<text x="5.63" y="1117.37" class="st16" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>PRIVKEY</text>		</g>
 		<g id="shape1071-321" v:mID="1071" v:groupContext="shape" v:layerMember="2" transform="translate(472.62,-647.858)">
 			<title>Custom 2.1039</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -901,11 +901,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1072-325" v:mID="1072" v:groupContext="shape" v:layerMember="2" transform="translate(544.62,-647.858)">
 			<title>Custom 2.1040</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -933,7 +933,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1073-329" v:mID="1073" v:groupContext="shape" v:layerMember="0" transform="translate(538.995,-715.794)">
 			<title>Dynamic connector.1041</title>
@@ -1078,7 +1078,7 @@
 			<text x="-27.77" y="1140.58" class="st22" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>key</text>		</g>
 		<g id="shape1088-413" v:mID="1088" v:groupContext="shape" v:layerMember="2" transform="translate(705.382,-798.307)">
 			<title>Custom 2.1057</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1106,7 +1106,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1089-417" v:mID="1089" v:groupContext="shape" v:layerMember="0" transform="translate(727.939,-798.307)">
 			<title>Dynamic connector.1058</title>
@@ -1157,7 +1157,7 @@
 						dy="-0.289em" class="st8" v:baseFontSize="9">FMC</tspan></text>		</g>
 		<g id="shape1094-447" v:mID="1094" v:groupContext="shape" v:layerMember="2" transform="translate(670.62,-648.058)">
 			<title>Custom 2.1066</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1185,11 +1185,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1095-451" v:mID="1095" v:groupContext="shape" v:layerMember="2" transform="translate(742.62,-648.058)">
 			<title>Custom 2.1067</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1217,7 +1217,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1096-455" v:mID="1096" v:groupContext="shape" v:layerMember="0" transform="translate(736.995,-715.994)">
 			<title>Dynamic connector.1068</title>
@@ -1653,7 +1653,7 @@
 		</g>
 		<g id="shape1157-684" v:mID="1157" v:groupContext="shape" v:layerMember="2" transform="translate(955.695,-797.679)">
 			<title>Custom 2.1175</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1681,7 +1681,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st26"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1158-688" v:mID="1158" v:groupContext="shape" v:layerMember="0" transform="translate(978.251,-797.679)">
 			<title>Dynamic connector.1158</title>
@@ -1732,7 +1732,7 @@
 						dy="-0.289em" class="st8" v:baseFontSize="9">RT</tspan></text>		</g>
 		<g id="shape1163-718" v:mID="1163" v:groupContext="shape" v:layerMember="2" transform="translate(920.932,-647.429)">
 			<title>Custom 2.1181</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1760,11 +1760,11 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1164-722" v:mID="1164" v:groupContext="shape" v:layerMember="2" transform="translate(992.932,-647.429)">
 			<title>Custom 2.1182</title>
-			<desc>HKDF 512</desc>
+			<desc>KBKDF 512</desc>
 			<v:custProps>
 				<v:cp v:nameU="Cost" v:lbl="Cost" v:prompt="" v:type="7" v:format="@" v:sortKey="" v:invis="false" v:ask="false"
 						v:langID="1033" v:cal="0"/>
@@ -1792,7 +1792,7 @@
 			<v:textBlock v:margins="rect(2,2,2,2)"/>
 			<v:textRect cx="31.5" cy="1108.93" width="31.51" height="31.5"/>
 			<path d="M15.75 1124.68 L47.25 1124.68 L63 1093.18 L0 1093.18 L15.75 1124.68 Z" class="st29"/>
-			<text x="21.3" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>HKDF <tspan x="24.66"
+			<text x="19.62" y="1106.23" class="st5" v:langID="1033"><v:paragraph v:horizAlign="1"/><v:tabList/>KBKDF <tspan x="24.66"
 						dy="1.2em" class="st11">512 </tspan> </text>		</g>
 		<g id="shape1165-726" v:mID="1165" v:groupContext="shape" v:layerMember="0" transform="translate(987.307,-715.365)">
 			<title>Dynamic connector.1183</title>

--- a/rom/dev/src/flow/cold_reset/fmc_alias.rs
+++ b/rom/dev/src/flow/cold_reset/fmc_alias.rs
@@ -237,6 +237,7 @@ impl FmcAliasLayer {
             data_vault.vendor_pqc_pk_index() as u8,
             fw_proc_info.pqc_key_type,
             fw_proc_info.owner_pub_keys_digest_in_fuses as u8,
+            soc_ifc.subsystem_mode() as u8,
         ])?;
         hasher.update(&<[u8; 48]>::from(
             soc_ifc.fuse_bank().vendor_pub_key_info_hash(),
@@ -344,6 +345,7 @@ impl FmcAliasLayer {
             data_vault.vendor_pqc_pk_index() as u8,
             fw_proc_info.pqc_key_type,
             fw_proc_info.owner_pub_keys_digest_in_fuses as u8,
+            soc_ifc.subsystem_mode() as u8,
         ])?;
         hasher.update(&<[u8; 48]>::from(
             soc_ifc.fuse_bank().vendor_pub_key_info_hash(),

--- a/rom/dev/src/pcr.rs
+++ b/rom/dev/src/pcr.rs
@@ -84,7 +84,7 @@ pub(crate) fn extend_pcrs(
     // Clear the Current PCR, but do not clear the Journey PCR
     pcr_bank.erase_pcr(PCR_ID_FMC_CURRENT)?;
 
-    let device_status: [u8; 9] = [
+    let device_status: [u8; 10] = [
         soc_ifc.lifecycle() as u8,
         soc_ifc.debug_locked() as u8,
         soc_ifc.fuse_bank().anti_rollback_disable() as u8,
@@ -94,6 +94,7 @@ pub(crate) fn extend_pcrs(
         data_vault.vendor_pqc_pk_index() as u8,
         info.pqc_key_type as u8,
         info.owner_pub_keys_digest_in_fuses as u8,
+        soc_ifc.subsystem_mode() as u8,
     ];
 
     let mut pcr = PcrExtender {

--- a/rom/dev/tests/rom_integration_tests/main.rs
+++ b/rom/dev/tests/rom_integration_tests/main.rs
@@ -9,6 +9,7 @@ mod test_cm_sha;
 mod test_cpu_fault;
 mod test_debug_unlock;
 mod test_derive_stable_key;
+mod test_device_status_mode;
 mod test_dice_derivations;
 mod test_ecdsa_verify;
 mod test_fake_rom;

--- a/rom/dev/tests/rom_integration_tests/test_device_status_mode.rs
+++ b/rom/dev/tests/rom_integration_tests/test_device_status_mode.rs
@@ -64,11 +64,13 @@ fn test_device_status_mode(subsystem_mode: bool, expected_mode: u8) {
 }
 
 #[test]
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
 fn test_device_status_mode_passive() {
     test_device_status_mode(false, DEVICE_STATUS_MODE_PASSIVE);
 }
 
 #[test]
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
 fn test_device_status_mode_subsystem() {
     test_device_status_mode(true, DEVICE_STATUS_MODE_SUBSYSTEM);
 }

--- a/rom/dev/tests/rom_integration_tests/test_device_status_mode.rs
+++ b/rom/dev/tests/rom_integration_tests/test_device_status_mode.rs
@@ -1,0 +1,74 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_builder::{
+    firmware::{rom_tests::TEST_FMC_INTERACTIVE, APP_WITH_UART},
+    ImageOptions,
+};
+use caliptra_common::RomBootStatus::ColdResetComplete;
+use caliptra_common::{PcrLogEntry, PcrLogEntryId};
+use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
+use caliptra_image_types::FwVerificationPqcKeyType;
+use zerocopy::{FromBytes, IntoBytes};
+
+const PCR_ENTRY_SIZE: usize = core::mem::size_of::<PcrLogEntry>();
+const DEVICE_STATUS_MODE_OFFSET: usize = 9;
+const DEVICE_STATUS_MODE_PASSIVE: u8 = 0;
+const DEVICE_STATUS_MODE_SUBSYSTEM: u8 = 1;
+
+fn test_device_status_mode(subsystem_mode: bool, expected_mode: u8) {
+    let fuses = Fuses {
+        fuse_pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+        ..Default::default()
+    };
+    let rom = caliptra_builder::build_firmware_rom(crate::helpers::rom_from_env()).unwrap();
+    let life_cycle = fuses.life_cycle;
+    let mut hw = caliptra_hw_model::new(
+        InitParams {
+            fuses,
+            rom: &rom,
+            security_state: SecurityState::from(life_cycle as u32),
+            subsystem_mode,
+            ..Default::default()
+        },
+        BootParams::default(),
+    )
+    .unwrap();
+
+    let image_bundle = caliptra_builder::build_and_sign_image(
+        &TEST_FMC_INTERACTIVE,
+        &APP_WITH_UART,
+        ImageOptions {
+            pqc_key_type: FwVerificationPqcKeyType::LMS,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    crate::helpers::test_upload_firmware(
+        &mut hw,
+        &image_bundle.to_bytes().unwrap(),
+        FwVerificationPqcKeyType::LMS,
+    );
+
+    hw.step_until_boot_status(u32::from(ColdResetComplete), true);
+
+    let pcr_entry_arr = hw.mailbox_execute(0x1000_0000, &[]).unwrap().unwrap();
+    let (device_status, _) =
+        PcrLogEntry::ref_from_prefix(pcr_entry_arr[0..PCR_ENTRY_SIZE].as_bytes()).unwrap();
+
+    assert_eq!(device_status.id, PcrLogEntryId::DeviceStatus as u16);
+    assert_eq!(
+        device_status.measured_data()[DEVICE_STATUS_MODE_OFFSET],
+        expected_mode
+    );
+}
+
+#[test]
+fn test_device_status_mode_passive() {
+    test_device_status_mode(false, DEVICE_STATUS_MODE_PASSIVE);
+}
+
+#[test]
+fn test_device_status_mode_subsystem() {
+    test_device_status_mode(true, DEVICE_STATUS_MODE_SUBSYSTEM);
+}

--- a/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
+++ b/rom/dev/tests/rom_integration_tests/test_fmcalias_derivation.rs
@@ -193,6 +193,7 @@ fn test_pcr_log() {
         let debug_locked = hw.soc_ifc().cptra_security_state().read().debug_locked();
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
+        let subsystem_mode = hw.subsystem_mode();
 
         // In subsystem mode, the owner PK hash flows through the DOT
         // mailbox command, not the fuse controller, so
@@ -214,6 +215,7 @@ fn test_pcr_log() {
                 VENDOR_CONFIG_KEY_1.pqc_key_idx as u8,
                 *pqc_key_type as u8,
                 owner_pk_in_fuses as u8,
+                subsystem_mode as u8,
             ],
         );
 
@@ -311,6 +313,7 @@ fn test_pcr_log_no_owner_key_digest_fuse() {
         let debug_locked = hw.soc_ifc().cptra_security_state().read().debug_locked();
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
+        let subsystem_mode = hw.subsystem_mode();
 
         check_pcr_log_entry(
             &pcr_entry_arr,
@@ -327,6 +330,7 @@ fn test_pcr_log_no_owner_key_digest_fuse() {
                 VENDOR_CONFIG_KEY_1.pqc_key_idx as u8,
                 *pqc_key_type as u8,
                 false as u8,
+                subsystem_mode as u8,
             ],
         );
 
@@ -418,6 +422,7 @@ fn test_pcr_log_fmc_fuse_svn() {
         let debug_locked = hw.soc_ifc().cptra_security_state().read().debug_locked();
 
         let anti_rollback_disable = hw.soc_ifc().fuse_anti_rollback_disable().read().dis();
+        let subsystem_mode = hw.subsystem_mode();
 
         // In subsystem mode, the owner PK hash flows through the DOT
         // mailbox command, not the fuse controller, so
@@ -439,6 +444,7 @@ fn test_pcr_log_fmc_fuse_svn() {
                 VENDOR_CONFIG_KEY_1.pqc_key_idx as u8,
                 *pqc_key_type as u8,
                 owner_pk_in_fuses as u8,
+                subsystem_mode as u8,
             ],
         );
     }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -35,7 +35,7 @@ The Runtime Firmware main function SHALL perform the following on cold boot rese
 
 * Initialize the [DICE Protection Environment (DPE)](#dice-protection-environment-dpe)
 * Initialize any SRAM structures used by Runtime Firmware
-* Upload the firwmare to the Manufacturer Control Unit (2.0, susbystem mode only)
+* Upload the firmware to the Manufacturer Control Unit (2.0, subsystem mode only)
 
 For behavior during other types of reset, see [Runtime firmware updates](#runtime-firmware-updates).
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2334,6 +2334,10 @@ mailbox functions can be used to derive a key from the returned CMK.
 
 Note that in Caliptra 2.0 in subsystem mode, derived stable keys, their derivatives, and commands using them will be marked with a FIPS status of invalid since the UDS and FE cannot be completely zeroized.
 
+The command derivation is summarized below:
+
+![CM_DERIVE_STABLE_KEY Derivation](../rom/dev/doc/svg/cm-derive-stable-key.svg)
+
 Command Code: `0x434D_4453` ("CMDS")
 
 *Table: `CM_DERIVE_STABLE_KEY` input arguments*

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -68,12 +68,21 @@ pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
 const MCU_TCI_TAG: u32 = u32::from_be_bytes(*b"MCFW");
 
-/// Create non-returning RISC-V firmware from `jal x0, 0` instructions encoded
-/// in the big-endian word order expected by the MCI MMIO window.
+/// Create non-returning RISC-V firmware from a byte-swap-invariant word whose
+/// first halfword is `c.j 0` (`0xa001`).
 fn mcu_test_firmware() -> Vec<u8> {
-    const LOOP_INSTRUCTION: [u8; 4] = [0x00, 0x00, 0x00, 0x6f];
+    const LOOP_INSTRUCTION: [u8; 4] = [0x01, 0xa0, 0xa0, 0x01];
 
     LOOP_INSTRUCTION.repeat(MCU_FW_SIZE / LOOP_INSTRUCTION.len())
+}
+
+#[test]
+fn test_mcu_test_firmware_encoding() {
+    for word in mcu_test_firmware().chunks_exact(4) {
+        let word: [u8; 4] = word.try_into().unwrap();
+        assert_eq!(word, [word[3], word[2], word[1], word[0]]);
+        assert_eq!(u16::from_le_bytes([word[0], word[1]]), 0xa001);
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -259,6 +259,7 @@ fn send_activate_firmware_cmd(
     model.finish_mailbox_execute()
 }
 
+#[cfg_attr(feature = "fpga_subsystem", allow(dead_code))]
 fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     let mut tag_cmd = MailboxReq::TagTci(TagTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -277,6 +278,7 @@ fn tag_and_get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     get_mcu_tci(model)
 }
 
+#[cfg_attr(feature = "fpga_subsystem", allow(dead_code))]
 fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
     let mut get_cmd = MailboxReq::GetTaggedTci(GetTaggedTciReq {
         hdr: MailboxReqHeader { chksum: 0 },
@@ -298,9 +300,12 @@ fn get_mcu_tci(model: &mut DefaultHwModel) -> GetTaggedTciResp {
 #[test]
 fn test_activate_mcu_fw_success() {
     let mcu_contents = mcu_test_firmware();
-    let mut hasher = Sha384::new();
-    hasher.update(&mcu_contents);
-    let mcu_digest: [u8; 48] = hasher.finalize().into();
+    #[cfg(not(feature = "fpga_subsystem"))]
+    let mcu_digest: [u8; 48] = {
+        let mut hasher = Sha384::new();
+        hasher.update(&mcu_contents);
+        hasher.finalize().into()
+    };
 
     let mcu_image = Image {
         fw_id: MCU_FW_ID_1,
@@ -311,8 +316,19 @@ fn test_activate_mcu_fw_success() {
     };
 
     let mut model = load_and_authorize_fw(&[mcu_image]);
-    let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
-    assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
+
+    // The MCU firmware DPE context is located by tagging the DPE default
+    // context. That only works when Caliptra's measurement of the MCU firmware
+    // is the last context derived. On the subsystem FPGA, MCU ROM stashes the
+    // field entropy state after Caliptra measures the MCU firmware, so the
+    // field entropy context is the default one and the MCU firmware context
+    // cannot be reached by handle.
+    #[cfg(not(feature = "fpga_subsystem"))]
+    let initial_mcu_tci = {
+        let initial_mcu_tci = tag_and_get_mcu_tci(&mut model);
+        assert_eq!(initial_mcu_tci.tci_current, mcu_digest);
+        initial_mcu_tci
+    };
 
     // Send ActivateFirmware command
     let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -68,14 +68,12 @@ pub const MCU_FW_SIZE: usize = 0x200;
 pub const SOC_FW_SIZE: usize = 256;
 const MCU_TCI_TAG: u32 = u32::from_be_bytes(*b"MCFW");
 
-/// Create a valid RISC-V firmware image that won't crash with an illegal
-/// instruction exception on real FPGA hardware. Uses `0x37` repeated, which
-/// encodes as `LUI x6, 0x37373` — a valid, harmless RISC-V instruction.
-/// The single-byte pattern is byte-swap invariant, which is required because
-/// `write_payload_to_mcu_sram` applies a BE byte swap when writing to MCU
-/// SRAM via the MCI MMIO window.
+/// Create non-returning RISC-V firmware from `jal x0, 0` instructions encoded
+/// in the big-endian word order expected by the MCI MMIO window.
 fn mcu_test_firmware() -> Vec<u8> {
-    vec![0x37u8; MCU_FW_SIZE]
+    const LOOP_INSTRUCTION: [u8; 4] = [0x00, 0x00, 0x00, 0x6f];
+
+    LOOP_INSTRUCTION.repeat(MCU_FW_SIZE / LOOP_INSTRUCTION.len())
 }
 
 #[derive(Debug, Clone)]

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -1253,6 +1253,76 @@ fn test_authorize_from_load_address() {
     assert_eq!(tagged_tci.tci_current, fw_digest);
 }
 
+// Exercises an image larger than the DMA engine's 1 MiB per-transfer limit
+// (see caliptra-rtl axi_dma_ctrl.sv DMA_MAX_XFER_SIZE). The driver must split
+// the hash into multiple <= 1 MiB DMA transfers; this checks the resulting
+// digest matches a single-shot SHA384 over the whole image.
+// Ignored on FPGA: needs > 1 MiB of staging SRAM.
+#[cfg_attr(any(feature = "fpga_realtime", feature = "fpga_subsystem"), ignore)]
+#[test]
+fn test_authorize_from_load_address_larger_than_1mib() {
+    let mut flags = ImageMetadataFlags(0);
+    flags.set_ignore_auth_check(false);
+    flags.set_image_source(ImageHashSource::LoadAddress as u32);
+
+    // 2 MiB + 3 KiB: spans three DMA transfers (1 MiB, 1 MiB, remainder).
+    let mut load_memory_contents = vec![0u8; 2 * 1024 * 1024 + 3 * 1024];
+    for (i, b) in load_memory_contents.iter_mut().enumerate() {
+        *b = i as u8;
+    }
+
+    let mut hasher = Sha384::new();
+    hasher.update(&load_memory_contents);
+    let fw_digest: [u8; 48] = hasher.finalize().into();
+
+    let image_metadata = AuthManifestImageMetadata {
+        fw_id: u32::from_le_bytes(FW_ID_1),
+        flags: flags.0,
+        digest: fw_digest,
+        image_load_address: Addr64 {
+            lo: TEST_SRAM_BASE.lo,
+            hi: TEST_SRAM_BASE.hi,
+        },
+        ..Default::default()
+    };
+    let mcu_image = [0xAAu8; 256];
+    let mcu_image_metadata = get_mcu_image_metadata(&mcu_image);
+    let auth_manifest =
+        create_auth_manifest_with_metadata([mcu_image_metadata, image_metadata].to_vec());
+    let mut model =
+        set_auth_manifest_with_test_sram(Some(auth_manifest), &load_memory_contents, &mcu_image);
+
+    write_to_test_sram(
+        &mut model,
+        image_metadata.image_load_address,
+        &load_memory_contents,
+    );
+    let mut authorize_and_stash_cmd = MailboxReq::AuthorizeAndStash(AuthorizeAndStashReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id: FW_ID_1,
+        measurement: [0; 48],
+        source: ImageHashSource::LoadAddress as u32,
+        flags: 0, // Don't skip stash
+        image_size: load_memory_contents.len() as u32,
+        ..Default::default()
+    });
+    authorize_and_stash_cmd.populate_chksum().unwrap();
+
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::AUTHORIZE_AND_STASH),
+            authorize_and_stash_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+
+    let authorize_and_stash_resp = AuthorizeAndStashResp::read_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(authorize_and_stash_resp.auth_req_result, IMAGE_AUTHORIZED);
+
+    let tagged_tci = tag_and_get_default_tci(&mut model);
+    assert_eq!(tagged_tci.tci_current, fw_digest);
+}
+
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]
 fn test_authorize_from_load_address_incorrect_digest() {

--- a/sw-emulator/lib/cpu/src/cpu.rs
+++ b/sw-emulator/lib/cpu/src/cpu.rs
@@ -495,6 +495,13 @@ impl<TBus: Bus> Cpu<TBus> {
         self.csrs.write(self.priv_mode, csr, val)
     }
 
+    /// Returns true when the core is halted via the VeeR MPMC low-power CSR
+    /// (not the RISC-V `wfi` instruction, which this emulator treats as a
+    /// no-op).
+    pub fn read_halted(&self) -> bool {
+        self.halted
+    }
+
     /// Write the specified Configuration status register as if we were in M mode
     ///
     /// # Arguments

--- a/sw-emulator/lib/cpu/src/instr/op.rs
+++ b/sw-emulator/lib/cpu/src/instr/op.rs
@@ -389,7 +389,7 @@ mod tests {
     test_rr_zerodest!(test_slt_38, slt, 16, 30);
 
     // ---------------------------------------------------------------------------------------------
-    // Tests For Multiply High Singed and Unsigned (`mulhsu`) Instruction
+    // Tests For Multiply High Signed and Unsigned (`mulhsu`) Instruction
     //
     // Test suite based on riscv-tests
     // https://github.com/riscv-software-src/riscv-tests/blob/master/isa/rv64um/mulhsu.S

--- a/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
+++ b/sw-emulator/lib/periph/src/dma/axi_root_bus.rs
@@ -29,7 +29,9 @@ use std::{rc::Rc, sync::mpsc};
 
 pub type AxiAddr = u64;
 
-const TEST_SRAM_SIZE: usize = 4 * 1024;
+// Large enough to stage firmware images bigger than the DMA's 1 MiB
+// per-transfer limit, so tests can exercise multi-transfer image hashing.
+const TEST_SRAM_SIZE: usize = 4 * 1024 * 1024;
 const EXTERNAL_TEST_SRAM_SIZE: usize = 1024 * 1024;
 const MCU_SRAM_SIZE: usize = 512 * 1024;
 
@@ -110,9 +112,11 @@ impl AxiRootBus {
             if test_sram_content.len() > TEST_SRAM_SIZE {
                 panic!("test_sram_content length exceeds TEST_SRAM_SIZE");
             }
-            let mut sram_data = [0u8; TEST_SRAM_SIZE];
-            sram_data[..test_sram_content.len()].copy_from_slice(test_sram_content);
-            Some(ReadWriteMemory::new_with_data(sram_data))
+            // Allocate zeroed (heap-backed, so a large TEST_SRAM_SIZE does not
+            // overflow the stack) and copy the caller's content into the front.
+            let mut sram = ReadWriteMemory::new();
+            sram.data_mut()[..test_sram_content.len()].copy_from_slice(test_sram_content);
+            Some(sram)
         } else {
             None
         };

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -469,16 +469,18 @@ impl Bus for SocRegistersInternal {
                 .modify(NotifGlobalIntr::AGG_STS.val(1));
         }
 
-        if regs.global_intr_en_r.reg.is_set(GlobalIntrEn::ERROR_EN)
-            && regs.error_intr_en_r.reg.get() & regs.error_internal_intr_r.reg.get() != 0
-        {
-            regs.err_irq.set_level(true);
-        }
-        if regs.global_intr_en_r.reg.is_set(GlobalIntrEn::NOTIF_EN)
-            && regs.notif_intr_en_r.reg.get() & regs.notif_internal_intr_r.reg.get() != 0
-        {
-            regs.notif_irq.set_level(true);
-        }
+        // Level interrupts: raise when an enabled status bit is pending, and
+        // (fix) LOWER when none remain. Without the else-branch the irq line
+        // latches high forever after the first event, so a core that halts
+        // (WFI/MPMC) waiting on this interrupt is immediately and perpetually
+        // re-woken -- breaking interrupt-driven idle / external descheduling.
+        let err_pending = regs.global_intr_en_r.reg.is_set(GlobalIntrEn::ERROR_EN)
+            && regs.error_intr_en_r.reg.get() & regs.error_internal_intr_r.reg.get() != 0;
+        regs.err_irq.set_level(err_pending);
+
+        let notif_pending = regs.global_intr_en_r.reg.is_set(GlobalIntrEn::NOTIF_EN)
+            && regs.notif_intr_en_r.reg.get() & regs.notif_internal_intr_r.reg.get() != 0;
+        regs.notif_irq.set_level(notif_pending);
     }
 
     fn warm_reset(&mut self) {

--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -357,6 +357,7 @@ pub struct Pcr0Input {
     pub fw_fuse_svn: u32,
     pub pqc_vendor_pub_key_index: u32,
     pub pqc_key_type: u32,
+    pub subsystem_mode: bool,
 }
 impl Pcr0Input {}
 
@@ -381,6 +382,7 @@ impl Pcr0 {
                 input.pqc_vendor_pub_key_index as u8,
                 input.pqc_key_type as u8,
                 input.owner_pub_key_hash_from_fuses as u8,
+                input.subsystem_mode as u8,
             ],
         );
         extend(
@@ -424,12 +426,13 @@ fn test_derive_pcr0() {
         fw_fuse_svn: 2,
         pqc_vendor_pub_key_index: u32::MAX,
         pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
+        subsystem_mode: false,
     });
     assert_eq!(
         pcr0,
         Pcr0([
-            1597321057, 3306746665, 3870835391, 3103173150, 3318383838, 3407565263, 3776158384,
-            4231654246, 1759479765, 3561253448, 1491479508, 1619944441
+            679012617, 2870272304, 32685831, 354009394, 790136628, 2021707955, 888925035,
+            559203880, 4286345466, 3614569310, 131280581, 1288174965
         ])
     )
 }

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -282,6 +282,7 @@ fn fake_boot_test() {
                     fw_fuse_svn: 7,
                     pqc_vendor_pub_key_index: image.manifest.header.vendor_pqc_pub_key_idx,
                     pqc_key_type: 1 as u32, // MLDSA
+                    subsystem_mode: false,
                 }),
                 &expected_ldevid_key,
             );

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -421,6 +421,8 @@ fn smoke_test() {
                 String::from_utf8_lossy(&fmc_alias_cert.to_text().unwrap())
             );
 
+            let owner_pk_in_fuses = (fuses.owner_pk_hash != [0u32; 12]) && !hw.subsystem_mode();
+
             let mut hasher = Sha384::new();
             hasher.update(&[security_state.device_lifecycle() as u8]);
             hasher.update(&[security_state.debug_locked() as u8]);
@@ -428,7 +430,7 @@ fn smoke_test() {
             hasher.update(/*vendor_ecc_pk_index=*/ &[0u8]); // No keys are revoked
             hasher.update(&[image.manifest.header.vendor_pqc_pub_key_idx as u8]);
             hasher.update(&[image.manifest.pqc_key_type]);
-            hasher.update(&[true as u8]);
+            hasher.update(&[owner_pk_in_fuses as u8]);
             hasher.update(vendor_pk_desc_hash.as_bytes());
             hasher.update(&owner_pk_hash);
             let device_info_hash = hasher.finish();
@@ -476,7 +478,7 @@ fn smoke_test() {
                     fuse_anti_rollback_disable: false,
                     vendor_pub_key_hash: vendor_pk_desc_hash_words,
                     owner_pub_key_hash: owner_pk_hash_words,
-                    owner_pub_key_hash_from_fuses: true,
+                    owner_pub_key_hash_from_fuses: owner_pk_in_fuses,
                     ecc_vendor_pub_key_index: image.manifest.preamble.vendor_ecc_pub_key_idx,
                     fmc_digest: image.manifest.fmc.digest,
                     cold_boot_fw_svn: image.manifest.header.svn,

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -431,6 +431,7 @@ fn smoke_test() {
             hasher.update(&[image.manifest.header.vendor_pqc_pub_key_idx as u8]);
             hasher.update(&[image.manifest.pqc_key_type]);
             hasher.update(&[owner_pk_in_fuses as u8]);
+            hasher.update(&[hw.subsystem_mode() as u8]);
             hasher.update(vendor_pk_desc_hash.as_bytes());
             hasher.update(&owner_pk_hash);
             let device_info_hash = hasher.finish();
@@ -486,6 +487,7 @@ fn smoke_test() {
                     fw_fuse_svn: 7,
                     pqc_vendor_pub_key_index: image.manifest.header.vendor_pqc_pub_key_idx,
                     pqc_key_type: *pqc_key_type as u32,
+                    subsystem_mode: hw.subsystem_mode(),
                 }),
                 &expected_ldevid_key,
             );

--- a/x509/build/cert.rs
+++ b/x509/build/cert.rs
@@ -8,7 +8,7 @@ File Name:
 
 Abstract:
 
-    File contains generation of X509 Certificate To Be Singed (TBS) template that can be
+    File contains generation of X509 Certificate To Be Signed (TBS) template that can be
     substituted at firmware runtime.
 
 --*/

--- a/x509/src/der_helper.rs
+++ b/x509/src/der_helper.rs
@@ -37,7 +37,7 @@ fn encode_length(val: &[u8]) -> usize {
     1
 }
 
-/// Compute len of DER encoding of an unsinged integer
+/// Compute len of DER encoding of an unsigned integer
 #[inline(never)]
 pub fn der_uint_len(val: &[u8]) -> usize {
     let encode_length = encode_length(val);


### PR DESCRIPTION
## Summary

Backport 16 changes merged after `fw-2.1.1` that are applicable to `caliptra-2.0` and not otherwise represented there. A separate final commit updates the frozen ROM hashes.

- Preserve source attribution with `git cherry-pick -x` on every backport commit.
- Adapt conflicts to the 2.0 feature set and data layouts instead of importing unavailable 2.1 functionality.
- Keep unrelated submodule worktree changes out of this branch.

## Notable changes

- Chunk SHA-384 DMA image hashing above the 1 MiB transfer limit and add regression coverage.
- Ignore ELF load segments containing ELF/program-header metadata.
- Include subsystem mode in the 2.0 DeviceStatus/PCR0 and FMC alias measurements.
- Add staged subsystem OTP provisioning and related model/test fixes.
- Backport emulator halt/interrupt fixes and OpenOCD `load_image` support.
- Add prebuilt release-artifact support and deterministic FPGA MAC generation.
- Backport applicable documentation and ownership updates.
- Regenerate `FROZEN_IMAGES.sha384sum` in separate commit `ee92965e`.

## Deliberately excluded

- Main PR #4077 is covered by active 2.0 backport PR #4119.
- `811d0d8f`: modifies a bitstream workflow absent on 2.0.
- `eda00a95`: optimizes `SIGN_WITH_EXPORTED_MLDSA`, which is unsupported on 2.0.
- `f352a153`: modifies HPKE/OCP LOCK code absent on 2.0.
- `dcaae0c7`: assumes the main branch ML-DSA test default; 2.0 deliberately defaults to LMS.

## Validation

- `cargo fmt --check --all`
- `cargo tree --locked`
- `cargo check --workspace --all-targets`
- `cargo check -p caliptra-hw-model --features fpga_subsystem`
- `cargo test -p caliptra-builder --lib`
- `cargo test -p caliptra-image-elf`
- Emulator CPU/peripheral test suites
- Large-image DMA authorization regression
- Passive/subsystem DeviceStatus ROM tests
- PCR-log and end-to-end FMC alias derivation tests
- Subsystem smoke test
- `./ci.sh check_frozen_images` (`caliptra-rom-no-log.bin`: OK, `caliptra-rom-with-log.bin`: OK)
