### PR TITLE
xtask: Add build command for OCP recovery images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6189,8 +6189,11 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "caliptra-auth-man-gen",
  "caliptra-bitstream-downloader",
  "caliptra-builder",
+ "caliptra-image-crypto",
+ "caliptra-image-types",
  "caliptra-size-history",
  "clap",
  "hex",
@@ -6203,6 +6206,7 @@ dependencies = [
  "simple_logger",
  "tokio",
  "toml_edit 0.22.27",
+ "zerocopy",
  "zip",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,7 +12,10 @@ fpga_subsystem = []
 [dependencies]
 anyhow.workspace = true
 bitstream-downloader.workspace = true
+caliptra-auth-man-gen.workspace = true
 caliptra-builder.workspace = true
+caliptra-image-crypto.workspace = true
+caliptra-image-types.workspace = true
 clap.workspace = true
 hex = "0.4"
 log.workspace = true
@@ -25,4 +28,5 @@ simple_logger.workspace = true
 size-history.workspace = true
 tokio = { version = "1.49.0", features = ["rt", "macros"] }
 toml_edit.workspace = true
+zerocopy.workspace = true
 zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,8 +3,17 @@
 use crate::util::run_command;
 use crate::PROJECT_ROOT;
 use anyhow::{bail, Result};
+use caliptra_auth_man_gen::default_test_manifest::{default_test_soc_manifest, DEFAULT_MCU_FW};
+use caliptra_builder::{
+    firmware::{APP_WITH_UART_FPGA, FMC_FPGA_WITH_UART},
+    ImageOptions,
+};
+use caliptra_image_crypto::OsslCrypto as Crypto;
+use caliptra_image_types::FwVerificationPqcKeyType;
 use log::{error, info};
+use std::path::Path;
 use std::process::Command;
+use zerocopy::IntoBytes;
 
 pub fn build_all() -> Result<()> {
     build_rom()?;
@@ -106,5 +115,56 @@ pub fn build_driver_test_fw() -> Result<()> {
         bail!("cargo build for driver test-fw failed");
     }
     info!("driver test-fw build succeeded");
+    Ok(())
+}
+
+pub fn build_ocp_recovery_images(
+    out_dir: &Path,
+    pqc_key_type: FwVerificationPqcKeyType,
+) -> Result<()> {
+    std::fs::create_dir_all(out_dir)?;
+
+    info!("Compiling Caliptra FPGA Firmware Bundle (FMC + RT)...");
+    let opts = ImageOptions {
+        pqc_key_type,
+        ..Default::default()
+    };
+    let image_bundle =
+        caliptra_builder::build_and_sign_image(&FMC_FPGA_WITH_UART, &APP_WITH_UART_FPGA, opts)?;
+    let bundle_bytes = image_bundle
+        .to_bytes()
+        .map_err(|e| anyhow::anyhow!("Failed to serialize image bundle: {e}"))?;
+    let fw_path = out_dir.join("caliptra_firmware.bin");
+    std::fs::write(&fw_path, &bundle_bytes)?;
+    info!(
+        "Created {} ({} bytes)",
+        fw_path.display(),
+        bundle_bytes.len()
+    );
+
+    info!("Generating test SoC Authorization Manifest...");
+    let manifest = default_test_soc_manifest(&DEFAULT_MCU_FW, pqc_key_type, 0, Crypto::default());
+    let manifest_bytes = manifest.as_bytes();
+    let manifest_path = out_dir.join("soc_manifest.bin");
+    std::fs::write(&manifest_path, manifest_bytes)?;
+    info!(
+        "Created {} ({} bytes)",
+        manifest_path.display(),
+        manifest_bytes.len()
+    );
+
+    info!("Writing test MCU firmware binary...");
+    let mcu_path = out_dir.join("mcu_firmware.bin");
+    std::fs::write(&mcu_path, DEFAULT_MCU_FW)?;
+    info!(
+        "Created {} ({} bytes)",
+        mcu_path.display(),
+        DEFAULT_MCU_FW.len()
+    );
+
+    info!(
+        "All 3 FPGA recovery artifacts generated in {}",
+        out_dir.display()
+    );
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -120,6 +120,15 @@ pub enum BuildCommands {
     Runtime,
     TestFw,
     All,
+    /// Build OCP recovery images (Caliptra bundle, SoC manifest, MCU firmware)
+    RecoveryImages {
+        /// Directory to output the recovery binary artifacts
+        #[arg(short, long, default_value = "target")]
+        out_dir: PathBuf,
+        /// PQC key type (1 for MLDSA, 3 for LMS)
+        #[arg(long, default_value_t = 1)]
+        pqc_key_type: u32,
+    },
 }
 
 pub static PROJECT_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -182,6 +191,22 @@ fn main() {
             BuildCommands::Runtime => build::build_runtime(),
             BuildCommands::TestFw => build::build_driver_test_fw(),
             BuildCommands::All => build::build_all(),
+            BuildCommands::RecoveryImages {
+                out_dir,
+                pqc_key_type,
+            } => match pqc_key_type {
+                1 => build::build_ocp_recovery_images(
+                    out_dir,
+                    caliptra_image_types::FwVerificationPqcKeyType::MLDSA,
+                ),
+                3 => build::build_ocp_recovery_images(
+                    out_dir,
+                    caliptra_image_types::FwVerificationPqcKeyType::LMS,
+                ),
+                _ => Err(anyhow::anyhow!(
+                    "--pqc-key-type must be 1 (MLDSA) or 3 (LMS)"
+                )),
+            },
         },
     };
     result.unwrap_or_else(|e| {


### PR DESCRIPTION
Add `cargo xtask build recovery-images` to generate the three binary artifacts required for OCP Recovery testing: Caliptra FPGA firmware bundle, SoC authorization manifest, and MCU firmware.