### PR TITLE
emulator: add callbacks for both debug unlock level entries

### DIFF
--- a/sw-emulator/lib/periph/src/lib.rs
+++ b/sw-emulator/lib/periph/src/lib.rs
@@ -51,8 +51,8 @@ pub use key_vault::KeyVault;
 pub use mailbox::{MailboxExternal, MailboxInternal, MailboxRam, MailboxRequester};
 pub use mci::Mci;
 pub use root_bus::{
-    ActionCb, CaliptraRootBus, CaliptraRootBusArgs, DownloadIdevidCsrCb, ReadyForFwCb,
-    SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
+    ActionCb, CaliptraRootBus, CaliptraRootBusArgs, DbgSocUnlockLevelCb, DownloadIdevidCsrCb,
+    ReadyForFwCb, SocToCaliptraBus, TbServicesCb, UploadUpdateFwCb,
 };
 pub use sha512_acc::Sha512Accelerator;
 pub use soc_reg::SocRegistersInternal;

--- a/sw-emulator/lib/periph/src/root_bus.rs
+++ b/sw-emulator/lib/periph/src/root_bus.rs
@@ -208,6 +208,40 @@ impl From<Box<dyn FnMut() + 'static>> for ActionCb {
     }
 }
 
+/// Observes changes to either entry of `SS_SOC_DBG_UNLOCK_LEVEL`.
+///
+/// Called synchronously after a successful write through either bus interface
+/// changes an entry. Arguments are the entry index (0 or 1) and its full new
+/// 32-bit value. Repeated writes, construction, and the existing warm/update
+/// resets do not notify. The default callback does nothing; register access and
+/// reset behavior are unchanged. Callbacks must not reenter the SoC register bus.
+pub struct DbgSocUnlockLevelCb(Box<dyn FnMut(usize, u32)>);
+impl DbgSocUnlockLevelCb {
+    pub fn new(f: impl FnMut(usize, u32) + 'static) -> Self {
+        Self(Box::new(f))
+    }
+    pub(crate) fn take(&mut self) -> Box<dyn FnMut(usize, u32)> {
+        std::mem::take(self).0
+    }
+}
+impl Default for DbgSocUnlockLevelCb {
+    fn default() -> Self {
+        Self(Box::new(|_, _| {}))
+    }
+}
+impl std::fmt::Debug for DbgSocUnlockLevelCb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DbgSocUnlockLevelCb")
+            .field(&"<unknown closure>")
+            .finish()
+    }
+}
+impl From<Box<dyn FnMut(usize, u32) + 'static>> for DbgSocUnlockLevelCb {
+    fn from(value: Box<dyn FnMut(usize, u32)>) -> Self {
+        Self(value)
+    }
+}
+
 /// Caliptra Root Bus Arguments
 pub struct CaliptraRootBusArgs<'a> {
     pub pic: Rc<Pic>,
@@ -228,6 +262,8 @@ pub struct CaliptraRootBusArgs<'a> {
     pub upload_update_fw: UploadUpdateFwCb,
     pub bootfsm_go_cb: ActionCb,
     pub download_idevid_csr_cb: DownloadIdevidCsrCb,
+    /// Optional observer of changes to either debug unlock level entry.
+    pub dbg_soc_unlock_level_cb: DbgSocUnlockLevelCb,
 
     // The obfuscation key, as passed to caliptra-top
     pub cptra_obf_key: [u32; 8],
@@ -259,6 +295,7 @@ impl Default for CaliptraRootBusArgs<'_> {
             upload_update_fw: Default::default(),
             bootfsm_go_cb: Default::default(),
             download_idevid_csr_cb: Default::default(),
+            dbg_soc_unlock_level_cb: Default::default(),
             cptra_obf_key: words_from_bytes_be(&DEFAULT_DOE_KEY),
             itrng_nibbles: Some(Box::new(RandomNibbles::new_from_thread_rng())),
             etrng_responses: Box::new(RandomEtrngResponses::new_from_stdrng()),

