### PR TITLE
fpga: Adds a test for external I3C host boot

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -79,6 +79,10 @@ slow-timeout = { period = "30s", terminate-after = 100 }
 filter = 'test(test_pl0_pl1_reallocation_range)'
 slow-timeout = { period = "30s", terminate-after = 100 }
 
+[[profile.fpga-subsystem.overrides]]
+filter = 'test(test_boot_external_i3c_host)'
+slow-timeout = { period = "1m", terminate-after = 60 }
+
 [profile.fpga-subsystem.junit]
 path = "/tmp/junit.xml"
 store-success-output = true
@@ -167,6 +171,10 @@ slow-timeout = { period = "30s", terminate-after = 100 }
 [[profile.nightly.overrides]]
 filter = 'test(test_pl0_pl1_reallocation_range)'
 slow-timeout = { period = "30s", terminate-after = 100 }
+
+[[profile.nightly.overrides]]
+filter = 'test(test_boot_external_i3c_host)'
+slow-timeout = { period = "1m", terminate-after = 60 }
 
 [profile.nightly.junit]
 path = "/tmp/junit.xml"

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -176,6 +176,8 @@ pub struct RuntimeTestArgs<'a> {
     pub rom_callback: Option<ModelCallback>,
     /// Use encrypted firmware boot (RI_DOWNLOAD_ENCRYPTED_FIRMWARE instead of RI_DOWNLOAD_FIRMWARE)
     pub encrypted_boot: bool,
+    // Whether or not to use external I3C host instead of soft IP.
+    pub use_external_i3c_host: bool,
 }
 
 impl RuntimeTestArgs<'_> {
@@ -224,6 +226,7 @@ impl Default for RuntimeTestArgs<'_> {
             key_type: None,
             rom_callback: None,
             encrypted_boot: false,
+            use_external_i3c_host: false,
         }
     }
 }
@@ -346,6 +349,7 @@ pub fn start_rt_test_pqc_model(
         stable_owner_key_en: args.stable_owner_key_en,
         ss_init_params: SubsystemInitParams {
             enable_mcu_uart_log: args.subsystem_mode,
+            use_external_i3c_host: args.use_external_i3c_host,
             ..Default::default()
         },
         rom_callback: args.rom_callback,

--- a/runtime/tests/runtime_integration_tests/test_boot.rs
+++ b/runtime/tests/runtime_integration_tests/test_boot.rs
@@ -44,6 +44,19 @@ fn test_boot() {
 }
 
 #[test]
+#[ignore]
+#[cfg(all(feature = "fpga_subsystem", not(feature = "flash-boot")))]
+fn test_boot_external_i3c_host() {
+    let mut args = RuntimeTestArgs {
+        use_external_i3c_host: true,
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
+    // Waits until MCU FW is loaded.
+    model.step_until(|m| (m.soc_ifc().ss_generic_fw_exec_ctrl().at(0).read() & (1 << 2)) != 0);
+}
+
+#[test]
 /// This test differs from the drivers' test_persistent() in that it is ran with the "runtime" flag so
 /// it allows us to test conditionally compiled runtime-only persistent data that ROM/FMC may have corrupted.
 fn test_persistent_data() {


### PR DESCRIPTION
The test is ignored by default and needs to be explicitly invoked with something such as
`cargo xtask-subsystem fpga test --target-host root@192.168.0.12 --test-filter='package(caliptra-runtime) and test(test_boot_external)" --run-ignored all -E "none()'`