### PR TITLE
libcaliptra: Fix Zephyr include path and MLDSA verify declaration

### DIFF
--- a/libcaliptra/inc/caliptra_api.h
+++ b/libcaliptra/inc/caliptra_api.h
@@ -200,6 +200,8 @@ int caliptra_get_fmc_alias_mldsa87_cert(struct caliptra_get_fmc_alias_mldsa87_ce
 // Get MLDSA87 RT Alias cert
 int caliptra_get_rt_alias_mldsa87_cert(struct caliptra_get_rt_alias_mldsa87_cert_resp *resp, bool async);
 
+struct caliptra_mldsa_verify_req;
+
 // ECDSA384 Verify
 int caliptra_mldsa87_verify(struct caliptra_mldsa_verify_req *req, bool async);
 

--- a/libcaliptra/zephyr/CMakeLists.txt
+++ b/libcaliptra/zephyr/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/src)
 
 # This is for caliptra_top_reg.h which has all of the register definitions for Caliptra.
 zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/../hw/latest/rtl/src/soc_ifc/rtl)
+zephyr_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/../hw/latest/rtl/src/soc_ifc/rtl/caliptra_top_reg)
 
 zephyr_library_sources(${ZEPHYR_CURRENT_MODULE_DIR}/src/caliptra_api.c)
 


### PR DESCRIPTION
1. Add caliptra_top_reg subdirectory to zephyr_include_directories to locate caliptra_top_reg.h.
2. Forward declare struct caliptra_mldsa_verify_req in caliptra_api.h to prevent -Werror parameter list scope warning.