### PR TITLE
[persistent-data] add marker and versioning

### DIFF
--- a/drivers/src/persistent.rs
+++ b/drivers/src/persistent.rs
@@ -47,12 +47,18 @@ pub const AUTH_MAN_IMAGE_METADATA_MAX_SIZE: u32 = 7 * 1024;
 pub const IDEVID_CSR_SIZE: u32 = 1024;
 pub const FMC_ALIAS_CSR_SIZE: u32 = 1024;
 pub const DPE_PL_CONTEXT_LIMITS_SIZE: u32 = 2;
+pub const DPE_PL_CONTEXT_LIMITS_PADDING_SIZE: u32 = 2;
+pub const PERSISTENT_DATA_MARKER_SIZE: u32 = 4;
+pub const PERSISTENT_DATA_VERSION_SIZE: u32 = 4;
 pub const PQ_DEVID_CDI_SIZE: u32 = 48;
 pub const PQ_DEVID_PUB_KEY_DIGEST_SIZE: u32 = 32;
 pub const PQC_STATUS_FLAGS_SIZE: u32 = 1;
 pub const PQC_MODE_ENABLED_FLAG: u8 = 1;
 pub const RESERVED_MEMORY_SIZE: u32 = 1024
-    - 2
+    - DPE_PL_CONTEXT_LIMITS_SIZE
+    - DPE_PL_CONTEXT_LIMITS_PADDING_SIZE
+    - PERSISTENT_DATA_MARKER_SIZE
+    - PERSISTENT_DATA_VERSION_SIZE
     - PQ_DEVID_CDI_SIZE
     - PQ_DEVID_PUB_KEY_DIGEST_SIZE
     - PQC_STATUS_FLAGS_SIZE
