### PR TITLE
rom: set FIPS status on ML-DSA verify response

### DIFF
--- a/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
+++ b/rom/dev/src/flow/cold_reset/fw_processor/mldsa_verify.rs
@@ -14,6 +14,7 @@ Abstract:
 
 use caliptra_common::mailbox_api::MailboxRespHeader;
 use caliptra_drivers::{report_fw_error_non_fatal, CaliptraResult, Mldsa87};
+use zerocopy::FromBytes;
 
 pub struct MldsaVerifyCmd;
 impl MldsaVerifyCmd {
@@ -21,13 +22,16 @@ impl MldsaVerifyCmd {
     pub(crate) fn execute(
         cmd_bytes: &[u8],
         mldsa87: &mut Mldsa87,
-        _resp: &mut [u8],
+        resp: &mut [u8],
     ) -> CaliptraResult<usize> {
         let result = caliptra_common::verify::MldsaVerifyCmd::execute(mldsa87, cmd_bytes);
 
         match result {
             Ok(_) => {
-                // Zero value of response buffer is good
+                let resp = MailboxRespHeader::mut_from_prefix(resp)
+                    .map_err(|_| caliptra_drivers::CaliptraError::ROM_GLOBAL_EXCEPTION)?
+                    .0;
+                resp.fips_status = MailboxRespHeader::FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST;
                 Ok(core::mem::size_of::<MailboxRespHeader>())
             }
             Err(e) => {


### PR DESCRIPTION
`ECDSA384_SIGNATURE_VERIFY` sets `fips_status` to `FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST` on success, because the caller supplies the digest rather than the message being signed (`rom/dev/src/flow/cold_reset/fw_processor/ecdsa_verify.rs`).

`MLDSA87_SIGNATURE_VERIFY` is the same class of operation, but its handler took the response buffer as `_resp` and left it untouched, with the comment "Zero value of response buffer is good". Since `FIPS_STATUS_APPROVED = 0` and `FIPS_STATUS_NOT_APPROVED_USER_SUPPLIED_DIGEST = 0x5553_5244` ("USRD") (`api/src/mailbox.rs:1158-1159`), that response reported **approved** status for an operation its ECDSA counterpart reports as **not approved**.

This populates the field the same way `ecdsa_verify.rs` does. No behavioural change beyond the reported status; the error path is untouched.

## Verification

`cargo check -p caliptra-rom` passes on the host target, which typechecks the modified source. The change also builds for `riscv32imc-unknown-none-elf` under `--profile firmware --no-default-features --features cfi`, invoked from `rom/dev`.

## Note: `main` does not build with `--no-default-features`

Worth flagging separately, as it is unrelated to this change:

```
error: cannot find macro `cfi_assert` in this scope
  --> rom/dev/src/flow/cold_reset/ocp_lock.rs:33:9
error[E0425]: cannot find function `cfi_launder` in this scope
  --> rom/dev/src/flow/cold_reset/ocp_lock.rs:30:8
```

plus the same pair at `:142` and `:145`. `ocp_lock.rs:6-9` gates its `cfi_assert` / `cfi_launder` imports behind `#[cfg(feature = "cfi")]` but uses them unconditionally at those four sites. Since `rom/dev/Cargo.toml:69` sets `default = ["std", "cfi"]`, dropping default features removes the imports but not the uses. Other ROM files import the same helpers ungated, for example `fw_processor/mod.rs:27-28`.

Reproduces identically on unmodified `main`, verified with a clean worktree as a control. Happy to file it separately.
