### PR TITLE
runtime: Add LOAD_KAT_MEK command to help Encryption Engine self-test

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -280,6 +280,7 @@ impl CommandId {
     pub const OCP_LOCK_GET_STATUS: Self = Self(0x4753_5441); // "GSTA"
     pub const OCP_LOCK_UNLOAD_MEK: Self = Self(0x554D_454B); // "UMEK"
     pub const OCP_LOCK_LOAD_MEK: Self = Self(0x4C4D_454B); // "LMEK"
+    pub const OCP_LOCK_LOAD_KAT_MEK: Self = Self(0x4C4B_4154); // "LKAT"
 
     pub const REALLOCATE_DPE_CONTEXT_LIMITS: Self = Self(0x5243_5458); // "RCTX"
     pub const CERTIFY_KEY_CHUNKS: Self = Self(0x434B4348); // "CKCH"
@@ -447,6 +448,7 @@ pub enum MailboxResp {
     OcpLockClearKeyCache(OcpLockClearKeyCacheResp),
     OcpLockUnloadMek(OcpLockUnloadMekResp),
     OcpLockLoadMek(OcpLockLoadMekResp),
+    OcpLockLoadKatMek(OcpLockLoadKatMekResp),
     CertifyKeyChunks(CertifyKeyChunksResp),
 }
 
@@ -536,6 +538,7 @@ impl MailboxResp {
             MailboxResp::OcpLockClearKeyCache(resp) => Ok(resp.as_bytes()),
             MailboxResp::OcpLockUnloadMek(resp) => Ok(resp.as_bytes()),
             MailboxResp::OcpLockLoadMek(resp) => Ok(resp.as_bytes()),
+            MailboxResp::OcpLockLoadKatMek(resp) => Ok(resp.as_bytes()),
             MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_bytes()),
         }
     }
@@ -623,6 +626,7 @@ impl MailboxResp {
             MailboxResp::OcpLockClearKeyCache(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::OcpLockUnloadMek(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::OcpLockLoadMek(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::OcpLockLoadKatMek(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CertifyKeyChunks(resp) => Ok(resp.as_mut_bytes()),
         }
     }
@@ -783,6 +787,7 @@ pub enum MailboxReq {
     OcpLockClearKeyCache(OcpLockClearKeyCacheReq),
     OcpLockUnloadMek(OcpLockUnloadMekReq),
     OcpLockLoadMek(OcpLockLoadMekReq),
+    OcpLockLoadKatMek(OcpLockLoadKatMekReq),
     CertifyKeyChunks(CertifyKeyChunksReq),
 }
 
@@ -893,6 +898,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockUnloadMek(req) => Ok(req.as_bytes()),
             MailboxReq::OcpLockLoadMek(req) => Ok(req.as_bytes()),
+            MailboxReq::OcpLockLoadKatMek(req) => Ok(req.as_bytes()),
             MailboxReq::CertifyKeyChunks(req) => Ok(req.as_bytes()),
         }
     }
@@ -1001,6 +1007,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockUnloadMek(req) => Ok(req.as_mut_bytes()),
             MailboxReq::OcpLockLoadMek(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::OcpLockLoadKatMek(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CertifyKeyChunks(req) => Ok(req.as_mut_bytes()),
         }
     }
@@ -1115,6 +1122,7 @@ impl MailboxReq {
             MailboxReq::OcpLockClearKeyCache(_) => CommandId::OCP_LOCK_CLEAR_KEY_CACHE,
             MailboxReq::OcpLockUnloadMek(_) => CommandId::OCP_LOCK_UNLOAD_MEK,
             MailboxReq::OcpLockLoadMek(_) => CommandId::OCP_LOCK_LOAD_MEK,
+            MailboxReq::OcpLockLoadKatMek(_) => CommandId::OCP_LOCK_LOAD_KAT_MEK,
             MailboxReq::CertifyKeyChunks(_) => CommandId::CERTIFY_KEY_CHUNKS,
         }
     }
@@ -5918,6 +5926,31 @@ pub struct OcpLockLoadMekResp {
 }
 
 impl Response for OcpLockLoadMekResp {}
