### PR TITLE
Update MCU revision for 2.0 FPGA tests

### DIFF
--- a/.github/workflows/fpga-subsystem.yml
+++ b/.github/workflows/fpga-subsystem.yml
@@ -47,7 +47,6 @@ on:
         default: true
         type: boolean
 
-
 jobs:
   check_cache:
     runs-on: ubuntu-22.04
@@ -86,7 +85,7 @@ jobs:
     env:
       # Change this to a new random value if you suspect the cache is corrupted
       CACHE_BUSTER: 9ff0db8889e8
-      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || '7328113c31713b3ff3da89de7901b8393dafff3c' }}
+      CALIPTRA_MCU_COMMIT: ${{ inputs.mcu-commit || 'a8b5eb8cf8ef98279988237e58f3ed9ade0072f5' }}
 
     steps:
       - name: Checkout repo

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -355,11 +355,10 @@ fn test_populate_idev_cannot_be_called_from_pl1() {
 #[test]
 fn test_stash_measurement_cannot_be_called_from_pl1() {
     for pqc_key_type in PQC_KEY_TYPE.iter() {
-        let mut image_opts = ImageOptions {
+        let image_opts = ImageOptions {
             pqc_key_type: *pqc_key_type,
             ..Default::default()
         };
-        image_opts.vendor_config.pl0_pauser = None;
 
         let args = RuntimeTestArgs {
             test_image_options: Some(image_opts),
@@ -370,6 +369,7 @@ fn test_stash_measurement_cannot_be_called_from_pl1() {
         model.step_until(|m| {
             m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
         });
+        model.set_axi_user(2);
 
         let mut cmd = MailboxReq::StashMeasurement(StashMeasurementReq::default());
         cmd.populate_chksum().unwrap();

--- a/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
+++ b/runtime/tests/runtime_integration_tests/test_stash_measurement.rs
@@ -112,7 +112,6 @@ fn test_pcr31_extended_upon_stash_measurement() {
             ..Default::default()
         };
         let runtime_test_args = RuntimeTestArgs {
-            test_fwid: Some(crate::test_update_reset::mbox_test_image()),
             test_image_options: Some(image_options.clone()),
             ..Default::default()
         };


### PR DESCRIPTION
Bump the FPGA subsystem MCU revision and update stash measurement tests to let MCU boot-time initialization complete under PL0 with the production runtime.