### PR TITLE
Upload 2.0 nightly test artifacts individually

### DIFF
--- a/.github/workflows/nightly-release-2.0.yml
+++ b/.github/workflows/nightly-release-2.0.yml
@@ -169,9 +169,15 @@ jobs:
         with:
           path: /tmp/artifacts
 
-      - name: Package all test artifacts for release
+      - name: Package test artifacts per artifact directory
         run: |
-          (cd /tmp/artifacts && zip -r - .) > ./release/test_artifacts_${{ needs.find-latest-release-2-0.outputs.new_release_tag }}.zip
+          TAG="${{ needs.find-latest-release-2-0.outputs.new_release_tag }}"
+          cd /tmp/artifacts
+          for dir in */; do
+            dirname="${dir%/}"
+            echo "Zipping ${dirname}"
+            zip -qr "$GITHUB_WORKSPACE/release/test_artifacts_${TAG}_${dirname}.zip" "$dirname"
+          done
 
       - name: Tag repo with new release number
         run: |
@@ -181,11 +187,11 @@ jobs:
           git push origin ${{ needs.find-latest-release-2-0.outputs.new_release_tag }}
 
       - name: Upload release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             ./release/caliptra_${{ needs.find-latest-release-2-0.outputs.new_release_tag }}.zip
-            ./release/test_artifacts_${{ needs.find-latest-release-2-0.outputs.new_release_tag }}.zip
+            ./release/test_artifacts_*.zip
           tag_name: ${{ needs.find-latest-release-2-0.outputs.new_release_tag }}
           prerelease: true
           draft: true


### PR DESCRIPTION
## Summary

- package each downloaded test artifact directory as a separate ZIP
- upload all test artifact ZIPs to the draft release
- update `softprops/action-gh-release` to v2, matching the current 2.x nightly workflow

## Why

Nightly run [32328487611](https://github.com/chipsalliance/caliptra-sw/actions/runs/32328487611) produced a 2,256,679,357-byte aggregate test artifact, exceeding GitHub's 2 GiB per-release-asset limit. Uploading each Actions artifact separately preserves the complete test output while keeping every release asset below the limit.

## Validation

- parsed the workflow as YAML
- ran `git diff --check`
- packaged all 80 retained artifacts from the failed nightly using this loop
- verified all 80 ZIPs with `unzip -tqq`; the largest was 103,551,422 bytes
- confirmed the same per-artifact layout is used by the 2.1.2 draft release