### PR TITLE
Adding pairwise consistency test to MLDSA

### DIFF
--- a/drivers/src/fips_test_hooks.rs
+++ b/drivers/src/fips_test_hooks.rs
@@ -24,6 +24,7 @@ impl FipsTestHook {
     pub const HALT_FW_LOAD: u8 = 0x2A;
     pub const HALT_SHUTDOWN_RT: u8 = 0x2B;
     pub const ECC384_CORRUPT_KEY_PAIR: u8 = 0x2C;
+    pub const MLDSA87_PCT_FAILURE: u8 = 0x2D;
 
     pub const SHA1_DIGEST_FAILURE: u8 = 0x40;
     pub const SHA256_DIGEST_FAILURE: u8 = 0x41;

--- a/drivers/src/mldsa87.rs
+++ b/drivers/src/mldsa87.rs
@@ -17,7 +17,7 @@ Abstract:
 
 --*/
 
-use crate::CaliptraResult;
+use crate::{CaliptraError, CaliptraResult};
 use caliptra_mldsa::Mldsa87 as Mldsa87Sw;
 use core::ops::{Deref, DerefMut};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -95,9 +95,9 @@ impl_helper_traits!(Mldsa87Mu);
 /// Software ML-DSA-87 engine.
 ///
 /// This is a stateless wrapper; there is no hardware to own. The methods return
-/// [`CaliptraResult`] for consistency with the other crypto drivers and to keep
-/// the API stable if validation (e.g. a pairwise-consistency self-test) is added
-/// later. The underlying software operations are currently infallible.
+/// [`CaliptraResult`] for consistency with the other crypto drivers though is
+/// only currently leveraged by the pairwise-consistency self-test. All other
+/// underlying software operations are currently infallible.
 ///
 /// Each operation is marked `#[inline(never)]` so that the large (tens of KB)
 /// stack frames used by keygen and signing do not get inlined into — and
@@ -201,6 +201,41 @@ impl Mldsa87 {
         msg: &[u8],
     ) -> CaliptraResult<Mldsa87Result> {
         Ok(Mldsa87Sw::verify(pub_key, sig, msg))
+    }
+
+    /// Pairwise Consistency Test (PCT) per ISO/IEC 19790 7.10.3
+    ///
+    /// # Arguments
+    ///
+    /// * `seed`        - 32-byte ML-DSA-87 private seed
+    /// * `sig_scratch` - Caller-provided scratch buffer for signature
+    #[inline(never)]
+    pub fn pct(seed: &Mldsa87Seed, sig_scratch: &mut Mldsa87Signature) -> CaliptraResult<()> {
+        const PCT_MESSAGE: [u8; 1] = [0x00];
+        Mldsa87Sw::sign_deterministic(seed, &PCT_MESSAGE, sig_scratch);
+
+        #[cfg(feature = "fips-test-hooks")]
+        // SAFETY: corrupts sig_scratch to force a PCT verify failure for testing.
+        unsafe {
+            crate::FipsTestHook::corrupt_data_if_hook_set(
+                crate::FipsTestHook::MLDSA87_PCT_FAILURE,
+                sig_scratch,
+            )
+        };
+
+        Self::pct_verify(seed, sig_scratch, &PCT_MESSAGE)
+    }
+
+    // Separate #[inline(never)] fn so pub_key lives in its own stack frame
+    // and is never simultaneously alive with the ML-DSA sign frames in pct().
+    #[inline(never)]
+    fn pct_verify(seed: &Mldsa87Seed, sig: &Mldsa87Signature, msg: &[u8]) -> CaliptraResult<()> {
+        let mut pub_key = Mldsa87PubKey::default();
+        Mldsa87Sw::pub_from_seed(seed, &mut pub_key);
+        if Mldsa87Sw::verify(&pub_key, sig, msg) != Mldsa87Result::Success {
+            return Err(CaliptraError::RUNTIME_PQ_PCT_VERIFY_FAILURE);
+        }
+        Ok(())
     }
 
     /// Verify an ML-DSA-87 signature over `msg` using an explicit signing

--- a/error/src/lib.rs
+++ b/error/src/lib.rs
@@ -1348,6 +1348,11 @@ impl CaliptraError {
             0x000E0073,
             "Runtime Error: Invalid FW persistent data version"
         ),
+        (
+            RUNTIME_PQ_PCT_VERIFY_FAILURE,
+            0x000E0074,
+            "Runtime Error: ML-DSA-87 pairwise consistency test (PCT) verify failed"
+        ),
         // FMC Errors
         (FMC_GLOBAL_NMI, 0x000F0001, "FMC Error: Global NMI"),
         (

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -575,7 +575,14 @@ impl Crypto for DpeCrypto<'_> {
                 };
                 let mut seed = Mldsa87Seed::default();
                 self.derive_key_pair_mldsa((&*cdi).into(), label, info, &mut seed)?;
-                self.derived_key = Some(DerivedKey::Mldsa(seed));
+                // Skip overwriting if seed matches existing derived_key. Preserves pct_done=true from the first call.
+                if !matches!(&self.derived_key, Some(DerivedKey::Mldsa { seed: prev, .. }) if constant_time_eq(&**prev, &*seed))
+                {
+                    self.derived_key = Some(DerivedKey::Mldsa {
+                        seed,
+                        pct_done: false,
+                    });
+                }
             }
         }
 
