### PR TITLE
doc: fix ROM README manifest SVN field placement and LDevID stable identity

### DIFF
--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -224,6 +224,7 @@ The header contains the security version and SHA2-384 hash of the table of conte
 | TOC Entry Count | 4 | Number of entries in TOC. |
 | PL0 PAUSER | 4 | The PAUSER with PL0 privileges. |
 | TOC Digest | 48 | SHA2-384 Digest of table of contents. |
+| FW SVN | 4 | Security Version Number for the firmware image bundle. Compared to FW SVN fuses during image validation. |
 | Vendor Data | 40 | Vendor Data. <br> **Not Before:** Vendor Start Date [ASN1 Time Format] For Alias FMC and Alias RT certificates (15 bytes) <br> **Not After:** Vendor End Date [ASN1 Time Format] For Alias FMC and Alias RT certificates (15 bytes) <br> **Reserved:** (10 bytes) |
 | Owner Data | 40 | Owner Data. <br> **Not Before:** Owner Start Date [ASN1 Time Format] For Alias FMC and Alias RT certificates. Takes preference over vendor start date (15 bytes) <br> **Not After:** Owner End Date [ASN1 Time Format] For Alias FMC and Alias RT certificates. Takes preference over vendor end date (15 bytes) <br> **Reserved:** (10 bytes) |
 
@@ -236,8 +237,7 @@ It contains the image information and SHA-384 hash of individual firmware images
 | Image Type | 4 | Image Type that defines format of the image section <br> **0x0000_0001:** Executable |
 | Image Revision | 20 | Git Commit hash of the build |
 | Image Version | 4 | Firmware release number |
-| Image SVN | 4 | Security Version Number for the image. It is compared to FW SVN fuses. FMC TOC entry's SVN field is ignored. |
-| Reserved | 4 | Reserved field |
+| Reserved | 8 | Reserved field |
 | Image Load Address | 4 | Load address |
 | Image Entry Point | 4 | Entry point to start the execution from  |
 | Image Offset | 4 | Offset from beginning of the image |

--- a/rom/dev/README.md
+++ b/rom/dev/README.md
@@ -726,7 +726,7 @@ Local Device ID Layer derives the Owner CDI, ECC and MLDSA Keys. This layer repr
 
 1. Derive the stable identity root secret from IDevID and store the resultant MAC in Key Vault Slot 0.
 
-    `hmac512_mac(KvSlot0, b"stable_identity_root_idev", KvSlot6)`
+    `hmac512_kdf(KvSlot6, b"stable_identity_root_idev", KvSlot0)`
 
 2. Derive the LDevID CDI using IDevID CDI in Key Vault Slot 6 as HMAC Key and Field Entropy stored in Key Vault Slot 1 as data. The resultant MAC is stored back in Key Vault Slot 6.
 
@@ -742,7 +742,7 @@ Local Device ID Layer derives the Owner CDI, ECC and MLDSA Keys. This layer repr
 
 4. Derive the stable identity root secret from LDevID and store the resultant MAC in Key Vault Slot 1.
 
-    `hmac512_mac(KvSlot1, b"stable_identity_root_ldev", KvSlot6)`
+    `hmac512_kdf(KvSlot6, b"stable_identity_root_ldev", KvSlot1)`
 
 5. Derive ECDSA Key Pair using CDI in Key Vault Slot 6 and store the generated private key in Key Vault Slot 5.
 


### PR DESCRIPTION
## Summary                                                                                                                 
                                         
  Two documentation errors in `rom/dev/README.md` where the manifest                                                         
  tables and DICE diverge from the implementation.
                                                                                                                             
  **Fix 1 — SVN field in wrong manifest table**                                                                              
   
  `ImageHeader` has `pub svn: u32` and `verifier.rs` reads it as                                                             
  `manifest.header.svn`, but the README omitted it from the Header
  table and instead documented a nonexistent SVN field in                                                                    
  `ImageTocEntry`. The TOC struct has `pub reserved: [u32; 2]` (8                                                            
  bytes) with no SVN at any offset.                                                                                          
                                                                                                                             
  **Fix 2 — LDevID stable identity root**                                                                         
                                                                                                                             
  `ldev_id.rs` passes `KEY_ID_ROM_FMC_CDI` (KvSlot6) as the HMAC key                                                         
  and `KEY_ID_STABLE_IDEV/LDEV` (KvSlot0/1) as outputs — the README
  had the slots reversed. The primitive is also corrected from                                                               
  `hmac512_mac` to `hmac512_kdf`, matching the `Crypto::hmac_kdf` call                                                       
  in the implementation and consistent with all adjacent label-based                                                         
  derivations in the same section.   