### PR TITLE
pl0 checks

### DIFF
--- a/runtime/src/activate_firmware.rs
+++ b/runtime/src/activate_firmware.rs
@@ -40,6 +40,9 @@ impl ActivateFirmwareCmd {
         cmd_args: &[u8],
         resp: &mut [u8],
     ) -> CaliptraResult<usize> {
+        // Restrict to PL0
+        drivers.ensure_pl0()?;
+
         let fw_id_count: usize = {
             let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
             let offset = offset_of!(ActivateFirmwareReq, fw_id_count);

--- a/runtime/src/certify_key_extended.rs
+++ b/runtime/src/certify_key_extended.rs
@@ -14,7 +14,7 @@ Abstract:
 
 use crate::{
     invoke_dpe::{dpe_error_detail, invoke_dpe_cmd},
-    mutrefbytes, CaliptraDpeProfile, Drivers, PauserPrivileges,
+    mutrefbytes, CaliptraDpeProfile, Drivers,
 };
 use arrayvec::ArrayVec;
 use caliptra_api::mailbox::CertifyKeyExtendedMldsa87Req;
@@ -70,13 +70,8 @@ impl CertifyKeyExtendedCmd {
         certify_key_req: &[u8; CertifyKeyExtendedEcc384Req::CERTIFY_KEY_REQ_SIZE],
         mbox_resp: &mut [u8],
     ) -> CaliptraResult<usize> {
-        match drivers.caller_privilege_level() {
-            // CERTIFY_KEY_EXTENDED MUST only be called from PL0
-            PauserPrivileges::PL0 => (),
-            PauserPrivileges::PL1 => {
-                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-            }
-        }
+        // CERTIFY_KEY_EXTENDED MUST only be called from PL0
+        drivers.ensure_pl0()?;
 
         // Populate the otherName only if requested and provided by ADD_SUBJECT_ALT_NAME
         let dmtf_device_info = if flags.contains(CertifyKeyExtendedFlags::DMTF_OTHER_NAME) {

--- a/runtime/src/drivers.rs
+++ b/runtime/src/drivers.rs
@@ -1143,6 +1143,16 @@ impl Drivers {
         self.privilege_level_from_locality(locality)
     }
 
+    /// Reject the command unless the caller is PL0. Used by the several commands
+    /// that are restricted to PL0, so the check is compiled once.
+    #[inline(never)]
+    pub fn ensure_pl0(&self) -> CaliptraResult<()> {
+        match self.caller_privilege_level() {
+            PauserPrivileges::PL0 => Ok(()),
+            PauserPrivileges::PL1 => Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL),
+        }
+    }
+
     pub fn privilege_level_from_locality(&self, locality: u32) -> PauserPrivileges {
         let manifest_header = self.persistent_data.get().manifest1.header;
         let flags = manifest_header.flags;

--- a/runtime/src/fe_programming.rs
+++ b/runtime/src/fe_programming.rs
@@ -26,6 +26,9 @@ impl FeProgrammingCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_bytes: &[u8]) -> CaliptraResult<usize> {
+        // Restrict to PL0
+        drivers.ensure_pl0()?;
+
         let cmd = FeProgReq::ref_from_bytes(cmd_bytes)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -432,7 +432,13 @@ fn execute_command_with_common_resp(
         }
         CommandId::EXTEND_PCR => ExtendPcrCmd::execute(drivers, cmd_bytes),
         CommandId::STASH_MEASUREMENT => StashMeasurementCmd::execute(drivers, cmd_bytes, resp),
-        CommandId::DISABLE_ATTESTATION => DisableAttestationCmd::execute(drivers),
+        CommandId::DISABLE_ATTESTATION => {
+            // Restrict to PL0. The check lives here rather than in
+            // DisableAttestationCmd::execute because the reset/error paths call
+            // execute() directly, outside of any mailbox command.
+            drivers.ensure_pl0()?;
+            DisableAttestationCmd::execute(drivers)
+        }
         CommandId::AUTHORIZE_AND_STASH => AuthorizeAndStashCmd::execute(drivers, cmd_bytes, resp),
         CommandId::CAPABILITIES => CapabilitiesCmd::execute(resp),
         CommandId::FW_INFO => FwInfoCmd::execute(drivers, resp),

--- a/runtime/src/populate_idev.rs
+++ b/runtime/src/populate_idev.rs
@@ -16,7 +16,7 @@ use caliptra_common::mailbox_api::{PopulateIdevEcc384CertReq, PopulateIdevMldsa8
 use caliptra_error::{CaliptraError, CaliptraResult};
 use zerocopy::FromBytes;
 
-use crate::{Drivers, PauserPrivileges};
+use crate::Drivers;
 
 pub struct PopulateIDevIdEcc384CertCmd;
 impl PopulateIDevIdEcc384CertCmd {
@@ -42,9 +42,7 @@ impl PopulateIDevIdEcc384CertCmd {
         }
 
         // PL1 cannot call this mailbox command
-        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-        }
+        drivers.ensure_pl0()?;
 
         // Avoid stack allocation by reusing the existing ArrayVec in-place.
         // Instead of creating a temporary ArrayVec, we shift existing content
@@ -124,9 +122,7 @@ impl PopulateIDevIdMldsa87CertCmd {
         }
 
         // PL1 cannot call this mailbox command
-        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-            return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-        }
+        drivers.ensure_pl0()?;
 
         // Avoid stack allocation by reusing the existing ArrayVec in-place.
         // Instead of creating a temporary ArrayVec, we shift existing content

--- a/runtime/src/reallocate_dpe_context_limits.rs
+++ b/runtime/src/reallocate_dpe_context_limits.rs
@@ -15,8 +15,8 @@ Abstract:
 use crate::mutrefbytes;
 use crate::Drivers;
 use crate::{
-    PauserPrivileges, PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
-    PL0_DPE_ACTIVE_CONTEXT_THRESHOLD_MIN, PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
+    PL0_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD, PL0_DPE_ACTIVE_CONTEXT_THRESHOLD_MIN,
+    PL1_DPE_ACTIVE_CONTEXT_DEFAULT_THRESHOLD,
 };
 use caliptra_common::mailbox_api::{
     MailboxRespHeader, ReallocateDpeContextLimitsReq, ReallocateDpeContextLimitsResp,
@@ -41,9 +41,7 @@ impl ReallocateDpeContextLimitsCmd {
         let pl1_context_limit = TOTAL_DPE_CONTEXT_LIMIT as u32 - cmd.pl0_context_limit;
 
         // Only allowed by PL0
-        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-            Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?
-        }
+        drivers.ensure_pl0()?;
 
         // Error checking for distribution limits
         if cmd.pl0_context_limit < PL0_DPE_ACTIVE_CONTEXT_THRESHOLD_MIN as u32 {

--- a/runtime/src/set_auth_manifest.rs
+++ b/runtime/src/set_auth_manifest.rs
@@ -15,10 +15,7 @@ Abstract:
 use core::cmp::min;
 use core::mem::size_of;
 
-use crate::{
-    drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers,
-    PauserPrivileges,
-};
+use crate::{drivers::CaliptraManagedDpeContext, manifest::sorted_metadata_lists_overlap, Drivers};
 use caliptra_auth_man_types::{
     AuthManifestFlags, AuthManifestImageMetadata, AuthManifestImageMetadataCollection,
     AuthManifestPreamble, OwnerAuthManifestImageMetadataCollection,
@@ -747,9 +744,7 @@ impl SetAuthManifestCmd {
         verify_only: bool,
     ) -> CaliptraResult<usize> {
         // Restrict to PL0
-        if drivers.caller_privilege_level() != PauserPrivileges::PL0 {
-            Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL)?
-        }
+        drivers.ensure_pl0()?;
 
         // Validate cmd length
         let manifest_size: usize = {

--- a/runtime/src/set_owner_auth_manifest.rs
+++ b/runtime/src/set_owner_auth_manifest.rs
@@ -328,6 +328,9 @@ impl SetOwnerAuthManifestCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<usize> {
+        // Restrict to PL0
+        drivers.ensure_pl0()?;
+
         let manifest_size: usize = {
             let err = CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS;
             let offset = offset_of!(SetOwnerAuthManifestReq, manifest_size);

--- a/runtime/src/sign_with_exported_ecdsa.rs
+++ b/runtime/src/sign_with_exported_ecdsa.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::{dpe_crypto::DpeCrypto, mutrefbytes, Drivers, PauserPrivileges};
+use crate::{dpe_crypto::DpeCrypto, mutrefbytes, Drivers};
 
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -61,13 +61,8 @@ impl SignWithExportedEcdsaCmd {
         let cmd = SignWithExportedEcdsaReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
 
-        match drivers.caller_privilege_level() {
-            // SIGN_WITH_EXPORTED_ECDSA MUST only be called from PL0
-            PauserPrivileges::PL0 => (),
-            PauserPrivileges::PL1 => {
-                return Err(CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL);
-            }
-        }
+        // SIGN_WITH_EXPORTED_ECDSA MUST only be called from PL0
+        drivers.ensure_pl0()?;
 
         let key_id_rt_cdi = Drivers::get_key_id_rt_cdi(drivers)?;
         let key_id_rt_priv_key = Drivers::get_key_id_rt_ecc_priv_key(drivers)?;

--- a/runtime/tests/runtime_integration_tests/common.rs
+++ b/runtime/tests/runtime_integration_tests/common.rs
@@ -490,6 +490,7 @@ pub fn check_header_checksum(resp: &[u8]) -> anyhow::Result<()> {
 
 /// Response from `execute_dpe_cmd_raw` that can hold responses larger than
 /// `InvokeDpeResp::DATA_MAX_SIZE` (needed for MLDSA87 certify-key responses).
+#[derive(Debug)]
 pub struct DpeRawResp {
     pub data_size: u32,
     pub data: Vec<u8>,

--- a/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
+++ b/runtime/tests/runtime_integration_tests/test_activate_firmware.rs
@@ -1,14 +1,17 @@
 // Licensed under the Apache-2.0 license
+use crate::common::{run_rt_test, RuntimeTestArgs};
 use crate::test_authorize_and_stash::set_auth_manifest_with_test_sram;
 use crate::test_set_auth_manifest::create_auth_manifest_with_metadata;
-use caliptra_api::mailbox::ActivateFirmwareReq;
+use caliptra_api::{mailbox::ActivateFirmwareReq, SocManager};
 use caliptra_auth_man_types::AuthManifestImageMetadata;
 use caliptra_auth_man_types::{Addr64, ImageMetadataFlags};
 use caliptra_common::mailbox_api::{
     AuthorizeAndStashReq, AuthorizeAndStashResp, CommandId, GetTaggedTciReq, GetTaggedTciResp,
     ImageHashSource, MailboxReq, MailboxReqHeader, TagTciReq,
 };
+use caliptra_error::CaliptraError;
 use caliptra_hw_model::{DefaultHwModel, HwModel, ModelError};
+use caliptra_image_types::FwVerificationPqcKeyType;
 use caliptra_runtime::IMAGE_AUTHORIZED;
 use sha2::{Digest, Sha384};
 use zerocopy::FromBytes;
@@ -552,4 +555,54 @@ fn test_invalid_exec_bit_in_manifest() {
     activate_cmd.populate_chksum().unwrap();
 
     assert!(send_activate_firmware_cmd(&mut model, activate_cmd, false).is_err());
+}
+
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+#[test]
+fn test_activate_firmware_cannot_be_called_from_pl1() {
+    // Boot with no PL0 pauser so that every caller is PL1. No auth manifest is
+    // loaded: the privilege check is the first thing ACTIVATE_FIRMWARE does, so
+    // a PL1 caller must be rejected before any request parsing or manifest
+    // lookup. A PL0 caller would instead get past the check and fail later with
+    // RUNTIME_MAILBOX_INVALID_PARAMS.
+    // The key type must match the fuse value `run_rt_test` programs, or ROM
+    // rejects the image and the boot never reaches the runtime.
+    let mut image_opts = caliptra_builder::ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read()
+            == u32::from(caliptra_runtime::RtBootStatus::RtReadyForCommands)
+    });
+
+    let mut activate_cmd = MailboxReq::ActivateFirmware(ActivateFirmwareReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        fw_id_count: 1,
+        mcu_fw_image_size: MCU_FW_SIZE as u32,
+        fw_ids: {
+            let mut arr = [0u32; 128];
+            arr[0] = MCU_FW_ID_1;
+            arr
+        },
+    });
+    activate_cmd.populate_chksum().unwrap();
+
+    assert_eq!(
+        model.mailbox_execute(
+            u32::from(CommandId::ACTIVATE_FIRMWARE),
+            activate_cmd.as_bytes().unwrap(),
+        ),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL.into()
+        ))
+    );
 }

--- a/runtime/tests/runtime_integration_tests/test_fe_programming.rs
+++ b/runtime/tests/runtime_integration_tests/test_fe_programming.rs
@@ -5,11 +5,14 @@ use caliptra_api::{
     mailbox::{FeProgReq, MailboxReq, MailboxReqHeader},
     SocManager,
 };
+use caliptra_builder::ImageOptions;
 use caliptra_common::mailbox_api::CommandId;
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{
     DeviceLifecycle, HwModel, InitParams, ModelError, SecurityState, SubsystemInitParams,
 };
+use caliptra_image_types::FwVerificationPqcKeyType;
+use caliptra_runtime::RtBootStatus;
 
 #[cfg_attr(feature = "fpga_realtime", ignore)] // FE programming is not supported on core FPGA
 #[test]
@@ -78,6 +81,49 @@ fn test_fe_programming_invalid_partition() {
         model.mailbox_execute(u32::from(CommandId::FE_PROG), cmd.as_bytes().unwrap()),
         Err(ModelError::MailboxCmdFailed(
             CaliptraError::RUNTIME_FE_PROG_INVALID_PARTITION.into()
+        ))
+    );
+}
+
+#[test]
+fn test_fe_programming_cannot_be_called_from_pl1() {
+    let rom = crate::common::rom_for_fw_integration_tests().unwrap();
+    let init_params = InitParams {
+        rom: &rom,
+        security_state: *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Production),
+        ..Default::default()
+    };
+
+    // Boot with no PL0 pauser so that every caller is PL1. The key type must
+    // match the fuse value run_rt_test programs, or the image fails verification.
+    let mut image_opts = ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        init_params: Some(init_params),
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    // A partition that would otherwise be valid, on a Production part: the only
+    // reason for the rejection is the caller's privilege level.
+    let mut cmd = MailboxReq::FeProg(FeProgReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        partition: 1,
+    });
+    cmd.populate_chksum().unwrap();
+
+    assert_eq!(
+        model.mailbox_execute(u32::from(CommandId::FE_PROG), cmd.as_bytes().unwrap()),
+        Err(ModelError::MailboxCmdFailed(
+            CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL.into()
         ))
     );
 }

--- a/runtime/tests/runtime_integration_tests/test_fe_programming.rs
+++ b/runtime/tests/runtime_integration_tests/test_fe_programming.rs
@@ -91,6 +91,11 @@ fn test_fe_programming_cannot_be_called_from_pl1() {
     let init_params = InitParams {
         rom: &rom,
         security_state: *SecurityState::default().set_device_lifecycle(DeviceLifecycle::Production),
+        ss_init_params: SubsystemInitParams {
+            enable_mcu_uart_log: true,
+            ..Default::default()
+        },
+        subsystem_mode: true,
         ..Default::default()
     };
 
@@ -105,6 +110,7 @@ fn test_fe_programming_cannot_be_called_from_pl1() {
     let mut model = run_rt_test(RuntimeTestArgs {
         init_params: Some(init_params),
         test_image_options: Some(image_opts),
+        subsystem_mode: true,
         ..Default::default()
     });
 

--- a/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
+++ b/runtime/tests/runtime_integration_tests/test_pauser_privilege_levels.rs
@@ -1,10 +1,12 @@
 // Licensed under the Apache-2.0 license
 
-use crate::common::{CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE};
+use crate::common::{
+    execute_dpe_cmd_raw, CertifyKeyCommandNoRef, CreateCertifyKeyCmdArgs, PQC_KEY_TYPE,
+};
 use caliptra_api::{
     mailbox::{
-        CertifyKeyChunksFlags, CertifyKeyChunksReq, RevokeExportedCdiHandleReq,
-        SignWithExportedEcdsaReq,
+        CertifyKeyChunksFlags, CertifyKeyChunksReq, CertifyKeyExtendedReq,
+        RevokeExportedCdiHandleReq, SignWithExportedEcdsaReq,
     },
     SocManager,
 };
@@ -14,8 +16,8 @@ use caliptra_builder::{
     ImageOptions,
 };
 use caliptra_common::mailbox_api::{
-    CertifyKeyExtendedFlags, CertifyKeyExtendedReq, CommandId, MailboxReq, MailboxReqHeader,
-    PopulateIdevEcc384CertReq, SetAuthManifestReq, StashMeasurementReq,
+    CertifyKeyExtendedFlags, CommandId, MailboxReq, MailboxReqHeader, PopulateIdevEcc384CertReq,
+    SetAuthManifestReq, SetOwnerAuthManifestReq, StashMeasurementReq,
 };
 use caliptra_error::CaliptraError;
 use caliptra_hw_model::{BootParams, Fuses, HwModel, InitParams, SecurityState};
@@ -42,6 +44,7 @@ use crate::common::{
     assert_error, execute_dpe_cmd, run_rt_test, run_rt_test_pqc, DpeResult, RuntimeTestArgs,
     TEST_LABEL,
 };
+use crate::test_info::get_fwinfo;
 
 #[test]
 fn test_pl0_derive_context_dpe_context_thresholds() {
@@ -951,4 +954,121 @@ fn test_user_not_pl0() {
         );
         assert!(resp.is_none());
     }
+}
+
+#[test]
+#[cfg_attr(feature = "fpga_realtime", ignore)]
+fn test_external_dpe_responses_cannot_be_called_from_pl1() {
+    // Boot with no PL0 pauser so that every caller is PL1. The key type must
+    // match the fuse value `run_rt_test` programs, and the rest of the vendor
+    // config must stay as the default fake signing keys.
+    let mut image_opts = ImageOptions {
+        pqc_key_type: FwVerificationPqcKeyType::LMS,
+        ..Default::default()
+    };
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        subsystem_mode: true,
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let certify_key_cmd = CertifyKeyCommandNoRef::new(CreateCertifyKeyCmdArgs::default());
+
+    let resp = execute_dpe_cmd_raw(
+        &mut model,
+        CaliptraDpeProfile::Mldsa87,
+        &mut Command::from(&certify_key_cmd),
+    )
+    .unwrap_err();
+
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        resp,
+    );
+}
+
+#[test]
+fn test_set_owner_auth_manifest_cannot_be_called_from_pl1() {
+    for pqc_key_type in PQC_KEY_TYPE.iter() {
+        let mut image_opts = ImageOptions {
+            pqc_key_type: *pqc_key_type,
+            ..Default::default()
+        };
+        image_opts.vendor_config.pl0_pauser = None;
+
+        let args = RuntimeTestArgs {
+            test_image_options: Some(image_opts),
+            ..Default::default()
+        };
+        let mut model = run_rt_test_pqc(args, *pqc_key_type);
+
+        model.step_until(|m| {
+            m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+        });
+
+        let mut cmd = MailboxReq::SetOwnerAuthManifest(SetOwnerAuthManifestReq {
+            hdr: MailboxReqHeader { chksum: 0 },
+            manifest_size: 0,
+            manifest: [0u8; SetOwnerAuthManifestReq::MAX_MAN_SIZE],
+        });
+        cmd.populate_chksum().unwrap();
+
+        let resp = model
+            .mailbox_execute(
+                u32::from(CommandId::SET_OWNER_AUTH_MANIFEST),
+                cmd.as_bytes().unwrap(),
+            )
+            .unwrap_err();
+        assert_error(
+            &mut model,
+            CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+            resp,
+        );
+    }
+}
+
+#[test]
+fn test_disable_attestation_cannot_be_called_from_pl1() {
+    let mut image_opts = ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let args = RuntimeTestArgs {
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    };
+    let mut model = run_rt_test(args);
+
+    model.step_until(|m| {
+        m.soc_ifc().cptra_boot_status().read() == u32::from(RtBootStatus::RtReadyForCommands)
+    });
+
+    let payload = MailboxReqHeader {
+        chksum: caliptra_common::checksum::calc_checksum(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            &[],
+        ),
+    };
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::DISABLE_ATTESTATION),
+            payload.as_bytes(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL,
+        resp,
+    );
+
+    // The rejected command must not have zeroized any CDIs: attestation is
+    // still enabled. get_fwinfo() asserts attestation_disabled == 0.
+    get_fwinfo(&mut model);
 }


### PR DESCRIPTION
Change ensure pl0 to be a helper function to save ~1.3Kb of instruction memory.  Include some commands.