@@ -633,7 +640,14 @@ impl CdiManager for DpeCrypto<'_> {
                 };
                 let mut seed = Mldsa87Seed::default();
                 self.derive_key_pair_mldsa((&*cdi_bytes).into(), label, info, &mut seed)?;
-                self.derived_key = Some(DerivedKey::Mldsa(seed));
+                // Skip overwriting if seed matches existing derived_key. Preserves pct_done=true from the first call.
+                if !matches!(&self.derived_key, Some(DerivedKey::Mldsa { seed: prev, .. }) if constant_time_eq(&**prev, &*seed))
+                {
+                    self.derived_key = Some(DerivedKey::Mldsa {
+                        seed,
+                        pct_done: false,
+                    });
+                }
             }
         };
 
@@ -657,11 +671,10 @@ impl crypto::Signer for DpeCrypto<'_> {
             }
 
             Signer::Mldsa { .. } => {
-                let Some(DerivedKey::Mldsa(seed)) = &self.derived_key else {
+                let Some(DerivedKey::Mldsa { seed, pct_done }) = &mut self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
-                // PCT for DPE leaf keys.
-                {
+                if !*pct_done {
                     let Signature::Mldsa(MldsaSignature(buf)) = out else {
                         return Err(CryptoError::MismatchedAlgorithm);
                     };
@@ -669,6 +682,7 @@ impl crypto::Signer for DpeCrypto<'_> {
                         .map_err(|_| CryptoError::Size)?;
                     Mldsa87::pct(seed, sig)
                         .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                    *pct_done = true;
                 }
                 Self::sign_helper_mldsa(data, seed, out)
             }
@@ -676,12 +690,12 @@ impl crypto::Signer for DpeCrypto<'_> {
     }
 
     fn public_key(&mut self, out: &mut PubKey) -> Result<(), CryptoError> {
-        match &self.derived_key {
+        match &mut self.derived_key {
             Some(DerivedKey::Ec((_, pub_key))) => {
                 *out = PubKey::Ecdsa(pub_key.clone());
                 Ok(())
             }
-            Some(DerivedKey::Mldsa(seed)) => {
+            Some(DerivedKey::Mldsa { seed, pct_done }) => {
                 let PubKey::Mldsa(MldsaPublicKey(bytes)) = out else {
                     return Err(CryptoError::MismatchedAlgorithm);
                 };
@@ -689,10 +703,12 @@ impl crypto::Signer for DpeCrypto<'_> {
                     .map_err(|_| CryptoError::Size)?;
                 Mldsa87::pub_from_seed(seed, pub_key, None)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
-                // PCT verify key-pair consistency before the public key is exported.
-                let mut sig_scratch = Mldsa87Signature::default();
-                Mldsa87::pct(seed, &mut sig_scratch)
-                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                if !*pct_done {
+                    let mut sig_scratch = Mldsa87Signature::default();
+                    Mldsa87::pct(seed, &mut sig_scratch)
+                        .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                    *pct_done = true;
+                }
                 Ok(())
             }
             _ => Err(CryptoError::CryptoLibError(4)),
@@ -724,5 +740,5 @@ enum DerivedKey {
     // its 2,592-byte ML-DSA variant, so this ~96-byte P-384 key would otherwise
     // bloat the live DPE env on the sign stack by ~2.5 KB for an unused variant.
     Ec((KeyId, EcdsaPubKey)),
-    Mldsa(Mldsa87Seed),
+    Mldsa { seed: Mldsa87Seed, pct_done: bool },
 }

--- a/runtime/src/dpe_crypto.rs
+++ b/runtime/src/dpe_crypto.rs
@@ -660,6 +660,16 @@ impl crypto::Signer for DpeCrypto<'_> {
                 let Some(DerivedKey::Mldsa(seed)) = &self.derived_key else {
                     return Err(CryptoError::CryptoLibError(3));
                 };
+                // PCT for DPE leaf keys.
+                {
+                    let Signature::Mldsa(MldsaSignature(buf)) = out else {
+                        return Err(CryptoError::MismatchedAlgorithm);
+                    };
+                    let sig = Mldsa87Signature::mut_from_bytes(buf.as_mut_slice())
+                        .map_err(|_| CryptoError::Size)?;
+                    Mldsa87::pct(seed, sig)
+                        .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                }
                 Self::sign_helper_mldsa(data, seed, out)
             }
         }
@@ -678,6 +688,10 @@ impl crypto::Signer for DpeCrypto<'_> {
                 let pub_key = Mldsa87PubKey::mut_from_bytes(bytes.as_mut_slice())
                     .map_err(|_| CryptoError::Size)?;
                 Mldsa87::pub_from_seed(seed, pub_key, None)
+                    .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
+                // PCT verify key-pair consistency before the public key is exported.
+                let mut sig_scratch = Mldsa87Signature::default();
+                Mldsa87::pct(seed, &mut sig_scratch)
                     .map_err(|e| CryptoError::CryptoLibError(u32::from(e)))?;
                 Ok(())
             }

--- a/runtime/src/set_pq_seed.rs
+++ b/runtime/src/set_pq_seed.rs
@@ -15,7 +15,9 @@ Abstract:
 use crate::Drivers;
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_common::mailbox_api::{MailboxRespHeader, SetPqSeedReq, SET_PQ_SEED_SEED_SIZE};
-use caliptra_drivers::{hmac384_kdf, Array4x12, CaliptraError, CaliptraResult};
+use caliptra_drivers::{
+    hmac384_kdf, Array4x12, CaliptraError, CaliptraResult, Mldsa87, Mldsa87Signature,
+};
 use crypto::{Digest, Sha256};
 use zerocopy::{FromZeros, IntoBytes};
 use zeroize::{Zeroize, Zeroizing};
@@ -53,13 +55,20 @@ impl SetPqSeedCmd {
         // Calculate the digest of the PQ.DevID public key and cache it
         // in the persistent data to avoid repeated key generation passes
         // involved in DPE invocation.
-        let (_, _, Digest::Sha256(Sha256(digest))) = drivers.compute_mldsa_key_material()? else {
+        let (seed, _, Digest::Sha256(Sha256(digest))) = drivers.compute_mldsa_key_material()?
+        else {
             return Err(CaliptraError::RUNTIME_PQ_INVALID_PUBKEY_DIGEST);
         };
         drivers
             .persistent_data
             .get_mut()
             .set_pq_devid_pub_key_digest(digest)?;
+
+        // Pairwise Consistency Test (PCT)
+        // Required once prior to first use of the key pair.
+        // Re-derivations from the stored CDI do not require repeating the PCT
+        let mut sig_scratch = Mldsa87Signature::default();
+        Mldsa87::pct(&seed, &mut sig_scratch)?;
 
         crate::packet::copy_to_mbox(drivers, MailboxRespHeader::default().as_mut_bytes())
     }

--- a/runtime/tests/runtime_integration_tests/test_measurements_common.rs
+++ b/runtime/tests/runtime_integration_tests/test_measurements_common.rs
@@ -612,6 +612,20 @@ pub fn measure_mldsa_dpe_subcommands(sampler: &mut dyn CommandSampler) -> Vec<(&
         measure_dpe_profile(sampler, model, P, &mut Command::from(&certify_cmd)),
     ));
 
+    // 4a. CertifyKey / CSR. Unlike X509 (signed with the alias key), the CSR form
+    //     signs with the derived key, so it is the certify path that goes through
+    //     `Signer::sign`.
+    let certify_csr_cmd = CertifyKeyMldsa87Cmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        format: CertifyKeyCommand::FORMAT_CSR,
+        label: TEST_LABEL,
+    };
+    results.push((
+        "INVOKE_DPE_MLDSA87(CertifyKey/CSR)",
+        measure_dpe_profile(sampler, model, P, &mut Command::from(&certify_csr_cmd)),
+    ));
+
     // 4b. SIGN_WITH_EXPORTED_MLDSA (data mode) — export an ML-DSA CDI first
     //     (populates the exported-CDI slot; the export derives from the default
     //     context, so this runs before the default is retired in step 8), then sign

--- a/test/tests/fips_test_suite/self_tests.rs
+++ b/test/tests/fips_test_suite/self_tests.rs
@@ -610,3 +610,46 @@ pub fn integrity_check_failure_rom() {
 //         u32::from(CaliptraError::DRIVER_ECC384_KEYGEN_PAIRWISE_CONSISTENCY_FAILURE),
 //     );
 // }
+
+#[test]
+pub fn mldsa_pairwise_consistency_error() {
+    let fw_image = caliptra_builder::build_and_sign_image(
+        &FMC_WITH_UART,
+        &APP_WITH_UART_FIPS_TEST_HOOKS,
+        ImageOptions::default(),
+    )
+    .unwrap()
+    .to_bytes()
+    .unwrap();
+
+    let mut hw = fips_test_init_to_rt(
+        None,
+        Some(BootParams {
+            fw_image: Some(&fw_image),
+            ..fips_default_boot_params()
+        }),
+    );
+
+    hw.step_until(|m| m.soc_ifc().cptra_flow_status().read().ready_for_runtime());
+
+    // Arm the hook so the next PCT call corrupts the test signature.
+    hw.soc_ifc()
+        .cptra_dbg_manuf_service_reg()
+        .write(|_| (FipsTestHook::MLDSA87_PCT_FAILURE as u32) << HOOK_CODE_OFFSET);
+
+    // SET_PQ_SEED triggers a PCT; the hook should make it fail.
+    let mut cmd = MailboxReq::SetPqSeed(SetPqSeedReq {
+        hdr: MailboxReqHeader::default(),
+        seed: [0x5a; caliptra_common::mailbox_api::SET_PQ_SEED_SEED_SIZE],
+    });
+    cmd.populate_chksum().unwrap();
+    match hw.mailbox_execute(u32::from(CommandId::SET_PQ_SEED), cmd.as_bytes().unwrap()) {
+        Err(ModelError::MailboxCmdFailed(code)) => {
+            assert_eq!(
+                code,
+                u32::from(CaliptraError::RUNTIME_PQ_PCT_VERIFY_FAILURE)
+            );
+        }
+        other => panic!("Expected PCT failure, got {:?}", other),
+    }
+}


### PR DESCRIPTION
Add a pairwise consistency test to MLDSA.

FIPS requires this to be performed prior to use of or export of the keys. However, it only requires it be performed once even if the keys are re-derived from the same seed (which we do to avoid storing them).

This adds execution of the PCT when setting the PQ seed as well as in DPE commands that derive MLDSA keys.