### PR TITLE
Fix frozen ROM device status expectations

### DIFF
--- a/test/src/derive.rs
+++ b/test/src/derive.rs
@@ -358,6 +358,7 @@ pub struct Pcr0Input {
     pub pqc_vendor_pub_key_index: u32,
     pub pqc_key_type: u32,
     pub subsystem_mode: bool,
+    pub include_subsystem_mode: bool,
 }
 impl Pcr0Input {}
 
@@ -370,21 +371,24 @@ impl Pcr0 {
             *value = sha384(&[value.as_slice(), buf].concat());
         };
 
-        extend(
-            &mut value,
-            &[
-                input.security_state.device_lifecycle() as u8,
-                input.security_state.debug_locked() as u8,
-                input.fuse_anti_rollback_disable as u8,
-                input.ecc_vendor_pub_key_index as u8,
-                input.cold_boot_fw_svn as u8,
-                input.fw_fuse_svn as u8,
-                input.pqc_vendor_pub_key_index as u8,
-                input.pqc_key_type as u8,
-                input.owner_pub_key_hash_from_fuses as u8,
-                input.subsystem_mode as u8,
-            ],
-        );
+        let device_status = [
+            input.security_state.device_lifecycle() as u8,
+            input.security_state.debug_locked() as u8,
+            input.fuse_anti_rollback_disable as u8,
+            input.ecc_vendor_pub_key_index as u8,
+            input.cold_boot_fw_svn as u8,
+            input.fw_fuse_svn as u8,
+            input.pqc_vendor_pub_key_index as u8,
+            input.pqc_key_type as u8,
+            input.owner_pub_key_hash_from_fuses as u8,
+            input.subsystem_mode as u8,
+        ];
+        let device_status_len = if input.include_subsystem_mode {
+            device_status.len()
+        } else {
+            device_status.len() - 1
+        };
+        extend(&mut value, &device_status[..device_status_len]);
         extend(
             &mut value,
             swap_word_bytes(&input.vendor_pub_key_hash).as_bytes(),
@@ -427,6 +431,7 @@ fn test_derive_pcr0() {
         pqc_vendor_pub_key_index: u32::MAX,
         pqc_key_type: FwVerificationPqcKeyType::LMS as u32,
         subsystem_mode: false,
+        include_subsystem_mode: true,
     });
     assert_eq!(
         pcr0,

--- a/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
+++ b/test/tests/caliptra_integration_tests/fake_collateral_boot_test.rs
@@ -283,6 +283,7 @@ fn fake_boot_test() {
                     pqc_vendor_pub_key_index: image.manifest.header.vendor_pqc_pub_key_idx,
                     pqc_key_type: 1 as u32, // MLDSA
                     subsystem_mode: false,
+                    include_subsystem_mode: true,
                 }),
                 &expected_ldevid_key,
             );

--- a/test/tests/caliptra_integration_tests/smoke_test.rs
+++ b/test/tests/caliptra_integration_tests/smoke_test.rs
@@ -3,7 +3,7 @@ use caliptra_api::mailbox::AlgorithmType;
 use caliptra_api::soc_mgr::SocManager;
 use caliptra_api_types::{DeviceLifecycle, Fuses};
 use caliptra_builder::firmware::{APP_WITH_UART, FMC_WITH_UART};
