### PR TITLE
emulator: add a manufacturing debug success callback

### DIFF
--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -51,8 +51,8 @@ pub use key_vault::KeyVault;
 pub use mailbox::{MailboxExternal, MailboxInternal, MailboxRam, MailboxRequester};
 pub use mci::Mci;
 pub use root_bus::{
-    ActionCb, CaliptraRootBus, CaliptraRootBusArgs, DownloadIdevidCsrCb, ReadyForFwCb,
-    SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
+    ActionCb, CaliptraRootBus, CaliptraRootBusArgs, DbgManufServiceCb, DownloadIdevidCsrCb,
+    ReadyForFwCb, SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
 };
 pub use sha512_acc::Sha512Accelerator;
 pub use soc_reg::SocRegistersInternal;

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -208,6 +208,42 @@ impl From<Box<dyn FnMut() + 'static>> for ActionCb {
     }
 }
 
+/// Observes changes to `MANUF_DBG_UNLOCK_SUCCESS` (bit 0 of
+/// `SS_DBG_MANUF_SERVICE_REG_RSP`), which drives `ss_dbg_manuf_enable`.
+///
+/// Called synchronously after a successful write through either bus interface,
+/// only when that bit changes. The argument is the full stored register value,
+/// not just the success bit. Changes to other fields and repeated writes do not
+/// notify. Construction and the existing warm/update resets do not notify.
+/// The default callback does nothing; register access and reset behavior are
+/// unchanged. Callbacks must not reenter the SoC register bus.
+pub struct DbgManufServiceCb(Box<dyn FnMut(u32)>);
+impl DbgManufServiceCb {
+    pub fn new(f: impl FnMut(u32) + 'static) -> Self {
+        Self(Box::new(f))
+    }
+    pub(crate) fn take(&mut self) -> Box<dyn FnMut(u32)> {
+        std::mem::take(self).0
+    }
+}
+impl Default for DbgManufServiceCb {
+    fn default() -> Self {
+        Self(Box::new(|_| {}))
+    }
+}
+impl std::fmt::Debug for DbgManufServiceCb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DbgManufServiceCb")
+            .field(&"<unknown closure>")
+            .finish()
+    }
+}
+impl From<Box<dyn FnMut(u32) + 'static>> for DbgManufServiceCb {
+    fn from(value: Box<dyn FnMut(u32)>) -> Self {
+        Self(value)
+    }
+}
+
 /// Caliptra Root Bus Arguments
 pub struct CaliptraRootBusArgs<'a> {
     pub pic: Rc<Pic>,
@@ -228,6 +264,8 @@ pub struct CaliptraRootBusArgs<'a> {
     pub upload_update_fw: UploadUpdateFwCb,
     pub bootfsm_go_cb: ActionCb,
     pub download_idevid_csr_cb: DownloadIdevidCsrCb,
+    /// Optional observer of manufacturing debug success transitions.
+    pub dbg_manuf_service_cb: DbgManufServiceCb,
 
     // The obfuscation key, as passed to caliptra-top
     pub cptra_obf_key: [u32; 8],
@@ -259,6 +297,7 @@ impl Default for CaliptraRootBusArgs<'_> {
             upload_update_fw: Default::default(),
             bootfsm_go_cb: Default::default(),
             download_idevid_csr_cb: Default::default(),