@@ -356,6 +362,10 @@ pub struct PersistentData {
 
     pub dpe_pl0_context_limit: u8,
     pub dpe_pl1_context_limit: u8,
+    pub dpe_pl_context_limits_padding: [u8; DPE_PL_CONTEXT_LIMITS_PADDING_SIZE as usize],
+
+    pub marker: u32,
+    pub version: u32,
 
     // Always private: the PQ.DevID CDI must only be reached through
     // `pq_devid_cdi()`, which hands out a reference exclusively once the seed
@@ -383,6 +393,9 @@ impl Zeroize for PersistentData {
 }
 
 impl PersistentData {
+    pub const MAGIC: u32 = u32::from_be_bytes(*b"FWPD");
+    pub const VERSION: u32 = 1;
+
     pub fn pqc_mode_enabled(&self) -> bool {
         self.pqc_status_flags & PQC_MODE_ENABLED_FLAG != 0
     }
@@ -540,7 +553,20 @@ impl PersistentData {
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
             );
 
-            persistent_data_offset += DPE_PL_CONTEXT_LIMITS_SIZE;
+            persistent_data_offset +=
+                DPE_PL_CONTEXT_LIMITS_SIZE + DPE_PL_CONTEXT_LIMITS_PADDING_SIZE;
+            assert_eq!(
+                addr_of!((*P).marker) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+
+            persistent_data_offset += PERSISTENT_DATA_VERSION_SIZE;
+            assert_eq!(
+                addr_of!((*P).version) as u32,
+                memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
+            );
+
+            persistent_data_offset += PERSISTENT_DATA_MARKER_SIZE;
             assert_eq!(
                 addr_of!((*P).pq_devid_cdi) as u32,
                 memory_layout::PERSISTENT_DATA_ORG + persistent_data_offset
@@ -642,11 +668,66 @@ unsafe fn ref_mut_from_addr<'a, T: TryFromBytes>(addr: u32) -> &'a mut T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::mem::offset_of;
 
     #[test]
     fn test_layout() {
         // NOTE: It's not good enough to test this from the host; we also need
         // to call assert_matches_layout() in a risc-v test.
         PersistentData::assert_matches_layout();
+    }
+
+    #[test]
+    fn test_fw_persistent_data_size() {
+        let expected_size = memory_layout::PERSISTENT_DATA_SIZE as usize;
+        if size_of::<PersistentData>() != expected_size {
+            panic!(
+                "PersistentData size has changed from {} to {}. If this is intentional, update \
+                the expected_size in this test and CONSIDER BUMPING THE VERSION NUMBER",
+                expected_size,
+                size_of::<PersistentData>()
+            );
+        }
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_fw_persistent_data_offsets() {
+        let actual_expected = [
+            (offset_of!(PersistentData, manifest1), 0, "manifest1"),
+            (offset_of!(PersistentData, manifest2), 6144, "manifest2"),
+            (offset_of!(PersistentData, fht), 12288, "fht"),
+            (offset_of!(PersistentData, ldevid_tbs), 14336, "ldevid_tbs"),
+            (offset_of!(PersistentData, fmcalias_tbs), 15360, "fmcalias_tbs"),
+            (offset_of!(PersistentData, rtalias_tbs), 16384, "rtalias_tbs"),
+            (offset_of!(PersistentData, pcr_log), 17408, "pcr_log"),
+            (offset_of!(PersistentData, measurement_log), 18432, "measurement_log"),
+            (offset_of!(PersistentData, fuse_log), 19456, "fuse_log"),
+            (offset_of!(PersistentData, dpe), 20480, "dpe"),
+            (offset_of!(PersistentData, pcr_reset), 25600, "pcr_reset"),
+            (offset_of!(PersistentData, auth_manifest_image_metadata_col), 26624, "auth_manifest_image_metadata_col"),
+            (offset_of!(PersistentData, idevid_csr), 33792, "idevid_csr"),
+            (offset_of!(PersistentData, fmc_alias_csr), 34816, "fmc_alias_csr"),
+            (offset_of!(PersistentData, dpe_pl0_context_limit), 35840, "dpe_pl0_context_limit"),
+            (offset_of!(PersistentData, dpe_pl1_context_limit), 35841, "dpe_pl1_context_limit"),
+            (offset_of!(PersistentData, marker), 35844, "marker"),
+            (offset_of!(PersistentData, version), 35848, "version"),
+            (offset_of!(PersistentData, pq_devid_cdi), 35852, "pq_devid_cdi"),
+            (offset_of!(PersistentData, pq_devid_pub_key_digest), 35900, "pq_devid_pub_key_digest"),
+            (offset_of!(PersistentData, pqc_status_flags), 35932, "pqc_status_flags"),
+            (offset_of!(PersistentData, mldsa_exported_cdi_slots), 35933, "mldsa_exported_cdi_slots"),
+            (offset_of!(PersistentData, reserved_memory), 36014, "reserved_memory"),
+        ];
+
+        for (actual, expected, name) in actual_expected {
+            if actual != expected {
+                panic!(
+                    "PersistentData offset for {} has changed from {} to {}. If this is \
+                    intentional, update the expected values in this test and CONSIDER BUMPING THE \
+                    VERSION NUMBER",
+                    name, expected, actual
+                );
+            }
+        }
     }
 }

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1338,6 +1338,16 @@ impl CaliptraError {
             0x000E0071,
             "Runtime Error: Invalid PQ.DevID Public Key Hash"
         ),
+        (
+            RUNTIME_INVALID_FW_PERSISTENT_DATA_MARKER,
+            0x000E0072,
+            "Runtime Error: Invalid FW persistent data marker"
+        ),
+        (
+            RUNTIME_INVALID_FW_PERSISTENT_DATA_VERSION,
+            0x000E0073,
+            "Runtime Error: Invalid FW persistent data version"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (
@@ -1416,6 +1426,16 @@ impl CaliptraError {
         ),
         (FMC_ALIAS_CSR_OVERFLOW, 0x000F0013, "FMC Alias CSR Overflow"),
         (FMC_REGENERATE_FMC_KEY_PAIR_FAILED, 0x000F0014, "FMC Error: Regenerating FMC Key Pair Failed"),
+        (
+            FMC_INVALID_FW_PERSISTENT_DATA_MARKER,
+            0x000F0015,
+            "FMC Error: Invalid FW persistent data marker"
+        ),
+        (
+            FMC_INVALID_FW_PERSISTENT_DATA_VERSION,
+            0x000F0016,
+            "FMC Error: Invalid FW persistent data version"
+        ),
         (
             DRIVER_TRNG_EXT_TIMEOUT,
             0x00100001,

--- a/fmc/src/flow/mod.rs
+++ b/fmc/src/flow/mod.rs
@@ -31,15 +31,32 @@ use caliptra_drivers::CaliptraResult;
 /// * `env` - FMC Environment
 pub fn run(env: &mut FmcEnv) -> CaliptraResult<()> {
     {
-        use caliptra_cfi_lib::cfi_assert_eq;
-        use caliptra_drivers::ResetReason;
+        use caliptra_cfi_lib::{cfi_assert_eq, cfi_assert_ne};
+        use caliptra_drivers::{PersistentData, ResetReason};
+        use caliptra_error::CaliptraError;
 
         let reset_reason = env.soc_ifc.reset_reason();
 
         if reset_reason == ResetReason::ColdReset {
             cfi_assert_eq(env.soc_ifc.reset_reason(), ResetReason::ColdReset);
+
+            let pdata = env.persistent_data.get_mut();
+            pdata.marker = PersistentData::MAGIC;
+            pdata.version = PersistentData::VERSION;
+
             // Generate the FMC Alias Certificate Signing Request (CSR)
             fmc_alias_csr::generate_csr(env)?;
+        } else {
+            cfi_assert_ne(env.soc_ifc.reset_reason(), ResetReason::ColdReset);
+
+            // Check persistent data is valid
+            let pdata = env.persistent_data.get();
+            if pdata.marker != PersistentData::MAGIC {
+                return Err(CaliptraError::FMC_INVALID_FW_PERSISTENT_DATA_MARKER);
+            }
+            if pdata.version != PersistentData::VERSION {
+                return Err(CaliptraError::FMC_INVALID_FW_PERSISTENT_DATA_VERSION);
+            }
         }
     }
 

--- a/fmc/src/main.rs
+++ b/fmc/src/main.rs
@@ -81,6 +81,10 @@ pub extern "C" fn entry_point() -> ! {
     if env.persistent_data.get().fht.is_valid() {
         // Set FHT fields and jump to RT for val-FMC for now
         if cfg!(feature = "fake-fmc") {
+            let pdata = env.persistent_data.get_mut();
+            pdata.marker = caliptra_drivers::PersistentData::MAGIC;
+            pdata.version = caliptra_drivers::PersistentData::VERSION;
+
             env.persistent_data.get_mut().fht.rt_cdi_kv_hdl =
                 HandOffDataHandle::from(DataStore::KeyVaultSlot(KEY_ID_RT_CDI));
             env.persistent_data.get_mut().fht.rt_priv_key_kv_hdl =

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -20,6 +20,7 @@ core::arch::global_asm!(include_str!("ext_intr.S"));
 use caliptra_cfi_lib::CfiCounter;
 use caliptra_common::{cprintln, handle_fatal_error};
 use caliptra_cpu::{log_trap_record, TrapRecord};
+use caliptra_drivers::PersistentData;
 use caliptra_error::CaliptraError;
 use caliptra_registers::soc_ifc::SocIfcReg;
 use caliptra_runtime::Drivers;
@@ -71,6 +72,15 @@ pub extern "C" fn entry_point() -> ! {
         CfiCounter::reset(&mut entropy_gen);
     } else {
         cprintln!("[state] CFI Disabled");
+    }
+
+    // Check persistent data is valid
+    let pdata = drivers.persistent_data.get();
+    if pdata.marker != PersistentData::MAGIC {
+        handle_fatal_error(CaliptraError::RUNTIME_INVALID_FW_PERSISTENT_DATA_MARKER.into());
+    }
+    if pdata.version != PersistentData::VERSION {
+        handle_fatal_error(CaliptraError::RUNTIME_INVALID_FW_PERSISTENT_DATA_VERSION.into());
     }
 
     drivers.run_reset_flow().unwrap_or_else(|e| {


### PR DESCRIPTION
This will make it easier to evolve in the future and ensure we are interpreting the information correctly on hitless updates. Similar to #2944.

This adds tests that check general size and offset values to see if anything has changed. If it fails, it could be breaking backwards compatibility so it recommends bumping the version number. Similar to #3476.