-use caliptra_builder::{firmware, ImageOptions};
+use caliptra_builder::{firmware, CiRomVersion, ImageOptions};
 use caliptra_common::mailbox_api::{
     GetFmcAliasEcc384CertReq, GetFmcAliasEccCsrReq, GetFmcAliasMlDsa87CertReq,
     GetFmcAliasMldsaCsrReq, GetLdevEcc384CertReq, GetLdevMldsa87CertReq, GetRtAliasEcc384CertReq,
@@ -63,6 +63,13 @@ const ROM_LATEST_TEST_PARAMS: RomTestParams = RomTestParams {
 
 fn get_rom_test_params() -> RomTestParams<'static> {
     ROM_LATEST_TEST_PARAMS
+}
+
+fn device_status_includes_subsystem_mode() -> bool {
+    match caliptra_builder::get_ci_rom_version() {
+        CiRomVersion::Rom2_0_0 | CiRomVersion::Rom2_0_1 | CiRomVersion::Rom2_0_2 => false,
+        CiRomVersion::Latest => true,
+    }
 }
 
 #[track_caller]
@@ -423,18 +430,24 @@ fn smoke_test() {
 
             let owner_pk_in_fuses = (fuses.owner_pk_hash != [0u32; 12]) && !hw.subsystem_mode();
 
-            let mut hasher = Sha384::new();
-            hasher.update(&[security_state.device_lifecycle() as u8]);
-            hasher.update(&[security_state.debug_locked() as u8]);
-            hasher.update(&[fuses.anti_rollback_disable as u8]);
-            hasher.update(/*vendor_ecc_pk_index=*/ &[0u8]); // No keys are revoked
-            hasher.update(&[image.manifest.header.vendor_pqc_pub_key_idx as u8]);
-            hasher.update(&[image.manifest.pqc_key_type]);
-            hasher.update(&[owner_pk_in_fuses as u8]);
-            hasher.update(&[hw.subsystem_mode() as u8]);
-            hasher.update(vendor_pk_desc_hash.as_bytes());
-            hasher.update(&owner_pk_hash);
-            let device_info_hash = hasher.finish();
+            let include_subsystem_mode = device_status_includes_subsystem_mode();
+            let calculate_device_info_hash = |include_subsystem_mode: bool| {
+                let mut hasher = Sha384::new();
+                hasher.update(&[security_state.device_lifecycle() as u8]);
+                hasher.update(&[security_state.debug_locked() as u8]);
+                hasher.update(&[fuses.anti_rollback_disable as u8]);
+                hasher.update(/*vendor_ecc_pk_index=*/ &[0u8]); // No keys are revoked
+                hasher.update(&[image.manifest.header.vendor_pqc_pub_key_idx as u8]);
+                hasher.update(&[image.manifest.pqc_key_type]);
+                hasher.update(&[owner_pk_in_fuses as u8]);
+                if include_subsystem_mode {
+                    hasher.update(&[hw.subsystem_mode() as u8]);
+                }
+                hasher.update(vendor_pk_desc_hash.as_bytes());
+                hasher.update(&owner_pk_hash);
+                hasher.finish()
+            };
+            let device_info_hash = calculate_device_info_hash(include_subsystem_mode);
 
             let fmc_expected_tcb_info = [
                 DiceTcbInfo {
@@ -488,6 +501,7 @@ fn smoke_test() {
                     pqc_vendor_pub_key_index: image.manifest.header.vendor_pqc_pub_key_idx,
                     pqc_key_type: *pqc_key_type as u32,
                     subsystem_mode: hw.subsystem_mode(),
+                    include_subsystem_mode,
                 }),
                 &expected_ldevid_key,
             );
@@ -626,6 +640,10 @@ fn smoke_test() {
                 );
             }
 
+            let mut fmc_csr_expected_tcb_info = fmc_expected_tcb_info;
+            fmc_csr_expected_tcb_info[0].fwids[0].digest =
+                calculate_device_info_hash(true).to_vec();
+
             // Get FMC Alias CSR so we can verify it
             let fmc_alias_csr_resp = match algorithm_type {
                 AlgorithmType::Ecc384 => hw
@@ -648,8 +666,7 @@ fn smoke_test() {
             // Validate TCB info
             let dice_tcb_info = DiceTcbInfo::find_multiple_in_csr(fmc_alias_csr_der).unwrap();
 
-            // Use the same expected TCB info from FMC Alias cert
-            assert_eq!(dice_tcb_info, fmc_expected_tcb_info);
+            assert_eq!(dice_tcb_info, fmc_csr_expected_tcb_info);
 
             // Use the same expected public key from FMC Alias cert
             match algorithm_type {


### PR DESCRIPTION
## Summary

- preserve the legacy DeviceStatus measurement layout for frozen ROMs 2.0.0 through 2.0.2
- continue validating the subsystem-mode byte for the current ROM and FMC-generated CSR
- make the ROM-version decision exhaustive so future frozen versions require an explicit layout choice

## Context

[Nightly Release 2.0 run 32269112228](https://github.com/chipsalliance/caliptra-sw/actions/runs/32269112228) failed every frozen-ROM emulator and FPGA job in `smoke_test::smoke_test`, while all latest-ROM jobs passed. The current test always included the subsystem-mode byte added by #3930, but the frozen ROM certificates and PCR0 values predate that measurement change.

## Testing

- `CPTRA_CI_ROM_VERSION=2.0.0 CPTRA_ROM_TYPE=ROM_WITH_UART cargo test -p caliptra-test --test caliptra_integration_tests smoke_test::smoke_test -- --exact`
- repeated for frozen ROMs `2.0.1` and `2.0.2`
- repeated without `CPTRA_CI_ROM_VERSION` for the current ROM
- `cargo test -p caliptra-test --lib derive::test_derive_pcr0 -- --exact`
- `cargo check -p caliptra-test --tests`
- `cargo clippy -p caliptra-test --tests -- -D warnings`
- `cargo fmt --all -- --check`