+            dbg_manuf_service_cb: Default::default(),
             cptra_obf_key: words_from_bytes_be(&DEFAULT_DOE_KEY),
             itrng_nibbles: Some(Box::new(RandomNibbles::new_from_thread_rng())),
             etrng_responses: Box::new(RandomEtrngResponses::new_from_stdrng()),

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -780,7 +780,7 @@ struct SocRegistersImpl {
     #[register(offset = 0x5c0)]
     ss_dbg_manuf_service_reg_req: ReadWriteRegister<u32, SsDbgManufServiceRegReq::Register>,
 
-    #[register(offset = 0x5c4)]
+    #[register(offset = 0x5c4, write_fn = on_write_ss_dbg_manuf_service_reg_rsp)]
     ss_dbg_manuf_service_reg_rsp: ReadWriteRegister<u32, SsDbgManufServiceRegRsp::Register>,
 
     #[register_array(offset = 0x5c8)]
@@ -882,6 +882,7 @@ struct SocRegistersImpl {
     upload_update_fw: UploadUpdateFwCallback,
 
     bootfsm_go_cb: BootFsmGoCallback,
+    dbg_manuf_service_cb: Box<dyn FnMut(u32)>,
 
     fuses_can_be_written: bool,
 
@@ -1045,6 +1046,7 @@ impl SocRegistersImpl {
             ready_for_fw_cb: args.ready_for_fw_cb.take(),
             upload_update_fw: args.upload_update_fw.take(),
             bootfsm_go_cb: args.bootfsm_go_cb.take(),
+            dbg_manuf_service_cb: args.dbg_manuf_service_cb.take(),
             fuses_can_be_written: true,
             download_idevid_csr_cb: args.download_idevid_csr_cb.take(),
             op_wdt_timer1_expired_action: None,
@@ -1354,6 +1356,26 @@ impl SocRegistersImpl {
         if val != 0 {
             self.notif_internal_intr_r.reg.set(val);
             self.timer.schedule_poll_in(2);
+        }
+        Ok(())
+    }
+
+    fn on_write_ss_dbg_manuf_service_reg_rsp(
+        &mut self,
+        size: RvSize,
+        val: RvData,
+    ) -> Result<(), BusError> {
+        let prev_success = self
+            .ss_dbg_manuf_service_reg_rsp
+            .reg
+            .is_set(SsDbgManufServiceRegRsp::MANUF_DBG_UNLOCK_SUCCESS);
+        self.ss_dbg_manuf_service_reg_rsp.write(size, val)?;
+        let new_success = self
+            .ss_dbg_manuf_service_reg_rsp
+            .reg
+            .is_set(SsDbgManufServiceRegRsp::MANUF_DBG_UNLOCK_SUCCESS);
+        if new_success != prev_success {
+            (self.dbg_manuf_service_cb)(self.ss_dbg_manuf_service_reg_rsp.reg.get());
         }
         Ok(())
     }

--- a/sw-emulator/lib/periph/tests/debug_manuf_service.rs
+++ b/sw-emulator/lib/periph/tests/debug_manuf_service.rs
@@ -1,0 +1,113 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_emu_bus::{Bus, BusError};
+use caliptra_emu_periph::{CaliptraRootBus, CaliptraRootBusArgs, DbgManufServiceCb};
+use caliptra_emu_types::RvSize;
+use std::{cell::RefCell, rc::Rc};
+
+const RESPONSE: u32 = 0x3003_05c4;
+
+fn exercise_response(registered: bool) {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let captured = calls.clone();
+    let mut bus = CaliptraRootBus::new(CaliptraRootBusArgs {
+        dbg_manuf_service_cb: if registered {
+            DbgManufServiceCb::new(move |value| captured.borrow_mut().push(value))
+        } else {
+            Default::default()
+        },
+        ..Default::default()
+    });
+    let mut external = bus.soc_reg.external_regs();
+    let debug_locked = bus.soc_reg.is_debug_locked();
+    let mut expected = Vec::new();
+    assert!(calls.borrow().is_empty());
+    assert_eq!(bus.read(RvSize::Word, RESPONSE), Ok(0));
+
+    // Include every other defined field, reserved bits, repeated writes, and
+    // both edges of the success bit. Bit 3 is production success, not manufacturing.
+    let values = [
+        0,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        0xffff_fffe,
+        0xffff_ffff,
+        0xffff_ffff,
+        1,
+        3,
+        2,
+        0,
+        1,
+    ];
+    let mut previous = 0;
+    for (index, value) in values.into_iter().enumerate() {
+        if index % 2 == 0 {
+            bus.write(RvSize::Word, RESPONSE, value).unwrap();
+        } else {
+            external.write(RvSize::Word, 0x5c4, value).unwrap();
+        }
+        if registered && (previous ^ value) & 1 != 0 {
+            expected.push(value);
+        }
+        assert_eq!(*calls.borrow(), expected);
+        assert_eq!(bus.read(RvSize::Word, RESPONSE), Ok(value));
+        assert_eq!(external.read(RvSize::Word, 0x5c4), Ok(value));
+        previous = value;
+    }
+
+    for size in [RvSize::Byte, RvSize::HalfWord] {
+        assert_eq!(
+            bus.write(size, RESPONSE, 0),
+            Err(BusError::StoreAccessFault)
+        );
+        assert_eq!(
+            external.write(size, 0x5c4, 0),
+            Err(BusError::StoreAccessFault)
+        );
+        assert_eq!(bus.read(size, RESPONSE), Err(BusError::LoadAccessFault));
+        assert_eq!(external.read(size, 0x5c4), Err(BusError::LoadAccessFault));
+    }
+    for offset in 1..4 {
+        assert!(bus.write(RvSize::Word, RESPONSE + offset, 0).is_err());
+        assert!(bus.read(RvSize::Word, RESPONSE + offset).is_err());
+    }
+    assert_eq!(bus.read(RvSize::Word, RESPONSE), Ok(1));
+    assert_eq!(*calls.borrow(), expected);
+    assert_eq!(bus.soc_reg.is_debug_locked(), debug_locked);
+    for address in [0x3003_05c0, 0x3003_05c8, 0x3003_05cc] {
+        assert_eq!(bus.read(RvSize::Word, address), Ok(0));
+    }
+
+    // Preserve the emulator's existing reset domains: neither reset clears this
+    // register, and neither should manufacture a callback notification.
+    bus.soc_reg.warm_reset();
+    bus.soc_reg.update_reset();
+    external.warm_reset();
+    external.update_reset();
+    assert_eq!(bus.read(RvSize::Word, RESPONSE), Ok(1));
+    assert_eq!(*calls.borrow(), expected);
+    bus.write(RvSize::Word, RESPONSE, 1).unwrap();
+    assert_eq!(*calls.borrow(), expected);
+    bus.write(RvSize::Word, RESPONSE, 0).unwrap();
+    if registered {
+        expected.push(0);
+    }
+    assert_eq!(*calls.borrow(), expected);
+    assert_eq!(external.read(RvSize::Word, 0x5c4), Ok(0));
+}
+
+#[test]
+fn default_callback_preserves_register_semantics() {
+    exercise_response(false);
+}
+
+#[test]
+fn callback_observes_only_manufacturing_success_transitions() {
+    exercise_response(true);
+}


### PR DESCRIPTION
Add a no-op-by-default `DbgManufServiceCb` callback for changes to `SS_DBG_MANUF_SERVICE_REG_RSP.MANUF_DBG_UNLOCK_SUCCESS`, the bit driving `ss_dbg_manuf_enable`.

The callback receives the full stored response after a successful write through either bus interface changes the success bit. Changes to other fields and repeated writes do not notify. Register access widths, readback, security state, and existing reset behavior remain unchanged.

Tests cover registered and default callbacks, success-bit transitions, other fields, both bus interfaces, invalid accesses, readback, and reset retention.
