### PR TITLE
Update the MCU firmware revision

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -61,7 +61,7 @@ permissions:
   contents: read
 
 env:
-  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '067e8dbdafc36123f99189aa14eba3ee480182ff' }}
+  CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '24ea8b90bb56c0aed5512232dfbbca3dd2e39716' }}
 
 jobs:
   check_cache:

--- a/hw-model/src/flash_image.rs
+++ b/hw-model/src/flash_image.rs
@@ -3,7 +3,7 @@
 //! Flash image builder for creating flash images in the MCU ROM format.
 //!
 //! The flash image format consists of:
-//! - A [`FlashHeader`] with magic number "FLSH", version, image count, and checksum
+//! - A [`FlashHeader`] with version, image count, and checksum
 //! - An array of [`ImageHeader`] entries describing each image
 //! - The image data itself, padded to 256-byte alignment
 //!
@@ -14,19 +14,16 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 pub const CALIPTRA_FMC_RT_IDENTIFIER: u32 = 0x0000_0000;
 pub const SOC_MANIFEST_IDENTIFIER: u32 = 0x0000_0001;
 pub const MCU_RT_IDENTIFIER: u32 = 0x0000_0002;
+pub const MAX_FILENAME_LEN: usize = 64;
+pub const HEADER_VERSION: u16 = 0x0003;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct FlashHeader {
-    pub magic: [u8; 4],
     pub version: u16,
     pub image_count: u16,
     pub image_headers_offset: u32,
     pub header_checksum: u32,
-}
-
-impl FlashHeader {
-    pub const HEADER_VERSION: u16 = 0x0001;
 }
 
 #[repr(C)]
@@ -35,6 +32,7 @@ pub struct ImageHeader {
     pub identifier: u32,
     pub offset: u32,
     pub size: u32,
+    pub filename: [u8; MAX_FILENAME_LEN],
     pub image_checksum: u32,
     pub image_header_checksum: u32,
 }
@@ -94,6 +92,7 @@ pub fn build_flash_image_bytes(
                 identifier: *id,
                 offset: current_offset,
                 size: data.len() as u32,
+                filename: [0u8; MAX_FILENAME_LEN],
                 image_checksum,
                 image_header_checksum: 0,
             };
