### PR TITLE
fpga: Turns flash-boot into a compile-time flag.

### DIFF
--- a/hw-model/src/model_fpga_subsystem.rs
+++ b/hw-model/src/model_fpga_subsystem.rs
@@ -1987,8 +1987,8 @@ impl HwModel for ModelFpgaSubsystem {
         };
 
         if m.flash_boot && m.use_external_i3c_host {
-            eprintln!(
-                "Warning: `use_external_i3c_host` does not make sense when flash boot is enabled (`primary_flash_initial_contents` is some)."
+            panic!(
+                "Warning: `use_external_i3c_host` does not make sense when flash boot is enabled (`primary_flash_initial_contents` is some). Try the --flash-boot=false flag."
             );
         }
 

--- a/xtask/src/fpga/configurations.rs
+++ b/xtask/src/fpga/configurations.rs
@@ -272,8 +272,12 @@ impl<'a> ActionHandler<'a> for CoreOnSubsystem {
 
     fn build_test(&self, args: &'a BuildTestArgs<'a>) -> Result<()> {
         let mut container = build_base_container_command()?;
+        let mut features = vec!["fpga_subsystem", "itrng", "ocp-lock"];
+        if *args.flash_boot {
+            features.push("flash-boot");
+        }
         let cmd = NextestArchiveCommand::new("/work-dir")
-            .features(&["fpga_subsystem", "itrng", "ocp-lock", "flash-boot"])
+            .features(&features)
             .package_filter(args.package_filter.as_deref())
             .build();
 

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -22,6 +22,7 @@ pub struct BuildArgs<'a> {
 
 pub struct BuildTestArgs<'a> {
     pub package_filter: &'a Option<String>,
+    pub flash_boot: &'a bool,
 }
 pub struct TestArgs<'a> {
     pub test_filter: &'a Option<String>,
@@ -74,6 +75,9 @@ pub enum Fpga {
         /// Uses a `cargo-nextest` package filter-set, e.g. `package(caliptra-rom)`.
         #[arg(long)]
         package_filter: Option<String>,
+        /// Enable the flash-boot feature
+        #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+        flash_boot: bool,
     },
     /// Run FPGA tests
     Test {
@@ -119,13 +123,17 @@ pub fn fpga_entry(args: &Fpga) -> Result<()> {
         Fpga::BuildTest {
             target_host,
             package_filter,
+            flash_boot,
         } => {
             println!("Building FPGA tests");
             let config = Configuration::from_cmd(target_host)?;
             config
                 .executor()
                 .set_target_host(target_host)
-                .build_test(&BuildTestArgs { package_filter })?;
+                .build_test(&BuildTestArgs {
+                    package_filter,
+                    flash_boot,
+                })?;
         }
         Fpga::Bootstrap {
             target_host,


### PR DESCRIPTION
Flag defaults to true to maintain current behavior. Turning it off might be of interest for some testing scenarios, such as testing I3C recovery.