### PR TITLE
runtime: restrict EXTEND_PCR to PL0

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1044,7 +1044,9 @@ is needed because the signature was computed over these exact bytes.
 
 ### EXTEND\_PCR
 
-Extends a Caliptra hardware PCR.
+Extends a Caliptra hardware PCR. This command is restricted to the PL0 PAUSER.
+PCR0 through PCR3 are reserved and cannot be extended with this command. PCR31
+is available to PL0 for MCU-managed SoC firmware measurements.
 
 Command Code: `0x5043_5245` ("PCRE")
 

--- a/runtime/src/pcr.rs
+++ b/runtime/src/pcr.rs
@@ -121,6 +121,8 @@ impl ExtendPcrCmd {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     pub(crate) fn execute(drivers: &mut Drivers, cmd_args: &[u8]) -> CaliptraResult<usize> {
+        drivers.ensure_pl0()?;
+
         let cmd = ExtendPcrReq::ref_from_bytes(cmd_args)
             .map_err(|_| CaliptraError::RUNTIME_INSUFFICIENT_MEMORY)?;
 
@@ -129,7 +131,7 @@ impl ExtendPcrCmd {
 
         let pcr_index: PcrId =
             match PcrId::try_from(idx).map_err(|_| CaliptraError::RUNTIME_PCR_INVALID_INDEX)? {
-                PcrId::PcrId0 | PcrId::PcrId1 | PcrId::PcrId2 | PcrId::PcrId3 | PcrId::PcrId31 => {
+                PcrId::PcrId0 | PcrId::PcrId1 | PcrId::PcrId2 | PcrId::PcrId3 => {
                     return Err(CaliptraError::RUNTIME_PCR_RESERVED)
                 }
                 pcr_id => pcr_id,

--- a/runtime/tests/runtime_integration_tests/test_pcr.rs
+++ b/runtime/tests/runtime_integration_tests/test_pcr.rs
@@ -26,6 +26,14 @@ use x509_cert::certificate::Certificate;
 use x509_cert::der::{Decode, Encode};
 use zerocopy::{FromBytes, IntoBytes};
 
+fn extend_pcr(current: &[u8; 48], data: &[u8; 48]) -> [u8; 48] {
+    let mut h = Hasher::new(MessageDigest::sha384()).unwrap();
+    let _ = h.update(current);
+    let _ = h.update(data);
+    let res = h.finish().unwrap();
+    res.as_bytes().try_into().unwrap()
+}
+
 #[test]
 fn test_pcr_quote_ecc() {
     let mut model = run_rt_test(RuntimeTestArgs::default());
@@ -188,14 +196,6 @@ pub fn get_model_pcrs(model: &mut DefaultHwModel) -> [[u8; 48]; 32] {
 
 #[test]
 fn test_extend_pcr_cmd_multiple_extensions() {
-    fn extend_pcr(current: &[u8; 48], data: &[u8; 48]) -> [u8; 48] {
-        let mut h = Hasher::new(MessageDigest::sha384()).unwrap();
-        let _ = h.update(current);
-        let _ = h.update(data);
-        let res = h.finish().unwrap();
-        res.as_bytes().try_into().unwrap()
-    }
-
     // 0. Get fresh pcr state and verify
     let mut model = run_rt_test(RuntimeTestArgs::default());
     assert_eq!(get_model_pcrs(&mut model)[4], [0u8; 48]);
@@ -262,13 +262,7 @@ fn test_extend_pcr_cmd_reserved_range() {
     let extension_data: [u8; 48] = [0u8; 48];
 
     // 4. Ensure reserved PCR range
-    let reserved_pcrs = [
-        PcrId::PcrId0,
-        PcrId::PcrId1,
-        PcrId::PcrId2,
-        PcrId::PcrId3,
-        PcrId::PcrId31,
-    ];
+    let reserved_pcrs = [PcrId::PcrId0, PcrId::PcrId1, PcrId::PcrId2, PcrId::PcrId3];
     for test_pcr_index_reserved in reserved_pcrs {
         let cmd = generate_mailbox_extend_pcr_req(test_pcr_index_reserved.into(), extension_data);
 
@@ -280,6 +274,61 @@ fn test_extend_pcr_cmd_reserved_range() {
             )))
         );
     }
+}
+
+#[test]
+fn test_extend_pcr31_from_pl0_for_mcu_soc_measurements() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    let extension_data = [0xa5; 48];
+    let current_pcr = get_model_pcrs(&mut model)[PcrId::PcrId31 as usize];
+
+    // The MCU uses its PL0 locality to extend SoC firmware measurements into PCR31.
+    let cmd = generate_mailbox_extend_pcr_req(PcrId::PcrId31.into(), extension_data);
+    let res = model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), cmd.as_bytes().unwrap());
+
+    assert!(res.is_ok());
+    assert_eq!(
+        get_model_pcrs(&mut model)[PcrId::PcrId31 as usize],
+        extend_pcr(&current_pcr, &extension_data)
+    );
+}
+
+#[test]
+fn test_extend_pcr_cmd_restricted_to_pl0() {
+    let mut model = run_rt_test(RuntimeTestArgs::default());
+    model.set_axi_user(2);
+
+    for pcr in [PcrId::PcrId4, PcrId::PcrId31] {
+        let cmd = generate_mailbox_extend_pcr_req(pcr.into(), [0xa5; 48]);
+        let res = model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), cmd.as_bytes().unwrap());
+
+        assert_eq!(
+            res,
+            Err(ModelError::MailboxCmdFailed(u32::from(
+                CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL
+            )))
+        );
+    }
+}
+
+#[test]
+fn test_extend_pcr_cmd_rejected_without_pl0_pauser() {
+    let mut image_opts = caliptra_builder::ImageOptions::default();
+    image_opts.vendor_config.pl0_pauser = None;
+
+    let mut model = run_rt_test(RuntimeTestArgs {
+        subsystem_mode: true,
+        test_image_options: Some(image_opts),
+        ..Default::default()
+    });
+    let cmd = generate_mailbox_extend_pcr_req(PcrId::PcrId31.into(), [0xa5; 48]);
+
+    assert_eq!(
+        model.mailbox_execute(u32::from(CommandId::EXTEND_PCR), cmd.as_bytes().unwrap()),
+        Err(ModelError::MailboxCmdFailed(u32::from(
+            CaliptraError::RUNTIME_INCORRECT_PAUSER_PRIVILEGE_LEVEL
+        )))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Keep PCR0-3 reserved and permit PL0 MCU callers to extend PCR31. Add tests for PCR31 and PL1 rejection.