### PR TITLE
mldsa: Add some additional zeroizing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "hex",
  "serde_json",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]

--- a/common/crypto/mldsa/Cargo.toml
+++ b/common/crypto/mldsa/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 caliptra-dpe-response-buffer.workspace = true
 caliptra-shake.workspace = true
 zerocopy.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 hex = {workspace = true}

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -4,6 +4,7 @@ use crate::ct::{ct_ge, ct_if, ct_lt};
 use caliptra_dpe_response_buffer::{ResponseBufError, ResponseBuffer};
 use caliptra_shake::{Shake128, Shake256};
 use core::convert::TryInto;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /* Public API Constants */
 pub const MLDSA87_PRIVATE_SEED_BYTES: usize = 32;
@@ -67,7 +68,7 @@ const A_CACHE_BYTES: usize = A_CACHE_POLYS * A_CACHE_POLY_BYTES;
 
 /* Fundamental types. */
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Zeroize)]
 pub struct Scalar {
     pub c: [u32; K_DEGREE],
 }
@@ -80,18 +81,19 @@ impl Default for Scalar {
     }
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Zeroize)]
 pub struct Vector8 {
     pub v: [Scalar; 8],
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Zeroize)]
 pub struct Vector7 {
     pub v: [Scalar; 7],
 }
 
 /* Complex types. */
 
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKey {
     pub rho: [u8; K_RHO_BYTES],
     pub k: [u8; K_K_BYTES],
@@ -902,6 +904,7 @@ fn generate_key_internal(
     vector7_ntt(s1_ntt);
 
     matrix87_expand_mul(&mut priv_key.t0_ntt, rho.try_into().unwrap(), s1_ntt);
+    // s1 is cleared by overwriting it with s2, therefore we do not need to zeroize.
     vector8_inverse_ntt(&mut priv_key.t0_ntt);
 
     state = KeygenState::V8(Vector8::default());
@@ -919,6 +922,8 @@ fn generate_key_internal(
     }
 
     vector8_add_assign(&mut priv_key.t0_ntt, s2_ntt);
+    // s2 is secret and dead from here; see the s1 scrub above.
+    s2_ntt.zeroize();
 
     state = KeygenState::V8(Vector8::default());
     let t1 = match &mut state {
@@ -960,6 +965,9 @@ fn generate_key_internal(
             pub_key_hash.copy_from_slice(&tr);
         }
     }
+
+    augmented_entropy.zeroize();
+    expanded_seed.zeroize();
 }
 
 /// FIPS 204 `BitPack` of one polynomial, LSB-first, `bits` per coefficient.
@@ -1084,6 +1092,8 @@ fn sign_internal_with_mu(
                 [2 * LAMBDA_BYTES + i * 640..2 * LAMBDA_BYTES + (i + 1) * 640];
             scalar_encode_signed_20_19(out_slice, &z_i);
         }
+        // Copy of rho_prime; dead from here, and this runs per rejection iteration.
+        mask_seed.zeroize();
 
         let mut r0_max = 0u32;
         let mut ct0_max = 0u32;
@@ -1138,8 +1148,11 @@ fn sign_internal_with_mu(
             .try_into()
             .unwrap();
         hint_bit_pack(hint_out, &tmp);
-        return;
+        break;
     }
+
+    // rho_prime derives every mask y; with a published signature it recovers s1.
+    rho_prime.zeroize();
 }
 
 fn verify_internal_with_mu(
@@ -1518,6 +1531,38 @@ pub fn mldsa87_sign_mu_deterministic_from_sk(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `PrivateKey` carries `ZeroizeOnDrop` so expanded ML-DSA private key material
+    /// does not outlive a keygen/sign scope on the DCCM stack. Guards both halves of
+    /// that: the `Zeroize` impl actually clears every field, and the type still
+    /// satisfies `ZeroizeOnDrop` (so the drop glue is wired up).
+    #[test]
+    fn test_private_key_zeroize() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+        assert_zeroize_on_drop::<PrivateKey>();
+
+        let mut priv_key = PrivateKey {
+            rho: [0xAA; K_RHO_BYTES],
+            k: [0xBB; K_K_BYTES],
+            sigma: [0xCC; K_SIGMA_BYTES],
+            t0_ntt: Vector8 {
+                v: [Scalar {
+                    c: [0xDDDD_DDDD; K_DEGREE],
+                }; 8],
+            },
+        };
+
+        priv_key.zeroize();
+
+        assert!(priv_key.rho.iter().all(|&b| b == 0));
+        assert!(priv_key.k.iter().all(|&b| b == 0));
+        assert!(priv_key.sigma.iter().all(|&b| b == 0));
+        assert!(priv_key
+            .t0_ntt
+            .v
+            .iter()
+            .all(|s| s.c.iter().all(|&c| c == 0)));
+    }
 
     #[test]
     fn test_mldsa87_keygen() {

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -496,10 +496,11 @@ impl Crypto for DpeCrypto<'_> {
                 }
 
                 let mldsa_cdi = self.derive_cdi_inner_mldsa(measurement, info)?;
-                let cdi_bytes = <[u8; PQ_DEVID_CDI_SIZE as usize]>::from(*mldsa_cdi);
+                let cdi_bytes =
+                    Zeroizing::new(<[u8; PQ_DEVID_CDI_SIZE as usize]>::from(*mldsa_cdi));
                 // The borrow will be trivially true since we entered this branch of the match.
                 if let Signer::Mldsa { exported_cdi_slot } = &mut self.signer {
-                    exported_cdi_slot.cdi = cdi_bytes;
+                    exported_cdi_slot.cdi = *cdi_bytes;
                     exported_cdi_slot.handle = exported_cdi_handle;
                     exported_cdi_slot.active = U8Bool::new(true);
                 }
@@ -627,11 +628,11 @@ impl CdiManager for DpeCrypto<'_> {
                 // Copy CDI bytes to the stack so we can release the borrow on self.cdi
                 // before calling derive_key_pair_mldsa which needs &mut self.
                 let cdi_bytes = match &self.cdi {
-                    Some(Cdi::Mldsa(b)) => **b,
+                    Some(Cdi::Mldsa(b)) => Zeroizing::new(**b),
                     _ => return Err(CryptoError::CryptoLibError(1)),
                 };
                 let mut seed = Mldsa87Seed::default();
-                self.derive_key_pair_mldsa((&cdi_bytes).into(), label, info, &mut seed)?;
+                self.derive_key_pair_mldsa((&*cdi_bytes).into(), label, info, &mut seed)?;
                 self.derived_key = Some(DerivedKey::Mldsa(seed));
             }
         };

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -30,14 +30,16 @@ impl SetPqSeedCmd {
         drivers.ensure_pl0()?;
 
         let mut cmd = SetPqSeedReq::new_zeroed();
-        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())?;
+        crate::packet::copy_from_mbox(drivers, cmd.as_mut_bytes())
+            .inspect_err(|_| cmd.seed.zeroize())?;
 
         // Deriving the PQ.DevID CDI and computing the ML-DSA-87 key material
         // below exceeds the default 20M-cycle command watchdog budget; extend it.
         drivers.extend_wdt_for_pqc();
 
         let mut out = Zeroizing::new(Array4x12::default());
