### PR TITLE
[mjolnir]: enable full scan workflow

### DIFF
--- a/.github/workflows/mjolnir_full_scan.yml
+++ b/.github/workflows/mjolnir_full_scan.yml
@@ -1,0 +1,51 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+
+name: Mjolnir Security Audit (Full Scan)
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        default: "caliptra-1.x"
+        type: string
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch or ref to scan"
+        default: "caliptra-1.x"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  mjolnir-full-scan:
+    name: Mjolnir Security Audit (Full Scan)
+    runs-on: e2-standard-2-reporter
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || 'caliptra-1.x' }}
+          fetch-depth: 0
+
+      - name: Install Nix
+        run: |
+          sh <(curl -L https://nixos.org/nix/install) --no-daemon
+          . ~/.nix-profile/etc/profile.d/nix.sh
+          mkdir -p ~/.config/nix
+          echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+
+      - name: Run Mjolnir Full Security Audit
+        run: |
+          nix run path:.#full-scan
+
+      - name: Sync Audit Artifacts to GCS
+        run: |
+          nix run path:.#deploy-gcs-runs -- \
+            --bucket "caliptra-github-ci-caliptra-reports-embargoed" \
+            --output-dir "./tools/mjolnir/results"

--- a/tools/mjolnir/jobs/full-scan.nix
+++ b/tools/mjolnir/jobs/full-scan.nix
@@ -1,0 +1,12 @@
+# Licensed under the Apache-2.0 license
+# SPDX-License-Identifier: Apache-2.0
+{
+  name = "Full Scan";
+  localDir = ".";
+  srcDirs = [
+    "runtime/src"
+    "drivers/src"
+    "rom/dev/src"
+    "fmc/src"
+  ];
+}


### PR DESCRIPTION
This PR adds the ability to initiate manual codebase-wide scans via GitHub Actions, as well as scheduled weekly scans.