### PR TITLE
runtime: AES-XTS requirement compliance

### DIFF
--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1784,6 +1784,11 @@ impl CaliptraError {
             "OCP LOCK Error: LOCKED MPK is not valid"
         ),
         (
+            RUNTIME_OCP_LOCK_MEK_INVALID_XTS_KEY,
+            0x000E00B1,
+            "OCP LOCK Error: MEK is invalid XTS key"
+        ),
+        (
             RUNTIME_INVALID_ROM_PERSISTENT_DATA_MARKER,
             0x000E007A,
             "Runtime Error: Invalid ROM persistent data marker"

--- a/runtime/src/ocp_lock/mod.rs
+++ b/runtime/src/ocp_lock/mod.rs
@@ -557,11 +557,16 @@ pub struct Mek {
 impl Mek {
     /// Generate a new `Mek`
     pub fn generate(trng: &mut Trng) -> CaliptraResult<Self> {
-        let key = {
-            let seed = trng.generate16()?;
-            transmute!(seed)
-        };
-        Ok(Self { key })
+        loop {
+            let key = {
+                let seed = trng.generate16()?;
+                transmute!(seed)
+            };
+
+            if is_valid_xts_key(&key) {
+                return Ok(Self { key });
+            }
+        }
     }
 
     /// Consumes `Mek` and encrypts `Mek` with the `Mdk` and returns a `SingleEncryptedMek`
@@ -1102,6 +1107,13 @@ impl OcpLockContext {
             cfi_assert!(expect_mek_checksum == checksum);
         }
 
+        // Check validity just before AES-ECB decryption.
+        // Equality between both halves is preserved across decryption,
+        // this is the case because the half-size is a multiple of the 128-bit AES block size.
+        if !is_valid_xts_key(&mek_seed.as_ref().into()) {
+            return Err(CaliptraError::RUNTIME_OCP_LOCK_MEK_INVALID_XTS_KEY);
+        }
+
         // Decrypt MEK from MEK seed using MDK.
         aes.aes_256_ecb_decrypt_kv(mek_seed.as_ref())?;
 
@@ -1449,6 +1461,14 @@ impl OcpLockContext {
         let mek_secret = intermediate_secret.wrapping_mek_secret(hmac, trng, kv)?;
 
         let single_encrypted_mek = mek_secret.decrypt_mek(aes, trng, hmac, wrapped_mek)?;
+
+        // Check validity just before AES-ECB decryption.
+        // Equality between both halves is preserved across decryption,
+        // this is the case because the half-size is a multiple of the 128-bit AES block size.
+        if !is_valid_xts_key(&single_encrypted_mek.key) {
+            return Err(CaliptraError::RUNTIME_OCP_LOCK_MEK_INVALID_XTS_KEY);
+        }
+
         aes.aes_256_ecb_decrypt_kv(&LEArray4x16::from(single_encrypted_mek.key))?;
 
         Ok(())
@@ -1481,6 +1501,11 @@ fn timeout_to_mtime(command_timeout: Millisecond, clock_period: Picosecond) -> u
     };
 
     walltime_to_mtime(bounded_command_timeout, period)
+}
+
+/// Check if the given key is a valid key for AES-XTS-{128, 256}
+fn is_valid_xts_key(key: &[u8; 64]) -> bool {
+    key[..16] != key[16..32] && key[..32] != key[32..]
 }
 
 /// Entry point for OCP LOCK commands


### PR DESCRIPTION
AES-XTS requires that the two halves of a key be distinct. Enforce this at generation by redrawing until the key is valid, and again just before decryption, as equality between the halves is preserved across AES-ECB decryption.

The halves are checked at both 128-bit and 256-bit granularity, so the AES-XTS-{128,256} requirements are both satisfied.

Resolves #3526