-        Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)?;
+        Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)
+            .inspect_err(|_| cmd.seed.zeroize())?;
 
         drivers
             .persistent_data

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -18,6 +18,7 @@ use caliptra_common::mailbox_api::{MailboxRespHeader, SetPqSeedReq, SET_PQ_SEED_
 use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult};
 use crypto::{Digest, Sha256};
 use zerocopy::{FromZeros, IntoBytes};
+use zeroize::{Zeroize, Zeroizing};
 
 pub struct SetPqSeedCmd;
 
@@ -35,13 +36,16 @@ impl SetPqSeedCmd {
         // below exceeds the default 20M-cycle command watchdog budget; extend it.
         drivers.extend_wdt_for_pqc();
 
-        let mut out = Array4x12::default();
+        let mut out = Zeroizing::new(Array4x12::default());
         Self::derive_pq_devid_cdi(drivers, &cmd.seed, &mut out)?;
 
         drivers
             .persistent_data
             .get_mut()
-            .set_pq_devid_cdi(out.into())?;
+            .set_pq_devid_cdi((*out).into())?;
+
+        // The request buffer still holds the caller-supplied seed.
+        cmd.seed.zeroize();
 
         // Calculate the digest of the PQ.DevID public key and cache it
         // in the persistent data to avoid repeated key generation passes
@@ -63,15 +67,17 @@ impl SetPqSeedCmd {
         seed: &[u8; SET_PQ_SEED_SEED_SIZE],
         out: &mut Array4x12,
     ) -> CaliptraResult<()> {
-        let mut buf = [0u8; core::mem::size_of::<Array4x12>()];
+        let mut buf = Zeroizing::new([0u8; core::mem::size_of::<Array4x12>()]);
 
         buf.get_mut(..SET_PQ_SEED_SEED_SIZE)
             .ok_or(CaliptraError::RUNTIME_MLDSA87_DEVID_SEED_TOO_LARGE)?
             .copy_from_slice(seed);
 
+        let key = Zeroizing::new(Array4x12::from(&*buf));
+
         hmac384_kdf(
             &mut drivers.hmac384,
-            (&Array4x12::from(&buf)).into(),
+            (&*key).into(),
             b"pq_devid_cdi",
             None,
             &mut drivers.trng,


### PR DESCRIPTION
As a defence in depth precaution add some additional zeroizing of sensitive information calculated as part of the MLDSA library internals and utilizing callers.

This does not effect stack usage at all, increases imem by ~400 bytes, with more than 5Kb of imem remaining, and does slightly increase the runtime of MDLSA operations.  The marginal performance regression is determined to be worth the defense in depth provided.