### PR TITLE
runtime: Add CM_KEY_GEN command for standalone TRNG key generation

### DIFF
--- a/api/src/mailbox.rs
+++ b/api/src/mailbox.rs
@@ -219,6 +219,7 @@ impl CommandId {
 
     // Cryptographic mailbox commands
     pub const CM_IMPORT: Self = Self(0x434D_494D); // "CMIM"
+    pub const CM_KEY_GEN: Self = Self(0x434D_4B47); // "CMKG"
     pub const CM_DELETE: Self = Self(0x434D_444C); // "CMDL"
     pub const CM_CLEAR: Self = Self(0x434D_434C); // "CMCL"
     pub const CM_STATUS: Self = Self(0x434D_5354); // "CMST"
@@ -392,6 +393,7 @@ pub enum MailboxResp {
     RevokeExportedCdiHandle(RevokeExportedCdiHandleResp),
     GetImageInfo(GetImageInfoResp),
     CmImport(CmImportResp),
+    CmKeyGen(CmKeyGenResp),
     CmStatus(CmStatusResp),
     CmShaInit(CmShaInitResp),
     CmShaFinal(CmShaFinalResp),
@@ -481,6 +483,7 @@ impl MailboxResp {
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_bytes()),
             MailboxResp::GetImageInfo(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmImport(resp) => Ok(resp.as_bytes()),
+            MailboxResp::CmKeyGen(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmStatus(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmShaInit(resp) => Ok(resp.as_bytes()),
             MailboxResp::CmShaFinal(resp) => resp.as_bytes_partial(),
@@ -568,6 +571,7 @@ impl MailboxResp {
             MailboxResp::RevokeExportedCdiHandle(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::GetImageInfo(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmImport(resp) => Ok(resp.as_mut_bytes()),
+            MailboxResp::CmKeyGen(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmStatus(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmShaInit(resp) => Ok(resp.as_mut_bytes()),
             MailboxResp::CmShaFinal(resp) => resp.as_bytes_partial_mut(),
@@ -720,6 +724,7 @@ pub enum MailboxReq {
     GetImageInfo(GetImageInfoReq),
     CmStatus(MailboxReqHeader),
     CmImport(CmImportReq),
+    CmKeyGen(CmKeyGenReq),
     CmDelete(CmDeleteReq),
     CmClear(MailboxReqHeader),
     CmShaInit(CmShaInitReq),
@@ -830,6 +835,7 @@ impl MailboxReq {
             MailboxReq::GetImageInfo(req) => Ok(req.as_bytes()),
             MailboxReq::CmStatus(req) => Ok(req.as_bytes()),
             MailboxReq::CmImport(req) => req.as_bytes_partial(),
+            MailboxReq::CmKeyGen(req) => Ok(req.as_bytes()),
             MailboxReq::CmDelete(req) => Ok(req.as_bytes()),
             MailboxReq::CmClear(req) => Ok(req.as_bytes()),
             MailboxReq::CmShaInit(req) => req.as_bytes_partial(),
@@ -938,6 +944,7 @@ impl MailboxReq {
             MailboxReq::GetImageInfo(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmStatus(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmImport(req) => Ok(req.as_mut_bytes()),
+            MailboxReq::CmKeyGen(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmDelete(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmClear(req) => Ok(req.as_mut_bytes()),
             MailboxReq::CmShaInit(req) => req.as_bytes_partial_mut(),
@@ -1046,6 +1053,7 @@ impl MailboxReq {
             MailboxReq::GetImageInfo(_) => CommandId::GET_IMAGE_INFO,
             MailboxReq::CmStatus(_) => CommandId::CM_STATUS,
             MailboxReq::CmImport(_) => CommandId::CM_IMPORT,
+            MailboxReq::CmKeyGen(_) => CommandId::CM_KEY_GEN,
             MailboxReq::CmDelete(_) => CommandId::CM_DELETE,
             MailboxReq::CmClear(_) => CommandId::CM_CLEAR,
             MailboxReq::CmShaInit(_) => CommandId::CM_SHA_INIT,
@@ -2939,6 +2947,29 @@ pub struct CmImportResp {
 }
 
 impl Response for CmImportResp {}
+
+// CM_KEY_GEN
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmKeyGenReq {
+    pub hdr: MailboxReqHeader,
+    pub key_usage: u32,
+    pub key_size: u32,
+}
+
+impl Request for CmKeyGenReq {
+    const ID: CommandId = CommandId::CM_KEY_GEN;
+    type Resp = CmKeyGenResp;
+}
+
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq)]
+pub struct CmKeyGenResp {
+    pub hdr: MailboxRespHeader,
+    pub cmk: Cmk,
+}
+
+impl Response for CmKeyGenResp {}
 
 // CM_DELETE
 #[repr(C)]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -2848,6 +2848,30 @@ Command Code: `0x434D_494D` ("CMIM")
 | fips_status | u32      | FIPS approved or an error   |
 | CMK         | CMK      | CMK containing imported key |
 
+### CM_KEY_GEN
+
+Generates a key using internal TRNG and returns an encrypted CMK for it.
+
+Usage and size information are required so that the key can be verified and used appropriately.
+
+Command Code: `0x434D_4B47` ("CMKG")
+
+*Table: `CM_KEY_GEN` input arguments*
+
+| **Name**   | **Type** | **Description**                         |
+| ---------- | -------- | --------------------------------------- |
+| chksum     | u32      |                                         |
+| key usage  | u32      | Tag to specify how the data can be used |
+| key size   | u32      | Size in bytes (must agree with usage)   |
+
+*Table: `CM_KEY_GEN` output arguments*
+
+| **Name**    | **Type** | **Description**              |
+| ----------- | -------- | ---------------------------- |
+| chksum      | u32      |                              |
+| fips_status | u32      | FIPS approved or an error    |
+| CMK         | CMK      | CMK containing generated key |
+
 ### CM_DELETE
 
 Deletes the object stored with the given mailbox ID.

--- a/runtime/src/cryptographic_mailbox.rs
+++ b/runtime/src/cryptographic_mailbox.rs
@@ -33,15 +33,15 @@ use caliptra_common::{
         CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp, CmEcdsaSignReq,
         CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm, CmHkdfExpandReq, CmHkdfExpandResp,
         CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq, CmHmacKdfCounterResp,
-        CmImportReq, CmImportResp, CmKeyUsage, CmMldsaPublicKeyReq, CmMldsaPublicKeyResp,
-        CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq, CmMlkemDecapsulateReq,
-        CmMlkemDecapsulateResp, CmMlkemEncapsulateReq, CmMlkemEncapsulateResp, CmMlkemKeyGenReq,
-        CmMlkemKeyGenResp, CmRandomGenerateReq, CmRandomGenerateResp, CmRandomStirReq,
-        CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmShake256FinalReq,
-        CmShake256FinalResp, CmShake256InitReq, CmShake256InitResp, CmShake256UpdateReq,
-        CmStableKeyType, CmStatusResp, Cmk as MailboxCmk, MailboxRespHeader,
-        MailboxRespHeaderVarSize, ResponseVarSize, CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE,
-        CMB_ECDH_CONTEXT_SIZE, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE,
+        CmImportReq, CmImportResp, CmKeyGenReq, CmKeyGenResp, CmKeyUsage, CmMldsaPublicKeyReq,
+        CmMldsaPublicKeyResp, CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq,
+        CmMlkemDecapsulateReq, CmMlkemDecapsulateResp, CmMlkemEncapsulateReq,
+        CmMlkemEncapsulateResp, CmMlkemKeyGenReq, CmMlkemKeyGenResp, CmRandomGenerateReq,
+        CmRandomGenerateResp, CmRandomStirReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp,
+        CmShaUpdateReq, CmShake256FinalReq, CmShake256FinalResp, CmShake256InitReq,
+        CmShake256InitResp, CmShake256UpdateReq, CmStableKeyType, CmStatusResp, Cmk as MailboxCmk,
+        MailboxRespHeader, MailboxRespHeaderVarSize, ResponseVarSize,
+        CMB_AES_GCM_ENCRYPTED_CONTEXT_SIZE, CMB_ECDH_CONTEXT_SIZE, CMB_ECDH_ENCRYPTED_CONTEXT_SIZE,
         CMB_SHAKE256_CONTEXT_PLAINTEXT_SIZE, CMB_SHAKE256_CONTEXT_SIZE, CMB_SHA_CONTEXT_SIZE,
         CMK_MAX_KEY_SIZE_BITS, CMK_SIZE_BYTES, CM_STABLE_KEY_INFO_SIZE_BYTES, MAX_CMB_DATA_SIZE,
         MLKEM1024_SHARED_KEY_SIZE,
@@ -547,6 +547,63 @@ impl Commands {
         resp.hdr = MailboxRespHeader::default();
         resp.cmk = transmute!(encrypted_cmk);
         Ok(core::mem::size_of::<CmImportResp>())
+    }
+
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    pub(crate) fn key_gen(
+        drivers: &mut Drivers,
+        cmd_bytes: &[u8],
+        resp: &mut [u8],
+    ) -> CaliptraResult<usize> {
+        if !drivers.cryptographic_mailbox.initialized {
+            Err(CaliptraError::RUNTIME_CMB_NOT_INITIALIZED)?;
+        }
+        if cmd_bytes.len() != core::mem::size_of::<CmKeyGenReq>() {
+            Err(CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+        }
+        let cmd = CmKeyGenReq::ref_from_bytes(cmd_bytes)
+            .map_err(|_| CaliptraError::RUNTIME_MAILBOX_INVALID_PARAMS)?;
+
+        let key_usage = CmKeyUsage::from(cmd.key_usage);
+
+        match (key_usage, cmd.key_size) {
+            (CmKeyUsage::Aes | CmKeyUsage::Mldsa, 32) => (),
+            (CmKeyUsage::Ecdsa, 48) => (),
+            (CmKeyUsage::Hmac, 48 | 64) => (),
+            (CmKeyUsage::Mlkem, 64) => (),
+            _ => Err(CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE)?,
+        }
+
+        let key_size = cmd.key_size as usize;
+        let mut unencrypted_cmk = UnencryptedCmk {
+            version: 1,
+            length: cmd.key_size as u16,
+            key_usage: key_usage as u32 as u8,
+            id: if matches!(key_usage, CmKeyUsage::Aes) {
+                drivers.cryptographic_mailbox.add_counter()?
+            } else {
+                [0u8; 3]
+            },
+            usage_counter: 0,
+            key_material: [0u8; CMK_MAX_KEY_SIZE_BITS / 8],
+        };
+
+        for chunk in unencrypted_cmk.key_material[..key_size].chunks_mut(48) {
+            let rand: [u8; 48] = drivers.trng.generate()?.into();
+            chunk.copy_from_slice(&rand[..chunk.len()]);
+        }
+
+        let encrypted_cmk = drivers.cryptographic_mailbox.encrypt_cmk(
+            &mut drivers.aes,
+            &mut drivers.trng,
+            &unencrypted_cmk,
+        )?;
+
+        let resp = mutrefbytes::<CmKeyGenResp>(resp)?;
+        resp.hdr = MailboxRespHeader::default();
+        resp.cmk = transmute!(encrypted_cmk);
+        Ok(core::mem::size_of::<CmKeyGenResp>())
     }
 
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -488,6 +488,7 @@ fn execute_command(
         CommandId::GET_MCU_FW_SIZE => get_mcu_fw_size::GetMcuFwSizeCmd::execute(drivers, resp),
         // Cryptographic mailbox commands
         CommandId::CM_IMPORT => cryptographic_mailbox::Commands::import(drivers, cmd_bytes, resp),
+        CommandId::CM_KEY_GEN => cryptographic_mailbox::Commands::key_gen(drivers, cmd_bytes, resp),
         CommandId::CM_DELETE => cryptographic_mailbox::Commands::delete(drivers, cmd_bytes, resp),
         CommandId::CM_CLEAR => cryptographic_mailbox::Commands::clear(drivers, resp),
         CommandId::CM_STATUS => cryptographic_mailbox::Commands::status(drivers, resp),

--- a/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
+++ b/runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs
@@ -19,16 +19,16 @@ use caliptra_api::mailbox::{
     CmEcdhGenerateReq, CmEcdhGenerateResp, CmEcdsaPublicKeyReq, CmEcdsaPublicKeyResp,
     CmEcdsaSignReq, CmEcdsaSignResp, CmEcdsaVerifyReq, CmHashAlgorithm, CmHkdfExpandReq,
     CmHkdfExpandResp, CmHkdfExtractReq, CmHkdfExtractResp, CmHmacKdfCounterReq,
-    CmHmacKdfCounterResp, CmHmacReq, CmHmacResp, CmImportReq, CmImportResp, CmKeyUsage,
-    CmMldsaPublicKeyReq, CmMldsaPublicKeyResp, CmMldsaSignReq, CmMldsaSignResp, CmMldsaVerifyReq,
-    CmMlkemDecapsulateReq, CmMlkemDecapsulateResp, CmMlkemEncapsulateReq, CmMlkemEncapsulateResp,
-    CmMlkemKeyGenReq, CmMlkemKeyGenResp, CmRandomGenerateReq, CmRandomGenerateResp,
-    CmRandomStirReq, CmShaFinalReq, CmShaFinalResp, CmShaInitReq, CmShaInitResp, CmShaUpdateReq,
-    CmShake256FinalReq, CmShake256FinalResp, CmShake256InitReq, CmShake256InitResp,
-    CmShake256UpdateReq, CmStableKeyType, CmStatusResp, Cmk, CommandId, MailboxReq,
-    MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize, ResponseVarSize,
-    CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_SHAKE256_CONTEXT_SIZE, CMK_SIZE_BYTES, MAX_CMB_DATA_SIZE,
-    MLKEM1024_ENCAPS_KEY_SIZE, SHAKE256_MAX_DIGEST_BYTE_SIZE,
+    CmHmacKdfCounterResp, CmHmacReq, CmHmacResp, CmImportReq, CmImportResp, CmKeyGenReq,
+    CmKeyGenResp, CmKeyUsage, CmMldsaPublicKeyReq, CmMldsaPublicKeyResp, CmMldsaSignReq,
+    CmMldsaSignResp, CmMldsaVerifyReq, CmMlkemDecapsulateReq, CmMlkemDecapsulateResp,
+    CmMlkemEncapsulateReq, CmMlkemEncapsulateResp, CmMlkemKeyGenReq, CmMlkemKeyGenResp,
+    CmRandomGenerateReq, CmRandomGenerateResp, CmRandomStirReq, CmShaFinalReq, CmShaFinalResp,
+    CmShaInitReq, CmShaInitResp, CmShaUpdateReq, CmShake256FinalReq, CmShake256FinalResp,
+    CmShake256InitReq, CmShake256InitResp, CmShake256UpdateReq, CmStableKeyType, CmStatusResp, Cmk,
+    CommandId, MailboxReq, MailboxReqHeader, MailboxRespHeader, MailboxRespHeaderVarSize,
+    ResponseVarSize, CMB_ECDH_EXCHANGE_DATA_MAX_SIZE, CMB_SHAKE256_CONTEXT_SIZE, CMK_SIZE_BYTES,
+    MAX_CMB_DATA_SIZE, MLKEM1024_ENCAPS_KEY_SIZE, SHAKE256_MAX_DIGEST_BYTE_SIZE,
 };
 use caliptra_api::{Capabilities, SocManager};
 use caliptra_drivers::AES_BLOCK_SIZE_BYTES;
@@ -164,6 +164,179 @@ fn test_import() {
     let cm_resp = CmStatusResp::ref_from_bytes(status_resp.as_slice()).unwrap();
     assert_eq!(cm_resp.used_usage_storage, 1);
     assert_eq!(cm_resp.total_usage_storage, 256);
+}
+
+#[test]
+fn test_key_gen() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.step_until_ready_for_runtime();
+
+    // Wrong size for AES
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Aes.into(),
+        key_size: 64,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap_err();
+    assert_error(
+        &mut model,
+        caliptra_drivers::CaliptraError::RUNTIME_CMB_INVALID_KEY_USAGE_AND_SIZE,
+        resp,
+    );
+
+    // AES key gen (32 bytes)
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Aes.into(),
+        key_size: 32,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let cm_key_gen_resp = CmKeyGenResp::ref_from_bytes(resp.as_slice()).unwrap();
+    let cmk = cm_key_gen_resp.cmk.as_bytes();
+    assert_eq!(CMK_SIZE_BYTES, cmk.len());
+    assert!(!cmk.iter().all(|&x| x == 0));
+    assert_eq!(
+        cm_key_gen_resp.hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+
+    // Verify storage counter used for AES
+    let cm_resp = status(&mut model);
+    assert_eq!(cm_resp.used_usage_storage, 1);
+
+    // ML-KEM key gen (64 bytes)
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Mlkem.into(),
+        key_size: 64,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let cm_key_gen_resp = CmKeyGenResp::ref_from_bytes(resp.as_slice()).unwrap();
+    let mlkem_cmk = cm_key_gen_resp.cmk.clone();
+    assert!(!mlkem_cmk.as_bytes().iter().all(|&x| x == 0));
+
+    // Verify ML-KEM key gen works with CM_MLKEM_KEY_GEN to derive public key
+    let mut mlkem_pub_req = MailboxReq::CmMlkemKeyGen(CmMlkemKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cmk: mlkem_cmk,
+    });
+    mlkem_pub_req.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_MLKEM_KEY_GEN),
+            mlkem_pub_req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let pub_resp = CmMlkemKeyGenResp::ref_from_bytes(resp.as_slice()).unwrap();
+    assert_eq!(
+        pub_resp.hdr.fips_status,
+        MailboxRespHeader::FIPS_STATUS_APPROVED
+    );
+    assert!(!pub_resp.encaps_key.iter().all(|&x| x == 0));
+
+    // ML-DSA key gen (32 bytes)
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Mldsa.into(),
+        key_size: 32,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let mldsa_cmk = CmKeyGenResp::ref_from_bytes(resp.as_slice())
+        .unwrap()
+        .cmk
+        .clone();
+    let mut mldsa_pub_req = MailboxReq::CmMldsaPublicKey(CmMldsaPublicKeyReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cmk: mldsa_cmk,
+    });
+    mldsa_pub_req.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_MLDSA_PUBLIC_KEY),
+            mldsa_pub_req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let mldsa_pub_resp = CmMldsaPublicKeyResp::ref_from_bytes(resp.as_slice()).unwrap();
+    assert!(!mldsa_pub_resp.public_key.iter().all(|&x| x == 0));
+
+    // ECDSA key gen (48 bytes)
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Ecdsa.into(),
+        key_size: 48,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let ecdsa_cmk = CmKeyGenResp::ref_from_bytes(resp.as_slice())
+        .unwrap()
+        .cmk
+        .clone();
+    let mut ecdsa_pub_req = MailboxReq::CmEcdsaPublicKey(CmEcdsaPublicKeyReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        cmk: ecdsa_cmk,
+    });
+    ecdsa_pub_req.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_ECDSA_PUBLIC_KEY),
+            ecdsa_pub_req.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let ecdsa_pub_resp = CmEcdsaPublicKeyResp::ref_from_bytes(resp.as_slice()).unwrap();
+    assert!(!ecdsa_pub_resp.public_key_x.iter().all(|&x| x == 0));
+
+    // HMAC key gen (64 bytes)
+    let mut cm_key_gen_cmd = MailboxReq::CmKeyGen(CmKeyGenReq {
+        hdr: MailboxReqHeader { chksum: 0 },
+        key_usage: CmKeyUsage::Hmac.into(),
+        key_size: 64,
+    });
+    cm_key_gen_cmd.populate_chksum().unwrap();
+    let resp = model
+        .mailbox_execute(
+            u32::from(CommandId::CM_KEY_GEN),
+            cm_key_gen_cmd.as_bytes().unwrap(),
+        )
+        .unwrap()
+        .expect("We should have received a response");
+    let hmac_resp = CmKeyGenResp::ref_from_bytes(resp.as_slice()).unwrap();
+    assert!(!hmac_resp.cmk.as_bytes().iter().all(|&x| x == 0));
 }
 
 #[test]


### PR DESCRIPTION
Introduce the CM_KEY_GEN (0x434D_4B47 / "CMKG") cryptographic mailbox command to allow callers to generate symmetric and asymmetric keys directly inside Caliptra using internal TRNG entropy without exposing raw secret material over the mailbox.

Previously, obtaining an encrypted CMK required either:

1. Plaintext import via CM_IMPORT (caller sees raw key/seed).
2. Key agreement/derivation (CM_ECDH_FINISH, CM_MLKEM_ENCAPSULATE/DECAPSULATE, or CM_HKDF_EXPAND).

CM_KEY_GEN samples entropy directly from Caliptra's SP 800-90A CSRNG peripheral and seals it into an encrypted CMK wrapped under the Caliptra Key Encryption Key (KEK) using AES-256-GCM.

Key changes:

- api/src/mailbox.rs:
  - Define CommandId::CM_KEY_GEN (0x434D_4B47).
  - Add CmKeyGenReq (header, key_usage, key_size) and CmKeyGenResp (header, cmk).
  - Update MailboxReq and MailboxResp enums, including byte serialization and command ID mapping.
- runtime/src/lib.rs:
  - Route CommandId::CM_KEY_GEN to cryptographic_mailbox::Commands::key_gen.
- runtime/src/cryptographic_mailbox.rs:
  - Implement Commands::key_gen with key usage and length validation:
    - AES-256 (32 bytes): allocates and binds an AES usage counter.
    - ML-DSA-87 (32 bytes): samples 32-byte seed xi.
    - ECDSA P-384 (48 bytes): samples 48-byte scalar/seed.
    - HMAC (48 or 64 bytes): samples 384-bit or 512-bit key.
    - ML-KEM-1024 (64 bytes): samples 64-byte seed (seed_d || seed_z).
  - Sample 48-byte chunks from drivers.trng via slice iterator (chunks_mut).
  - Encrypt raw key material into an EncryptedCmk using AES-256-GCM.
- runtime/README.md:
  - Document CM_KEY_GEN command code, input arguments, and output format.
- runtime/tests/runtime_integration_tests/test_cryptographic_mailbox.rs:
  - Add test_key_gen integration test covering invalid size rejection, AES usage counter allocation, ML-KEM seed generation and encapsulation public key derivation, ML-DSA seed generation and public key derivation, ECDSA keygen and public key verification, and HMAC key generation.