--- a/sw-emulator/lib/periph/src/soc_reg.rs
+++ b/sw-emulator/lib/periph/src/soc_reg.rs
@@ -783,7 +783,7 @@ struct SocRegistersImpl {
     #[register(offset = 0x5c4)]
     ss_dbg_manuf_service_reg_rsp: ReadWriteRegister<u32, SsDbgManufServiceRegRsp::Register>,
 
-    #[register_array(offset = 0x5c8)]
+    #[register_array(offset = 0x5c8, write_fn = on_write_ss_soc_dbg_unlock_level)]
     ss_soc_dbg_unlock_level: [u32; 2],
 
     #[register_array(offset = 0x5d0, write_fn = on_write_ss_generic_fw_exec_ctrl)]
@@ -882,6 +882,7 @@ struct SocRegistersImpl {
     upload_update_fw: UploadUpdateFwCallback,
 
     bootfsm_go_cb: BootFsmGoCallback,
+    dbg_soc_unlock_level_cb: Box<dyn FnMut(usize, u32)>,
 
     fuses_can_be_written: bool,
 
@@ -1045,6 +1046,7 @@ impl SocRegistersImpl {
             ready_for_fw_cb: args.ready_for_fw_cb.take(),
             upload_update_fw: args.upload_update_fw.take(),
             bootfsm_go_cb: args.bootfsm_go_cb.take(),
+            dbg_soc_unlock_level_cb: args.dbg_soc_unlock_level_cb.take(),
             fuses_can_be_written: true,
             download_idevid_csr_cb: args.download_idevid_csr_cb.take(),
             op_wdt_timer1_expired_action: None,
@@ -1354,6 +1356,20 @@ impl SocRegistersImpl {
         if val != 0 {
             self.notif_internal_intr_r.reg.set(val);
             self.timer.schedule_poll_in(2);
+        }
+        Ok(())
+    }
+
+    fn on_write_ss_soc_dbg_unlock_level(
+        &mut self,
+        size: RvSize,
+        index: usize,
+        val: RvData,
+    ) -> Result<(), BusError> {
+        let prev = self.ss_soc_dbg_unlock_level[index];
+        self.ss_soc_dbg_unlock_level[index].write(size, val)?;
+        if prev != self.ss_soc_dbg_unlock_level[index] {
+            (self.dbg_soc_unlock_level_cb)(index, self.ss_soc_dbg_unlock_level[index]);
         }
         Ok(())
     }

--- a/sw-emulator/lib/periph/tests/debug_unlock_level.rs
+++ b/sw-emulator/lib/periph/tests/debug_unlock_level.rs
@@ -1,0 +1,127 @@
+// Licensed under the Apache-2.0 license
+
+use caliptra_emu_bus::{Bus, BusError};
+use caliptra_emu_periph::{CaliptraRootBus, CaliptraRootBusArgs, DbgSocUnlockLevelCb};
+use caliptra_emu_types::RvSize;
+use std::{cell::RefCell, rc::Rc};
+
+const LEVEL: u32 = 0x3003_05c8;
+
+fn exercise_unlock_level(registered: bool) {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    let captured = calls.clone();
+    let mut bus = CaliptraRootBus::new(CaliptraRootBusArgs {
+        dbg_soc_unlock_level_cb: if registered {
+            DbgSocUnlockLevelCb::new(move |index, value| captured.borrow_mut().push((index, value)))
+        } else {
+            Default::default()
+        },
+        ..Default::default()
+    });
+    let mut external = bus.soc_reg.external_regs();
+    let debug_locked = bus.soc_reg.is_debug_locked();
+    let mut expected = Vec::new();
+    let mut levels = [0; 2];
+    assert!(calls.borrow().is_empty());
+    for index in 0..2 {
+        assert_eq!(bus.read(RvSize::Word, LEVEL + index * 4), Ok(0));
+    }
+
+    for (index, value) in [
+        (0, 0),
+        (1, 0),
+        (1, 0x8000_0000),
+        (1, 0x8000_0000),
+        (0, 0x1234_5678),
+        (0, 0x1234_5678),
+        (1, u32::MAX),
+        (0, 0),
+        (1, 0),
+    ] {
+        // Exercise writes through both bus interfaces to both entries.
+        bus.write(RvSize::Word, LEVEL + index as u32 * 4, value)
+            .unwrap();
+        if registered && levels[index] != value {
+            expected.push((index, value));
+        }
+        levels[index] = value;
+        assert_eq!(*calls.borrow(), expected);
+        external
+            .write(RvSize::Word, 0x5c8 + index as u32 * 4, value ^ 1)
+            .unwrap();
+        levels[index] = value ^ 1;
+        if registered {
+            expected.push((index, value ^ 1));
+        }
+        assert_eq!(*calls.borrow(), expected);
+        external
+            .write(RvSize::Word, 0x5c8 + index as u32 * 4, value ^ 1)
+            .unwrap();
+        assert_eq!(*calls.borrow(), expected);
+        for (entry, stored) in levels.iter().enumerate() {
+            assert_eq!(
+                bus.read(RvSize::Word, LEVEL + entry as u32 * 4),
+                Ok(*stored)
+            );
+            assert_eq!(
+                external.read(RvSize::Word, 0x5c8 + entry as u32 * 4),
+                Ok(*stored)
+            );
+        }
+    }
+
+    for index in 0..2 {
+        let address = LEVEL + index * 4;
+        for size in [RvSize::Byte, RvSize::HalfWord] {
+            assert_eq!(bus.write(size, address, 0), Err(BusError::StoreAccessFault));
+            assert_eq!(
+                external.write(size, 0x5c8 + index * 4, 0),
+                Err(BusError::StoreAccessFault)
+            );
+            assert_eq!(bus.read(size, address), Err(BusError::LoadAccessFault));
+            assert_eq!(
+                external.read(size, 0x5c8 + index * 4),
+                Err(BusError::LoadAccessFault)
+            );
+        }
+        for offset in 1..4 {
+            assert!(bus.write(RvSize::Word, address + offset, 0).is_err());
+            assert!(bus.read(RvSize::Word, address + offset).is_err());
+        }
+    }
+    assert_eq!(*calls.borrow(), expected);
+    assert_eq!(bus.soc_reg.is_debug_locked(), debug_locked);
+    for address in [0x3003_05c0, 0x3003_05c4, 0x3003_05d0] {
+        assert_eq!(bus.read(RvSize::Word, address), Ok(0));
+    }
+    bus.soc_reg.warm_reset();
+    bus.soc_reg.update_reset();
+    external.warm_reset();
+    external.update_reset();
+    assert_eq!(*calls.borrow(), expected);
+    for (index, value) in levels.into_iter().enumerate() {
+        let address = LEVEL + index as u32 * 4;
+        assert_eq!(bus.read(RvSize::Word, address), Ok(value));
+        bus.write(RvSize::Word, address, value).unwrap();
+        assert_eq!(*calls.borrow(), expected);
+        bus.write(RvSize::Word, address, value ^ 1).unwrap();
+        if registered {
+            expected.push((index, value ^ 1));
+        }
+        assert_eq!(*calls.borrow(), expected);
+        assert_eq!(
+            external.read(RvSize::Word, 0x5c8 + index as u32 * 4),
+            Ok(value ^ 1)
+        );
+    }
+}
+
+#[test]
+fn default_callback_preserves_both_entries() {
+    exercise_unlock_level(false);
+}
+
+#[test]
+fn callback_observes_changes_to_both_entries() {
+    exercise_unlock_level(true);
+}


### PR DESCRIPTION
Add a no-op-by-default `DbgSocUnlockLevelCb` callback for changes to `SS_SOC_DBG_UNLOCK_LEVEL`.

The callback reports the entry index and new 32-bit value for either entry after a successful write through either bus interface. Repeated writes do not notify. Word-only accesses, readback, security state, and existing reset behavior remain unchanged.

Tests cover both entries and bus interfaces, registered and default callbacks, unchanged writes, invalid accesses, readback, and reset retention.
