### PR TITLE
mldsa87: reject contexts longer than 255 bytes

### DIFF
--- a/common/crypto/mldsa/src/acvp/mod.rs
+++ b/common/crypto/mldsa/src/acvp/mod.rs
@@ -112,7 +112,9 @@ fn test_acvp_mldsa87_siggen() {
                 // Group 5: external interface with context
                 let msg = hex::decode(test["message"].as_str().unwrap()).unwrap();
                 let context = hex::decode(test["context"].as_str().unwrap_or("")).unwrap();
-                Mldsa87::sign_with_context_deterministic_from_sk(&sk, &msg, &context, &mut sig);
+                let result =
+                    Mldsa87::sign_with_context_deterministic_from_sk(&sk, &msg, &context, &mut sig);
+                assert_eq!(result, Mldsa87Result::Success);
             }
 
             assert_eq!(sig, expected_sig, "siggen tcId {} failed", test["tcId"]);

--- a/common/crypto/mldsa/src/lib.rs
+++ b/common/crypto/mldsa/src/lib.rs
@@ -103,8 +103,8 @@ impl Mldsa87 {
         msg: &[u8],
         context: &[u8],
         sig: &mut [u8; MLDSA87_SIGNATURE_BYTES],
-    ) {
-        mldsa87_sign_with_context_from_sk(sig, sk, randomizer, msg, context);
+    ) -> Mldsa87Result {
+        mldsa87_sign_with_context_from_sk(sig, sk, randomizer, msg, context)
     }
 
     /// Deterministic variant of [`Self::sign_with_context_from_sk`].
@@ -114,8 +114,8 @@ impl Mldsa87 {
         msg: &[u8],
         context: &[u8],
         sig: &mut [u8; MLDSA87_SIGNATURE_BYTES],
-    ) {
-        mldsa87_sign_with_context_deterministic_from_sk(sig, sk, msg, context);
+    ) -> Mldsa87Result {
+        mldsa87_sign_with_context_deterministic_from_sk(sig, sk, msg, context)
     }
 
     /// Sign a pre-computed `mu` using an encoded private key.

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -55,9 +55,6 @@ const K_GAMMA_2: u32 = (K_PRIME - 1) / 32;
 const BETA: u32 = 120;
 const OMEGA: usize = 75;
 
-/// Maximum length of the context string defined in Section 5.2 and 5.3 of FIPS 204.
-const MAX_CONTEXT_BYTES: usize = 255;
-
 /// Number of ML-DSA-87 matrix A polynomials cached across the signing rejection
 /// loop. A is 8 rows x 7 columns = 56 polynomials and depends only on `rho`, so
 /// caching avoids re-expanding these via SHAKE128 on every iteration — the
@@ -1244,10 +1241,6 @@ fn verify_with_mu_context(
     msg: &[u8],
     context: &[u8],
 ) -> Mldsa87Result {
-    if context.len() > MAX_CONTEXT_BYTES {
-        return Mldsa87Result::SigVerifyFailed;
-    }
-
     let mut tr_mu = [0u8; K_TR_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(encoded_public_key);
@@ -1255,7 +1248,10 @@ fn verify_with_mu_context(
 
     let mut shake256 = Shake256::new();
     shake256.absorb(&tr_mu);
-    let context_prefix = [0u8, context.len() as u8];
+    let Ok(context_len) = u8::try_from(context.len()) else {
+        return Mldsa87Result::SigVerifyFailed;
+    };
+    let context_prefix = [0u8, context_len];
     shake256.absorb(&context_prefix);
     shake256.absorb(context);
     shake256.absorb(msg);
@@ -1437,10 +1433,6 @@ pub fn mldsa87_sign_with_context_from_sk(
     msg: &[u8],
     context: &[u8],
 ) -> Mldsa87Result {
-    if context.len() > MAX_CONTEXT_BYTES {
-        return Mldsa87Result::SigVerifyFailed;
-    }
-
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
@@ -1452,7 +1444,10 @@ pub fn mldsa87_sign_with_context_from_sk(
     let mut mu = [0u8; K_MU_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(&tr);
-    let context_prefix = [0u8, context.len() as u8];
+    let Ok(context_len) = u8::try_from(context.len()) else {
+        return Mldsa87Result::SigVerifyFailed;
+    };
+    let context_prefix = [0u8, context_len];
     shake256.absorb(&context_prefix);
     shake256.absorb(context);
     shake256.absorb(msg);

--- a/common/crypto/mldsa/src/mldsa87.rs
+++ b/common/crypto/mldsa/src/mldsa87.rs
@@ -55,6 +55,9 @@ const K_GAMMA_2: u32 = (K_PRIME - 1) / 32;
 const BETA: u32 = 120;
 const OMEGA: usize = 75;
 
+/// Maximum length of the context string defined in Section 5.2 and 5.3 of FIPS 204.
+const MAX_CONTEXT_BYTES: usize = 255;
+
 /// Number of ML-DSA-87 matrix A polynomials cached across the signing rejection
 /// loop. A is 8 rows x 7 columns = 56 polynomials and depends only on `rho`, so
 /// caching avoids re-expanding these via SHAKE128 on every iteration — the
@@ -1241,6 +1244,10 @@ fn verify_with_mu_context(
     msg: &[u8],
     context: &[u8],
 ) -> Mldsa87Result {
+    if context.len() > MAX_CONTEXT_BYTES {
+        return Mldsa87Result::SigVerifyFailed;
+    }
+
     let mut tr_mu = [0u8; K_TR_BYTES];
     let mut shake256 = Shake256::new();
     shake256.absorb(encoded_public_key);
@@ -1429,7 +1436,11 @@ pub fn mldsa87_sign_with_context_from_sk(
     randomizer: &[u8; MLDSA87_RANDOMIZER_BYTES],
     msg: &[u8],
     context: &[u8],
-) {
+) -> Mldsa87Result {
+    if context.len() > MAX_CONTEXT_BYTES {
+        return Mldsa87Result::SigVerifyFailed;
+    }
+
     let mut priv_key = PrivateKey {
         rho: [0u8; K_RHO_BYTES],
         k: [0u8; K_K_BYTES],
@@ -1448,6 +1459,8 @@ pub fn mldsa87_sign_with_context_from_sk(
     shake256.squeeze(&mut mu);
 
     sign_internal_with_mu(out_encoded_signature, &priv_key, &mu, randomizer, Some(sk));
+
+    Mldsa87Result::Success
 }
 
 /// Deterministic variant of [`mldsa87_sign_with_context_from_sk`].
@@ -1457,9 +1470,9 @@ pub fn mldsa87_sign_with_context_deterministic_from_sk(
     sk: &[u8; MLDSA87_PRIVATE_KEY_BYTES],
     msg: &[u8],
     context: &[u8],
-) {
+) -> Mldsa87Result {
     let randomizer = [0u8; MLDSA87_RANDOMIZER_BYTES];
-    mldsa87_sign_with_context_from_sk(out_encoded_signature, sk, &randomizer, msg, context);
+    mldsa87_sign_with_context_from_sk(out_encoded_signature, sk, &randomizer, msg, context)
 }
 
 /// Sign a pre-computed `mu` using an encoded private key.


### PR DESCRIPTION
Explicitly return an error if a given context is longer than the maximum length defined by FIPS 204, following the the pseudo code provided by the same spec.