### PR TITLE
runtime: zeroize seed on set_pq_seed error path

### DIFF
--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -44,7 +44,8 @@ impl SetPqSeedCmd {
         drivers
             .persistent_data
             .get_mut()
-            .set_pq_devid_cdi((*out).into())?;
+            .set_pq_devid_cdi((*out).into())
+            .inspect_err(|_| cmd.seed.zeroize())?;
 
         // The request buffer still holds the caller-supplied seed.
         cmd.seed.zeroize();


### PR DESCRIPTION
Zeroize `cmd.seed` on the error path of `set_pq_devid_cdi` to make sure the in-memory seed is wiped out on every execution path.