### PR TITLE
tests: Increase nightly timeouts + ignore test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,12 @@ slow-timeout = { period = "30s", terminate-after = 140 }
 filter = 'test(test_stress_update)'
 slow-timeout = { period = "30s", terminate-after = 17 }
 
+# The measurement suites walk every runtime command, including the ML-DSA-87
+# keygen/sign paths, against a debug-built emulator. Allow 6 minutes.
+[[profile.nightly.overrides]]
+filter = 'test(=test_command_timing::measure_runtime_command_timing) + test(=test_stack_usage::measure_runtime_command_stack_usage)'
+slow-timeout = { period = "30s", terminate-after = 12 }
+
 [profile.nightly.junit]
 path = "/tmp/junit.xml"
 store-success-output = true

--- a/runtime/tests/runtime_integration_tests/test_command_timing.rs
+++ b/runtime/tests/runtime_integration_tests/test_command_timing.rs
@@ -113,6 +113,7 @@ fn measure_runtime_command_timing() {
 }
 
 #[test]
+#[ignore = "Traces the stack; invoke with --ignored"]
 fn measure_runtime_command_timing_and_sample_stack_traces() {
     measure_timing(test_args(true, None));
 }


### PR DESCRIPTION
Ignore a test which traces the stack - useful for debugging but not helpful for a nightly regression run and increase the nightly timeout for useful tests which execute every command.