### PR TITLE
Correct CM_DERIVE_STABLE_KEY command encoding documentation

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -251,7 +251,7 @@ impl CommandId {
     pub const CM_ECDSA_PUBLIC_KEY: Self = Self(0x434D_4550); // "CMEP"
     pub const CM_ECDSA_SIGN: Self = Self(0x434D_4553); // "CMES"
     pub const CM_ECDSA_VERIFY: Self = Self(0x434D_4556); // "CMEV"
-    pub const CM_DERIVE_STABLE_KEY: Self = Self(0x494D_4453); // "CMDS"
+    pub const CM_DERIVE_STABLE_KEY: Self = Self(0x494D_4453); // "IMDS"
     pub const CM_SHA: Self = Self(0x434D_5348); // "CMSH"
     pub const CM_SHAKE256_INIT: Self = Self(0x434D_5849); // "CMXI"
     pub const CM_SHAKE256_UPDATE: Self = Self(0x434D_5855); // "CMXU"

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2808,7 +2808,7 @@ The command derivation is summarized below:
 
 ![CM_DERIVE_STABLE_KEY Derivation](../rom/dev/doc/svg/cm-derive-stable-key.svg)
 
-Command Code: `0x434D_4453` ("CMDS")
+Command Code: `0x494D_4453` ("IMDS")
 
 *Table: `CM_DERIVE_STABLE_KEY` input arguments*
 


### PR DESCRIPTION
## Summary

- preserve the released `CM_DERIVE_STABLE_KEY` command value `0x494D_4453` for backward compatibility
- correct its ASCII label from `CMDS` to `IMDS`
- update the runtime documentation to match the firmware value

## Testing

- `cargo test -p caliptra-api`
- `git diff --check`

Fixes #4155