+
+// LOAD_KAT_MEK
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct OcpLockLoadKatMekReq {
+    pub hdr: MailboxReqHeader,
+    pub reserved: u32,
+    pub metadata: [u8; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE],
+    pub aux_metadata: [u8; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE],
+    pub cmd_timeout: u32,
+}
+
+impl Request for OcpLockLoadKatMekReq {
+    const ID: CommandId = CommandId::OCP_LOCK_LOAD_KAT_MEK;
+    type Resp = OcpLockLoadKatMekResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
+pub struct OcpLockLoadKatMekResp {
+    pub hdr: MailboxRespHeader,
+    pub reserved: u32,
+}
+
+impl Response for OcpLockLoadKatMekResp {}
 
 /// Retrieves dlen bytes  from the mailbox.
 pub fn mbox_read_response(

--- a/drivers/src/dma.rs
+++ b/drivers/src/dma.rs
@@ -1431,6 +1431,7 @@ enum EncryptionEngineCommandCode {
     LoadMek = 1,
     UnloadMek = 2,
     Zeroize = 3,
+    LoadKatMek = 4,
 }
 impl From<EncryptionEngineCommandCode> for u8 {
     fn from(val: EncryptionEngineCommandCode) -> Self {
@@ -1438,6 +1439,7 @@ impl From<EncryptionEngineCommandCode> for u8 {
             EncryptionEngineCommandCode::LoadMek => 1u8,
             EncryptionEngineCommandCode::UnloadMek => 2u8,
             EncryptionEngineCommandCode::Zeroize => 3u8,
+            EncryptionEngineCommandCode::LoadKatMek => 4u8,
         }
     }
 }
@@ -1532,6 +1534,32 @@ impl<'a> DmaEncryptionEngine<'a> {
         self.write_array_fifo(write_transaction, &aligned_aux);
     }
 
+    pub fn write_kat_mek(
+        &self,
+        mek: &[u32; OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE / size_of::<u32>()],
+        mek_size: u32,
+    ) -> CaliptraResult<()> {
+        if mek_size > OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE as u32 || mek_size & 0x3 != 0 {
+            Err(CaliptraError::OCP_LOCK_ENGINE_INVALID_MEK_SIZE)?
+        }
+
+        let write_addr = self.key_release_base + Self::OCP_LOCK_ENCRYPTION_ENGINE_MEK_OFFSET;
+        let write_transaction = DmaWriteTransaction {
+            write_addr,
+            fixed_addr: false,
+            length: mek_size,
+            origin: DmaWriteOrigin::AhbFifo,
+            aes_mode: false,
+            aes_gcm: false,
+        };
+
+        self.write_array_fifo(
+            write_transaction,
+            &mek[..mek_size as usize / size_of::<u32>()],
+        );
+        Ok(())
+    }
+
     /// Used by OCP LOCK to release an MEK to the Encryption Engine key vault
     pub fn release_mek_from_key_vault(
         &self,
@@ -1577,6 +1605,11 @@ impl<'a> DmaEncryptionEngine<'a> {
 
     pub fn execute_load_command(&self) {
         let ctrl = EncryptionEngineCtrl::execute(EncryptionEngineCommandCode::LoadMek);
+        self.write_ctrl(ctrl.0);
+    }
+
+    pub fn execute_load_kat_command(&self) {
+        let ctrl = EncryptionEngineCtrl::execute(EncryptionEngineCommandCode::LoadKatMek);
         self.write_ctrl(ctrl.0);
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -636,7 +636,8 @@ fn execute_command(
         | ocp_lock_command_id @ CommandId::OCP_LOCK_CLEAR_KEY_CACHE
         | ocp_lock_command_id @ CommandId::OCP_LOCK_UNLOAD_MEK
         | ocp_lock_command_id @ CommandId::OCP_LOCK_DERIVE_MEK
-        | ocp_lock_command_id @ CommandId::OCP_LOCK_LOAD_MEK => {
+        | ocp_lock_command_id @ CommandId::OCP_LOCK_LOAD_MEK
+        | ocp_lock_command_id @ CommandId::OCP_LOCK_LOAD_KAT_MEK => {
             ocp_lock::command_handler(ocp_lock_command_id, drivers, cmd_bytes, resp)
         }
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),

--- a/runtime/src/ocp_lock/load_kat_mek.rs
+++ b/runtime/src/ocp_lock/load_kat_mek.rs
@@ -4,11 +4,11 @@ Licensed under the Apache-2.0 license.
 
 File Name:
 
-    load_mek.rs
+    load_kat_mek.rs
 
 Abstract:
 
-    File contains LOAD_MEK mailbox command.
+    File contains LOAD_KAT_MEK mailbox command.
 
 --*/
 
@@ -16,15 +16,37 @@ use crate::mutrefbytes;
 use crate::Drivers;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use caliptra_common::keyids::ocp_lock::KEY_ID_MEK;
-use caliptra_common::mailbox_api::{MailboxRespHeader, OcpLockLoadMekReq, OcpLockLoadMekResp};
+use caliptra_common::mailbox_api::{
+    MailboxRespHeader, OcpLockLoadKatMekReq, OcpLockLoadKatMekResp,
+    OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE,
+};
 use caliptra_drivers::{CaliptraError, CaliptraResult, DmaEncryptionEngine};
 use zerocopy::FromBytes;
 
 use super::timeout_to_mtime;
 
-pub struct LoadMekCmd;
-impl LoadMekCmd {
+/// MEK for KAT support. The value is fixed in the OCP L.O.C.K. specification
+const KAT_MEK: [u32; OCP_LOCK_ENCRYPTION_ENGINE_MAX_MEK_SIZE / size_of::<u32>()] = [
+    0x0000_0000,
+    0x0000_0000,
+    0x0000_0000,
+    0x0000_0000,
+    0x1111_1111,
+    0x1111_1111,
+    0x1111_1111,
+    0x1111_1111,
+    0x2222_2222,
+    0x2222_2222,
+    0x2222_2222,
+    0x2222_2222,
+    0x3333_3333,
+    0x3333_3333,
+    0x3333_3333,
+    0x3333_3333,
+];
+
+pub struct LoadKatMekCmd;
+impl LoadKatMekCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(
@@ -32,11 +54,11 @@ impl LoadMekCmd {
         cmd_bytes: &[u8],
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        if cmd_bytes.len() != size_of::<OcpLockLoadMekReq>() {
+        if cmd_bytes.len() != size_of::<OcpLockLoadKatMekReq>() {
             Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
         }
 
-        let cmd = OcpLockLoadMekReq::ref_from_bytes(cmd_bytes)
+        let cmd = OcpLockLoadKatMekReq::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
         let soc_ifc = &mut drivers.soc_ifc;
 
@@ -59,24 +81,11 @@ impl LoadMekCmd {
         // Write AUX
         dma_encryption_engine.write_aux(&cmd.aux_metadata);
 
-        // Handle MEK generation
-        let wrapped_mek = (&cmd.wrapped_mek).try_into()?;
-        drivers.ocp_lock_context.load_mek_into_key_vault(
-            &mut drivers.aes,
-            &mut drivers.trng,
-            &mut drivers.hmac,
-            &mut drivers.key_vault,
-            &wrapped_mek,
-        )?;
+        // Write Known MEK
+        dma_encryption_engine.write_kat_mek(&KAT_MEK, soc_ifc.ocp_lock_get_key_size())?;
 
-        // Write MEK
-        dma_encryption_engine
-            .release_mek_from_key_vault(soc_ifc.ocp_lock_get_key_size(), || {
-                drivers.key_vault.erase_key(KEY_ID_MEK)
-            })?;
-
-        // Write Load command
-        dma_encryption_engine.execute_load_command();
+        // Write Load KAT test key command
+        dma_encryption_engine.execute_load_kat_command();
 
         // Wait the execution to be done
         let result = dma_encryption_engine.wait_done(soc_ifc, cmd_mtimeout)?;
@@ -91,9 +100,9 @@ impl LoadMekCmd {
         };
 
         // Populate response
-        let resp = mutrefbytes::<OcpLockLoadMekResp>(resp)?;
+        let resp = mutrefbytes::<OcpLockLoadKatMekResp>(resp)?;
         resp.hdr = MailboxRespHeader::default();
 
-        Ok(core::mem::size_of::<OcpLockLoadMekResp>())
+        Ok(core::mem::size_of::<OcpLockLoadKatMekResp>())
     }
 }

--- a/runtime/src/ocp_lock/mod.rs
+++ b/runtime/src/ocp_lock/mod.rs
@@ -49,6 +49,7 @@ mod get_algorithms;
 mod get_hpke_pubkey;
 mod get_status;
 mod initialize_mek_secret;
+mod load_kat_mek;
 mod load_mek;
 mod mix_mpk;
 mod rewrap_mpk;
@@ -61,6 +62,7 @@ pub use derive_mek::DeriveMekCmd;
 pub use get_algorithms::GetAlgorithmsCmd;
 pub use get_status::GetStatusCmd;
 pub use initialize_mek_secret::InitializeMekSecretCmd;
+pub use load_kat_mek::LoadKatMekCmd;
 pub use load_mek::LoadMekCmd;
 pub use mix_mpk::MixMpkCmd;
 pub use unload_mek::UnloadMekCmd;
@@ -1554,6 +1556,7 @@ pub fn command_handler(
         CommandId::OCP_LOCK_CLEAR_KEY_CACHE => ClearKeyCacheCmd::execute(drivers, cmd_bytes, resp),
         CommandId::OCP_LOCK_UNLOAD_MEK => UnloadMekCmd::execute(drivers, cmd_bytes, resp),
         CommandId::OCP_LOCK_LOAD_MEK => LoadMekCmd::execute(drivers, cmd_bytes, resp),
+        CommandId::OCP_LOCK_LOAD_KAT_MEK => LoadKatMekCmd::execute(drivers, cmd_bytes, resp),
         _ => Err(CaliptraError::RUNTIME_UNIMPLEMENTED_COMMAND),
     }
 }

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/mod.rs
@@ -8,6 +8,7 @@ use caliptra_api::{
         OcpLockGetHpkePubKeyReq, OcpLockGetHpkePubKeyResp, OcpLockInitializeMekSecretReq,
         OcpLockReportHekMetadataReq, OcpLockReportHekMetadataResp,
         OcpLockReportHekMetadataRespFlags, OcpLockRewrapMpkReq, SealedAccessKey, WrappedKey,
+        OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE, OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE,
         OCP_LOCK_MAX_ENC_LEN, OCP_LOCK_WRAPPED_KEY_MAX_INFO_LEN,
         OCP_LOCK_WRAPPED_KEY_MAX_METADATA_LEN,
     },
@@ -39,6 +40,7 @@ mod test_get_algorithms;
 mod test_get_hpke_pubkey;
 mod test_get_status;
 mod test_initialize_mek_secret;
+mod test_load_kat_mek;
 mod test_load_mek;
 mod test_mix_mpk;
 mod test_rewrap_mpk;
@@ -51,6 +53,12 @@ const ALL_HPKE_ALGS: &[HpkeAlgorithms] = &[
     HpkeAlgorithms::ECDH_P384_HKDF_SHA384_AES_256_GCM,
     HpkeAlgorithms::ML_KEM_1024_ECDH_P384_HKDF_SHA384_AES_256_GCM,
 ];
+
+const TEST_METADATA: [u8; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE] =
+    [0xDE; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE];
+
+const TEST_AUX: [u8; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE] =
+    [0xFE; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE];
 
 #[cfg_attr(feature = "fpga_realtime", ignore)]
 #[test]

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_kat_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_kat_mek.rs
@@ -1,0 +1,158 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_api::mailbox::{
+    CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, OcpLockLoadKatMekReq,
+    OcpLockLoadKatMekResp,
+};
+use caliptra_error::CaliptraError;
+use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use zerocopy::{FromBytes, IntoBytes};
+
+use super::{
+    boot_ocp_lock_runtime, validate_ocp_lock_response, OcpLockBootParams, TEST_AUX, TEST_METADATA,
+};
+
+fn validate_failure_response(
+    model: &mut DefaultHwModel,
+    response: std::result::Result<Option<Vec<u8>>, ModelError>,
+    expected_error: CaliptraError,
+) {
+    validate_ocp_lock_response(model, response, |response, _| {
+        let error_code = response.unwrap_err();
+        assert_eq!(
+            error_code,
+            ModelError::MailboxCmdFailed(expected_error.into())
+        );
+    });
+}
+
+fn validate_success_response(
+    model: &mut DefaultHwModel,
+    response: std::result::Result<Option<Vec<u8>>, ModelError>,
+) {
+    validate_ocp_lock_response(model, response, |response, _| {
+        let response = response.unwrap().unwrap();
+        let response = OcpLockLoadKatMekResp::ref_from_bytes(response.as_bytes()).unwrap();
+
+        // Verify response checksum
+        assert!(caliptra_common::checksum::verify_checksum(
+            response.hdr.chksum,
+            0x0,
+            &response.as_bytes()[core::mem::size_of_val(&response.hdr.chksum)..],
+        ));
+
+        // Verify FIPS status
+        assert_eq!(
+            response.hdr.fips_status,
+            MailboxRespHeader::FIPS_STATUS_APPROVED
+        );
+    });
+}
+
+#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[test]
+fn test_load_kat_mek_command_success() {
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
+        force_ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    let mut cmd = MailboxReq::OcpLockLoadKatMek(OcpLockLoadKatMekReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        reserved: 0,
+        metadata: TEST_METADATA,
+        aux_metadata: TEST_AUX,
+        cmd_timeout: 0xFFFF_FFFF,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let response = model.mailbox_execute(
+        CommandId::OCP_LOCK_LOAD_KAT_MEK.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    validate_success_response(&mut model, response);
+}
+
+#[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
+#[test]
+fn test_load_kat_mek_timeout() {
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
+        force_ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    let mut cmd = MailboxReq::OcpLockLoadKatMek(OcpLockLoadKatMekReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        reserved: 0,
+        metadata: TEST_METADATA,
+        aux_metadata: TEST_AUX,
+        cmd_timeout: 0,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let response = model.mailbox_execute(
+        CommandId::OCP_LOCK_LOAD_KAT_MEK.into(),
+        cmd.as_bytes().unwrap(),
+    );
+
+    validate_failure_response(&mut model, response, CaliptraError::OCP_LOCK_ENGINE_TIMEOUT);
+}
+
+#[test]
+fn test_load_kat_mek_truncated_request() {
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
+        force_ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    let mut cmd = MailboxReq::OcpLockLoadKatMek(OcpLockLoadKatMekReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        reserved: 0,
+        metadata: TEST_METADATA,
+        aux_metadata: TEST_AUX,
+        cmd_timeout: 0,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let payload = cmd.as_bytes().unwrap();
+
+    let response = model.mailbox_execute(
+        CommandId::OCP_LOCK_LOAD_KAT_MEK.into(),
+        &payload[..payload.len() - 4],
+    );
+
+    validate_failure_response(
+        &mut model,
+        response,
+        CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS,
+    );
+}
+
+#[test]
+fn test_load_kat_mek_request_with_trailing_zero() {
+    let mut model = boot_ocp_lock_runtime(OcpLockBootParams {
+        force_ocp_lock_en: true,
+        ..Default::default()
+    });
+
+    let mut cmd = MailboxReq::OcpLockLoadKatMek(OcpLockLoadKatMekReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        reserved: 0,
+        metadata: TEST_METADATA,
+        aux_metadata: TEST_AUX,
+        cmd_timeout: 0xFFFF_FFFF,
+    });
+    cmd.populate_chksum().unwrap();
+
+    let mut payload = [0u8; size_of::<OcpLockLoadKatMekReq>() + 4];
+    payload[..size_of::<OcpLockLoadKatMekReq>()].copy_from_slice(cmd.as_bytes().unwrap());
+
+    let response = model.mailbox_execute(CommandId::OCP_LOCK_LOAD_KAT_MEK.into(), &payload);
+
+    validate_failure_response(
+        &mut model,
+        response,
+        CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS,
+    );
+}

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_load_mek.rs
@@ -4,7 +4,7 @@ use crate::test_update_reset::update_fw;
 use caliptra_api::mailbox::{
     CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, OcpLockGenerateMekReq,
     OcpLockGenerateMekResp, OcpLockInitializeMekSecretReq, OcpLockLoadMekReq, OcpLockLoadMekResp,
-    WrappedKey, OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE, OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE,
+    WrappedKey,
 };
 use caliptra_builder::{firmware::APP_WITH_UART_OCP_LOCK_FPGA, ImageOptions};
 use caliptra_error::CaliptraError;
@@ -15,14 +15,9 @@ use caliptra_test::derive::{DoeInput, DoeOutput, Mek, OcpLockKeyLadderBuilder};
 use zerocopy::{FromBytes, IntoBytes};
 
 use super::{
-    boot_ocp_lock_runtime, validate_ocp_lock_response, InitializeMekSecretParams, OcpLockBootParams,
+    boot_ocp_lock_runtime, validate_ocp_lock_response, InitializeMekSecretParams,
+    OcpLockBootParams, TEST_AUX, TEST_METADATA,
 };
-
-const TEST_METADATA: [u8; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE] =
-    [0xDE; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE];
-
-const TEST_AUX: [u8; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE] =
-    [0xFE; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE];
 
 fn generate_test_mek() -> (Mek, WrappedKey) {
     let doe_out = DoeOutput::generate(&DoeInput::default());

--- a/runtime/tests/runtime_integration_tests/test_ocp_lock/test_unload_mek.rs
+++ b/runtime/tests/runtime_integration_tests/test_ocp_lock/test_unload_mek.rs
@@ -3,8 +3,7 @@
 use caliptra_api::mailbox::{
     CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, OcpLockGenerateMekReq,
     OcpLockGenerateMekResp, OcpLockInitializeMekSecretReq, OcpLockLoadMekReq, OcpLockLoadMekResp,
-    OcpLockUnloadMekReq, OcpLockUnloadMekResp, OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE,
-    OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE,
+    OcpLockUnloadMekReq, OcpLockUnloadMekResp,
 };
 use caliptra_api::SocManager;
 use caliptra_error::CaliptraError;
@@ -12,14 +11,9 @@ use caliptra_hw_model::{HwModel, ModelError};
 use zerocopy::{FromBytes, IntoBytes};
 
 use super::{
-    boot_ocp_lock_runtime, validate_ocp_lock_response, InitializeMekSecretParams, OcpLockBootParams,
+    boot_ocp_lock_runtime, validate_ocp_lock_response, InitializeMekSecretParams,
+    OcpLockBootParams, TEST_AUX, TEST_METADATA,
 };
-
-const TEST_METADATA: [u8; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE] =
-    [0xDE; OCP_LOCK_ENCRYPTION_ENGINE_METADATA_SIZE];
-
-const TEST_AUX: [u8; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE] =
-    [0xFE; OCP_LOCK_ENCRYPTION_ENGINE_AUX_SIZE];
 
 #[cfg(not(any(feature = "fpga_realtime", feature = "fpga_subsystem")))]
 #[test]

--- a/sw-emulator/lib/periph/src/dma/encryption_engine.rs
+++ b/sw-emulator/lib/periph/src/dma/encryption_engine.rs
@@ -43,6 +43,7 @@ register_bitfields! [
             LOAD_MEK = 1,
             UNLOAD_MEK = 2,
             ZEROIZE = 3,
+            LOAD_KAT_MEK = 4,
         ],
         ERR OFFSET(16) NUMBITS(4) [
             NO_ERROR = 0,
@@ -81,6 +82,7 @@ impl TryFrom<u32> for Control::CMD::Value {
             0x1 => Ok(Control::CMD::Value::LOAD_MEK),
             0x2 => Ok(Control::CMD::Value::UNLOAD_MEK),
             0x3 => Ok(Control::CMD::Value::ZEROIZE),
+            0x4 => Ok(Control::CMD::Value::LOAD_KAT_MEK),
             _ => Err(()),
         }
     }
@@ -160,7 +162,7 @@ impl StateMachineContext for Context {
             Err(())
         } else {
             match Control::CMD::Value::try_from(self.command) {
-                Ok(Control::CMD::Value::LOAD_MEK) => {
+                Ok(Control::CMD::Value::LOAD_MEK) | Ok(Control::CMD::Value::LOAD_KAT_MEK) => {
                     if self.key_cache.len() >= KEY_CACHE_SIZE {
                         self.error = Control::ERR::Value::VENDOR_SPECIFIC_KEY_CACHE_FULL;
                     } else if let std::collections::hash_map::Entry::Vacant(e) =
@@ -559,6 +561,34 @@ mod tests {
         // Check if the MEK is not loaded
         let entry_count = ee.state_machine.context.key_cache.len();
         assert_eq!(entry_count, 1);
+    }
+
+    #[test]
+    fn test_encryption_engine_load_kat_mek_success() {
+        let mut ee = EncryptionEngine::new();
+
+        // Write (METD, AUX, MEK) into SFRs. Just like LOAD_MEK, the MEK bytes
+        // come from whatever was DMA'd into the SFR beforehand.
+        write_test_mek_entry(&mut ee);
+
+        // Execute "Load KAT MEK" command
+        let result = execute_command(&mut ee, Control::CMD::Value::LOAD_KAT_MEK as u32);
+        assert_eq!(result, Ok(()));
+
+        // Wait until the execution is done and check CTRL SFR
+        wait_done(&mut ee).unwrap();
+        assert_ctrl_eq!(
+            ee,
+            Control::RDY::READY + Control::DONE::DONE + Control::CMD::LOAD_KAT_MEK
+        );
+
+        // Clear SFRs
+        clear(&mut ee);
+        assert_ctrl_eq!(ee, Control::RDY::READY);
+
+        // Check that the SFR-written MEK was cached, same as LOAD_MEK would do
+        let entry = ee.state_machine.context.key_cache.get(&TEST_METD).unwrap();
+        assert_eq!(entry.1, TEST_MEK);
     }
 
     #[test]


### PR DESCRIPTION
Add LOAD_KAT_MEK mailbox command that loads a fixed MEK into the Encryption Engine. This operation bypasses the Key Vault slot for MEK, and use DMA FIFO to write an MEK.

Related emulator logics are added

Resolves #3527