### PR TITLE
Add execution of CSRNG KAT before usage in CFI init

### DIFF
--- a/FROZEN_IMAGES.sha384sum
+++ b/FROZEN_IMAGES.sha384sum
@@ -1,3 +1,3 @@
 # WARNING: Do not update this file without the approval of the Caliptra TAC
-a11e8bc61c80a462c67a78b936062bdfab258bc8fa4087d7378e3fb0c06718f926f3cbef7f4a509fad830450950c0d2b  caliptra-rom-no-log.bin
-f6b53df86db0b07935eb2c0f0caa12717652dabd233ebd11aff9a984439ba91261f4c8ee4275f8089f7f13fade8ec4ee  caliptra-rom-with-log.bin
+9c74eae1f628d9e14983f732aae48f1164155cbcd3aecb9bd5b4ba5082b7e2e52a10c5a0725526e26a2f2c6530b677bd  caliptra-rom-no-log.bin
+2b94c130494a7f395d3e1560a4cede745d3f47fdb82e28d4fce47f593aee20e664064bf488c4924b8e0636e543f9ef11  caliptra-rom-with-log.bin

--- a/rom/dev/src/main.rs
+++ b/rom/dev/src/main.rs
@@ -74,6 +74,12 @@ pub extern "C" fn rom_entry() -> ! {
         Err(e) => handle_fatal_error(e.into()),
     };
 
+    // Run CSRNG KAT before any CSRNG output is consumed
+    #[cfg(not(feature = "fake-rom"))]
+    if let Err(e) = CsrngKat::default().execute(&mut env.trng) {
+        handle_fatal_error(e.into());
+    }
+
     if !cfg!(feature = "no-cfi") {
         cprintln!("[state] CFI Enabled");
         let mut entropy_gen = || env.trng.generate4();

--- a/rom/dev/tests/rom_integration_tests/test_cfi.rs
+++ b/rom/dev/tests/rom_integration_tests/test_cfi.rs
@@ -9,6 +9,7 @@ use caliptra_common::RomBootStatus;
 use caliptra_emu_cpu::CoverageBitmaps;
 use caliptra_hw_model::{BootParams, HwModel, InitParams};
 
+#[allow(dead_code)]
 fn find_symbol<'a>(symbols: &'a [Symbol<'a>], name: &str) -> &'a Symbol<'a> {
     symbols
         .iter()
@@ -57,8 +58,7 @@ fn test_memcpy_not_called_before_cfi_init() {
 
         hw.step_until_boot_status(RomBootStatus::CfiInitialized.into(), true);
 
-        assert_symbol_not_called(&hw, find_symbol(&symbols, "memcpy"));
-        assert_symbol_not_called(&hw, find_symbol(&symbols, "memset"));
+        // Ideally we would also check for memcpy and memset, but the CSRNG KAT has to happen before the CFI init which uses it
         assert_symbol_not_called(&hw, find_symbol_containing(&symbols, "read_volatile_slice"));
         assert_symbol_not_called(
             &hw,


### PR DESCRIPTION
2.0 cherry pick of https://github.com/chipsalliance/caliptra-sw/pull/4106