@@ -108,8 +107,7 @@ pub fn build_flash_image_bytes(
 
     // Build flash header
     let mut flash_header = FlashHeader {
-        magic: *b"FLSH",
-        version: FlashHeader::HEADER_VERSION,
+        version: HEADER_VERSION,
         image_count: images.len() as u16,
         image_headers_offset: header_size as u32,
         header_checksum: 0,
@@ -152,9 +150,12 @@ mod tests {
 
         // Parse and verify the header
         let header = FlashHeader::read_from_prefix(&image).unwrap().0;
-        assert_eq!(&header.magic, b"FLSH");
-        assert_eq!(header.version, FlashHeader::HEADER_VERSION);
+        assert_eq!(header.version, HEADER_VERSION);
         assert_eq!(header.image_count, 3);
+        assert_eq!(
+            header.image_headers_offset,
+            core::mem::size_of::<FlashHeader>() as u32
+        );
 
         // Verify header checksum
         let checksum_offset = core::mem::offset_of!(FlashHeader, header_checksum);
@@ -168,6 +169,7 @@ mod tests {
         for i in 0..3 {
             let off = hdr_offset + i * hdr_size;
             let img_hdr = ImageHeader::read_from_prefix(&image[off..]).unwrap().0;
+            assert_eq!(img_hdr.filename, [0u8; MAX_FILENAME_LEN]);
 
             // Verify image header checksum
             let ih_checksum_offset = core::mem::offset_of!(ImageHeader, image_header_checksum);
@@ -194,6 +196,9 @@ mod tests {
         assert_eq!(hdr0.identifier, CALIPTRA_FMC_RT_IDENTIFIER);
         assert_eq!(hdr1.identifier, SOC_MANIFEST_IDENTIFIER);
         assert_eq!(hdr2.identifier, MCU_RT_IDENTIFIER);
+        assert_eq!(hdr0.offset as usize, hdr_offset + 3 * hdr_size);
+        assert_eq!(hdr1.offset, hdr0.offset + hdr0.size);
+        assert_eq!(hdr2.offset, hdr1.offset + hdr1.size);
 
         // Verify sizes are padded to 256
         assert_eq!(hdr0.size, 256); // 100 -> 256

--- a/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
+++ b/runtime/tests/runtime_integration_tests/test_authorize_and_stash.rs
@@ -215,7 +215,7 @@ fn test_authorize_and_stash_cmd_deny_authorization() {
         hasher.update(mcu_hasher.finalize());
         // MCU ROM stashes field_entropy_state measurement
         let mut fe_hasher = Sha384::new();
-        fe_hasher.update([0u8; 48]);
+        fe_hasher.update(0u32.to_le_bytes());
         hasher.update(fe_hasher.finalize());
     }
     let expected_measurement_hash = hasher.finalize();
@@ -288,7 +288,7 @@ fn test_authorize_and_stash_cmd_success() {
         hasher.update(mcu_hasher.finalize());
         // MCU ROM stashes field_entropy_state measurement
         let mut fe_hasher = Sha384::new();
-        fe_hasher.update([0u8; 48]);
+        fe_hasher.update(0u32.to_le_bytes());
         hasher.update(fe_hasher.finalize());
     }
     hasher.update(IMAGE_DIGEST1);

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -372,11 +372,10 @@ fn test_populate_idev_cannot_be_called_from_pl1() {
 #[test]
 fn test_stash_measurement_cannot_be_called_from_pl1() {
     for pqc_key_type in PQC_KEY_TYPE.iter() {
-        let mut image_opts = ImageOptions {
+        let image_opts = ImageOptions {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        image_opts.vendor_config.pl0_pauser = None;
 
         let args = RuntimeTestArgs {
             test_image_options: Some(image_opts),
@@ -387,6 +386,7 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
         model.step_until(|m| {
             m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
         });
+        model.set_axi_user(2);
 
         let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq::default());
         cmd.populate_chksum().unwrap();

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -110,7 +110,6 @@ fn test_pcr31_extended_upon_stash_measurement() {
     fn run_sequence(stash_measurement: bool) -> [u8; 48] {
         let image_options = ImageOptions::default();
         let runtime_test_args = RuntimeTestArgs {
-            test_fwid: Some(crate::test_update_reset::mbox_test_image()),
             test_image_options: Some(image_options.clone()),
             ..Default::default()
         };

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -95,7 +95,7 @@ fn test_stash_measurement() {
         hasher.update(mcu_hasher.finalize());
         // MCU ROM stashes field_entropy_state measurement
         let mut fe_hasher = Sha384::new();
-        fe_hasher.update([0u8; 48]);
+        fe_hasher.update(0u32.to_le_bytes());
         hasher.update(fe_hasher.finalize());
     }
     hasher.update(measurement);

--- a/xtask/src/fpga/mod.rs
+++ b/xtask/src/fpga/mod.rs
@@ -12,7 +12,7 @@ mod configurations;
 
 mod utils;
 
-const DEFAULT_MCU_REV: &str = "47810a48a4fcf6f80b50bac7a7e6721eb9123d6c";
+const DEFAULT_MCU_REV: &str = "24ea8b90bb56c0aed5512232dfbbca3dd2e39716";
 
 pub struct BuildArgs<'a> {
     pub fw_id: &'a Option<String>,


### PR DESCRIPTION
Update the MCU firmware revision used by FPGA builds to
`24ea8b90bb56c0aed5512232dfbbca3dd2e39716` and adapt Caliptra flash image
generation and integration tests to the behavior introduced by this MCU version.

## Changes

- Update the MCU revision used by:
  - the FPGA subsystem workflow
  - the FPGA `xtask` build flow
- Update the Caliptra flash image builder to MCU flash format v3:
  - use header version `0x0003`
  - remove the legacy `FLSH` magic
  - add the 64-byte filename field to image headers
  - update header offsets, checksums, and layout tests
- Update field entropy measurement expectations:
  - hash the one-word `FIELD_ENTROPY_STATE` fuse value
  - replace the previous assumption that the measurement contained 48 zero bytes
- Update the PL1 `STASH_MEASUREMENT` test:
  - retain the PL0 pauser while the MCU completes boot-time initialization
  - switch to the PL1 AXI user only before issuing the command under test
- Update the PCR31 stash measurement test:
  - boot with the production runtime so the MCU ROM's boot-time
    `STASH_MEASUREMENT` command is handled
  - retain the mailbox responder for the subsequent update-reset persistence checks

## Rationale

The updated MCU ROM introduces flash image format v3 and performs additional
boot-time mailbox operations, including stashing the MCU and field entropy
measurements. Tests that replaced the production runtime during initial boot or
removed the PL0 pauser before MCU initialization no longer matched the expected
boot sequence.